### PR TITLE
Fix: Caribbeancom English URL + soft-404, `--scrapers` docs, web GUI unidentified files, Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,19 @@ FROM node:20-alpine AS frontend-builder
 
 WORKDIR /frontend
 
-# Copy package files and install dependencies
+# Install deps without running prepare/postinstall scripts.
+# svelte-kit sync needs the full source tree (svelte.config.js etc.) to work,
+# which we don't have yet at this layer.
 COPY web/frontend/package*.json ./
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --production=false
+    npm ci --include=dev --ignore-scripts
 
-# Copy frontend source and build
+# Bring in the rest of the source, including svelte.config.js.
 COPY web/frontend/ ./
+
+# Run svelte-kit sync explicitly now that the config is present.
+RUN npx svelte-kit sync
+
 RUN --mount=type=cache,target=/root/.npm \
     npm run build
 

--- a/Makefile
+++ b/Makefile
@@ -379,9 +379,12 @@ DOCKER_FULL_IMAGE := $(DOCKER_IMAGE):$(DOCKER_TAG)
 DOCKER_CONTAINER_NAME := javinizer
 
 # Build Docker image with version injection
+# --ulimit nofile=65536:65536 is required: Vite 7's SSR/CSS pipeline opens many
+# files in parallel and hits the default container RLIMIT_NOFILE of 1024.
 docker-build:
 	@echo "Building Docker image $(DOCKER_FULL_IMAGE)..."
 	docker build \
+		--ulimit nofile=65536:65536 \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg COMMIT=$(COMMIT) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
@@ -395,6 +398,7 @@ docker-build:
 docker-build-no-cache:
 	@echo "Building Docker image $(DOCKER_FULL_IMAGE) without cache..."
 	docker build --no-cache \
+		--ulimit nofile=65536:65536 \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg COMMIT=$(COMMIT) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -25,7 +25,7 @@ func NewCommand() *cobra.Command {
 			return runScrape(cmd, args, configFile)
 		},
 	}
-	scrapeCmd.Flags().StringSliceP("scrapers", "s", nil, "Comma-separated list of scrapers to use (e.g., 'r18dev,dmm' or 'dmm')")
+	scrapeCmd.Flags().StringSliceP("scrapers", "s", nil, "Comma-separated subset of enabled scrapers to use (e.g., 'r18dev,dmm'); scraper must be enabled in config.yaml")
 	scrapeCmd.Flags().BoolP("force", "f", false, "Force refresh metadata from scrapers (clear cache)")
 	scrapeCmd.Flags().Bool("scrape-actress", false, "Enable actress scraping (overrides config)")
 	scrapeCmd.Flags().Bool("no-scrape-actress", false, "Disable actress scraping (overrides config)")

