### PR TITLE
fix(poster): preserve ShouldCropPoster so auto-crop runs after rescrape

### DIFF
--- a/internal/poster/generator.go
+++ b/internal/poster/generator.go
@@ -20,8 +20,14 @@ type PosterGenerator interface {
 //  1. Poster→Cover URL fallback: resolves the poster URL from the movie's
 //     PosterURL field, falling back to CoverURL when no explicit poster exists.
 //  2. Movie state mutation: after a successful download, sets
-//     CroppedPosterURL and ShouldCropPoster on the movie so downstream
-//     consumers (API handlers, persistence) see the updated poster state.
+//     CroppedPosterURL on the movie so downstream consumers (API handlers,
+//     persistence) see the updated temp preview poster. It intentionally
+//     does NOT touch ShouldCropPoster: that flag is the aggregator's
+//     source-derived statement about whether the FINAL poster needs
+//     cropping, and the apply-phase downloadPoster relies on it surviving
+//     scrape -> commit -> apply to crop the on-disk poster. Resetting it
+//     here (as an earlier version did) defeated that gate and left the
+//     final folder poster uncropped.
 //  3. Error sanitization: wraps download errors through sanitizedErrorFrom/
 //     stripSensitivePaths so internal filesystem paths never leak to callers.
 //
@@ -77,8 +83,11 @@ func (g *ScrapePosterGenerator) GeneratePoster(ctx context.Context, jobID string
 		return sanitizedErr
 	}
 
+	// CroppedPosterURL points at the temp preview poster (always cropped by
+	// DownloadFromURL). ShouldCropPoster is deliberately left untouched: it is
+	// the aggregator's source-derived flag that the apply-phase downloadPoster
+	// uses to decide whether to crop the FINAL on-disk poster.
 	movie.Poster.CroppedPosterURL = result.CroppedURL
-	movie.Poster.ShouldCropPoster = false
 	return nil
 }
 

