### PR TITLE
fix(web): no feedback when Reload Config pressed

### DIFF
--- a/web/frontend/src/routes/settings/+page.svelte
+++ b/web/frontend/src/routes/settings/+page.svelte
@@ -92,9 +92,9 @@
 				</div>
 			</div>
 			<div class="flex gap-2">
-				<Button variant="outline" onclick={settings.reloadConfig} disabled={settings.loading}>
+				<Button variant="outline" onclick={settings.reloadConfig} disabled={settings.loading || settings.reloading}>
 					{#snippet children()}
-						<RefreshCw class="h-4 w-4 mr-2" />
+						<RefreshCw class="h-4 w-4 mr-2 {settings.reloading ? 'animate-spin' : ''}" />
 						Reload
 					{/snippet}
 				</Button>

--- a/web/frontend/src/routes/settings/stores/settings-store.svelte.ts
+++ b/web/frontend/src/routes/settings/stores/settings-store.svelte.ts
@@ -218,28 +218,46 @@ export function createSettingsStore(deps: SettingsStoreDeps): SettingsStore {
 		if (!translation.anthropic.api_key) translation.anthropic.api_key = '';
 	}
 
+	// Rehydrate local state from a config payload. Shared by the initial-load
+	// $effect below and reloadConfig so the rehydrate steps live in one place.
+	// Callers own configInitialized: the effect sets it on first hydration; reload
+	// leaves it true (it only ever means "config is populated", and `reloading`
+	// signals the in-flight reload to the UI instead).
+	function applyConfigData(data: Config): void {
+		config = JSON.parse(JSON.stringify(data));
+		ensureProxyProfilesInitialized();
+		ensureTranslationConfig();
+		deps.onConfigInitialized();
+		updateProxyConfigBaseline();
+	}
+
 	$effect(() => {
 		const data = configQuery.data;
 		if (data && !configInitialized) {
 			untrack(() => {
 				configInitialized = true;
-				config = JSON.parse(JSON.stringify(data));
-				ensureProxyProfilesInitialized();
-				ensureTranslationConfig();
-				deps.onConfigInitialized();
-				updateProxyConfigBaseline();
+				applyConfigData(data);
 			});
 		}
 	});
 
 	async function reloadConfig() {
 		reloading = true;
-		configInitialized = false;
 		try {
 			// throwOnError makes refetchQueries reject on a failed fetch instead of
 			// silently swallowing the error (its default `.catch(noop)`), so the
 			// catch below can surface a failure toast to the user.
 			await queryClient.refetchQueries({ queryKey: ['config'] }, { throwOnError: true });
+			// Rehydrate from the awaited refetch result directly. We deliberately do
+			// NOT reset configInitialized to false before the await: that would let
+			// the rehydrating $effect above re-run against the still-cached (stale)
+			// configQuery.data and mark us initialized again before this fresh
+			// payload lands, so the new values would never get applied. On error we
+			// leave config as the last-known-good (configInitialized stays true).
+			const data = configQuery.data;
+			if (data) {
+				applyConfigData(data);
+			}
 			toastStore.success('Configuration reloaded successfully', 4000);
 		} catch (e) {
 			const msg = e instanceof Error ? e.message : 'Failed to reload configuration';

--- a/web/frontend/src/routes/settings/stores/settings-store.svelte.ts
+++ b/web/frontend/src/routes/settings/stores/settings-store.svelte.ts
@@ -19,6 +19,7 @@ export interface SettingsStore {
 	settingsConfig: SettingsConfig | null;
 	configInitialized: boolean;
 	loading: boolean;
+	reloading: boolean;
 	error: string | null;
 	inputClass: string;
 	configQuery: ReturnType<typeof createConfigQuery>;
@@ -57,6 +58,7 @@ export function createSettingsStore(deps: SettingsStoreDeps): SettingsStore {
 	const queryClient = useQueryClient();
 	const configQuery = createConfigQuery();
 	let loading = $derived(configQuery.isPending && !configQuery.data);
+	let reloading = $state(false);
 	let error = $state<string | null>(null);
 	let fetchingTranslationModels = $state(false);
 	let translationModelOptions = $state<string[]>([]);
@@ -231,8 +233,20 @@ export function createSettingsStore(deps: SettingsStoreDeps): SettingsStore {
 	});
 
 	async function reloadConfig() {
+		reloading = true;
 		configInitialized = false;
-		await queryClient.refetchQueries({ queryKey: ['config'] });
+		try {
+			// throwOnError makes refetchQueries reject on a failed fetch instead of
+			// silently swallowing the error (its default `.catch(noop)`), so the
+			// catch below can surface a failure toast to the user.
+			await queryClient.refetchQueries({ queryKey: ['config'] }, { throwOnError: true });
+			toastStore.success('Configuration reloaded successfully', 4000);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : 'Failed to reload configuration';
+			toastStore.error(msg, 5000);
+		} finally {
+			reloading = false;
+		}
 	}
 
 	const saveConfigMutation = createMutation(() => ({
@@ -309,6 +323,9 @@ export function createSettingsStore(deps: SettingsStoreDeps): SettingsStore {
 		},
 		get loading() {
 			return loading;
+		},
+		get reloading() {
+			return reloading;
 		},
 		get error() {
 			return error;


### PR DESCRIPTION
## Problem

Pressing the **Reload** button on the Settings page gives no reactive UI output — the user gets no indication that the config has been reloaded (or that it failed). The button doesn't even disable during the refetch, because `loading = configQuery.isPending && !configQuery.data` stays `false` when data already exists.

```ts
async function reloadConfig() {
    configInitialized = false;
    await queryClient.refetchQueries({ queryKey: ['config'] });
}
```

Silent on both success and failure.

## Fix

Add a `reloading` state plus toast feedback, mirroring the existing `saveConfigMutation` toast pattern:

- `toastStore.success('Configuration reloaded successfully')` on completion
- `toastStore.error(...)` on failure
- `refetchQueries` is called with `{ throwOnError: true }` so it **rejects** on a failed fetch instead of silently swallowing the error with its default `.catch(noop)` (without this, the success toast would fire even when the reload failed)
- The Reload button disables and the refresh icon spins while `reloading` is true

```ts
async function reloadConfig() {
    reloading = true;
    configInitialized = false;
    try {
        await queryClient.refetchQueries({ queryKey: ['config'] }, { throwOnError: true });
        toastStore.success('Configuration reloaded successfully', 4000);
    } catch (e) {
        const msg = e instanceof Error ? e.message : 'Failed to reload configuration';
        toastStore.error(msg, 5000);
    } finally {
        reloading = false;
    }
}
```

## Verification

- `svelte-check`: 0 errors / 0 warnings
- `vitest`: 224 tests pass (12 files)
- `vite build`: succeeds
- `throwOnError` is a valid `RefetchOptions` field (`RefetchOptions extends ResultOptions { throwOnError?: boolean }`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings reload now provides clear success and error notifications once the action finishes.
  * The reload button’s icon animates while a reload is in progress.

* **Bug Fixes**
  * The Reload button is now correctly disabled during both initial settings loading and active reloads, helping prevent duplicate reload attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->