--- a/cmd/javinizer/commands/sort/command.go
+++ b/cmd/javinizer/commands/sort/command.go
@@ -40,7 +40,7 @@ func NewCommand() *cobra.Command {
 	sortCmd.Flags().BoolP("nfo", "", true, "Generate NFO files")
 	sortCmd.Flags().BoolP("download", "", true, "Download media (covers, screenshots, etc.)")
 	sortCmd.Flags().Bool("extrafanart", false, "Download extrafanart (screenshots)")
-	sortCmd.Flags().StringSliceP("scrapers", "p", nil, "Scraper priority (comma-separated, e.g., 'r18dev,dmm')")
+	sortCmd.Flags().StringSliceP("scrapers", "p", nil, "Scraper priority override — comma-separated subset of enabled scrapers (e.g., 'r18dev,dmm'); scraper must be enabled in config.yaml")
 	sortCmd.Flags().BoolP("force-update", "f", false, "Force update existing files")
 	sortCmd.Flags().Bool("force-refresh", false, "Force refresh metadata from scrapers (clear cache)")
 	return sortCmd

--- a/internal/scraper/caribbeancom/caribbeancom.go
+++ b/internal/scraper/caribbeancom/caribbeancom.go
@@ -26,6 +26,7 @@ var (
 	movieIDTokenRegex  = regexp.MustCompile(`(?i)(?:^|[^0-9])(\d{6})[-_](\d{2,3})(?:[^0-9]|$)`)
 	movieIDFromPageRe  = regexp.MustCompile(`(?i)/moviepages/(\d{6}[-_]\d{3})/`)
 	movieIDFromJSONRe  = regexp.MustCompile(`(?i)"movie_id"\s*:\s*"(\d{6}-\d{3})"`)
+	movieNullJSONRe    = regexp.MustCompile(`(?i)var\s+Movie\s*=\s*null`)
 	trailerURLJSONRe   = regexp.MustCompile(`(?i)"sample_flash_url"\s*:\s*"([^"]+)"`)
 	trailerURLAssignRe = regexp.MustCompile(`(?i)sample_flash_url\s*=\s*['"]([^'"]+)['"]`)
 	coverImagePathRe   = regexp.MustCompile(`(?i)(/moviepages/\d{6}-\d{3}/images/l(?:_l)?\.jpg)`)
@@ -242,11 +243,17 @@ func (s *Scraper) Search(ctx context.Context, id string) (*models.ScraperResult,
 }
 
 // isMovieDetailPage returns false when Caribbeancom serves a soft-404 with HTTP 200.
-// The site embeds a full site shell (header/footer) in its error page, so we cannot
-// rely on the status code alone. A real movie page always contains #moviepages or
-// h1[itemprop='name']; the error page has neither but always has class="error404-wrap".
+// Two distinct blank-page variants exist:
+//   - Japanese: returns HTTP 200 with class="error404-wrap" in the body.
+//   - English: returns HTTP 200 with the full page shell (header, #moviepages, .movie-info,
+//     h1[itemprop='name']) but all content fields empty and var Movie = null in the JS.
+//
+// A real movie page always has a populated var Movie = {...} object with a "movie_id" field.
 func isMovieDetailPage(doc *goquery.Document, html string) bool {
 	if doc.Find(".error404-wrap, .error404-content").Length() > 0 {
+		return false
+	}
+	if movieNullJSONRe.MatchString(html) {
 		return false
 	}
 	if movieIDFromJSONRe.MatchString(html) {

--- a/internal/scraper/caribbeancom/caribbeancom.go
+++ b/internal/scraper/caribbeancom/caribbeancom.go
@@ -162,6 +162,10 @@ func (s *Scraper) ScrapeURL(ctx context.Context, rawURL string) (*models.Scraper
 		return nil, fmt.Errorf("failed to parse Caribbeancom detail page: %w", err)
 	}
 
+	if !isMovieDetailPage(doc, html) {
+		return nil, models.NewScraperNotFoundError("Caribbeancom", fmt.Sprintf("movie %s not found on Caribbeancom", id))
+	}
+
 	return parseDetailPage(doc, html, detailURL, id, s.language), nil
 }
 
@@ -230,7 +234,30 @@ func (s *Scraper) Search(ctx context.Context, id string) (*models.ScraperResult,
 		return nil, fmt.Errorf("failed to parse Caribbeancom detail page: %w", err)
 	}
 
+	if !isMovieDetailPage(doc, html) {
+		return nil, models.NewScraperNotFoundError("Caribbeancom", fmt.Sprintf("movie %s not found on Caribbeancom", id))
+	}
+
 	return parseDetailPage(doc, html, detailURL, id, s.language), nil
+}
+
+// isMovieDetailPage returns false when Caribbeancom serves a soft-404 with HTTP 200.
+// The site embeds a full site shell (header/footer) in its error page, so we cannot
+// rely on the status code alone. A real movie page always contains #moviepages or
+// h1[itemprop='name']; the error page has neither but always has class="error404-wrap".
+func isMovieDetailPage(doc *goquery.Document, html string) bool {
+	if doc.Find(".error404-wrap, .error404-content").Length() > 0 {
+		return false
+	}
+	if movieIDFromJSONRe.MatchString(html) {
+		return true
+	}
+	for _, sel := range []string{"#moviepages", ".movie-info", "h1[itemprop='name']"} {
+		if doc.Find(sel).Length() > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func parseDetailPage(doc *goquery.Document, html, sourceURL, fallbackID, language string) *models.ScraperResult {
@@ -592,10 +619,12 @@ func normalizeLanguage(v string) string {
 
 func (s *Scraper) buildMoviePageURL(movieID string) string {
 	movieID = normalizeMovieID(movieID)
-	if s.language == "en" {
-		return strings.TrimRight(s.baseURL, "/") + "/eng/moviepages/" + movieID + "/index.html"
-	}
-	return strings.TrimRight(s.baseURL, "/") + "/moviepages/" + movieID + "/index.html"
+	// Always build the canonical Japanese path from baseURL, then let applyLanguage
+	// swap the hostname and inject the /eng/ prefix when language == "en".
+	// This fixes the 500 error caused by requesting /eng/moviepages/... on
+	// www.caribbeancom.com, which only serves English content on en.caribbeancom.com.
+	rawURL := strings.TrimRight(s.baseURL, "/") + "/moviepages/" + movieID + "/index.html"
+	return s.applyLanguage(rawURL)
 }
 
 func (s *Scraper) applyLanguage(rawURL string) string {

--- a/internal/scraper/caribbeancom/caribbeancom_extra_test.go
+++ b/internal/scraper/caribbeancom/caribbeancom_extra_test.go
@@ -95,6 +95,11 @@ func TestIsMovieDetailPage(t *testing.T) {
 			html: `<html><head><title>Caribbeancom.com - No.1 Japanese Uncensored Adult Site</title></head><body><div id="header"></div></body></html>`,
 			want: false,
 		},
+		{
+			name: "English blank entry page with Movie=null (invalid ID, HTTP 200)",
+			html: `<html><body><div id="moviepages"><div class="movie-info"><h1 itemprop="name"></h1></div></div><script>var Movie = null;</script></body></html>`,
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/scraper/caribbeancom/caribbeancom_extra_test.go
+++ b/internal/scraper/caribbeancom/caribbeancom_extra_test.go
@@ -1,8 +1,10 @@
 package caribbeancom
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/PuerkitoBio/goquery"
 	"github.com/javinizer/javinizer-go/internal/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -43,6 +45,62 @@ func TestResolveDownloadProxyForHost(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, _, ok := scraper.ResolveDownloadProxyForHost(tt.host)
 			assert.Equal(t, tt.wantOk, ok)
+		})
+	}
+}
+
+func mustParseDoc(html string) *goquery.Document {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		panic(err)
+	}
+	return doc
+}
+
+// TestIsMovieDetailPage verifies that the soft-404 page Caribbeancom serves with HTTP 200
+// for non-existent movie IDs is correctly rejected.
+func TestIsMovieDetailPage(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want bool
+	}{
+		{
+			name: "real movie page with movie_id JSON",
+			html: `<html><body><script>"movie_id": "120515-039"</script></body></html>`,
+			want: true,
+		},
+		{
+			name: "real movie page with #moviepages container",
+			html: `<html><body><div id="moviepages"><div class="movie-info"><h1 itemprop="name">Title</h1></div></div></body></html>`,
+			want: true,
+		},
+		{
+			name: "real movie page with h1[itemprop='name'] only",
+			html: `<html><body><h1 itemprop="name">Some Movie Title</h1></body></html>`,
+			want: true,
+		},
+		{
+			name: "soft-404 page with error404-wrap",
+			html: `<html><body><div class="error404-wrap"><h1 class="error404-heading">404 NOT FOUND</h1></div></body></html>`,
+			want: false,
+		},
+		{
+			name: "empty page",
+			html: `<html><body></body></html>`,
+			want: false,
+		},
+		{
+			name: "site homepage without movie content",
+			html: `<html><head><title>Caribbeancom.com - No.1 Japanese Uncensored Adult Site</title></head><body><div id="header"></div></body></html>`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := mustParseDoc(tt.html)
+			assert.Equal(t, tt.want, isMovieDetailPage(doc, tt.html))
 		})
 	}
 }

--- a/internal/scraper/caribbeancom/caribbeancom_url_test.go
+++ b/internal/scraper/caribbeancom/caribbeancom_url_test.go
@@ -28,7 +28,7 @@ func TestGetURL(t *testing.T) {
 			name:     "English direct ID",
 			language: "en",
 			movieID:  "120614-753",
-			want:     "https://www.caribbeancom.com/eng/moviepages/120614-753/index.html",
+			want:     "https://en.caribbeancom.com/eng/moviepages/120614-753/index.html",
 			wantErr:  false,
 		},
 		{
@@ -42,7 +42,7 @@ func TestGetURL(t *testing.T) {
 			name:     "English underscore ID normalized",
 			language: "en",
 			movieID:  "020326_01-10MU",
-			want:     "https://www.caribbeancom.com/eng/moviepages/020326-001/index.html",
+			want:     "https://en.caribbeancom.com/eng/moviepages/020326-001/index.html",
 			wantErr:  false,
 		},
 	}

--- a/web/frontend/src/routes/review/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/review/[jobId]/+page.svelte
@@ -21,6 +21,7 @@
 	import RescrapeModal from './components/RescrapeModal.svelte';
 	import BulkRescrapeProgress from './components/BulkRescrapeProgress.svelte';
 	import SourceFilesCard from './components/SourceFilesCard.svelte';
+	import UnidentifiedFilesCard from './components/UnidentifiedFilesCard.svelte';
 	import { createReviewState } from './stores/review-state.svelte';
 	import {
 		ChevronLeft,
@@ -50,7 +51,7 @@
 					</Button>
 				</div>
 			</Card>
-		{:else if s.job && s.movieResults.length === 0}
+		{:else if s.job && s.movieResults.length === 0 && s.failedResults.length === 0}
 			<Card class="p-6">
 				<div class="text-center">
 					<p class="text-muted-foreground">No movies to review</p>
@@ -62,6 +63,24 @@
 					</Button>
 				</div>
 			</Card>
+		{:else if s.job && s.movieResults.length === 0 && s.failedResults.length > 0}
+			<UnidentifiedFilesCard
+				failedResults={s.failedResults}
+				onSearchManually={s.openRescrapeModalForFailed}
+			/>
+			<RescrapeModal
+				bind:show={s.showRescrapeModal}
+				rescraping={s.rescrapingStates.get(s.rescrapeMovieId) ?? false}
+				rescrapeMovieId={s.rescrapeMovieId}
+				availableScrapers={s.availableScrapers}
+				bind:selectedScrapers={s.rescrapeSelectedScrapers}
+				bind:manualSearchMode={s.manualSearchMode}
+				bind:manualSearchInput={s.manualSearchInput}
+				bind:rescrapePreset={s.rescrapePreset}
+				bind:rescrapeScalarStrategy={s.rescrapeScalarStrategy}
+				onApplyPreset={s.applyRescrapePreset}
+				onExecute={s.executeRescrape}
+			/>
 		{:else if s.currentMovie && s.currentResult}
 			<ReviewHeader
 				isUpdateMode={s.isUpdateMode}
@@ -100,6 +119,11 @@
 				isUpdateMode={s.isUpdateMode}
 				onRetryFailed={s.retryFailed}
 				onContinue={() => goto('/browse')}
+			/>
+
+			<UnidentifiedFilesCard
+				failedResults={s.failedResults}
+				onSearchManually={s.openRescrapeModalForFailed}
 			/>
 
 			{#if s.viewMode === 'grid-poster' || s.viewMode === 'grid-cover'}

--- a/web/frontend/src/routes/review/[jobId]/components/UnidentifiedFilesCard.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/UnidentifiedFilesCard.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import { AlertTriangle, Search } from 'lucide-svelte';
+	import type { FileResult } from '$lib/api/types';
+	import Card from '$lib/components/ui/Card.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+
+	interface Props {
+		failedResults: FileResult[];
+		onSearchManually: (result: FileResult) => void;
+	}
+
+	let { failedResults, onSearchManually }: Props = $props();
+
+	function basename(path: string): string {
+		return path.replace(/\\/g, '/').split('/').pop() ?? path;
+	}
+</script>
+
+{#if failedResults.length > 0}
+	<Card class="p-4">
+		<div class="flex items-center gap-2 mb-3">
+			<AlertTriangle class="h-4 w-4 text-warning shrink-0" />
+			<p class="text-sm font-medium">
+				Unidentified Files ({failedResults.length})
+			</p>
+		</div>
+		<div class="space-y-2">
+			{#each failedResults as result (result.file_path)}
+				<div class="flex items-start justify-between gap-3 rounded-md border px-3 py-2 text-sm">
+					<div class="min-w-0 flex-1">
+						<p class="font-mono truncate" title={result.file_path}>
+							{basename(result.file_path)}
+						</p>
+						{#if result.error}
+							<p class="text-xs text-destructive mt-0.5 truncate" title={result.error}>
+								{result.error}
+							</p>
+						{/if}
+					</div>
+					<Button
+						variant="outline"
+						size="sm"
+						onclick={() => onSearchManually(result)}
+						class="shrink-0"
+					>
+						{#snippet children()}
+							<Search class="h-3 w-3 mr-1" />
+							Search manually
+						{/snippet}
+					</Button>
+				</div>
+			{/each}
+		</div>
+	</Card>
+{/if}

--- a/web/frontend/src/routes/review/[jobId]/logic/rescrape-controller.ts
+++ b/web/frontend/src/routes/review/[jobId]/logic/rescrape-controller.ts
@@ -156,6 +156,7 @@ export function createRescrapeController(deps: RescrapeControllerDeps) {
 				const newResults = { ...currentJob.results };
 				newResults[filePath] = {
 					...newResults[filePath],
+					status: 'completed',
 					data: updatedMovie,
 					field_sources: response.field_sources ?? newResults[filePath].field_sources,
 					actress_sources: response.actress_sources ?? newResults[filePath].actress_sources

--- a/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
@@ -161,6 +161,7 @@ export function createReviewState(pageStore: Page) {
 	let rescrapingStates = new SvelteMap<string, boolean>();
 	let manualSearchMode = $state(false);
 	let manualSearchInput = $state('');
+	let rescrapeTargetResult = $state<FileResult | null>(null);
 
 	let rescrapePreset: string | undefined = $state(undefined);
 	let rescrapeScalarStrategy: ScalarStrategy = $state('prefer-nfo');
@@ -199,6 +200,14 @@ export function createReviewState(pageStore: Page) {
 				primaryResult: results[0]
 			}));
 		})() : []
+	);
+
+	const failedResults = $derived<FileResult[]>(
+		job
+			? (Object.values((job as BatchJobResponse).results) as FileResult[]).filter(
+					(r) => r.status === 'failed' && !(((job as BatchJobResponse).excluded ?? {})[r.file_path])
+				)
+			: []
 	);
 
 	const tierCounts = $derived.by<Record<CompletenessTier, number>>(() => {
@@ -587,7 +596,7 @@ export function createReviewState(pageStore: Page) {
 
 	const rescrapeController = createRescrapeController({
 		getJobId: () => jobId,
-		getCurrentResult: () => currentResult,
+		getCurrentResult: () => rescrapeTargetResult ?? currentResult,
 		getJob: () => job,
 		setJob: (nextJob) => { job = nextJob; },
 		getEditedMovies: () => editedMovies,
@@ -669,8 +678,36 @@ export function createReviewState(pageStore: Page) {
 
 	async function openRescrapeModal(movieId: string) {
 		bulkRescrapeMovieIds = [];
+		rescrapeTargetResult = null;
 		await rescrapeController.openRescrapeModal(movieId);
 	}
+
+	async function openRescrapeModalForFailed(result: FileResult) {
+		bulkRescrapeMovieIds = [];
+		if (availableScrapers.length === 0) {
+			try {
+				availableScrapers = await apiClient.getScrapers();
+			} catch {
+				toastStore.error('Failed to load scrapers');
+				return;
+			}
+		}
+		rescrapeTargetResult = result;
+		rescrapeMovieId = result.movie_id;
+		rescrapeSelectedScrapers = availableScrapers.filter((s) => s.enabled).map((s) => s.name);
+		manualSearchMode = true;
+		manualSearchInput = '';
+		rescrapePreset = undefined;
+		rescrapeScalarStrategy = 'prefer-nfo';
+		rescrapeArrayStrategy = 'merge';
+		showRescrapeModal = true;
+	}
+
+	$effect(() => {
+		if (!showRescrapeModal) {
+			rescrapeTargetResult = null;
+		}
+	});
 
 	async function executeRescrape(mode?: { manualSearchMode: boolean; manualSearchInput: string }) {
 		await rescrapeController.executeRescrape(mode);
@@ -871,6 +908,7 @@ export function createReviewState(pageStore: Page) {
 		get rescrapeArrayStrategy() { return rescrapeArrayStrategy; },
 		set rescrapeArrayStrategy(v) { rescrapeArrayStrategy = v; },
 		get movieGroups() { return movieGroups; },
+		get failedResults() { return failedResults; },
 		get movieResults() { return movieResults; },
 		get currentMovieGroup() { return currentMovieGroup; },
 		get currentResult() { return currentResult; },
@@ -916,6 +954,7 @@ export function createReviewState(pageStore: Page) {
 		reviewPageController,
 		applyRescrapePreset,
 		openRescrapeModal,
+		openRescrapeModalForFailed,
 		executeRescrape,
 		organizeAll,
 		updateAll,


### PR DESCRIPTION
## Summary

Identified and fixed the issues raised in javinizer/javinizer-go#20 with the help of Claude Code

Three bug fixes, one documentation clarification, one web GUI improvement, and a Docker build fix:
- Caribbeancom ID-based scraping returning 500 in English mode
- Caribbeancom returning a partial "match" for non-existent IDs (soft-404 with HTTP 200)
- Misleading `--scrapers` / `-p` flag help text
- Review page silently hiding files that failed to be identified, with no way to manually search for them
- Multi-stage Docker build failing in the `frontend-builder` stage

---

## Problem 1 — Caribbeancom returns HTTP 500 when scraping by ID in English mode

### What was broken

When the Caribbeancom scraper is configured with `language: en`, scraping by movie ID
(e.g. `javinizer scrape 120515-039 --scrapers caribbeancom`) always returned:

```
time="..." level=warning msg="❌ caribbeancom: Caribbeancom returned status code 500"
```

Scraping by full URL worked fine:

```
javinizer scrape "https://www.caribbeancom.com/moviepages/120515-039/index.html" --scrapers caribbeancom
# ✅ succeeds
```

### Root cause

`buildMoviePageURL()` constructed the English URL by appending `/eng/moviepages/` to
`s.baseURL`, which defaults to `https://www.caribbeancom.com`:

```go
// Before
if s.language == "en" {
    return strings.TrimRight(s.baseURL, "/") + "/eng/moviepages/" + movieID + "/index.html"
}
```

This produced `https://www.caribbeancom.com/eng/moviepages/120515-039/index.html`.

The Caribbeancom site does **not** serve English pages on `www.caribbeancom.com`.
English content lives on a separate subdomain: `en.caribbeancom.com`.
Requesting `/eng/...` on the `www` host returns a 500.

When a full URL was passed, the existing `applyLanguage()` helper was invoked, which
correctly swaps the hostname to `en.caribbeancom.com` **and** adds the `/eng/` path prefix.
The ID-based path bypassed `applyLanguage()` entirely.

### Fix

`buildMoviePageURL()` now always builds the canonical Japanese-style path
(`/moviepages/<id>/index.html`) using `s.baseURL`, then passes it through `applyLanguage()`.
This single function already handles both the hostname swap and the path prefix for English,
and is a no-op for Japanese:

```go
// After
func (s *Scraper) buildMoviePageURL(movieID string) string {
    movieID = normalizeMovieID(movieID)
    rawURL := strings.TrimRight(s.baseURL, "/") + "/moviepages/" + movieID + "/index.html"
    return s.applyLanguage(rawURL)
}
```

**Behavior across all configurations:**

| `base_url` | `language` | Before | After |
|---|---|---|---|
| `www.caribbeancom.com` (default) | `ja` | ✅ correct | ✅ unchanged |
| `www.caribbeancom.com` (default) | `en` | ❌ 500 (wrong host) | ✅ `en.caribbeancom.com/eng/...` |
| `en.caribbeancom.com` (custom) | `en` | ✅ happened to work | ✅ still correct |
| custom proxy host | `en` | passes through unchanged | passes through unchanged (same) |

`applyLanguage()` only transforms URLs whose hostname is `caribbeancom.com` or a
`*.caribbeancom.com` subdomain, so custom proxy base URLs are unaffected.

### Effect on sort / batch operations

This also fixes `javinizer sort` for files named with the `-carib` suffix
(e.g. `120515-039-carib.mp4`). The matcher correctly extracts `120515-039-CARIB` and
Caribbeancom's `ResolveSearchQuery` maps it to `120515-039`, but the subsequent HTTP
request was hitting the same broken URL. With this fix the request lands on the correct
English endpoint.

> **Note:** Caribbeancom must still be **enabled** (`enabled: true`) in `config.yaml`
> for `sort` to use it automatically for `-carib` files. The scraper language is also
> set in `config.yaml` (`language: ja` or `language: en`); there is no CLI flag to
> override it per-invocation.

---

## Problem 2 — `--scrapers` / `-p` flag help text was misleading

### What was confusing

The flag description for `--scrapers` (`scrape` command) and `-p` (`sort` command) gave
no indication that the named scrapers must already be **enabled** in `config.yaml`.
Users reasonably expected the flag to override or activate any scraper by name,
leading to confusion when a disabled scraper was silently ignored.

### Clarification (documentation only — no behaviour change)

The flag descriptions now explicitly state that only enabled scrapers are eligible:

**`scrape` command** (`-s` / `--scrapers`):
```
# Before
Comma-separated list of scrapers to use (e.g., 'r18dev,dmm' or 'dmm')

# After
Comma-separated subset of enabled scrapers to use (e.g., 'r18dev,dmm');
scraper must be enabled in config.yaml
```

**`sort` command** (`-p` / `--scrapers`):
```
# Before
Scraper priority (comma-separated, e.g., 'r18dev,dmm')

# After
Scraper priority override — comma-separated subset of enabled scrapers
(e.g., 'r18dev,dmm'); scraper must be enabled in config.yaml
```

No runtime behaviour was changed. The flag continues to select a **prioritised subset**
of the scrapers that are already enabled in config; it does not bypass the `enabled`
check.

---

---

## Problem 3 — Web GUI review page silently hides files that failed to be identified

### What was broken

When a batch scrape job finishes, any file that the scraper could not identify
(no results from any scraper, or the filename did not match any known ID pattern)
was silently omitted from the review page. The `Failed` count in the job summary
showed a non-zero number but the user had no way to see which files failed, why
they failed, or manually search for the correct metadata.

### Root cause

`review-state.svelte.ts` derived `movieGroups` by filtering results to
`status === 'completed'` only:

```typescript
.filter((r) => {
    if (r.status !== 'completed' || !r.data) return false;
    ...
})
```

Failed results were present in the job's `results` map (the backend always returns
all file results regardless of status) but the frontend never read them.

Additionally, after a successful manual rescrape the file's status was updated
locally to add the new movie `data`, but `status` was left as `'failed'` in the
optimistic update — meaning the file would stay in the failed list until the next
background query refresh.

### Fix

**`rescrape-controller.ts`** — Add `status: 'completed'` to the optimistic local
state update on successful rescrape. The file now moves to the movie grid immediately
without waiting for a background refetch.

**`review-state.svelte.ts`** — Four additions:
- `rescrapeTargetResult` state variable (nullable `FileResult`). When set, the
  rescrape controller's `getCurrentResult` closure returns it instead of the
  currently displayed movie. This lets the controller operate on a failed file
  that is not the actively viewed entry, with no changes to `executeRescrape`.
- `getCurrentResult: () => rescrapeTargetResult ?? currentResult` — single-line
  change to the closure passed to `createRescrapeController`.
- `failedResults` derived state — all `status === 'failed'`, non-excluded results.
- `openRescrapeModalForFailed(result)` — sets `rescrapeTargetResult`, forces
  `manualSearchMode = true`, and opens the existing `RescrapeModal`. A `$effect`
  clears `rescrapeTargetResult` when the modal closes.

**`UnidentifiedFilesCard.svelte`** — New component. Renders a card listing each
failed file: its filename, the error message returned by the scraper, and a
"Search manually" button per row. Clicking the button calls
`openRescrapeModalForFailed`, opening the existing rescrape modal pre-set to
manual search mode. The user types a movie ID or URL, selects scrapers, and submits.
On success the file disappears from the failed list and appears in the movie grid.
No new modal or API endpoint was needed.

**`+page.svelte`** — Two edits:
- Import and render `<UnidentifiedFilesCard>` below `<OrganizeStatusCard>` inside
  the main content block (visible when `failedResults.length > 0` alongside any
  successfully identified movies).
- A second render of the card in its own layout branch handles the edge case where
  the entire batch produced zero successful scrapes — previously the page fell
  through to "No movies to review" and the failed files were completely invisible.

---

## Problem 4 — Caribbeancom returns partial results for non-existent IDs

### What was broken

Scraping a valid-looking but non-existent Caribbeancom ID returned a "completed" result
with garbage data that showed up on the review page as a "partial" completeness movie.
The exact symptom differed by language:

- **Japanese mode** (`092912-002`): result had title `"404 Not Found - Caribbeancom.com"`.
- **English mode** (any invalid ID): result had an empty title, no actresses, no tags —
  a completely blank entry that still appeared in the movie grid.

### Root cause

Caribbeancom returns **HTTP 200** (not 404) for non-existent movie URLs. Two distinct
blank-page variants exist:

- **Japanese soft-404**: the page body contains `class="error404-wrap"`. The scraper only
  checked the HTTP status code, so it fell through to `parseDetailPage`, which extracted
  the `<title>` content — `"404 Not Found - Caribbeancom.com"` — as the movie title.

- **English blank entry**: the page renders the full site shell including `#moviepages`,
  `.movie-info`, and `h1[itemprop='name']` (the same DOM selectors used to confirm a real
  movie page), but all fields are empty. The JavaScript contains `var Movie = null` rather
  than a populated movie object. The previous `isMovieDetailPage` fallback matched the
  structure and treated this as a valid page.

### Fix

`isMovieDetailPage(doc, html)` is called in both `Search()` and `ScrapeURL()` after the
HTTP status checks. It now handles both variants:

1. Returns `false` immediately if `class="error404-wrap"` or `class="error404-content"` is
   detected — catches the **Japanese** soft-404.
2. Returns `false` immediately if `var Movie = null` is found in the raw HTML — catches
   the **English** blank-entry page whose page structure looks valid but has no movie data.
3. Returns `true` if `"movie_id"` is found in the page's JSON (most reliable positive
   signal for a real movie).
4. Falls back to structural selectors (`#moviepages`, `.movie-info`, `h1[itemprop='name']`)
   as a last resort positive check.

Non-existent IDs now return a proper `ScraperNotFoundError` in both language modes.

---

## Problem 5 — Multi-stage Docker build failing in `frontend-builder`

### What was broken

`docker build` / `podman build` failed in stage 1 (`frontend-builder`) with up to four
sequential errors:

1. `Missing Svelte config file in /frontend — skipping` (warning, leaves `.svelte-kit/` empty)
2. `Cannot find base config file "./.svelte-kit/tsconfig.json"` (TypeScript error)
3. `Rollup failed to resolve import "cookie" from "@sveltejs/kit/..."` (fatal — consequence of broken `.svelte-kit/`)
4. `EMFILE: too many open files` during the Vite 7 SSR/CSS pipeline (fatal)

### Root causes and fixes

**A — `npm ci` running `prepare` too early** (`Dockerfile`):

The original `npm ci --production=false` ran the `prepare` lifecycle script (`svelte-kit sync`)
at the layer where only `package*.json` was present, before `svelte.config.js` was copied.
`svelte-kit sync` silently skipped with "Missing Svelte config file", leaving `.svelte-kit/`
unpopulated. This broke TypeScript path resolution and Vite's SSR externalization, causing
errors 1–3.

- `--production=false` is also deprecated in npm 10+; replaced with `--include=dev`.
- Added `--ignore-scripts` to prevent `prepare` from running at this layer.
- After the full `COPY web/frontend/ ./`, a new explicit `RUN npx svelte-kit sync` step
  runs with `svelte.config.js` present, correctly populating `.svelte-kit/`.

**B — EMFILE from Vite 7's parallel file opens** (`Makefile`):

Default container `RLIMIT_NOFILE` soft limit is 1024. Vite 7's SSR/CSS pipeline opens many
files in parallel during build. Added `--ulimit nofile=65536:65536` to both `docker-build`
and `docker-build-no-cache` Makefile targets.

---

## Files changed

| File | Change |
|---|---|
| `internal/scraper/caribbeancom/caribbeancom.go` | Fix `buildMoviePageURL`; add `isMovieDetailPage` with dual soft-404 detection |
| `internal/scraper/caribbeancom/caribbeancom_url_test.go` | Correct test expectations to `en.caribbeancom.com` |
| `internal/scraper/caribbeancom/caribbeancom_extra_test.go` | Add `TestIsMovieDetailPage` unit tests (incl. English blank-entry case) |
| `cmd/javinizer/commands/scrape/command.go` | Clarify `--scrapers` flag description |
| `cmd/javinizer/commands/sort/command.go` | Clarify `--scrapers` / `-p` flag description |
| `web/frontend/src/routes/review/[jobId]/logic/rescrape-controller.ts` | Add `status: 'completed'` to optimistic local update |
| `web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts` | Add `failedResults`, `rescrapeTargetResult`, `openRescrapeModalForFailed` |
| `web/frontend/src/routes/review/[jobId]/components/UnidentifiedFilesCard.svelte` | New component |
| `web/frontend/src/routes/review/[jobId]/+page.svelte` | Wire up `UnidentifiedFilesCard`, fix empty-state guard |
| `Dockerfile` | Fix `npm ci` flags; add explicit `svelte-kit sync` after source COPY |
| `Makefile` | Add `--ulimit nofile=65536:65536` to `docker-build` and `docker-build-no-cache` |

## Testing

- `javinizer scrape 120515-039 --scrapers caribbeancom` with `language: en` now returns
  metadata instead of a 500 error.
- `javinizer scrape "https://www.caribbeancom.com/moviepages/120515-039/index.html"` with
  `language: en` continues to work (full-URL path was not changed).
- `javinizer scrape 120515-039 --scrapers caribbeancom` with `language: ja` (default)
  continues to work (Japanese path was not changed).
- Scraping a non-existent Caribbeancom ID in Japanese mode (e.g. `092912-002`) now returns
  a not-found error rather than a partial result with title `"404 Not Found - Caribbeancom.com"`.
- Scraping a non-existent Caribbeancom ID in English mode now returns a not-found error
  rather than a blank "completed" entry with no title, actress, or tag data.
- `javinizer --help` / `javinizer sort --help` now show the updated flag descriptions.
- Batch jobs with unidentified files now show an "Unidentified Files" panel on the
  review page listing each failed file with its error and a "Search manually" button.
- Manually searching for a failed file and successfully rescaping it moves the entry
  to the movie grid immediately without a page refresh.
- Batch jobs that produced zero successful scrapes no longer show "No movies to review"
  — the unidentified files panel is shown instead.
- `docker build --ulimit nofile=65536:65536 -t javinizer .` completes successfully;
  stage 1 output includes `✔ done` from `@sveltejs/adapter-static`.