--- a/internal/poster/generator_test.go
+++ b/internal/poster/generator_test.go
@@ -54,7 +54,53 @@ func TestScrapePosterGenerator_Success(t *testing.T) {
 	err := gen.GeneratePoster(context.Background(), "test-job", movie)
 	require.NoError(t, err)
 	assert.Contains(t, movie.Poster.CroppedPosterURL, "/api/v1/temp/posters/test-job/TEST-001.jpg")
+	// Input ShouldCropPoster was the zero value (false); GeneratePoster must
+	// preserve it, so it stays false here. See PreservesShouldCropPoster for
+	// the true-input case that guards the rescrape auto-crop regression.
 	assert.False(t, movie.Poster.ShouldCropPoster)
+}
+
+// TestScrapePosterGenerator_PreservesShouldCropPoster locks down the rescrape
+// auto-crop regression (introduced in PR #35): GeneratePoster must NOT reset
+// ShouldCropPoster. The aggregator sets that flag from the poster source
+// (javbus/dmm/javlibrary set it true for landscape covers needing a crop),
+// and the apply-phase Downloader.downloadPoster crops the FINAL on-disk
+// poster only when ShouldCropPoster is true. If GeneratePoster forces it to
+// false (as it once did), the aggregator's value is destroyed during the
+// scrape/rescrape phase and the final folder poster ends up uncropped.
+// CroppedPosterURL is still populated (the temp preview is always cropped by
+// DownloadFromURL) — only the source-derived crop flag must survive.
+func TestScrapePosterGenerator_PreservesShouldCropPoster(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		img := image.NewRGBA(image.Rect(0, 0, 200, 300))
+		w.Header().Set("Content-Type", "image/jpeg")
+		_ = jpeg.Encode(w, img, &jpeg.Options{Quality: 90})
+	}))
+	defer srv.Close()
+
+	fs := afero.NewMemMapFs()
+	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	gen := NewScrapePosterGenerator(pm, "TestAgent", "")
+
+	// Simulate a cropping source (e.g. javbus/dmm): the aggregator has set
+	// ShouldCropPoster=true because the source poster is a landscape cover.
+	movie := &models.Movie{
+		ID: "CROP-001",
+		Poster: models.PosterState{
+			PosterURL:        srv.URL + "/poster.jpg",
+			ShouldCropPoster: true,
+		},
+	}
+	err := gen.GeneratePoster(context.Background(), "test-job", movie)
+	require.NoError(t, err)
+
+	// The temp preview poster is generated and its URL recorded.
+	assert.Contains(t, movie.Poster.CroppedPosterURL, "/api/v1/temp/posters/test-job/CROP-001.jpg")
+
+	// The source-derived crop flag must survive GeneratePoster so the
+	// apply-phase downloadPoster crops the final on-disk poster.
+	assert.True(t, movie.Poster.ShouldCropPoster,
+		"GeneratePoster must not reset ShouldCropPoster; the apply phase relies on the aggregator's source-derived value")
 }
 
 func TestScrapePosterGenerator_UsesCoverURLFallback(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the poster auto-crop regression introduced in #35. After a fresh scrape or rescrape, the **final on-disk poster in the movie folder was not auto-cropped** for landscape-cover sources (javbus/dmm/javlibrary), even though the temp preview poster shown in the review UI *was* cropped.

## Root cause

`ShouldCropPoster` is overloaded and the scrape phase clobbered the value the apply phase needs:

1. The **aggregator** sets `ShouldCropPoster = true` for sources whose poster is a landscape cover needing a crop (`internal/aggregator/aggregate.go`, `assignShouldCropPoster`). Meaning: "this source's poster needs cropping."
2. `GeneratePoster` runs in **both** the scrape phase (`scrape_phase.go`) and the rescrape phase (`rescrape_phase.go`). After generating the temp preview poster it executed `movie.Poster.ShouldCropPoster = false` (`internal/poster/generator.go`). Meaning: "I've cropped the temp poster." This **destroyed** the aggregator's value.
3. The **apply-phase** `downloadPoster` re-downloads the ORIGINAL URL and crops it ONLY IF `ShouldCropPoster` is true (`internal/downloader/media.go`). It reads the flag as "should I crop the final poster?"

Net effect: after `GeneratePoster` ran, `ShouldCropPoster` was `false` → apply downloaded the original image directly, WITHOUT cropping. The final folder poster was uncropped. The apply phase does not re-derive the flag; it uses the committed movie, which carried `false`.

## The fix

In `internal/poster/generator.go` (`GeneratePoster`), **remove** `movie.Poster.ShouldCropPoster = false`. Keep `movie.Poster.CroppedPosterURL = result.CroppedURL`.

`GeneratePoster`'s job is to produce the temp preview poster (which `DownloadFromURL` always crops — an independent path). It must NOT mutate `ShouldCropPoster`, which is the aggregator's statement about the SOURCE and which the apply phase relies on to crop the final poster. After the fix, the aggregator's source-derived `ShouldCropPoster` survives `scrape → commit → apply`, so `downloadPoster` crops the final poster correctly.

The hypothesis (that the `= false` in `GeneratePoster` defeated the apply-phase crop gate) was confirmed correct by tracing the data flow and git history (the line was introduced in #35).

## Manual poster-edit path is unchanged

Other sites that set `ShouldCropPoster = false` are correct and were left alone:

- `internal/worker/poster_editor.go` (`UpdatePosterCrop`, `UpdatePosterFromURL`) — handle the user MANUALLY changing/choosing a poster URL in the review UI. The manual path sets `ShouldCropPoster = false` independently of `GeneratePoster` (the user picked a final poster; the cropped preview is already generated; no apply-phase crop is wanted). Removing the line from `GeneratePoster` does **not** regress the manual-poster-URL-change case.
- `internal/scraper/r18dev/r18dev.go` — a scraper deciding its own flag for a specific source case.

The fix is localized to `internal/poster/generator.go` only. No changes to `poster_editor.go`, `media.go`, `aggregate.go`, or any scraper.

## Tests

Added `TestScrapePosterGenerator_PreservesShouldCropPoster` (`internal/poster/generator_test.go`): builds a movie with `ShouldCropPoster: true` (simulating a cropping source), runs `GeneratePoster`, and asserts `ShouldCropPoster` is **still `true`** while `CroppedPosterURL` is populated. This locks down the regression.

No existing test assertions required changes. All other `assert.False(ShouldCropPoster)` sites in `batch_job_*_test.go`, `batch_job_test.go`, and `rescrape_crop_edge_test.go` exercise the **manual** poster-editor path (`UpdatePosterCrop`/`UpdatePosterFromURL`), which sets `false` itself — independent of `GeneratePoster` — so they remain correct. This was verified by running the full suite, not by assumption.

## Verification

- `gofmt -l .` → empty
- `go build ./...` → ok
- `go test ./internal/poster/... ./internal/worker/... ./internal/downloader/... ./internal/aggregator/...` → all pass
- `go test ./...` → **97 packages ok, 0 FAIL**
- pre-commit hooks (gofmt, golangci-lint, go vet, tests, build, swagger) → all pass

Fixes the regression introduced in #35.

🤖 Generated as part of swarm task-48.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved poster generation so the app now preserves the existing crop setting after downloading a preview poster.
  * Poster downloads continue to update the poster URL, while the crop choice is now left intact for the later apply step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->