### PR TITLE
fix(web): remove stray '}' in Rescrape modal title

### DIFF
--- a/web/frontend/src/routes/review/[jobId]/components/RescrapeModal.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/RescrapeModal.svelte
@@ -66,7 +66,7 @@
 					{#if bulkMovieCount}
 						Rescrape {bulkMovieCount} movie{bulkMovieCount !== 1 ? 's' : ''}
 					{:else}
-						{manualSearchMode ? 'Manual Search' : `Rescrape ${rescrapeMovieName || rescrapeMovieId}`}}
+						{manualSearchMode ? 'Manual Search' : `Rescrape ${rescrapeMovieName || rescrapeMovieId}`}
 					{/if}
 				</h2>
 					<Button variant="ghost" size="icon" onclick={close} disabled={rescraping}>


### PR DESCRIPTION
## Problem

The Rescrape modal title rendered a stray trailing `}`, e.g.

> Rescrape STARS-136}

instead of

> Rescrape STARS-136

## Root cause

In `web/frontend/src/routes/review/[jobId]/components/RescrapeModal.svelte`, line 69 ended with a double `}}`:

```svelte
{manualSearchMode ? 'Manual Search' : `Rescrape ${rescrapeMovieName || rescrapeMovieId}`}}
```

In Svelte, the first `}` closes the `{...}` expression; the **second** `}` is a literal character rendered into the DOM — that literal is the stray `}` the user sees in the title.

## Fix

Remove the extra trailing `}` so the title uses a single `}`:

```svelte
{manualSearchMode ? 'Manual Search' : `Rescrape ${rescrapeMovieName || rescrapeMovieId}`}
```

This matches the bulk-title form on line 67 (`Rescrape {bulkMovieCount} movie...`). One-character deletion; nothing else in the file changed.

## Verification

- `npx svelte-check --threshold error` → 0 errors, 0 warnings
- `npx vitest run` → 224 passed (12 files)
- `npm run build` → success
- Pre-commit hooks (fmt, golangci-lint, go vet, tests, build, swagger, svelte-check) all green
- Frontend-only change; no backend/Go changes

> Note: branch is pushed directly to this repo (not a fork) because the contributor has admin access; intended for squash-merge to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Rescrape modal header label in review workflows to display the correct action text more consistently (especially when no bulk movie count is present).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->