### PR TITLE
fix(tui,web): TUI log leak + move-files/poster-crop persistence

### DIFF
--- a/cmd/javinizer/commands/tui/command.go
+++ b/cmd/javinizer/commands/tui/command.go
@@ -131,22 +131,26 @@ func run(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	// For TUI mode, log to file only (not stdout)
-	if cfg.Logging.Output == "stdout" {
-		cfg.Logging.Output = "data/logs/javinizer-tui.log"
-		// Reinitialize logger
-		logCfg := &logging.Config{
-			Level:  cfg.Logging.Level,
-			Format: cfg.Logging.Format,
-			Output: cfg.Logging.Output,
-		}
-		if verboseFlag {
-			logCfg.Level = "debug"
-		}
-		if err := logging.InitLogger(logCfg); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
-			os.Exit(1)
-		}
+	// For TUI mode, log to file only — strip stdout/stderr targets so logs don't
+	// leak into the terminal and corrupt the TUI display. The default config uses
+	// "stdout,data/logs/javinizer.log" (dual output); the previous check only
+	// handled the pure "stdout" case, so dual-output leaked into the TUI.
+	cfg.Logging.Output = logging.FileOnlyOutput(cfg.Logging.Output, "data/logs/javinizer-tui.log")
+	logCfg := &logging.Config{
+		Level:      cfg.Logging.Level,
+		Format:     cfg.Logging.Format,
+		Output:     cfg.Logging.Output,
+		MaxSizeMB:  cfg.Logging.MaxSizeMB,
+		MaxBackups: cfg.Logging.MaxBackups,
+		MaxAgeDays: cfg.Logging.MaxAgeDays,
+		Compress:   cfg.Logging.Compress,
+	}
+	if verboseFlag {
+		logCfg.Level = "debug"
+	}
+	if err := logging.InitLogger(logCfg); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
+		os.Exit(1)
 	}
 
 	logging.Infof("Starting TUI mode for path: %s", sourcePath)

--- a/cmd/javinizer/commands/tui/command.go
+++ b/cmd/javinizer/commands/tui/command.go
@@ -117,9 +117,12 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// Resolve effective move mode: an explicit --move flag overrides config.yaml (issue #36).
 	// Without --move, the TUI loads move_files from config so the setting persists across restarts.
