### PR TITLE
ci(codecov): supply upload token + fail loud on upload error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,8 @@ jobs:
         files: ./coverage.out
         flags: unittests
         name: codecov-javinizer
-        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
         verbose: true
 
     - name: Archive coverage report


### PR DESCRIPTION
## Summary

CodeCov uploads have been **silently failing** on every `main` push and every PR with:

```
HTTP 400: "Token required because branch is protected"
```

`fail_ci_if_error: false` kept the job green, so the breakage went unnoticed — it looked like CodeCov "stopped reporting on main." The `CODECOV_TOKEN` repo secret is now configured, and this PR wires it in + makes upload failures visible.

## Root cause (from the CI logs)

- The `Upload coverage to Codecov` step runs on every push/PR ✓
- The upload itself is **rejected** (HTTP 400 "Token required because branch is protected") — a CodeCov-side setting requires a token for this repo, but the action ran tokenless
- `fail_ci_if_error: false` swallowed the error → CI stayed green → silent regression
- Confirmed repo-wide (not main-specific): a completed PR run failed with the identical 400
- No `CODECOV_TOKEN` secret existed until just now

## Change

`.github/workflows/test.yml` — the `Upload coverage to Codecov` step:

```diff
         name: codecov-javinizer
-        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
         verbose: true
```

Two parts:
1. **`token: ${{ secrets.CODECOV_TOKEN }}`** — authenticate the upload. `CODECOV_TOKEN` is now set as a repo secret (verified via `gh secret list`).
2. **`fail_ci_if_error: true`** — so a future upload breakage fails CI loudly instead of being swallowed. Safe to flip now that the token is supplied; the PR's own CI run will prove the upload succeeds before this merges.

## Verification path

This PR's `Unit Tests & Coverage` job will run the Codecov upload with the token. **If that job is green, the token works** — confirming uploads succeed before this hits `main`. If it's red, the token/upload is still broken and this should NOT merge (investigate before merging).

## Notes

- The action pin (`codecov/codecov-action@fb8b358…` v7) is unchanged.
- `id-token: write` is already set on the job (for potential OIDC); the explicit token is the reliable path.
- If, after merge, you'd prefer tokenless OIDC instead, the CodeCov GitHub App must be installed on the repo — separate concern, not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI to use the configured Codecov token during test uploads.
  * Test runs will now fail if the Codecov upload encounters an error, helping catch reporting issues sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->