### PR TITLE
fix: javstash runtime convert seconds to minutes

### DIFF
--- a/internal/scraper/javstash/javstash.go
+++ b/internal/scraper/javstash/javstash.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -313,7 +314,7 @@ func (s *Scraper) parseScene(scene *Scene, searchID string) (*models.ScraperResu
 		ContentID:   scene.Code,
 		Title:       scraperutil.CleanString(scene.Title),
 		Description: scraperutil.CleanString(scene.Details),
-		Runtime:     scene.Duration,
+		Runtime:     int(math.Round(float64(scene.Duration) / 60.0)),
 		Director:    scraperutil.CleanString(scene.Director),
 	}
 

--- a/internal/scraper/javstash/javstash.go
+++ b/internal/scraper/javstash/javstash.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"net/url"
 	"os"


### PR DESCRIPTION
Hey, 
javstash returns runtime in seconds instead of minutes

<img width="610" height="110" alt="Image" src="https://github.com/user-attachments/assets/a9aa87c0-123c-4a30-be13-11c4ff122986" />
thanks for taking a look