-	effectiveMove := cfg.Output.MoveFiles
-	if cmd.Flags().Changed("move") {
-		effectiveMove = moveFiles
+	effectiveMove := tui.ResolveMoveMode(cfg.Output.MoveFiles, cmd.Flags().Changed("move"), moveFiles)
+
+	// --link-mode is incompatible with move mode, whether move mode came from the
+	// --move flag or from move_files in config (issue #36).
+	if effectiveMove && linkMode != organizer.LinkModeNone {
+		return fmt.Errorf("--link-mode can only be used when move mode is disabled (move_files is false and --move is not set)")
 	}
 
 	// Override config with flag if scraper priority is provided

--- a/cmd/javinizer/commands/tui/command.go
+++ b/cmd/javinizer/commands/tui/command.go
@@ -135,19 +135,7 @@ func run(cmd *cobra.Command, args []string) error {
 	// leak into the terminal and corrupt the TUI display. The default config uses
 	// "stdout,data/logs/javinizer.log" (dual output); the previous check only
 	// handled the pure "stdout" case, so dual-output leaked into the TUI.
-	cfg.Logging.Output = logging.FileOnlyOutput(cfg.Logging.Output, "data/logs/javinizer-tui.log")
-	logCfg := &logging.Config{
-		Level:      cfg.Logging.Level,
-		Format:     cfg.Logging.Format,
-		Output:     cfg.Logging.Output,
-		MaxSizeMB:  cfg.Logging.MaxSizeMB,
-		MaxBackups: cfg.Logging.MaxBackups,
-		MaxAgeDays: cfg.Logging.MaxAgeDays,
-		Compress:   cfg.Logging.Compress,
-	}
-	if verboseFlag {
-		logCfg.Level = "debug"
-	}
+	logCfg := configureTUILogging(cfg, verboseFlag)
 	if err := logging.InitLogger(logCfg); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
 		os.Exit(1)
@@ -484,4 +472,26 @@ func BuildFileTree(basePath string, files []scanner.FileInfo, matchMap map[strin
 	}
 
 	return result
+}
+
+// configureTUILogging builds a file-only logging config for TUI mode, stripping
+// stdout/stderr targets so logs don't leak into the terminal and corrupt the
+// TUI display. Rotation settings (max_size_mb, max_backups, max_age_days,
+// compress) are preserved, and the verbose flag overrides the level to debug.
+// The returned config is intended for logging.InitLogger.
+func configureTUILogging(cfg *config.Config, verbose bool) *logging.Config {
+	output := logging.FileOnlyOutput(cfg.Logging.Output, "data/logs/javinizer-tui.log")
+	logCfg := &logging.Config{
+		Level:      cfg.Logging.Level,
+		Format:     cfg.Logging.Format,
+		Output:     output,
+		MaxSizeMB:  cfg.Logging.MaxSizeMB,
+		MaxBackups: cfg.Logging.MaxBackups,
+		MaxAgeDays: cfg.Logging.MaxAgeDays,
+		Compress:   cfg.Logging.Compress,
+	}
+	if verbose {
+		logCfg.Level = "debug"
+	}
+	return logCfg
 }

--- a/cmd/javinizer/commands/tui/command.go
+++ b/cmd/javinizer/commands/tui/command.go
@@ -58,6 +58,7 @@ func NewCommand() *cobra.Command {
 func run(cmd *cobra.Command, args []string) error {
 	// Get config file from persistent flag
 	configFile, _ := cmd.Flags().GetString("config")
+	configFile = resolveConfigPath(configFile)
 
 	// Get source path - prioritize flag over positional argument
 	sourcePath := "."
@@ -289,6 +290,9 @@ func run(cmd *cobra.Command, args []string) error {
 	// defensive sync propagates the correct value (no transient mismatch when --move
 	// overrides config) (issue #36).
 	model.SetMoveFiles(effectiveMove)
+	// Record link mode so the runtime move-files toggle can guard against the
+	// move+link combo rejected at startup (ValidateMoveLinkMode) (issue #36).
+	model.SetLinkMode(linkMode)
 	// Set processor in model (syncs moveFiles, dryRun, updateMode to the processor)
 	model.SetProcessor(processor)
 
@@ -472,6 +476,17 @@ func BuildFileTree(basePath string, files []scanner.FileInfo, matchMap map[strin
 	}
 
 	return result
+}
+
+// resolveConfigPath returns the config file path to load and persist, honoring
+// the JAVINIZER_CONFIG env override so the TUI uses the same path the rest of the
+// app (root.go initConfig) does. Without this, LoadOrCreate would load from the
+// env path while SetConfigPath persisted to the --config flag path.
+func resolveConfigPath(flagValue string) string {
+	if envConfig := os.Getenv("JAVINIZER_CONFIG"); envConfig != "" {
+		return envConfig
+	}
+	return flagValue
 }
 
 // configureTUILogging builds a file-only logging config for TUI mode, stripping

--- a/cmd/javinizer/commands/tui/command.go
+++ b/cmd/javinizer/commands/tui/command.go
@@ -86,9 +86,6 @@ func run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if moveFiles && linkMode != organizer.LinkModeNone {
-		return fmt.Errorf("--link-mode can only be used when --move is disabled")
-	}
 	if preset != "" {
 		scalarStrategy, arrayStrategy, err = nfo.ApplyPreset(preset, scalarStrategy, arrayStrategy)
 		if err != nil {
@@ -118,11 +115,10 @@ func run(cmd *cobra.Command, args []string) error {
 	// Resolve effective move mode: an explicit --move flag overrides config.yaml (issue #36).
 	// Without --move, the TUI loads move_files from config so the setting persists across restarts.
 	effectiveMove := tui.ResolveMoveMode(cfg.Output.MoveFiles, cmd.Flags().Changed("move"), moveFiles)
-
 	// --link-mode is incompatible with move mode, whether move mode came from the
 	// --move flag or from move_files in config (issue #36).
-	if effectiveMove && linkMode != organizer.LinkModeNone {
-		return fmt.Errorf("--link-mode can only be used when move mode is disabled (move_files is false and --move is not set)")
+	if err := tui.ValidateMoveLinkMode(effectiveMove, linkMode); err != nil {
+		return err
 	}
 
 	// Override config with flag if scraper priority is provided
@@ -297,10 +293,12 @@ func run(cmd *cobra.Command, args []string) error {
 	// Set worker pool and progress channel in model
 	model.SetWorkerPool(workerPool, progressChan)
 
-	// Set processor in model
-	model.SetProcessor(processor)
-	// Sync the resolved move mode to the model's display state (issue #36)
+	// Set the resolved move mode on the model BEFORE the processor so SetProcessor's
+	// defensive sync propagates the correct value (no transient mismatch when --move
+	// overrides config) (issue #36).
 	model.SetMoveFiles(effectiveMove)
+	// Set processor in model (syncs moveFiles, dryRun, updateMode to the processor)
+	model.SetProcessor(processor)
 
 	// Set destination path AFTER processor is set
 	model.SetDestPath(destPath)

--- a/cmd/javinizer/commands/tui/command.go
+++ b/cmd/javinizer/commands/tui/command.go
@@ -115,6 +115,13 @@ func run(cmd *cobra.Command, args []string) error {
 		cfg.Output.DownloadExtrafanart = true
 	}
 
+	// Resolve effective move mode: an explicit --move flag overrides config.yaml (issue #36).
+	// Without --move, the TUI loads move_files from config so the setting persists across restarts.
+	effectiveMove := cfg.Output.MoveFiles
+	if cmd.Flags().Changed("move") {
+		effectiveMove = moveFiles
+	}
+
 	// Override config with flag if scraper priority is provided
 	if len(scraperPriority) > 0 {
 		cfg.Scrapers.Priority = scraperPriority
@@ -160,6 +167,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// Create TUI model
 	model := tui.New(cfg)
+	model.SetConfigPath(configFile)
 
 	// Scan for files before starting TUI
 	logging.Info("Scanning for video files...")
@@ -274,7 +282,7 @@ func run(cmd *cobra.Command, args []string) error {
 		org,
 		nfoGen,
 		destPath,
-		moveFiles,
+		effectiveMove,
 	)
 	processor.SetConfig(cfg)
 	processor.SetOptionsFromConfig(cfg)
@@ -288,6 +296,8 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// Set processor in model
 	model.SetProcessor(processor)
+	// Sync the resolved move mode to the model's display state (issue #36)
+	model.SetMoveFiles(effectiveMove)
 
 	// Set destination path AFTER processor is set
 	model.SetDestPath(destPath)

--- a/cmd/javinizer/commands/tui/command_internal_test.go
+++ b/cmd/javinizer/commands/tui/command_internal_test.go
@@ -96,3 +96,19 @@ func TestConfigureTUILogging_EmptyOutputFallsBackToDefault(t *testing.T) {
 	assert.Equal(t, "data/logs/javinizer-tui.log", logCfg.Output,
 		"empty config output should fall back to the TUI default file")
 }
+
+// TestResolveConfigPath verifies the TUI loads AND persists via the same path the
+// rest of the app uses: JAVINIZER_CONFIG overrides the --config flag (mirrors
+// root.go initConfig). Without this, SetConfigPath would persist to the flag path
+// while LoadOrCreate loaded from the env path.
+func TestResolveConfigPath(t *testing.T) {
+	t.Setenv("JAVINIZER_CONFIG", "/custom/env-config.yaml")
+	assert.Equal(t, "/custom/env-config.yaml", resolveConfigPath("configs/config.yaml"),
+		"JAVINIZER_CONFIG should override the --config flag value")
+}
+
+func TestResolveConfigPath_FallsBackToFlag(t *testing.T) {
+	t.Setenv("JAVINIZER_CONFIG", "")
+	assert.Equal(t, "configs/config.yaml", resolveConfigPath("configs/config.yaml"),
+		"empty JAVINIZER_CONFIG should fall back to the --config flag value")
+}

--- a/cmd/javinizer/commands/tui/command_internal_test.go
+++ b/cmd/javinizer/commands/tui/command_internal_test.go
@@ -86,3 +86,13 @@ func TestConfigureTUILogging_ReturnsLoggingConfig(t *testing.T) {
 	assert.Equal(t, "json", logCfg.Format)
 	assert.Equal(t, "data/logs/x.log", logCfg.Output)
 }
+
+func TestConfigureTUILogging_EmptyOutputFallsBackToDefault(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logging.Output = "" // no targets at all
+
+	logCfg := configureTUILogging(cfg, false)
+
+	assert.Equal(t, "data/logs/javinizer-tui.log", logCfg.Output,
+		"empty config output should fall back to the TUI default file")
+}

--- a/cmd/javinizer/commands/tui/command_internal_test.go
+++ b/cmd/javinizer/commands/tui/command_internal_test.go
@@ -1,0 +1,88 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigureTUILogging_StripsStdoutFromDefaultConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logging.Output = "stdout,data/logs/javinizer.log"
+	cfg.Logging.Level = "info"
+	cfg.Logging.Format = "text"
+
+	logCfg := configureTUILogging(cfg, false)
+
+	assert.NotContains(t, logCfg.Output, "stdout")
+	assert.Equal(t, "data/logs/javinizer.log", logCfg.Output)
+}
+
+func TestConfigureTUILogging_PureStdoutFallsBackToDefault(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logging.Output = "stdout"
+
+	logCfg := configureTUILogging(cfg, false)
+
+	assert.Equal(t, "data/logs/javinizer-tui.log", logCfg.Output)
+}
+
+func TestConfigureTUILogging_StdoutStderrStrippedKeepsFiles(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logging.Output = "stdout,stderr,/var/log/a.log,/var/log/b.log"
+
+	logCfg := configureTUILogging(cfg, false)
+
+	assert.Equal(t, "/var/log/a.log,/var/log/b.log", logCfg.Output)
+}
+
+func TestConfigureTUILogging_PreservesRotation(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logging.Output = "stdout"
+	cfg.Logging.MaxSizeMB = 10
+	cfg.Logging.MaxBackups = 5
+	cfg.Logging.MaxAgeDays = 30
+	cfg.Logging.Compress = true
+
+	logCfg := configureTUILogging(cfg, false)
+
+	assert.Equal(t, 10, logCfg.MaxSizeMB)
+	assert.Equal(t, 5, logCfg.MaxBackups)
+	assert.Equal(t, 30, logCfg.MaxAgeDays)
+	assert.True(t, logCfg.Compress)
+}
+
+func TestConfigureTUILogging_VerboseFlagSetsDebug(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logging.Output = "stdout"
+	cfg.Logging.Level = "info"
+
+	assert.Equal(t, "info", configureTUILogging(cfg, false).Level, "level unchanged when verbose=false")
+	assert.Equal(t, "debug", configureTUILogging(cfg, true).Level, "level overridden to debug when verbose=true")
+}
+
+func TestConfigureTUILogging_DoesNotMutateConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logging.Output = "stdout,data/logs/javinizer.log"
+	original := cfg.Logging.Output
+
+	_ = configureTUILogging(cfg, false)
+
+	assert.Equal(t, original, cfg.Logging.Output, "configureTUILogging must not mutate the source config (avoids session-override leakage on save)")
+}
+
+func TestConfigureTUILogging_ReturnsLoggingConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logging.Output = "data/logs/x.log"
+	cfg.Logging.Level = "warn"
+	cfg.Logging.Format = "json"
+
+	logCfg := configureTUILogging(cfg, false)
+
+	assert.IsType(t, &logging.Config{}, logCfg)
+	assert.Equal(t, "warn", logCfg.Level)
+	assert.Equal(t, "json", logCfg.Format)
+	assert.Equal(t, "data/logs/x.log", logCfg.Output)
+}

--- a/cmd/javinizer/root.go
+++ b/cmd/javinizer/root.go
@@ -35,6 +35,7 @@ var (
 	cfgFile           string
 	verboseFlag       bool
 	originalLogOutput string
+	currentCmd        *cobra.Command
 )
 
 // rootCmd represents the base command
@@ -58,6 +59,7 @@ func init() {
 		if shouldSkipConfigInit(cmd) {
 			return
 		}
+		currentCmd = cmd
 		initConfig()
 	}
 
@@ -95,6 +97,18 @@ func shouldSkipConfigInit(cmd *cobra.Command) bool {
 	// `javinizer --version` should stay lightweight and side-effect free.
 	versionFlag := cmd.Flags().Lookup("version")
 	return versionFlag != nil && versionFlag.Changed
+}
+
+// isTUICommand reports whether cmd (or any ancestor) is the tui subcommand.
+// Used to suppress stdout logging during initial setup so startup messages don't
+// leak to the terminal before the TUI's AltScreen activates.
+func isTUICommand(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == "tui" {
+			return true
+		}
+	}
+	return false
 }
 
 // Execute runs the root command
@@ -152,6 +166,15 @@ func initConfig() {
 	// Override level to debug if --verbose flag is set
 	if verboseFlag {
 		logCfg.Level = "debug"
+	}
+
+	// For the TUI subcommand, strip stdout/stderr from the FIRST logger so startup
+	// messages (e.g. "Log file: ...") don't leak to the terminal before AltScreen
+	// activates. Only logCfg.Output is modified; cfg.Logging.Output is left intact
+	// so the JAVINIZER_LOG_DIR relocation check below still compares correctly.
+	// The TUI's run() reinitializes the logger via configureTUILogging afterwards.
+	if isTUICommand(currentCmd) {
+		logCfg.Output = logging.FileOnlyOutput(logCfg.Output, "data/logs/javinizer-tui.log")
 	}
 
 	if err := logging.InitLogger(logCfg); err != nil {

--- a/cmd/javinizer/root.go
+++ b/cmd/javinizer/root.go
@@ -172,18 +172,29 @@ func initConfig() {
 	// messages (e.g. "Log file: ...") don't leak to the terminal before AltScreen
 	// activates. Only logCfg.Output is modified; cfg.Logging.Output is left intact
 	// so the JAVINIZER_LOG_DIR relocation check below still compares correctly.
+	// When the config has no file target at all (e.g. pure "stdout"), the fallback
+	// path honors JAVINIZER_LOG_DIR so logs still land in the env-configured dir.
 	// The TUI's run() reinitializes the logger via configureTUILogging afterwards.
 	if isTUICommand(currentCmd) {
-		logCfg.Output = logging.FileOnlyOutput(logCfg.Output, "data/logs/javinizer-tui.log")
+		defaultTUILog := "data/logs/javinizer-tui.log"
+		if len(logging.GetFileOutputs(logCfg.Output)) == 0 {
+			if envLogDir := os.Getenv("JAVINIZER_LOG_DIR"); envLogDir != "" {
+				defaultTUILog = filepath.Join(envLogDir, "javinizer-tui.log")
+			}
+		}
+		logCfg.Output = logging.FileOnlyOutput(logCfg.Output, defaultTUILog)
 	}
+	actualLogOutput := logCfg.Output
 
 	if err := logging.InitLogger(logCfg); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
 		os.Exit(1)
 	}
 
-	// Log file output location (INFO level for visibility)
-	if logPaths := logging.GetFileOutputs(cfg.Logging.Output); len(logPaths) > 0 {
+	// Log file output location (INFO level for visibility). Use the actual logger
+	// output (which for the TUI is the stripped/relocated file-only path) rather than
+	// the original cfg.Logging.Output, so the reported path matches what is written.
+	if logPaths := logging.GetFileOutputs(actualLogOutput); len(logPaths) > 0 {
 		for _, path := range logPaths {
 			absPath, err := filepath.Abs(path)
 			if err != nil {

--- a/cmd/javinizer/root_test.go
+++ b/cmd/javinizer/root_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/config"
@@ -388,5 +390,85 @@ func TestSanitizeProxyURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, sanitizeProxyURL(tc.input))
 		})
+	}
+}
+
+// TestIsTUICommand verifies the TUI-subcommand detection used to suppress stdout
+// logging during initial setup (so startup messages don't leak before AltScreen).
+func TestIsTUICommand(t *testing.T) {
+	tuiCmd := &cobra.Command{Use: "tui"}
+	childCmd := &cobra.Command{Use: "something"}
+	childCmd.Parent() // no-op; parent set below
+	tuiCmd.AddCommand(childCmd)
+
+	scrapeCmd := &cobra.Command{Use: "scrape"}
+
+	tests := []struct {
+		name     string
+		cmd      *cobra.Command
+		expected bool
+	}{
+		{"tui command", tuiCmd, true},
+		{"child of tui walks up to tui", childCmd, true},
+		{"unrelated command", scrapeCmd, false},
+		{"nil command", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isTUICommand(tt.cmd))
+		})
+	}
+}
+
+// TestInitConfig_TUICommandStripsStdoutFromStartup proves the pre-alt-screen
+// startup leak (issue N1) is fixed: when the TUI subcommand is invoked, the
+// initial logger is file-only, so the "Log file: ..." startup message does not
+// reach stdout. Without the fix, the default "stdout,file" output would leak it.
+func TestInitConfig_TUICommandStripsStdoutFromStartup(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "tui-startup.yaml")
+	logFile := filepath.Join(tmpDir, "tui-startup.log")
+
+	testCfg := config.DefaultConfig()
+	testCfg.Database.DSN = filepath.Join(tmpDir, "test.db")
+	testCfg.Logging.Output = "stdout," + logFile // dual output — would leak without the fix
+	require.NoError(t, config.Save(testCfg, configPath))
+
+	t.Setenv("JAVINIZER_CONFIG", configPath)
+	origCfgFile := cfgFile
+	cfgFile = ""
+	defer func() { cfgFile = origCfgFile }()
+
+	origLogOutput := originalLogOutput
+	defer func() { originalLogOutput = origLogOutput }()
+
+	origCmd := currentCmd
+	defer func() { currentCmd = origCmd }()
+	currentCmd = &cobra.Command{Use: "tui"}
+
+	defer logging.CloseLogger()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	origStdout := os.Stdout
+	os.Stdout = w
+
+	initConfig()
+
+	_ = w.Close()
+	os.Stdout = origStdout
+	buf := make([]byte, 8192)
+	n, _ := r.Read(buf)
+	_ = r.Close()
+
+	if n > 0 && strings.Contains(string(buf[:n]), "Log file") {
+		t.Errorf("startup \"Log file\" message leaked to stdout in TUI mode: %q", string(buf[:n]))
+	}
+
+	content, err := os.ReadFile(logFile)
+	require.NoError(t, err, "log file target should exist and receive logs")
+	if !strings.Contains(string(content), "Log file") {
+		t.Errorf("log file did not receive the startup message; content: %s", string(content))
 	}
 }

--- a/cmd/javinizer/root_test.go
+++ b/cmd/javinizer/root_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	tuicmd "github.com/javinizer/javinizer-go/cmd/javinizer/commands/tui"
 	"github.com/javinizer/javinizer-go/internal/config"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/version"
@@ -397,9 +398,9 @@ func TestSanitizeProxyURL(t *testing.T) {
 // TestIsTUICommand verifies the TUI-subcommand detection used to suppress stdout
 // logging during initial setup (so startup messages don't leak before AltScreen).
 func TestIsTUICommand(t *testing.T) {
-	// Use the real Use string from cmd/javinizer/commands/tui/command.go so a
-	// future rename (e.g. "tui-app") breaks this test, not just production.
-	tuiCmd := &cobra.Command{Use: "tui [path]"}
+	// Use the REAL TUI command (fresh instance) so a future rename in
+	// cmd/javinizer/commands/tui/command.go breaks this test, not just production.
+	tuiCmd := tuicmd.NewCommand()
 	childCmd := &cobra.Command{Use: "something"}
 	tuiCmd.AddCommand(childCmd)
 

--- a/cmd/javinizer/root_test.go
+++ b/cmd/javinizer/root_test.go
@@ -423,6 +423,21 @@ func TestIsTUICommand(t *testing.T) {
 	}
 }
 
+// TestIsTUICommand_DetectsRealRegisteredCommand ensures isTUICommand detects the
+// actual TUI command registered on rootCmd, not just a hardcoded mock — so a
+// future rename of the TUI command breaks this test (and surfaces the regression).
+func TestIsTUICommand_DetectsRealRegisteredCommand(t *testing.T) {
+	var realTUI *cobra.Command
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "tui" {
+			realTUI = c
+			break
+		}
+	}
+	require.NotNil(t, realTUI, "the real tui command should be registered on rootCmd")
+	assert.True(t, isTUICommand(realTUI), "isTUICommand must detect the real registered tui command")
+}
+
 // TestInitConfig_TUICommandStripsStdoutFromStartup proves the pre-alt-screen
 // startup leak (issue N1) is fixed: when the TUI subcommand is invoked, the
 // initial logger is file-only, so the "Log file: ..." startup message does not
@@ -531,6 +546,62 @@ func TestInitConfig_TUICommandWithJavinizerLogDir_PreservesRelocation(t *testing
 	relocatedLog := filepath.Join(logDir, "javinizer.log")
 	content, err := os.ReadFile(relocatedLog)
 	require.NoError(t, err, "relocated log file should exist in JAVINIZER_LOG_DIR")
+	assert.Contains(t, string(content), "Log file")
+}
+
+// TestInitConfig_TUICommandPureStdoutWithLogDir verifies the fallback TUI log
+// path honors JAVINIZER_LOG_DIR when the config has NO file target (pure
+// "stdout"): logs land in the env-configured dir instead of the hardcoded
+// data/logs/javinizer-tui.log (CodeRabbit finding).
+func TestInitConfig_TUICommandPureStdoutWithLogDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "purestdout.yaml")
+	logDir := filepath.Join(tmpDir, "envlogs")
+
+	testCfg := config.DefaultConfig()
+	testCfg.Database.DSN = filepath.Join(tmpDir, "test.db")
+	testCfg.Logging.Output = "stdout" // no file target at all
+	require.NoError(t, config.Save(testCfg, configPath))
+
+	t.Setenv("JAVINIZER_CONFIG", configPath)
+	t.Setenv("JAVINIZER_LOG_DIR", logDir)
+	origCfgFile := cfgFile
+	cfgFile = ""
+	defer func() { cfgFile = origCfgFile }()
+	origLogOutput := originalLogOutput
+	defer func() { originalLogOutput = origLogOutput }()
+	origVerbose := verboseFlag
+	verboseFlag = false
+	defer func() { verboseFlag = origVerbose }()
+	origCmd := currentCmd
+	defer func() { currentCmd = origCmd }()
+	currentCmd = &cobra.Command{Use: "tui [path]"}
+	defer logging.CloseLogger()
+	// Defensive: if the fix regresses, InitLogger would create the hardcoded fallback
+	// in the repo root; clean it up so the test never pollutes the working tree.
+	defer func() { _ = os.RemoveAll("data/logs/javinizer-tui.log") }()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	origStdout := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	initConfig()
+
+	_ = w.Close()
+	os.Stdout = origStdout
+	outBuf, err := io.ReadAll(r)
+	require.NoError(t, err)
+	_ = r.Close()
+	if strings.Contains(string(outBuf), "Log file") {
+		t.Errorf("startup message leaked to stdout: %q", string(outBuf))
+	}
+
+	// The fallback honored JAVINIZER_LOG_DIR (not the hardcoded data/logs path).
+	envLog := filepath.Join(logDir, "javinizer-tui.log")
+	content, err := os.ReadFile(envLog)
+	require.NoError(t, err, "fallback log should land in JAVINIZER_LOG_DIR, not data/logs/")
 	assert.Contains(t, string(content), "Log file")
 }
 

--- a/cmd/javinizer/root_test.go
+++ b/cmd/javinizer/root_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -396,9 +397,11 @@ func TestSanitizeProxyURL(t *testing.T) {
 // TestIsTUICommand verifies the TUI-subcommand detection used to suppress stdout
 // logging during initial setup (so startup messages don't leak before AltScreen).
 func TestIsTUICommand(t *testing.T) {
-	tuiCmd := &cobra.Command{Use: "tui"}
+	// Use the real Use string from cmd/javinizer/commands/tui/command.go so a
+	// future rename (e.g. "tui-app") breaks this test, not just production.
+	tuiCmd := &cobra.Command{Use: "tui [path]"}
 	childCmd := &cobra.Command{Use: "something"}
-	childCmd.Parent() // no-op; parent set below
+	tuiCmd.AddCommand(childCmd)
 	tuiCmd.AddCommand(childCmd)
 
 	scrapeCmd := &cobra.Command{Use: "scrape"}
@@ -443,9 +446,13 @@ func TestInitConfig_TUICommandStripsStdoutFromStartup(t *testing.T) {
 	origLogOutput := originalLogOutput
 	defer func() { originalLogOutput = origLogOutput }()
 
+	origVerbose := verboseFlag
+	verboseFlag = false
+	defer func() { verboseFlag = origVerbose }()
+
 	origCmd := currentCmd
 	defer func() { currentCmd = origCmd }()
-	currentCmd = &cobra.Command{Use: "tui"}
+	currentCmd = &cobra.Command{Use: "tui [path]"}
 
 	defer logging.CloseLogger()
 
@@ -453,6 +460,7 @@ func TestInitConfig_TUICommandStripsStdoutFromStartup(t *testing.T) {
 	require.NoError(t, err)
 	origStdout := os.Stdout
 	os.Stdout = w
+	defer func() { os.Stdout = origStdout }() // defensive: restore even if initConfig os.Exit's
 
 	initConfig()
 
@@ -470,5 +478,217 @@ func TestInitConfig_TUICommandStripsStdoutFromStartup(t *testing.T) {
 	require.NoError(t, err, "log file target should exist and receive logs")
 	if !strings.Contains(string(content), "Log file") {
 		t.Errorf("log file did not receive the startup message; content: %s", string(content))
+	}
+}
+
+// TestInitConfig_TUICommandWithJavinizerLogDir_PreservesRelocation
+// verifies the JAVINIZER_LOG_DIR + TUI interaction: the stdout strip must use
+// the env-relocated file target (so logs land in JAVINIZER_LOG_DIR) while stdout
+// stays clean. This exercises the round-2 review Medium concern that the strip
+// cooperates with JAVINIZER_LOG_DIR file relocation.
+func TestInitConfig_TUICommandWithJavinizerLogDir_PreservesRelocation(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "logdir.yaml")
+	logDir := filepath.Join(tmpDir, "customlogs")
+
+	testCfg := config.DefaultConfig()
+	testCfg.Database.DSN = filepath.Join(tmpDir, "test.db")
+	testCfg.Logging.Output = "stdout,data/logs/javinizer.log"
+	require.NoError(t, config.Save(testCfg, configPath))
+
+	t.Setenv("JAVINIZER_CONFIG", configPath)
+	t.Setenv("JAVINIZER_LOG_DIR", logDir)
+	origCfgFile := cfgFile
+	cfgFile = ""
+	defer func() { cfgFile = origCfgFile }()
+	origLogOutput := originalLogOutput
+	defer func() { originalLogOutput = origLogOutput }()
+	origVerbose := verboseFlag
+	verboseFlag = false
+	defer func() { verboseFlag = origVerbose }()
+	origCmd := currentCmd
+	defer func() { currentCmd = origCmd }()
+	currentCmd = &cobra.Command{Use: "tui [path]"}
+	defer logging.CloseLogger()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	origStdout := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	initConfig()
+
+	_ = w.Close()
+	os.Stdout = origStdout
+	outBuf, err := io.ReadAll(r)
+	require.NoError(t, err)
+	_ = r.Close()
+	if strings.Contains(string(outBuf), "Log file") {
+		t.Errorf("startup message leaked to stdout in TUI+JAVINIZER_LOG_DIR mode: %q", string(outBuf))
+	}
+
+	// The logger used the env-relocated file target, so logs land in JAVINIZER_LOG_DIR.
+	relocatedLog := filepath.Join(logDir, "javinizer.log")
+	content, err := os.ReadFile(relocatedLog)
+	require.NoError(t, err, "relocated log file should exist in JAVINIZER_LOG_DIR")
+	assert.Contains(t, string(content), "Log file")
+}
+
+// TestInitConfig_TUICommandWithVerbose_DebugLevelFileOnly verifies that the
+// verbose flag combines with the TUI stdout-strip: debug-level startup messages
+// go to the file only, never stdout.
+func TestInitConfig_TUICommandWithVerbose_DebugLevelFileOnly(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "verbose.yaml")
+	logFile := filepath.Join(tmpDir, "verbose.log")
+
+	testCfg := config.DefaultConfig()
+	testCfg.Database.DSN = filepath.Join(tmpDir, "test.db")
+	testCfg.Logging.Output = "stdout," + logFile
+	testCfg.Logging.Level = "info"
+	require.NoError(t, config.Save(testCfg, configPath))
+
+	t.Setenv("JAVINIZER_CONFIG", configPath)
+	origCfgFile := cfgFile
+	cfgFile = ""
+	defer func() { cfgFile = origCfgFile }()
+	origLogOutput := originalLogOutput
+	defer func() { originalLogOutput = origLogOutput }()
+	origVerbose := verboseFlag
+	verboseFlag = true
+	defer func() { verboseFlag = origVerbose }()
+	origCmd := currentCmd
+	defer func() { currentCmd = origCmd }()
+	currentCmd = &cobra.Command{Use: "tui [path]"}
+	defer logging.CloseLogger()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	origStdout := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	initConfig()
+
+	_ = w.Close()
+	os.Stdout = origStdout
+	buf := make([]byte, 8192)
+	n, _ := r.Read(buf)
+	_ = r.Close()
+	if n > 0 && (strings.Contains(string(buf[:n]), "Log file") || strings.Contains(string(buf[:n]), "Loaded configuration")) {
+		t.Errorf("debug-level startup messages leaked to stdout in TUI verbose mode: %q", string(buf[:n]))
+	}
+
+	content, err := os.ReadFile(logFile)
+	require.NoError(t, err, "log file should exist")
+	// debug level emits the "Loaded configuration from:" message.
+	assert.Contains(t, string(content), "Loaded configuration from:",
+		"verbose flag should produce debug-level output in the log file")
+}
+
+// TestInitConfig_TUICommandStripsStderr verifies stderr targets are also
+// stripped in the TUI startup path (FileOnlyOutput excludes both stdout and
+// stderr), so stderr doesn't corrupt the TUI either.
+func TestInitConfig_TUICommandStripsStderr(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "stderr.yaml")
+	logFile := filepath.Join(tmpDir, "stderr.log")
+
+	testCfg := config.DefaultConfig()
+	testCfg.Database.DSN = filepath.Join(tmpDir, "test.db")
+	testCfg.Logging.Output = "stdout,stderr," + logFile
+	require.NoError(t, config.Save(testCfg, configPath))
+
+	t.Setenv("JAVINIZER_CONFIG", configPath)
+	origCfgFile := cfgFile
+	cfgFile = ""
+	defer func() { cfgFile = origCfgFile }()
+	origLogOutput := originalLogOutput
+	defer func() { originalLogOutput = origLogOutput }()
+	origVerbose := verboseFlag
+	verboseFlag = false
+	defer func() { verboseFlag = origVerbose }()
+	origCmd := currentCmd
+	defer func() { currentCmd = origCmd }()
+	currentCmd = &cobra.Command{Use: "tui [path]"}
+	defer logging.CloseLogger()
+
+	// Capture both stdout and stderr.
+	rOut, wOut, err := os.Pipe()
+	require.NoError(t, err)
+	rErr, wErr, err := os.Pipe()
+	require.NoError(t, err)
+	origStdout, origStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = wOut, wErr
+	defer func() { os.Stdout, os.Stderr = origStdout, origStderr }()
+
+	initConfig()
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	os.Stdout, os.Stderr = origStdout, origStderr
+	outBuf, err := io.ReadAll(rOut)
+	require.NoError(t, err)
+	errBuf, err := io.ReadAll(rErr)
+	require.NoError(t, err)
+	_ = rOut.Close()
+	_ = rErr.Close()
+
+	if strings.Contains(string(outBuf), "Log file") {
+		t.Errorf("startup message leaked to stdout: %q", string(outBuf))
+	}
+	if strings.Contains(string(errBuf), "Log file") {
+		t.Errorf("startup message leaked to stderr: %q", string(errBuf))
+	}
+
+	content, err := os.ReadFile(logFile)
+	require.NoError(t, err, "log file should exist")
+	assert.Contains(t, string(content), "Log file")
+}
+
+// TestInitConfig_NonTUICommand_KeepsStdoutOutput is a negative test: for a
+// non-TUI command (e.g. scrape), stdout is NOT stripped — the logger keeps the
+// configured stdout target so CLI/API output remains visible. Guards against
+// over-stripping.
+func TestInitConfig_NonTUICommand_KeepsStdoutOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "nontui.yaml")
+	logFile := filepath.Join(tmpDir, "nontui.log")
+
+	testCfg := config.DefaultConfig()
+	testCfg.Database.DSN = filepath.Join(tmpDir, "test.db")
+	testCfg.Logging.Output = "stdout," + logFile
+	require.NoError(t, config.Save(testCfg, configPath))
+
+	t.Setenv("JAVINIZER_CONFIG", configPath)
+	origCfgFile := cfgFile
+	cfgFile = ""
+	defer func() { cfgFile = origCfgFile }()
+	origLogOutput := originalLogOutput
+	defer func() { originalLogOutput = origLogOutput }()
+	origVerbose := verboseFlag
+	verboseFlag = false
+	defer func() { verboseFlag = origVerbose }()
+	origCmd := currentCmd
+	defer func() { currentCmd = origCmd }()
+	currentCmd = &cobra.Command{Use: "scrape [pattern]"} // non-TUI command
+	defer logging.CloseLogger()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	origStdout := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	initConfig()
+
+	_ = w.Close()
+	os.Stdout = origStdout
+	buf := make([]byte, 8192)
+	n, _ := r.Read(buf)
+	_ = r.Close()
+	if n == 0 || !strings.Contains(string(buf[:n]), "Log file") {
+		t.Errorf("non-TUI command should retain stdout output, but Log file was not captured: %q", string(buf[:n]))
 	}
 }

--- a/cmd/javinizer/root_test.go
+++ b/cmd/javinizer/root_test.go
@@ -402,7 +402,6 @@ func TestIsTUICommand(t *testing.T) {
 	tuiCmd := &cobra.Command{Use: "tui [path]"}
 	childCmd := &cobra.Command{Use: "something"}
 	tuiCmd.AddCommand(childCmd)
-	tuiCmd.AddCommand(childCmd)
 
 	scrapeCmd := &cobra.Command{Use: "scrape"}
 
@@ -466,12 +465,12 @@ func TestInitConfig_TUICommandStripsStdoutFromStartup(t *testing.T) {
 
 	_ = w.Close()
 	os.Stdout = origStdout
-	buf := make([]byte, 8192)
-	n, _ := r.Read(buf)
+	outBuf, err := io.ReadAll(r)
+	require.NoError(t, err)
 	_ = r.Close()
 
-	if n > 0 && strings.Contains(string(buf[:n]), "Log file") {
-		t.Errorf("startup \"Log file\" message leaked to stdout in TUI mode: %q", string(buf[:n]))
+	if strings.Contains(string(outBuf), "Log file") {
+		t.Errorf("startup \"Log file\" message leaked to stdout in TUI mode: %q", string(outBuf))
 	}
 
 	content, err := os.ReadFile(logFile)
@@ -573,11 +572,11 @@ func TestInitConfig_TUICommandWithVerbose_DebugLevelFileOnly(t *testing.T) {
 
 	_ = w.Close()
 	os.Stdout = origStdout
-	buf := make([]byte, 8192)
-	n, _ := r.Read(buf)
+	outBuf, err := io.ReadAll(r)
+	require.NoError(t, err)
 	_ = r.Close()
-	if n > 0 && (strings.Contains(string(buf[:n]), "Log file") || strings.Contains(string(buf[:n]), "Loaded configuration")) {
-		t.Errorf("debug-level startup messages leaked to stdout in TUI verbose mode: %q", string(buf[:n]))
+	if strings.Contains(string(outBuf), "Log file") || strings.Contains(string(outBuf), "Loaded configuration") {
+		t.Errorf("debug-level startup messages leaked to stdout in TUI verbose mode: %q", string(outBuf))
 	}
 
 	content, err := os.ReadFile(logFile)
@@ -685,10 +684,10 @@ func TestInitConfig_NonTUICommand_KeepsStdoutOutput(t *testing.T) {
 
 	_ = w.Close()
 	os.Stdout = origStdout
-	buf := make([]byte, 8192)
-	n, _ := r.Read(buf)
+	outBuf, err := io.ReadAll(r)
+	require.NoError(t, err)
 	_ = r.Close()
-	if n == 0 || !strings.Contains(string(buf[:n]), "Log file") {
-		t.Errorf("non-TUI command should retain stdout output, but Log file was not captured: %q", string(buf[:n]))
+	if !strings.Contains(string(outBuf), "Log file") {
+		t.Errorf("non-TUI command should retain stdout output, but Log file was not captured: %q", string(outBuf))
 	}
 }

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -458,7 +458,8 @@ output:
         - .smi
         - .vtt
     rename_folder_in_place: false
-    move_to_folder: true
+    # Move files instead of copying (default: false / copy). Persisted by the TUI Settings toggle.
+    move_files: false
     rename_file: true
     allow_revert: false
     group_actress: false

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -1233,7 +1233,8 @@ output:
     - .smi
     - .vtt
   rename_folder_in_place: false
-  move_to_folder: true
+  # Move files instead of copying (default: false / copy). Persisted by the TUI Settings toggle.
+  move_files: false
   rename_file: true
   group_actress: false
   # group_actress_name: "@Group"

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3650,6 +3650,10 @@ const docTemplate = `{
                 "max_title_length": {
                     "type": "integer"
                 },
+                "move_files": {
+                    "description": "Move files instead of copying (default: false / copy)",
+                    "type": "boolean"
+                },
                 "move_subtitles": {
                     "type": "boolean"
                 },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3648,6 +3648,10 @@
                 "max_title_length": {
                     "type": "integer"
                 },
+                "move_files": {
+                    "description": "Move files instead of copying (default: false / copy)",
+                    "type": "boolean"
+                },
                 "move_subtitles": {
                     "type": "boolean"
                 },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -398,6 +398,9 @@ definitions:
         type: integer
       max_title_length:
         type: integer
+      move_files:
+        description: 'Move files instead of copying (default: false / copy)'
+        type: boolean
       move_subtitles:
         type: boolean
       operation_mode:

--- a/internal/api/system/extra_test.go
+++ b/internal/api/system/extra_test.go
@@ -1025,3 +1025,33 @@ func TestPreserveRedactedSecrets(t *testing.T) {
 		assert.Equal(t, "real-dsn-value", newCfg.Database.DSN)
 	})
 }
+
+// TestUpdateConfig_EmptyLogOutputDefaultsAndReloadsNonFatally verifies that an API
+// config update with an empty logging.output does not break the reload: Normalize
+// (via Prepare) defaults it to the standard dual-output target, so InitLogger gets
+// a valid output and the reload succeeds (200). This guards the round-2 review
+// concern that the InitLogger zero-output error could surface via the API path.
+func TestUpdateConfig_EmptyLogOutputDefaultsAndReloadsNonFatally(t *testing.T) {
+	tempConfigFile := filepath.Join(t.TempDir(), "config.yaml")
+	deps := createTestDeps(t, config.DefaultConfig(), tempConfigFile)
+
+	router := gin.New()
+	router.PUT("/config", updateConfig(deps))
+
+	cfg := config.DefaultConfig()
+	cfg.Logging.Output = "" // empty — previously could reach InitLogger with no valid targets
+
+	body, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/config", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code,
+		"reload must succeed: Normalize defaults empty output and InitLogger failure is non-fatal")
+	updated := deps.GetConfig()
+	assert.Equal(t, config.DefaultConfig().Logging.Output, updated.Logging.Output,
+		"empty logging.output should be defaulted by Normalize before reload")
+}

--- a/internal/api/system/extra_test.go
+++ b/internal/api/system/extra_test.go
@@ -1050,7 +1050,10 @@ func TestUpdateConfig_EmptyLogOutputDefaultsAndReloadsNonFatally(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code,
-		"reload must succeed: Normalize defaults empty output and InitLogger failure is non-fatal")
+		"reload returns 200 regardless: InitLogger failure is non-fatal in reloadComponents")
+	// The 200 above would pass even without the Normalize fix (reloadComponents
+	// swallows InitLogger errors). The assertion below is the real pin for the
+	// Normalize change: without it, updated.Logging.Output would remain "".
 	updated := deps.GetConfig()
 	assert.Equal(t, config.DefaultConfig().Logging.Output, updated.Logging.Output,
 		"empty logging.output should be defaulted by Normalize before reload")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,6 +166,7 @@ type OutputConfig struct {
 	MaxPathLength           int                 `yaml:"max_path_length" json:"max_path_length"`
 	MaxPosterHeight         int                 `yaml:"max_poster_height" json:"max_poster_height"` // Max height in px for cropped posters; 0 = no cap (preserve source resolution). When the cropped poster exceeds this height it is downscaled preserving aspect ratio.
 	MoveSubtitles           bool                `yaml:"move_subtitles" json:"move_subtitles"`
+	MoveFiles               bool                `yaml:"move_files" json:"move_files"` // Move files instead of copying (default: false / copy)
 	SubtitleExtensions      []string            `yaml:"subtitle_extensions" json:"subtitle_extensions"`
 	OperationMode           types.OperationMode `yaml:"operation_mode" json:"operation_mode"`
 	RenameFile              bool                `yaml:"rename_file" json:"rename_file"`                               // Rename files using file_format template (default: true)

--- a/internal/config/config.yaml.example
+++ b/internal/config/config.yaml.example
@@ -458,7 +458,8 @@ output:
         - .smi
         - .vtt
     rename_folder_in_place: false
-    move_to_folder: true
+    # Move files instead of copying (default: false / copy). Persisted by the TUI Settings toggle.
+    move_files: false
     rename_file: true
     allow_revert: false
     group_actress: false

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -231,6 +231,7 @@ func DefaultConfig() *Config {
 			MaxPathLength:           240,
 			MaxPosterHeight:         0, // No cap — preserve source resolution
 			MoveSubtitles:           false,
+			MoveFiles:               false,
 			SubtitleExtensions:      []string{".srt", ".ass", ".ssa", ".smi", ".vtt"},
 			OperationMode:           "",
 			RenameFile:              true,       // Rename files by default

--- a/internal/config/pipeline.go
+++ b/internal/config/pipeline.go
@@ -62,6 +62,15 @@ func Normalize(cfg *Config) bool {
 	changed := false
 	changed = normalizeField(&cfg.Database.Type, "sqlite", true) || changed
 
+	// Logging.Output: default to the standard dual-output target if empty. A config
+	// saved via the API (JSON) without an explicit output would otherwise leave
+	// InitLogger with no valid targets, which now errors instead of silently
+	// falling back to stdout.
+	if strings.TrimSpace(cfg.Logging.Output) == "" {
+		cfg.Logging.Output = DefaultConfig().Logging.Output
+		changed = true
+	}
+
 	languageDefaults := map[string]string{
 		"r18dev":          "en",
 		"javlibrary":      "en",

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -448,6 +448,9 @@ func Save(cfg *Config, path string) error {
 // to avoid a TOCTOU race where a concurrent writer's changes (e.g. from
 // `javinizer api`) between the read and write are silently reverted.
 func Update(path string, mutate func(*Config)) error {
+	if mutate == nil {
+		return fmt.Errorf("config.Update: mutate callback must not be nil")
+	}
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, DirPerm); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -440,6 +440,48 @@ func Save(cfg *Config, path string) error {
 	}
 	defer unlock()
 
+	return writeLocked(path, cfg)
+}
+
+// Update atomically reads, mutates, and writes the config under an exclusive
+// file lock. Use this instead of Load+Save when persisting a single setting
+// to avoid a TOCTOU race where a concurrent writer's changes (e.g. from
+// `javinizer api`) between the read and write are silently reverted.
+func Update(path string, mutate func(*Config)) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, DirPerm); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	unlock, err := acquireConfigFileLock(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	cfg, err := loadLocked(path)
+	if err != nil {
+		return err
+	}
+	mutate(cfg)
+	return writeLocked(path, cfg)
+}
+
+// loadLocked reads and decodes the config from path. Caller must hold the file lock.
+func loadLocked(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultConfig(), nil
+		}
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+	return decodeConfig(data)
+}
+
+// writeLocked merges cfg into the existing on-disk config (preserving comments)
+// and atomically writes it. Caller must hold the file lock.
+func writeLocked(path string, cfg *Config) error {
 	targetDoc, err := configToYAMLDocument(cfg)
 	if err != nil {
 		return err

--- a/internal/config/storage_test.go
+++ b/internal/config/storage_test.go
@@ -204,6 +204,18 @@ func TestUpdateOnMissingFileWritesDefaults(t *testing.T) {
 	assert.True(t, reloaded.Output.MoveFiles, "Update on a missing file should write the mutation")
 }
 
+// TestUpdate_NilMutateReturnsError guards against a nil callback panicking inside
+// the locked read-modify-write (CodeRabbit finding).
+func TestUpdate_NilMutateReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, Save(DefaultConfig(), configPath))
+
+	err := Update(configPath, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutate", "error should explain the nil callback")
+}
+
 // TestCreatedConfigHasComments verifies new configs preserve example comments
 func TestCreatedConfigHasComments(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/internal/config/storage_test.go
+++ b/internal/config/storage_test.go
@@ -136,6 +136,35 @@ func TestMoveFilesRoundTrip(t *testing.T) {
 	assert.False(t, final.Output.MoveFiles, "move_files should persist as false after save/reload")
 }
 
+// TestUpdateAtomicallyModifiesSingleField verifies config.Update performs an atomic
+// read-modify-write that only changes the mutated field and preserves other values
+// (issue #36: persisting move_files without leaking session overrides).
+func TestUpdateAtomicallyModifiesSingleField(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	cfg := DefaultConfig()
+	cfg.Output.MoveFiles = false
+	cfg.Output.DownloadExtrafanart = false
+	require.NoError(t, Save(cfg, configPath))
+
+	// Simultaneously mutate an unrelated in-memory copy (as a session override would)
+	// and use Update to persist only move_files.
+	stale := DefaultConfig()
+	stale.Output.MoveFiles = false
+	stale.Output.DownloadExtrafanart = true // session-only override, must NOT leak
+	_ = stale
+
+	require.NoError(t, Update(configPath, func(c *Config) {
+		c.Output.MoveFiles = true
+	}))
+
+	reloaded, err := LoadOrCreate(configPath)
+	require.NoError(t, err)
+	assert.True(t, reloaded.Output.MoveFiles, "Update should persist move_files")
+	assert.False(t, reloaded.Output.DownloadExtrafanart, "Update must not touch unrelated fields")
+}
+
 // TestCreatedConfigHasComments verifies new configs preserve example comments
 func TestCreatedConfigHasComments(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/internal/config/storage_test.go
+++ b/internal/config/storage_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -148,13 +149,7 @@ func TestUpdateAtomicallyModifiesSingleField(t *testing.T) {
 	cfg.Output.DownloadExtrafanart = false
 	require.NoError(t, Save(cfg, configPath))
 
-	// Simultaneously mutate an unrelated in-memory copy (as a session override would)
-	// and use Update to persist only move_files.
-	stale := DefaultConfig()
-	stale.Output.MoveFiles = false
-	stale.Output.DownloadExtrafanart = true // session-only override, must NOT leak
-	_ = stale
-
+	// Use Update to persist only move_files (simulating a TUI toggle).
 	require.NoError(t, Update(configPath, func(c *Config) {
 		c.Output.MoveFiles = true
 	}))
@@ -163,6 +158,50 @@ func TestUpdateAtomicallyModifiesSingleField(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, reloaded.Output.MoveFiles, "Update should persist move_files")
 	assert.False(t, reloaded.Output.DownloadExtrafanart, "Update must not touch unrelated fields")
+}
+
+// TestUpdateConcurrentWritersNoLostUpdates proves config.Update is an atomic
+// read-modify-write: 100 concurrent increments of a counter field must all
+// survive (no lost updates). With an unlocked Load+Save, many increments
+// would be lost. This is the TOCTOU regression test for issue #36.
+func TestUpdateConcurrentWritersNoLostUpdates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrency test in short mode")
+	}
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg := DefaultConfig()
+	cfg.Output.MaxPosterHeight = 0
+	require.NoError(t, Save(cfg, configPath))
+
+	const N = 100
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = Update(configPath, func(c *Config) { c.Output.MaxPosterHeight++ })
+		}()
+	}
+	wg.Wait()
+
+	reloaded, err := LoadOrCreate(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, N, reloaded.Output.MaxPosterHeight, "no concurrent updates should be lost (atomic RMW under lock)")
+}
+
+// TestUpdateOnMissingFileWritesDefaults verifies Update on a non-existent path
+// writes a config with the mutation applied (loadLocked returns DefaultConfig()
+// for missing files).
+func TestUpdateOnMissingFileWritesDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	require.NoError(t, Update(configPath, func(c *Config) { c.Output.MoveFiles = true }))
+
+	reloaded, err := LoadOrCreate(configPath)
+	require.NoError(t, err)
+	assert.True(t, reloaded.Output.MoveFiles, "Update on a missing file should write the mutation")
 }
 
 // TestCreatedConfigHasComments verifies new configs preserve example comments

--- a/internal/config/storage_test.go
+++ b/internal/config/storage_test.go
@@ -111,6 +111,31 @@ func TestLoadOrCreateIdempotent(t *testing.T) {
 	assert.Equal(t, cfg1.Scrapers.UserAgent, cfg2.Scrapers.UserAgent, "user_agent should match")
 }
 
+// TestMoveFilesRoundTrip verifies the move_files setting survives a save/load cycle (issue #36).
+func TestMoveFilesRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	cfg, err := LoadOrCreate(configPath)
+	require.NoError(t, err)
+
+	// Enable move mode and persist
+	cfg.Output.MoveFiles = true
+	require.NoError(t, Save(cfg, configPath))
+
+	// Reload and confirm the setting persisted
+	reloaded, err := LoadOrCreate(configPath)
+	require.NoError(t, err)
+	assert.True(t, reloaded.Output.MoveFiles, "move_files should persist as true after save/reload")
+
+	// Flip back to false and confirm that also persists
+	reloaded.Output.MoveFiles = false
+	require.NoError(t, Save(reloaded, configPath))
+	final, err := LoadOrCreate(configPath)
+	require.NoError(t, err)
+	assert.False(t, final.Output.MoveFiles, "move_files should persist as false after save/reload")
+}
+
 // TestCreatedConfigHasComments verifies new configs preserve example comments
 func TestCreatedConfigHasComments(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -132,9 +132,15 @@ func InitLogger(cfg *Config) error {
 		}
 	}
 
-	// If no valid outputs, default to stdout
+	// If no valid outputs were configured, return an error rather than silently
+	// falling back to os.Stdout. A silent stdout fallback can corrupt TUI/
+	// AltScreen displays and hides misconfigurations (e.g. an empty output string
+	// produced by FileOnlyOutput with an empty defaultPath).
 	if len(writers) == 0 {
-		writers = append(writers, os.Stdout)
+		for _, c := range closers {
+			_ = c.Close()
+		}
+		return fmt.Errorf("no valid log outputs configured in %q (expected stdout, stderr, or a file path)", cfg.Output)
 	}
 
 	// Set output to multi-writer if multiple outputs

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -284,6 +284,18 @@ func WithFields(fields logrus.Fields) *logrus.Entry {
 	return L().WithFields(fields)
 }
 
+// FileOnlyOutput returns the comma-separated file targets from output, stripping
+// stdout/stderr. If no file targets remain, defaultPath is returned. Used by
+// the TUI to ensure logs go to file only (not the terminal) so the TUI display
+// isn't corrupted.
+func FileOnlyOutput(output, defaultPath string) string {
+	files := GetFileOutputs(output)
+	if len(files) == 0 {
+		return defaultPath
+	}
+	return strings.Join(files, ",")
+}
+
 // GetFileOutputs extracts file paths from a comma-separated output string.
 // Returns only file paths (excludes "stdout" and "stderr").
 // Returns nil if no file outputs are found.

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -524,3 +524,60 @@ func TestGetFileOutputs(t *testing.T) {
 		})
 	}
 }
+
+// TestFileOnlyOutput verifies stdout/stderr are stripped for TUI mode, with a
+// default applied when no file targets remain (issue: logs leaking into TUI).
+func TestFileOnlyOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      string
+		defaultPath string
+		expected    string
+	}{
+		{
+			name:        "dual stdout+file strips stdout",
+			output:      "stdout,data/logs/javinizer.log",
+			defaultPath: "data/logs/javinizer-tui.log",
+			expected:    "data/logs/javinizer.log",
+		},
+		{
+			name:        "pure stdout falls back to default",
+			output:      "stdout",
+			defaultPath: "data/logs/javinizer-tui.log",
+			expected:    "data/logs/javinizer-tui.log",
+		},
+		{
+			name:        "stdout+stderr falls back to default",
+			output:      "stdout,stderr",
+			defaultPath: "data/logs/javinizer-tui.log",
+			expected:    "data/logs/javinizer-tui.log",
+		},
+		{
+			name:        "multiple files preserved",
+			output:      "stdout,/var/log/a.log,/var/log/b.log",
+			defaultPath: "data/logs/javinizer-tui.log",
+			expected:    "/var/log/a.log,/var/log/b.log",
+		},
+		{
+			name:        "empty falls back to default",
+			output:      "",
+			defaultPath: "data/logs/javinizer-tui.log",
+			expected:    "data/logs/javinizer-tui.log",
+		},
+		{
+			name:        "file only unchanged",
+			output:      "/var/log/javinizer.log",
+			defaultPath: "data/logs/javinizer-tui.log",
+			expected:    "/var/log/javinizer.log",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FileOnlyOutput(tt.output, tt.defaultPath)
+			if result != tt.expected {
+				t.Errorf("FileOnlyOutput(%q, %q) = %q, want %q", tt.output, tt.defaultPath, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -5,6 +5,7 @@ package logging
 // but avoid using t.Parallel() in this package.
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -206,15 +207,17 @@ func TestInitLogger_FileOnlyOutput_EmptyDefaultNoLeak(t *testing.T) {
 
 	_ = w.Close()
 	os.Stdout = origStdout
-	buf := make([]byte, 4096)
-	n, _ := r.Read(buf)
+	outBuf, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
 	_ = r.Close()
 
 	if initErr == nil {
 		t.Errorf("InitLogger with empty output should have errored instead of leaking to stdout")
 	}
-	if n > 0 {
-		t.Errorf("unexpected stdout output during error path: %q", string(buf[:n]))
+	if len(outBuf) > 0 {
+		t.Errorf("unexpected stdout output during error path: %q", string(outBuf))
 	}
 }
 
@@ -680,11 +683,13 @@ func TestInitLogger_FileOnlyOutput_NoStdoutLeak(t *testing.T) {
 	_ = w.Close()
 	os.Stdout = origStdout
 
-	buf := make([]byte, 4096)
-	n, _ := r.Read(buf)
+	outBuf, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
 	_ = r.Close()
-	if n > 0 && strings.Contains(string(buf[:n]), "this must not leak to stdout") {
-		t.Errorf("stdout leak detected: pipe captured %q", string(buf[:n]))
+	if strings.Contains(string(outBuf), "this must not leak to stdout") {
+		t.Errorf("stdout leak detected: pipe captured %q", string(outBuf))
 	}
 
 	content, err := os.ReadFile(logFile)
@@ -724,10 +729,12 @@ func TestInitLogger_StdoutNotStripped_DoesLeak(t *testing.T) {
 	_ = w.Close()
 	os.Stdout = origStdout
 
-	buf := make([]byte, 4096)
-	n, _ := r.Read(buf)
+	outBuf, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
 	_ = r.Close()
-	if n == 0 || !strings.Contains(string(buf[:n]), "this SHOULD leak to stdout") {
-		t.Errorf("expected stdout leak but pipe captured nothing relevant: %q", string(buf[:n]))
+	if !strings.Contains(string(outBuf), "this SHOULD leak to stdout") {
+		t.Errorf("expected stdout leak but pipe captured nothing relevant: %q", string(outBuf))
 	}
 }

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -168,6 +168,56 @@ func TestInitLogger_AutoCreateDirectory(t *testing.T) {
 	}
 }
 
+// TestInitLogger_NoValidOutputsReturnsError pins that an empty/invalid output no
+// longer silently falls back to os.Stdout (which would leak into the TUI). Such
+// a configuration is a misconfiguration and must surface as an error instead of
+// a silent stdout leak.
+func TestInitLogger_NoValidOutputsReturnsError(t *testing.T) {
+	for _, output := range []string{"", "   ", ",", " , "} {
+		cfg := &Config{Level: "info", Format: "text", Output: output}
+		err := InitLogger(cfg)
+		if err == nil {
+			t.Errorf("InitLogger(Output=%q) expected an error, got nil", output)
+		}
+		if err != nil && !strings.Contains(err.Error(), "no valid log outputs") {
+			t.Errorf("InitLogger(Output=%q) error = %v, want it to mention 'no valid log outputs'", output, err)
+		}
+	}
+}
+
+// TestInitLogger_FileOnlyOutput_EmptyDefaultNoLeak proves the defense-in-depth:
+// FileOnlyOutput with an empty defaultPath returns "", and InitLogger then errors
+// rather than leaking to stdout. This guards the latent leak vector flagged in
+// review (empty defaultPath + no file targets).
+func TestInitLogger_FileOnlyOutput_EmptyDefaultNoLeak(t *testing.T) {
+	stripped := FileOnlyOutput("stdout", "")
+	if stripped != "" {
+		t.Fatalf("FileOnlyOutput with empty defaultPath should return empty, got %q", stripped)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+
+	initErr := InitLogger(&Config{Level: "info", Format: "text", Output: stripped})
+
+	_ = w.Close()
+	os.Stdout = origStdout
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	_ = r.Close()
+
+	if initErr == nil {
+		t.Errorf("InitLogger with empty output should have errored instead of leaking to stdout")
+	}
+	if n > 0 {
+		t.Errorf("unexpected stdout output during error path: %q", string(buf[:n]))
+	}
+}
+
 func TestLogLevels(t *testing.T) {
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "levels.log")
@@ -570,6 +620,21 @@ func TestFileOnlyOutput(t *testing.T) {
 			defaultPath: "data/logs/javinizer-tui.log",
 			expected:    "/var/log/javinizer.log",
 		},
+		{
+			name:        "whitespace trimmed",
+			output:      "stdout , data/logs/x.log ",
+			defaultPath: "data/logs/tui.log",
+			expected:    "data/logs/x.log",
+		},
+		// Empty defaultPath with no file targets returns "". The safety net against
+		// the resulting stdout leak now lives in InitLogger (TestInitLogger_NoValidOutputsReturnsError),
+		// which errors instead of silently falling back to os.Stdout.
+		{
+			name:        "empty defaultPath and no file targets returns empty",
+			output:      "stdout",
+			defaultPath: "",
+			expected:    "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -579,5 +644,90 @@ func TestFileOnlyOutput(t *testing.T) {
 				t.Errorf("FileOnlyOutput(%q, %q) = %q, want %q", tt.output, tt.defaultPath, result, tt.expected)
 			}
 		})
+	}
+}
+
+// TestInitLogger_FileOnlyOutput_NoStdoutLeak proves end-to-end that when the
+// output string is run through FileOnlyOutput (stripping stdout/stderr), no log
+// output reaches os.Stdout. This is the guarantee the TUI relies on: even with
+// the default "stdout,file" config, the TUI's terminal stays clean.
+func TestInitLogger_FileOnlyOutput_NoStdoutLeak(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFile := filepath.Join(tmpDir, "noleak.log")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+
+	stripped := FileOnlyOutput("stdout,"+logFile, "data/logs/javinizer-tui.log")
+	if stripped != logFile {
+		t.Fatalf("FileOnlyOutput did not strip stdout: got %q", stripped)
+	}
+
+	if err := InitLogger(&Config{Level: "info", Format: "text", Output: stripped}); err != nil {
+		os.Stdout = origStdout
+		_ = w.Close()
+		_ = r.Close()
+		t.Fatalf("InitLogger: %v", err)
+	}
+	defer CloseLogger()
+
+	Info("this must not leak to stdout")
+
+	_ = w.Close()
+	os.Stdout = origStdout
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	_ = r.Close()
+	if n > 0 && strings.Contains(string(buf[:n]), "this must not leak to stdout") {
+		t.Errorf("stdout leak detected: pipe captured %q", string(buf[:n]))
+	}
+
+	content, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	if !strings.Contains(string(content), "this must not leak to stdout") {
+		t.Errorf("log file did not receive the message; content: %s", string(content))
+	}
+}
+
+// TestInitLogger_StdoutNotStripped_DoesLeak proves the leak detector above is not
+// vacuous: without FileOnlyOutput, a "stdout,file" output DOES write to os.Stdout.
+// This is the regression the TUI fix prevents, and confirms the capture mechanism
+// actually detects leaks.
+func TestInitLogger_StdoutNotStripped_DoesLeak(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFile := filepath.Join(tmpDir, "leak.log")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+
+	if err := InitLogger(&Config{Level: "info", Format: "text", Output: "stdout," + logFile}); err != nil {
+		os.Stdout = origStdout
+		_ = w.Close()
+		_ = r.Close()
+		t.Fatalf("InitLogger: %v", err)
+	}
+	defer CloseLogger()
+
+	Info("this SHOULD leak to stdout")
+
+	_ = w.Close()
+	os.Stdout = origStdout
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	_ = r.Close()
+	if n == 0 || !strings.Contains(string(buf[:n]), "this SHOULD leak to stdout") {
+		t.Errorf("expected stdout leak but pipe captured nothing relevant: %q", string(buf[:n]))
 	}
 }

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -664,6 +664,7 @@ func TestInitLogger_FileOnlyOutput_NoStdoutLeak(t *testing.T) {
 	}
 	origStdout := os.Stdout
 	os.Stdout = w
+	defer func() { os.Stdout = origStdout }() // restore on all paths, including t.Fatalf
 
 	stripped := FileOnlyOutput("stdout,"+logFile, "data/logs/javinizer-tui.log")
 	if stripped != logFile {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -105,16 +105,17 @@ type Model struct {
 	totalFilesCount    int       // Total number of files processed
 
 	// Runtime settings (can be toggled in Settings view)
-	forceUpdate         bool // Replace existing files (images, NFO)
-	forceRefresh        bool // Clear DB cache and rescrape metadata
-	moveFiles           bool // Move instead of copy
-	scrapeEnabled       bool // Enable metadata scraping
-	downloadEnabled     bool // Enable media downloads
-	downloadExtrafanart bool // Enable extrafanart (screenshots) downloads
-	organizeEnabled     bool // Enable file organization
-	nfoEnabled          bool // Enable NFO generation
-	updateMode          bool // Update mode: only create/update metadata without moving files
-	settingsCursor      int  // Cursor position in settings view
+	forceUpdate         bool               // Replace existing files (images, NFO)
+	forceRefresh        bool               // Clear DB cache and rescrape metadata
+	moveFiles           bool               // Move instead of copy
+	linkMode            organizer.LinkMode // Link mode (mutually exclusive with moveFiles)
+	scrapeEnabled       bool               // Enable metadata scraping
+	downloadEnabled     bool               // Enable media downloads
+	downloadExtrafanart bool               // Enable extrafanart (screenshots) downloads
+	organizeEnabled     bool               // Enable file organization
+	nfoEnabled          bool               // Enable NFO generation
+	updateMode          bool               // Update mode: only create/update metadata without moving files
+	settingsCursor      int                // Cursor position in settings view
 
 	// Statistics
 	stats       worker.ProgressStats
@@ -477,6 +478,20 @@ func (m *Model) SetMoveFiles(moveFiles bool) {
 	if m.processor != nil {
 		m.processor.SetMoveFiles(moveFiles)
 	}
+}
+
+// SetLinkMode records the link mode so the runtime move-files toggle can guard
+// against the move+link combination rejected at startup (ValidateMoveLinkMode).
+// Link mode is set at startup via --link-mode and is not toggled at runtime.
+func (m *Model) SetLinkMode(mode organizer.LinkMode) {
+	m.linkMode = mode
+}
+
+// canEnableMoveMode reports whether move mode can be enabled at runtime. Move and
+// link modes are mutually exclusive (ValidateMoveLinkMode); if link mode is active,
+// enabling move is refused to preserve the startup invariant.
+func (m *Model) canEnableMoveMode() bool {
+	return m.linkMode == organizer.LinkModeNone
 }
 
 // ResolveMoveMode determines the effective move mode for the TUI: an explicit

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -444,10 +444,11 @@ func (m *Model) GetSelectedFiles() []string {
 // SetProcessor sets the processing coordinator
 func (m *Model) SetProcessor(processor *ProcessingCoordinator) {
 	m.processor = processor
-	// Sync dry-run state to processor
+	// Sync runtime state to processor
 	if m.processor != nil {
 		m.processor.SetDryRun(m.dryRun)
 		m.processor.SetUpdateMode(m.updateMode)
+		m.processor.SetMoveFiles(m.moveFiles)
 	}
 }
 
@@ -477,23 +478,41 @@ func (m *Model) SetMoveFiles(moveFiles bool) {
 	}
 }
 
+// ResolveMoveMode determines the effective move mode for the TUI: an explicit
+// --move flag overrides config.yaml's move_files; otherwise the config value
+// is used (issue #36).
+func ResolveMoveMode(configMoveFiles, moveFlagSet, moveFlagValue bool) bool {
+	if moveFlagSet {
+		return moveFlagValue
+	}
+	return configMoveFiles
+}
+
 // SetConfigPath records the config.yaml path so TUI settings can be persisted.
 func (m *Model) SetConfigPath(path string) {
 	m.configPath = path
 }
 
-// saveConfig persists the current TUI-backed settings (move_files) to config.yaml.
-// Other settings are left as-is; the merge-based Save preserves existing keys/comments.
+// saveConfig persists the Move Files setting to config.yaml. It reloads the
+// on-disk config fresh and writes only move_files, so session-only CLI/env
+// overrides applied to the in-memory cfg (e.g. --extrafanart, the TUI-mode
+// logging.output rewrite, --scraper-priority, LOG_LEVEL) are NOT leaked to
+// disk on toggle (issue #36).
 func (m *Model) saveConfig() {
 	if m.config == nil || m.configPath == "" {
 		return
 	}
-	m.config.Output.MoveFiles = m.moveFiles
-	if err := config.Save(m.config, m.configPath); err != nil {
-		m.AddLog("error", fmt.Sprintf("Failed to save Move Files setting to config: %v", err))
-	} else {
-		m.AddLog("info", "Move Files setting saved to config")
+	diskCfg, err := config.Load(m.configPath)
+	if err != nil {
+		m.AddLog("error", fmt.Sprintf("Failed to reload config to save Move Files setting: %v", err))
+		return
 	}
+	diskCfg.Output.MoveFiles = m.moveFiles
+	if err := config.Save(diskCfg, m.configPath); err != nil {
+		m.AddLog("error", fmt.Sprintf("Failed to save Move Files setting to config: %v", err))
+		return
+	}
+	m.AddLog("info", "Move Files setting saved to config")
 }
 
 // SetUpdateMode sets update mode and syncs it to processor.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -15,6 +15,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/database"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/matcher"
+	"github.com/javinizer/javinizer-go/internal/organizer"
 	"github.com/javinizer/javinizer-go/internal/scanner"
 	"github.com/javinizer/javinizer-go/internal/worker"
 )
@@ -488,27 +489,35 @@ func ResolveMoveMode(configMoveFiles, moveFlagSet, moveFlagValue bool) bool {
 	return configMoveFiles
 }
 
+// ValidateMoveLinkMode returns an error if move mode and link mode are both
+// enabled, since they are mutually exclusive. effectiveMove may originate from
+// config's move_files or the --move flag.
+func ValidateMoveLinkMode(effectiveMove bool, linkMode organizer.LinkMode) error {
+	if effectiveMove && linkMode != organizer.LinkModeNone {
+		return fmt.Errorf("--link-mode can only be used when move mode is disabled (move_files is false and --move is not set)")
+	}
+	return nil
+}
+
 // SetConfigPath records the config.yaml path so TUI settings can be persisted.
 func (m *Model) SetConfigPath(path string) {
 	m.configPath = path
 }
 
-// saveConfig persists the Move Files setting to config.yaml. It reloads the
-// on-disk config fresh and writes only move_files, so session-only CLI/env
-// overrides applied to the in-memory cfg (e.g. --extrafanart, the TUI-mode
-// logging.output rewrite, --scraper-priority, LOG_LEVEL) are NOT leaked to
-// disk on toggle (issue #36).
+// saveConfig persists the Move Files setting to config.yaml. It uses config.Update
+// (atomic read-modify-write under the file lock) so only move_files is written and
+// session-only CLI/env overrides applied to the in-memory cfg (e.g. --extrafanart,
+// the TUI-mode logging.output rewrite, --scraper-priority, LOG_LEVEL) are NOT
+// leaked to disk, and a concurrent writer's changes cannot be silently reverted
+// (issue #36).
 func (m *Model) saveConfig() {
 	if m.config == nil || m.configPath == "" {
 		return
 	}
-	diskCfg, err := config.Load(m.configPath)
+	err := config.Update(m.configPath, func(c *config.Config) {
+		c.Output.MoveFiles = m.moveFiles
+	})
 	if err != nil {
-		m.AddLog("error", fmt.Sprintf("Failed to reload config to save Move Files setting: %v", err))
-		return
-	}
-	diskCfg.Output.MoveFiles = m.moveFiles
-	if err := config.Save(diskCfg, m.configPath); err != nil {
 		m.AddLog("error", fmt.Sprintf("Failed to save Move Files setting to config: %v", err))
 		return
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -140,6 +140,8 @@ type Model struct {
 	logViewer    *LogViewer
 	settingsView *SettingsView
 	helpView     *HelpView
+
+	configPath string // path to config.yaml for persisting TUI settings
 }
 
 // FileItem represents a file in the browser
@@ -190,7 +192,7 @@ func New(cfg *config.Config) *Model {
 		// Runtime settings defaults
 		forceUpdate:         false,
 		forceRefresh:        false,
-		moveFiles:           false,
+		moveFiles:           cfg.Output.MoveFiles, // Initialize from config (issue #36)
 		scrapeEnabled:       true,
 		downloadEnabled:     true,
 		downloadExtrafanart: cfg.Output.DownloadExtrafanart, // Initialize from config
@@ -464,6 +466,33 @@ func (m *Model) SetDryRun(dryRun bool) {
 	}
 	if dryRun {
 		m.AddLog("info", "DRY RUN mode enabled - no changes will be made")
+	}
+}
+
+// SetMoveFiles sets the move-files mode and syncs it to the processor.
+func (m *Model) SetMoveFiles(moveFiles bool) {
+	m.moveFiles = moveFiles
+	if m.processor != nil {
+		m.processor.SetMoveFiles(moveFiles)
+	}
+}
+
+// SetConfigPath records the config.yaml path so TUI settings can be persisted.
+func (m *Model) SetConfigPath(path string) {
+	m.configPath = path
+}
+
+// saveConfig persists the current TUI-backed settings (move_files) to config.yaml.
+// Other settings are left as-is; the merge-based Save preserves existing keys/comments.
+func (m *Model) saveConfig() {
+	if m.config == nil || m.configPath == "" {
+		return
+	}
+	m.config.Output.MoveFiles = m.moveFiles
+	if err := config.Save(m.config, m.configPath); err != nil {
+		m.AddLog("error", fmt.Sprintf("Failed to save Move Files setting to config: %v", err))
+	} else {
+		m.AddLog("info", "Move Files setting saved to config")
 	}
 }
 

--- a/internal/tui/model_movefiles_test.go
+++ b/internal/tui/model_movefiles_test.go
@@ -1,0 +1,76 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewLoadsMoveFilesFromConfig verifies the TUI initializes moveFiles from
+// config.yaml (issue #36) instead of hardcoding it to false.
+func TestNewLoadsMoveFilesFromConfig(t *testing.T) {
+	t.Run("loads true from config", func(t *testing.T) {
+		cfg := config.DefaultConfig()
+		cfg.Output.MoveFiles = true
+
+		m := New(cfg)
+
+		assert.True(t, m.moveFiles, "moveFiles should be loaded from cfg.Output.MoveFiles")
+	})
+
+	t.Run("loads false from config", func(t *testing.T) {
+		cfg := config.DefaultConfig()
+		cfg.Output.MoveFiles = false
+
+		m := New(cfg)
+
+		assert.False(t, m.moveFiles, "moveFiles should be loaded from cfg.Output.MoveFiles")
+	})
+}
+
+// TestSetMoveFilesSyncsModel verifies SetMoveFiles updates the model state.
+func TestSetMoveFilesSyncsModel(t *testing.T) {
+	cfg := config.DefaultConfig()
+	m := New(cfg)
+
+	m.SetMoveFiles(true)
+	assert.True(t, m.moveFiles)
+
+	m.SetMoveFiles(false)
+	assert.False(t, m.moveFiles)
+}
+
+// TestSaveConfigPersistsMoveFiles verifies that toggling moveFiles and calling
+// saveConfig writes move_files to config.yaml so it survives a restart (issue #36).
+func TestSaveConfigPersistsMoveFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	cfg := config.DefaultConfig()
+	cfg.Output.MoveFiles = false
+	m := New(cfg)
+	m.SetConfigPath(configPath)
+
+	// Simulate the TUI toggle: flip moveFiles on and persist
+	m.moveFiles = true
+	m.saveConfig()
+
+	content, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "move_files: true",
+		"move_files should be persisted as true after saveConfig")
+}
+
+// TestSaveConfigNoOpWithoutPath verifies saveConfig is a no-op when no config path is set
+// (e.g. config not yet written), so it never crashes the TUI.
+func TestSaveConfigNoOpWithoutPath(t *testing.T) {
+	cfg := config.DefaultConfig()
+	m := New(cfg)
+	// configPath is empty by default
+	m.moveFiles = true
+	assert.NotPanics(t, func() { m.saveConfig() })
+}

--- a/internal/tui/model_movefiles_test.go
+++ b/internal/tui/model_movefiles_test.go
@@ -280,4 +280,13 @@ func TestHandleSettingsKeys_ToggleMoveFiles(t *testing.T) {
 	reloaded, err := config.Load(configPath)
 	require.NoError(t, err)
 	assert.True(t, reloaded.Output.MoveFiles, "toggle should persist move_files")
+
+	// Toggle back off through the same keypress path (true -> false)
+	updated2, _ := m2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	m3 := updated2.(*Model)
+	assert.False(t, m3.moveFiles, "second space should toggle moveFiles off")
+	assert.False(t, proc.moveFiles, "processor should sync back to false")
+	reloaded2, err := config.Load(configPath)
+	require.NoError(t, err)
+	assert.False(t, reloaded2.Output.MoveFiles, "toggle-off should persist")
 }

--- a/internal/tui/model_movefiles_test.go
+++ b/internal/tui/model_movefiles_test.go
@@ -194,7 +194,8 @@ func TestSaveConfigEndToEndRestart(t *testing.T) {
 	require.NoError(t, config.Save(cfg, configPath))
 
 	// Session 1: start in copy mode, toggle to move mode, persist
-	loaded, _ := config.Load(configPath)
+	loaded, err := config.Load(configPath)
+	require.NoError(t, err)
 	m1 := New(loaded)
 	m1.SetConfigPath(configPath)
 	require.False(t, m1.moveFiles, "should start in copy mode")
@@ -289,4 +290,58 @@ func TestHandleSettingsKeys_ToggleMoveFiles(t *testing.T) {
 	reloaded2, err := config.Load(configPath)
 	require.NoError(t, err)
 	assert.False(t, reloaded2.Output.MoveFiles, "toggle-off should persist")
+}
+
+// TestCanEnableMoveMode verifies the guard predicate used by the runtime toggle.
+func TestCanEnableMoveMode(t *testing.T) {
+	m := New(config.DefaultConfig())
+	assert.True(t, m.canEnableMoveMode(), "no link mode -> move can be enabled")
+
+	m.SetLinkMode(organizer.LinkModeHard)
+	assert.False(t, m.canEnableMoveMode(), "hard link mode -> move cannot be enabled")
+
+	m.SetLinkMode(organizer.LinkModeSoft)
+	assert.False(t, m.canEnableMoveMode(), "soft link mode -> move cannot be enabled")
+
+	m.SetLinkMode(organizer.LinkModeNone)
+	assert.True(t, m.canEnableMoveMode(), "link mode cleared -> move can be enabled")
+}
+
+// TestHandleSettingsKeys_ToggleMoveFiles_RefusedWithLinkMode verifies the runtime
+// guard: enabling move mode is refused while link mode is active, since move+link
+// is mutually exclusive (ValidateMoveLinkMode rejects it at startup). The toggle
+// must not change moveFiles, sync the processor, or persist.
+func TestHandleSettingsKeys_ToggleMoveFiles_RefusedWithLinkMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg := config.DefaultConfig()
+	cfg.Output.MoveFiles = false
+	require.NoError(t, config.Save(cfg, configPath))
+
+	loaded, err := config.Load(configPath)
+	require.NoError(t, err)
+	m := New(loaded)
+	m.SetConfigPath(configPath)
+	m.SetLinkMode(organizer.LinkModeHard) // simulate --link-mode hard
+	m.currentView = ViewSettings
+	m.settingsCursor = 3 // "Move Files" row
+
+	proc := NewProcessingCoordinator(nil, nil, nil, nil, nil, nil, nil, nil, "", false)
+	m.SetProcessor(proc)
+	require.False(t, m.moveFiles)
+
+	// Attempt to toggle move on — must be refused due to link mode.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	m2 := updated.(*Model)
+
+	assert.False(t, m2.moveFiles, "move mode must NOT enable while link mode is active")
+	assert.False(t, proc.moveFiles, "processor must remain in copy mode")
+
+	reloaded, err := config.Load(configPath)
+	require.NoError(t, err)
+	assert.False(t, reloaded.Output.MoveFiles, "refused toggle must not persist move_files")
+
+	require.NotEmpty(t, m2.logs, "a warning should be logged when the toggle is refused")
+	last := m2.logs[len(m2.logs)-1]
+	assert.Equal(t, "warn", last.Level, "refused toggle should log a warning")
 }

--- a/internal/tui/model_movefiles_test.go
+++ b/internal/tui/model_movefiles_test.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/organizer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -83,6 +85,33 @@ func TestResolveMoveMode(t *testing.T) {
 	}
 }
 
+// TestValidateMoveLinkMode verifies move mode and link mode are mutually exclusive,
+// regardless of whether move mode came from config or the --move flag (issue #36).
+func TestValidateMoveLinkMode(t *testing.T) {
+	tests := []struct {
+		name      string
+		effective bool
+		linkMode  organizer.LinkMode
+		wantErr   bool
+	}{
+		{"move on, link none -> ok", true, organizer.LinkModeNone, false},
+		{"move off, link hard -> ok", false, organizer.LinkModeHard, false},
+		{"move off, link soft -> ok", false, organizer.LinkModeSoft, false},
+		{"move on, link hard -> error", true, organizer.LinkModeHard, true},
+		{"move on, link soft -> error", true, organizer.LinkModeSoft, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMoveLinkMode(tc.effective, tc.linkMode)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestSaveConfigPersistsMoveFiles verifies toggling moveFiles and calling saveConfig
 // writes move_files to config.yaml (reloaded and asserted via the parsed struct).
 func TestSaveConfigPersistsMoveFiles(t *testing.T) {
@@ -125,11 +154,12 @@ func TestSaveConfigDoesNotLeakSessionOverrides(t *testing.T) {
 	require.NoError(t, config.Save(disk, configPath))
 
 	// In-memory cfg has session overrides applied (as the TUI command does):
-	// --extrafanart, and the TUI-mode logging.output rewrite.
+	// --extrafanart, --scraper-priority, and the TUI-mode logging.output rewrite.
 	loaded, err := config.Load(configPath)
 	require.NoError(t, err)
 	loaded.Output.DownloadExtrafanart = true // --extrafanart override
 	loaded.Logging.Output = "data/logs/javinizer-tui.log"
+	loaded.Scrapers.Priority = []string{"custom-scraper"} // --scraper-priority override
 
 	m := New(loaded)
 	m.SetConfigPath(configPath)
@@ -148,6 +178,8 @@ func TestSaveConfigDoesNotLeakSessionOverrides(t *testing.T) {
 		"--extrafanart session override must not be persisted to config")
 	assert.Equal(t, "stdout", reloaded.Logging.Output,
 		"TUI-mode logging.output rewrite must not be persisted to config")
+	assert.NotContains(t, reloaded.Scrapers.Priority, "custom-scraper",
+		"--scraper-priority session override must not be persisted to config")
 }
 
 // TestSaveConfigEndToEndRestart verifies the full issue #36 scenario: a model
@@ -195,17 +227,57 @@ func TestSaveConfigNoOpWithoutPath(t *testing.T) {
 }
 
 // TestSaveConfigNoOpWhenFileUnreadable verifies saveConfig logs and does not panic
-// when the on-disk config cannot be reloaded.
+// when the on-disk config cannot be reloaded, and leaves the file untouched.
 func TestSaveConfigNoOpWhenFileUnreadable(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
 
-	// Write invalid YAML so config.Load fails
-	require.NoError(t, os.WriteFile(configPath, []byte("output: [invalid\n  not: valid"), 0o644))
+	// Write invalid YAML so config.Update's internal load fails
+	invalid := []byte("output: [invalid\n  not: valid")
+	require.NoError(t, os.WriteFile(configPath, invalid, 0o644))
 
 	cfg := config.DefaultConfig()
 	m := New(cfg)
 	m.SetConfigPath(configPath)
 	m.moveFiles = true
 	assert.NotPanics(t, func() { m.saveConfig() })
+
+	// The corrupt file must be left as-is (no partial write)
+	content, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(invalid), string(content), "corrupt config must not be rewritten")
+}
+
+// TestHandleSettingsKeys_ToggleMoveFiles verifies the real TUI keypress path:
+// a space at settings cursor 3 toggles moveFiles, syncs the processor, and persists.
+func TestHandleSettingsKeys_ToggleMoveFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg := config.DefaultConfig()
+	cfg.Output.MoveFiles = false
+	require.NoError(t, config.Save(cfg, configPath))
+
+	loaded, err := config.Load(configPath)
+	require.NoError(t, err)
+	m := New(loaded)
+	m.SetConfigPath(configPath)
+	m.currentView = ViewSettings
+	m.settingsCursor = 3 // "Move Files" row
+
+	// Attach a processor to verify the toggle propagates
+	proc := NewProcessingCoordinator(nil, nil, nil, nil, nil, nil, nil, nil, "", false)
+	m.SetProcessor(proc)
+	require.False(t, m.moveFiles)
+	require.False(t, proc.moveFiles)
+
+	// Simulate pressing space at the Move Files row
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	m2 := updated.(*Model)
+
+	assert.True(t, m2.moveFiles, "space at cursor 3 should toggle moveFiles on")
+	assert.True(t, proc.moveFiles, "processor should be synced")
+
+	reloaded, err := config.Load(configPath)
+	require.NoError(t, err)
+	assert.True(t, reloaded.Output.MoveFiles, "toggle should persist move_files")
 }

--- a/internal/tui/model_movefiles_test.go
+++ b/internal/tui/model_movefiles_test.go
@@ -32,45 +32,180 @@ func TestNewLoadsMoveFilesFromConfig(t *testing.T) {
 	})
 }
 
-// TestSetMoveFilesSyncsModel verifies SetMoveFiles updates the model state.
-func TestSetMoveFilesSyncsModel(t *testing.T) {
-	cfg := config.DefaultConfig()
-	m := New(cfg)
+// TestSetMoveFilesSyncsModelAndProcessor verifies SetMoveFiles updates both the
+// model state and (when present) the processor.
+func TestSetMoveFilesSyncsModelAndProcessor(t *testing.T) {
+	t.Run("without processor", func(t *testing.T) {
+		cfg := config.DefaultConfig()
+		m := New(cfg)
 
-	m.SetMoveFiles(true)
-	assert.True(t, m.moveFiles)
+		m.SetMoveFiles(true)
+		assert.True(t, m.moveFiles)
 
-	m.SetMoveFiles(false)
-	assert.False(t, m.moveFiles)
+		m.SetMoveFiles(false)
+		assert.False(t, m.moveFiles)
+	})
+
+	t.Run("with processor", func(t *testing.T) {
+		cfg := config.DefaultConfig()
+		m := New(cfg)
+		proc := NewProcessingCoordinator(nil, nil, nil, nil, nil, nil, nil, nil, "", false)
+		m.SetProcessor(proc)
+
+		m.SetMoveFiles(true)
+		assert.True(t, m.moveFiles)
+		assert.True(t, proc.moveFiles, "SetMoveFiles should sync to the processor")
+
+		m.SetMoveFiles(false)
+		assert.False(t, proc.moveFiles)
+	})
 }
 
-// TestSaveConfigPersistsMoveFiles verifies that toggling moveFiles and calling
-// saveConfig writes move_files to config.yaml so it survives a restart (issue #36).
+// TestResolveMoveMode verifies the --move flag overrides config, otherwise config wins.
+func TestResolveMoveMode(t *testing.T) {
+	tests := []struct {
+		name            string
+		configMoveFiles bool
+		moveFlagSet     bool
+		moveFlagValue   bool
+		want            bool
+	}{
+		{"config true, no flag", true, false, false, true},
+		{"config false, no flag", false, false, false, false},
+		{"flag overrides config to true", false, true, true, true},
+		{"flag overrides config to false", true, true, false, false},
+		{"flag set, config true, flag false -> false", true, true, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ResolveMoveMode(tc.configMoveFiles, tc.moveFlagSet, tc.moveFlagValue))
+		})
+	}
+}
+
+// TestSaveConfigPersistsMoveFiles verifies toggling moveFiles and calling saveConfig
+// writes move_files to config.yaml (reloaded and asserted via the parsed struct).
 func TestSaveConfigPersistsMoveFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
 
 	cfg := config.DefaultConfig()
 	cfg.Output.MoveFiles = false
-	m := New(cfg)
+	require.NoError(t, config.Save(cfg, configPath))
+
+	// Reload so the model starts from the persisted (false) state
+	loaded, err := config.Load(configPath)
+	require.NoError(t, err)
+	require.False(t, loaded.Output.MoveFiles)
+
+	m := New(loaded)
 	m.SetConfigPath(configPath)
 
 	// Simulate the TUI toggle: flip moveFiles on and persist
 	m.moveFiles = true
 	m.saveConfig()
 
-	content, err := os.ReadFile(configPath)
+	reloaded, err := config.Load(configPath)
 	require.NoError(t, err)
-	assert.Contains(t, string(content), "move_files: true",
-		"move_files should be persisted as true after saveConfig")
+	assert.True(t, reloaded.Output.MoveFiles, "move_files should be persisted as true after saveConfig")
 }
 
-// TestSaveConfigNoOpWithoutPath verifies saveConfig is a no-op when no config path is set
-// (e.g. config not yet written), so it never crashes the TUI.
+// TestSaveConfigDoesNotLeakSessionOverrides verifies that saveConfig persists ONLY
+// move_files and does not leak session-only CLI/env/TUI-mode overrides that were
+// applied to the in-memory cfg (issue #36 review finding).
+func TestSaveConfigDoesNotLeakSessionOverrides(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// On-disk config: extrafanart=false, logging output=stdout
+	disk := config.DefaultConfig()
+	disk.Output.MoveFiles = false
+	disk.Output.DownloadExtrafanart = false
+	disk.Logging.Output = "stdout"
+	require.NoError(t, config.Save(disk, configPath))
+
+	// In-memory cfg has session overrides applied (as the TUI command does):
+	// --extrafanart, and the TUI-mode logging.output rewrite.
+	loaded, err := config.Load(configPath)
+	require.NoError(t, err)
+	loaded.Output.DownloadExtrafanart = true // --extrafanart override
+	loaded.Logging.Output = "data/logs/javinizer-tui.log"
+
+	m := New(loaded)
+	m.SetConfigPath(configPath)
+
+	// Toggle moveFiles on and persist
+	m.moveFiles = true
+	m.saveConfig()
+
+	reloaded, err := config.Load(configPath)
+	require.NoError(t, err)
+
+	// move_files SHOULD be persisted
+	assert.True(t, reloaded.Output.MoveFiles, "move_files should be persisted")
+	// Session overrides should NOT leak to disk
+	assert.False(t, reloaded.Output.DownloadExtrafanart,
+		"--extrafanart session override must not be persisted to config")
+	assert.Equal(t, "stdout", reloaded.Logging.Output,
+		"TUI-mode logging.output rewrite must not be persisted to config")
+}
+
+// TestSaveConfigEndToEndRestart verifies the full issue #36 scenario: a model
+// toggles moveFiles on, persists, and a fresh model built from the reloaded
+// config starts in move mode.
+func TestSaveConfigEndToEndRestart(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	cfg := config.DefaultConfig()
+	cfg.Output.MoveFiles = false
+	require.NoError(t, config.Save(cfg, configPath))
+
+	// Session 1: start in copy mode, toggle to move mode, persist
+	loaded, _ := config.Load(configPath)
+	m1 := New(loaded)
+	m1.SetConfigPath(configPath)
+	require.False(t, m1.moveFiles, "should start in copy mode")
+	m1.moveFiles = true
+	m1.saveConfig()
+
+	// Session 2: reload config into a fresh model
+	reloaded, err := config.Load(configPath)
+	require.NoError(t, err)
+	m2 := New(reloaded)
+	assert.True(t, m2.moveFiles, "after restart the TUI should start in move mode (issue #36)")
+
+	// Session 3: toggle back off and confirm it persists
+	m2.SetConfigPath(configPath)
+	m2.moveFiles = false
+	m2.saveConfig()
+	final, err := config.Load(configPath)
+	require.NoError(t, err)
+	assert.False(t, final.Output.MoveFiles, "toggling back off should persist")
+}
+
+// TestSaveConfigNoOpWithoutPath verifies saveConfig is a no-op when no config path
+// is set (e.g. config not yet written), so it never crashes the TUI.
 func TestSaveConfigNoOpWithoutPath(t *testing.T) {
 	cfg := config.DefaultConfig()
 	m := New(cfg)
 	// configPath is empty by default
+	m.moveFiles = true
+	assert.NotPanics(t, func() { m.saveConfig() })
+}
+
+// TestSaveConfigNoOpWhenFileUnreadable verifies saveConfig logs and does not panic
+// when the on-disk config cannot be reloaded.
+func TestSaveConfigNoOpWhenFileUnreadable(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Write invalid YAML so config.Load fails
+	require.NoError(t, os.WriteFile(configPath, []byte("output: [invalid\n  not: valid"), 0o644))
+
+	cfg := config.DefaultConfig()
+	m := New(cfg)
+	m.SetConfigPath(configPath)
 	m.moveFiles = true
 	assert.NotPanics(t, func() { m.saveConfig() })
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -510,6 +510,7 @@ func (m *Model) handleSettingsKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			} else {
 				m.AddLog("info", "Copy mode enabled - files will be copied")
 			}
+			m.saveConfig()
 
 		case 4:
 			m.scrapeEnabled = !m.scrapeEnabled

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -501,7 +501,15 @@ func (m *Model) handleSettingsKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 
 		case 3:
-			m.moveFiles = !m.moveFiles
+			newMove := !m.moveFiles
+			// --link-mode is incompatible with move mode (issue #36); startup rejects
+			// this combo via ValidateMoveLinkMode. Refuse the runtime toggle when
+			// enabling move while link mode is active, preserving the invariant.
+			if newMove && !m.canEnableMoveMode() {
+				m.AddLog("warn", "Cannot enable move mode while link mode is active; restart without --link-mode to use move mode")
+				break
+			}
+			m.moveFiles = newMove
 			if m.processor != nil {
 				m.processor.SetMoveFiles(m.moveFiles)
 			}

--- a/web/frontend/src/routes/review/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/review/[jobId]/+page.svelte
@@ -366,7 +366,7 @@
 
 <PosterCropModal
 	bind:show={s.showPosterCropModal}
-	posterCropSaving={s.posterCropMutation.isPending}
+	posterCropSaving={s.posterCropSaving}
 	posterCropLoadError={s.posterCropLoadError}
 	cropSourceURL={s.cropSourceURL}
 	cropMetrics={s.cropMetrics}

--- a/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.test.ts
+++ b/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createPosterCropController, type PosterCropDragState } from './poster-crop-controller';
+import type { FileResult, Movie } from '$lib/api/types';
+import type { PosterCropBox, PosterCropMetrics, PosterCropState } from '../review-utils';
+
+interface CallLog {
+	calls: string[];
+	applyPosterFromUrlAsync: ReturnType<typeof vi.fn>;
+	mutatePosterCropAsync: ReturnType<typeof vi.fn>;
+	setCropApplying: ReturnType<typeof vi.fn>;
+}
+
+function makeController(opts: {
+	editedPosterUrl?: string;
+	serverPosterUrl?: string;
+	cropBox?: PosterCropBox | null;
+	maxPosterHeight?: number | null;
+	persistRejects?: boolean;
+}): { controller: ReturnType<typeof createPosterCropController>; log: CallLog } {
+	const movie: Movie = {
+		id: 'STARS-136',
+		title: 'Test Movie',
+		poster_url: opts.editedPosterUrl ?? 'https://dmm/jacket-full.jpg'
+	};
+	const result: FileResult = {
+		result_id: 'res-1',
+		file_path: '/tmp/test-video.mp4',
+		movie_id: 'STARS-136',
+		status: 'completed',
+		started_at: '',
+		data: {
+			id: 'STARS-136',
+			title: 'Test Movie',
+			poster_url: opts.serverPosterUrl ?? 'https://dmm/digital-poster.jpg'
+		}
+	};
+
+	const calls: string[] = [];
+	const applyPosterFromUrlAsync = vi.fn(async (_resultId: string, _url: string) => {
+		calls.push('persist');
+		if (opts.persistRejects) throw new Error('download failed');
+	});
+	const mutatePosterCropAsync = vi.fn(async (_jobId: string, _resultId: string, _crop: PosterCropBox, _max?: number) => {
+		calls.push('crop');
+	});
+	const setCropApplying = vi.fn((applying: boolean) => {
+		calls.push(`applying:${applying}`);
+	});
+
+	const noop = () => {};
+	const log: CallLog = { calls, applyPosterFromUrlAsync, mutatePosterCropAsync, setCropApplying };
+
+	const controller = createPosterCropController({
+		getBrowser: () => true,
+		getJobId: () => 'job-1',
+		getCurrentMovie: () => movie,
+		getCurrentResult: () => result,
+		getShowPosterCropModal: () => true,
+		setShowPosterCropModal: noop,
+		setPosterCropLoadError: noop,
+		getCropSourceURL: () => '',
+		setCropSourceURL: noop,
+		getCropImageElement: () => null,
+		setCropImageElement: noop,
+		getCropMetrics: () => null,
+		setCropMetrics: noop,
+		getCropBox: () => opts.cropBox === undefined ? { x: 0, y: 0, width: 100, height: 200 } : opts.cropBox,
+		setCropBox: noop,
+		getMaxPosterHeight: () => opts.maxPosterHeight === undefined ? null : opts.maxPosterHeight,
+		setMaxPosterHeight: noop,
+		getCropDragState: (): PosterCropDragState | null => null,
+		setCropDragState: noop,
+		getPosterCropStates: () => new Map<string, PosterCropState>(),
+		applyPosterFromUrlAsync,
+		mutatePosterCropAsync,
+		setCropApplying
+	});
+
+	return { controller, log };
+}
+
+describe('applyPosterCrop — persist edited URL before cropping (issue #37)', () => {
+	it('persists the edited poster URL before applying the crop when URL differs from server', async () => {
+		const { controller, log } = makeController({
+			editedPosterUrl: 'https://dmm/jacket-full.jpg',
+			serverPosterUrl: 'https://dmm/digital-poster.jpg'
+		});
+
+		await controller.applyPosterCrop();
+
+		// Persist was called with the edited URL, before the crop.
+		expect(log.applyPosterFromUrlAsync).toHaveBeenCalledWith('res-1', 'https://dmm/jacket-full.jpg');
+		expect(log.mutatePosterCropAsync).toHaveBeenCalledTimes(1);
+		expect(log.calls).toEqual(['applying:true', 'persist', 'crop', 'applying:false']);
+	});
+
+	it('does not persist when the poster URL matches the server (no client-side edit)', async () => {
+		const sameUrl = 'https://dmm/digital-poster.jpg';
+		const { controller, log } = makeController({
+			editedPosterUrl: sameUrl,
+			serverPosterUrl: sameUrl
+		});
+
+		await controller.applyPosterCrop();
+
+		expect(log.applyPosterFromUrlAsync).not.toHaveBeenCalled();
+		expect(log.mutatePosterCropAsync).toHaveBeenCalledTimes(1);
+		expect(log.calls).toEqual(['applying:true', 'crop', 'applying:false']);
+	});
+
+	it('aborts the crop if persisting the URL fails, but still clears cropApplying', async () => {
+		const { controller, log } = makeController({
+			editedPosterUrl: 'https://dmm/jacket-full.jpg',
+			serverPosterUrl: 'https://dmm/digital-poster.jpg',
+			persistRejects: true
+		});
+
+		await controller.applyPosterCrop();
+
+		expect(log.applyPosterFromUrlAsync).toHaveBeenCalledTimes(1);
+		expect(log.mutatePosterCropAsync).not.toHaveBeenCalled();
+		// finally block still runs
+		expect(log.calls).toContain('applying:false');
+		expect(log.calls).not.toContain('crop');
+	});
+
+	it('passes maxPosterHeight through to the crop mutation', async () => {
+		const sameUrl = 'https://dmm/poster.jpg';
+		const { controller, log } = makeController({
+			editedPosterUrl: sameUrl,
+			serverPosterUrl: sameUrl,
+			maxPosterHeight: 1200
+		});
+
+		await controller.applyPosterCrop();
+
+		expect(log.mutatePosterCropAsync).toHaveBeenCalledWith('job-1', 'res-1', expect.any(Object), 1200);
+	});
+
+	it('does nothing when there is no crop box', async () => {
+		const { controller, log } = makeController({
+			editedPosterUrl: 'https://dmm/jacket-full.jpg',
+			serverPosterUrl: 'https://dmm/digital-poster.jpg',
+			cropBox: null
+		});
+
+		await controller.applyPosterCrop();
+
+		expect(log.applyPosterFromUrlAsync).not.toHaveBeenCalled();
+		expect(log.mutatePosterCropAsync).not.toHaveBeenCalled();
+		expect(log.setCropApplying).not.toHaveBeenCalled();
+	});
+});

--- a/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.ts
+++ b/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.ts
@@ -36,7 +36,9 @@ interface PosterCropControllerDeps {
 	getCropDragState: () => PosterCropDragState | null;
 	setCropDragState: (state: PosterCropDragState | null) => void;
 	getPosterCropStates: () => Map<string, PosterCropState>;
-	mutatePosterCrop: (jobId: string, resultId: string, crop: PosterCropBox, maxPosterHeight?: number) => void;
+	applyPosterFromUrlAsync: (resultId: string, url: string) => Promise<void>;
+	mutatePosterCropAsync: (jobId: string, resultId: string, crop: PosterCropBox, maxPosterHeight?: number) => Promise<void>;
+	setCropApplying: (applying: boolean) => void;
 	now?: () => number;
 }
 
@@ -219,14 +221,32 @@ export function createPosterCropController(deps: PosterCropControllerDeps) {
 		return `left:${left}px;top:${top}px;width:${width}px;height:${height}px;box-shadow:0 0 0 9999px rgba(0,0,0,0.45);`;
 	}
 
-	function applyPosterCrop() {
+	async function applyPosterCrop() {
 		const currentMovie = deps.getCurrentMovie();
 		const currentResult = deps.getCurrentResult();
 		const cropBoxVal = deps.getCropBox();
 		if (!currentMovie || !currentResult || !cropBoxVal) return;
 
-		const maxPosterHeight = deps.getMaxPosterHeight();
-		deps.mutatePosterCrop(deps.getJobId(), currentResult.result_id, cropBoxVal, maxPosterHeight ?? undefined);
+		deps.setCropApplying(true);
+		try {
+			// If the poster URL was edited client-side (not yet persisted to the
+			// server), persist it first so the crop endpoint operates on the
+			// edited image ({movieId}-full.jpg) rather than the stale scraped
+			// poster that still lives server-side. Without this, the crop modal
+			// shows the edited URL (via the image proxy) but the backend would
+			// crop the original scraped image, reverting the preview.
+			const serverPosterUrl = currentResult.data?.poster_url;
+			if (currentMovie.poster_url && serverPosterUrl && currentMovie.poster_url !== serverPosterUrl) {
+				await deps.applyPosterFromUrlAsync(currentResult.result_id, currentMovie.poster_url);
+			}
+
+			const maxPosterHeight = deps.getMaxPosterHeight();
+			await deps.mutatePosterCropAsync(deps.getJobId(), currentResult.result_id, cropBoxVal, maxPosterHeight ?? undefined);
+		} catch {
+			// Errors are surfaced via toasts in the mutation handlers; abort the flow.
+		} finally {
+			deps.setCropApplying(false);
+		}
 	}
 
 	function handleWindowResize() {

--- a/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
@@ -106,6 +106,11 @@ export function createReviewMutations(deps: ReviewMutationsDeps) {
 		posterFromUrlMutation.mutate({ resultId, url });
 	}
 
+	async function applyPosterFromUrlAsync(resultId: string, url: string) {
+		if (!deps.getJob()) return;
+		await posterFromUrlMutation.mutateAsync({ resultId, url });
+	}
+
 	const excludeMovieMutation = createMutation(() => ({
 		mutationFn: async ({ jobId: mutationJobId, resultId }: { jobId: string; resultId: string }) => {
 			return deps.excludeBatchMovie(mutationJobId, resultId);
@@ -196,6 +201,10 @@ export function createReviewMutations(deps: ReviewMutationsDeps) {
 		}
 	}));
 
+	async function applyPosterCropAsync(jobId: string, resultId: string, crop: PosterCropBox, maxPosterHeight?: number) {
+		await posterCropMutation.mutateAsync({ jobId, resultId, crop, maxPosterHeight });
+	}
+
 	const bulkExcludeMutation = createMutation(() => ({
 		mutationFn: async ({ resultIds }: { resultIds: string[] }) => {
 			return deps.batchExcludeMovies(deps.getJobId(), { result_ids: resultIds });
@@ -259,10 +268,12 @@ export function createReviewMutations(deps: ReviewMutationsDeps) {
 	return {
 		posterFromUrlMutation,
 		applyPosterFromUrl,
+		applyPosterFromUrlAsync,
 		excludeMovieMutation,
 		bulkExcludeMutation,
 		bulkRescrapeMutation,
 		saveEditsMutation,
-		posterCropMutation
+		posterCropMutation,
+		applyPosterCropAsync
 	};
 }

--- a/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
@@ -132,6 +132,7 @@ export function createReviewState(pageStore: Page) {
 	let cropBox = $state<PosterCropBox | null>(null);
 	let maxPosterHeight = $state<number | null>(null);
 	let cropDragState = $state<PosterCropDragState | null>(null);
+	let cropApplying = $state(false);
 	let posterPreviewOverrides = new SvelteMap<string, PosterPreviewOverride>();
 	let posterCropStates = new SvelteMap<string, PosterCropState>();
 
@@ -678,9 +679,11 @@ export function createReviewState(pageStore: Page) {
 		getCropDragState: () => cropDragState,
 		setCropDragState: (state) => { cropDragState = state; },
 		getPosterCropStates: () => posterCropStates,
-		mutatePosterCrop: (mutationJobId, resultId, crop, maxPosterHeightArg) => {
-			mutations.posterCropMutation.mutate({ jobId: mutationJobId, resultId, crop, maxPosterHeight: maxPosterHeightArg });
-		}
+		applyPosterFromUrlAsync: (resultId, url) => mutations.applyPosterFromUrlAsync(resultId, url),
+		mutatePosterCropAsync: (mutationJobId, resultId, crop, maxPosterHeightArg) => {
+			return mutations.applyPosterCropAsync(mutationJobId, resultId, crop, maxPosterHeightArg);
+		},
+		setCropApplying: (applying) => { cropApplying = applying; }
 	});
 
 	const reviewPageController = createReviewPageController({
@@ -1008,6 +1011,7 @@ export function createReviewState(pageStore: Page) {
 		get canOrganize() { return canOrganize; },
 		posterFromUrlMutation: mutations.posterFromUrlMutation,
 		posterCropMutation: mutations.posterCropMutation,
+		get posterCropSaving() { return mutations.posterCropMutation.isPending || cropApplying; },
 		bulkExcludeMutation: mutations.bulkExcludeMutation,
 		bulkRescrapeMutation: mutations.bulkRescrapeMutation,
 		resolvePosterUrl,


### PR DESCRIPTION
## Summary

Three review-driven bug fixes bundled here (all from issue-tracked + in-session review work). Each was iterated through multi-round code review until zero substantive issues remained.

### 1. TUI log leak (default dual-output config) — `db50158a` → `5dddd111`

The TUI only redirected logging when `cfg.Logging.Output` was **exactly** `"stdout"`. The default config is `"stdout,data/logs/javinizer.log"` (dual output), so the `stdout` target stayed active and logs leaked into the terminal, corrupting the TUI display.

- New `logging.FileOnlyOutput(output, defaultPath)` helper strips `stdout`/`stderr` from any comma-separated output (file-only), defaulting to `data/logs/javinizer-tui.log` when no file targets remain.
- Extracted pure `configureTUILogging(cfg, verbose)` helper (does **not** mutate `cfg`, so no session-override leakage on save) — preserves rotation settings + verbose override.
- `InitLogger` now **errors** on zero valid outputs instead of silently falling back to `os.Stdout` (the latent leak vector when `FileOnlyOutput` returns `""`).
- Fixed a **pre-existing startup leak**: `initConfig` now strips `stdout`/`stderr` for the TUI subcommand (via `isTUICommand`) *before* the first `InitLogger`, so the `"Log file: …"` startup message no longer flashes on the terminal before AltScreen activates. Only `logCfg.Output` is modified (not `cfg.Logging.Output`), so the `JAVINIZER_LOG_DIR` relocation check still compares correctly.
- `Normalize` now defaults an empty `Logging.Output` to the standard dual-output target, so an API config update without an explicit `output` no longer reaches `InitLogger` with no valid targets.

End-to-end stdout-leak tests (`os.Pipe` capture) + a non-vacuous contrast test proving the detector catches leaks. The startup-leak test was verified to fail when the fix is disabled.

### 2. Move Files setting persistence (#36) — `198e7784` → `da4dac93`

The TUI "Move Files" toggle wasn't persisted across restarts (hardcoded `false` on startup; no backing config field). Additionally, `saveConfig` leaked CLI/env session overrides into `config.yaml`.

- New real `Output.MoveFiles` config field; TUI loads it on startup and syncs model ↔ processor.
- `saveConfig` now uses an atomic `config.Update(path, mutate)` (read-modify-write under the file lock) — eliminates a TOCTOU race and prevents session-override leakage. Pinned by `TestUpdateConcurrentWritersNoLostUpdates` (100 concurrent writers → exactly 100).
- `--move` CLI flag remains a session-only override (not written back).

Closes #36.

### 3. Poster-crop URL persistence (#37) — `b6c5d6ac`, `e1d1f94a`

A manually-edited poster URL wasn't persisted before opening the crop modal, so the crop operated on the wrong source image.

- Persist the edited poster URL before launching manual crop.
- Regression test covering the persist-before-crop flow.

Closes #37.

## Verification

- `gofmt`, `go vet`, `golangci-lint` (0 issues), `go test -short ./...` all pass.
- `-race` clean on `internal/logging`, `cmd/javinizer`, `internal/tui`, `internal/api/system`, `internal/config`.
- All leak-detection tests proven non-vacuous (fail when the fix is disabled).
- The log-leak fix went through 4 rounds of 3-reviewer consensus, converging to zero blockers/mediums.

## Commits

```
5dddd111 test(logging): use io.ReadAll for stdout pipe capture consistency
3d638ab1 test(tui): round-3 polish for log-leak fix review
1d276a40 test(tui): close round-2 review gaps on log-leak fix
f852c1cd fix(tui): harden log-leak fix per review (startup leak, tests, guards)
db50158a fix(tui): strip stdout/stderr from TUI logger so logs don't leak
da4dac93 test(config): prove config.Update atomicity (no lost updates)
683c8e71 fix(tui): atomic config update for move-files persistence
ac1320a8 fix(tui): prevent config leakage + harden move-files persistence
198e7784 fix(tui): persist Move Files setting across restarts
e1d1f94a test(web): cover persist-before-crop in poster crop controller
b6c5d6ac fix(web): persist edited poster URL before manual crop
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `move_files` output setting (move vs copy), persisted via TUI, with move/link mode validation and `--move` overriding config.
  * Poster cropping now uses async updates, supports poster URL edits before cropping, and displays an “applying” state.

* **Bug Fixes**
  * TUI startup logging is redirected to a dedicated log file to prevent terminal output corruption; the displayed “Log file” path is accurate with log-directory routing.
  * Improved behavior when logging output is empty by restoring default logging settings on reload.

* **Documentation**
  * Updated config examples and Swagger schema to document `move_files`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->