### PR TITLE
fix(web): Rescrape button fails with 'Unable to open rescrape: movie not found'

### DIFF
--- a/web/frontend/src/routes/review/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/review/[jobId]/+page.svelte
@@ -267,7 +267,7 @@
 								currentResult={s.currentResult}
 								bind:showFieldScraperSources={s.showFieldScraperSources}
 								isRescraping={s.rescrapingStates.get(s.currentResult?.result_id || '') || false}
-								onOpenRescrape={() => s.currentResult && s.openRescrapeModal(s.currentResult.result_id)}
+								onOpenRescrape={() => s.currentResult && s.openRescrapeModal(s.currentResult.movie_id)}
 								onResetCurrentMovie={s.resetCurrentMovie}
 								onUpdateCurrentMovie={s.updateCurrentMovie}
 							/>


### PR DESCRIPTION
## Problem

Clicking **Rescrape** on a completed movie in the review page shows a toast:

> Unable to open rescrape: movie not found

and never opens the rescrape modal.

## Root cause

The Rescrape button call site passes the wrong identifier to `openRescrapeModal`:

```ts
// +page.svelte
onOpenRescrape={() => s.currentResult && s.openRescrapeModal(s.currentResult.result_id)}
```

But `openRescrapeModal` resolves the movie by looking up `movieGroups` keyed on `movie_id`:

```ts
// review-state.svelte.ts
async function openRescrapeModal(movieId: string) {
    ...
    const group = movieGroups.find((g) => g.movieId === movieId); // g.movieId === result.movie_id
    if (!group) {
        toastStore.error('Unable to open rescrape: movie not found');
        return;
    }
    await rescrapeController.openRescrapeModal(group.primaryResult.result_id);
}
```

`result_id` != `movie_id` (both are `string` fields on `FileResult`, but distinct values), so the `find` always misses -> the error toast.

This regressed when the call site was switched to the stable `result_id` during the stable-ResultID refactor, but `openRescrapeModal` still keys the group lookup on `movie_id`.

## Fix

Pass `currentResult.movie_id` — the exact value `movieGroups` is keyed on — so the group resolves and the modal opens with `group.primaryResult.result_id`:

```diff
- onOpenRescrape={() => s.currentResult && s.openRescrapeModal(s.currentResult.result_id)}
+ onOpenRescrape={() => s.currentResult && s.openRescrapeModal(s.currentResult.movie_id)}
```

## Verification

- `svelte-check`: 0 errors / 0 warnings
- `vitest`: 224 tests pass (12 files)
- `vite build`: succeeds
- Type-safe: `FileResult.movie_id` is a `string`, matching `openRescrapeModal(movieId: string)`

No unit test added: the store is Svelte 5 rune-based (`$derived`/`$state`) and isn't importable into a plain vitest test (the existing `review-state.test.ts` reimplements logic locally for the same reason). The fix is a single, inspection-verifiable identifier correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Open rescrape” action in the Movies detail view now uses the correct movie identifier, so rescrape requests open for the intended item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->