### PR TITLE
fix(update): wire background update checker + startup check (#39)

### DIFF
--- a/internal/api/core/bootstrap.go
+++ b/internal/api/core/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/template"
+	"github.com/javinizer/javinizer-go/internal/update"
 	"github.com/javinizer/javinizer-go/internal/worker"
 	"github.com/spf13/afero"
 )
@@ -76,6 +77,10 @@ func bootstrapAPIDeps(cfg *config.Config, configFile string, auth commandutil.Au
 
 	rt.SetConfig(cfg)
 	rt.EnsureRuntime()
+
+	// Start the background update checker, gated on cfg.System.VersionCheckEnabled.
+	// Bound to rt.ServerCtx() so it stops cleanly on rt.Shutdown().
+	startUpdateChecker(rt, cfg, update.ServiceOptions{})
 
 	// Temp poster cleanup is intentionally NOT started automatically.
 	// Running CleanupStaleTempDirs on startup (or on a periodic ticker) wipes

--- a/internal/api/core/update_checker.go
+++ b/internal/api/core/update_checker.go
@@ -31,11 +31,18 @@ func startUpdateChecker(rt *APIRuntime, cfg *config.Config, opts update.ServiceO
 
 	ctx := rt.ServerCtx()
 
-	// One-shot check warms the cache before the first GetStatus read so the
-	// nil-state skip in GetStatus stays benign for fresh installs. Errors are
-	// logged inside BackgroundCheck and never propagate to the caller, so a
-	// transient network failure cannot break startup.
-	go svc.BackgroundCheck(ctx)
+	// One-shot check warms the cache SYNCHRONOUSLY before the first GetStatus
+	// read so the nil-state skip in GetStatus stays benign for fresh installs.
+	// This runs blocking (not `go`) by design: dispatching it as a goroutine would
+	// let GetStatus race ahead of the cache write and return UpdateSourceNone on
+	// the very first read — defeating the warm-up. BackgroundCheck bounds itself
+	// with a 30s context timeout (and the GitHub HTTP client has a 10s timeout),
+	// so the worst-case startup delay on a network failure is bounded; the common
+	// case (GitHub reachable) completes in well under a second. Errors are logged
+	// inside BackgroundCheck and never propagate to the caller, so a transient
+	// network failure delays — but cannot break — startup. Gated on
+	// VersionCheckEnabled above, so a disabled config never blocks.
+	svc.BackgroundCheck(ctx)
 
 	// Periodic ticker; stops when ctx (rt.ServerCtx) is cancelled on shutdown.
 	svc.StartBackgroundCheck(ctx, svc.Interval())

--- a/internal/api/core/update_checker.go
+++ b/internal/api/core/update_checker.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/javinizer/javinizer-go/internal/update"
+)
+
+// startUpdateChecker wires the background update checker into the API server
+// lifecycle. It is gated on cfg.System.VersionCheckEnabled: when disabled, no
+// goroutine is started and no one-shot check fires, so a disabled config never
+// touches the network or the on-disk cache.
+//
+// Both the periodic ticker (StartBackgroundCheck) and the one-shot cache-warming
+// check (BackgroundCheck) are bound to rt.ServerCtx(), which rt.Shutdown()
+// cancels — so background work stops cleanly on server shutdown rather than
+// leaking past process lifetime.
+//
+// opts allows tests to inject a stub Checker (no real network) and a temp-dir
+// StatePath (no real filesystem writes); production callers pass a zero-value
+// ServiceOptions, which reproduces NewService behavior exactly.
+func startUpdateChecker(rt *APIRuntime, cfg *config.Config, opts update.ServiceOptions) {
+	if cfg == nil || !cfg.System.VersionCheckEnabled {
+		return
+	}
+
+	svc := update.NewServiceWithOptions(update.UpdateConfig{
+		Enabled:                   cfg.System.VersionCheckEnabled,
+		VersionCheckIntervalHours: cfg.System.VersionCheckIntervalHours,
+	}, opts)
+
+	ctx := rt.ServerCtx()
+
+	// One-shot check warms the cache before the first GetStatus read so the
+	// nil-state skip in GetStatus stays benign for fresh installs. Errors are
+	// logged inside BackgroundCheck and never propagate to the caller, so a
+	// transient network failure cannot break startup.
+	go svc.BackgroundCheck(ctx)
+
+	// Periodic ticker; stops when ctx (rt.ServerCtx) is cancelled on shutdown.
+	svc.StartBackgroundCheck(ctx, svc.Interval())
+	logging.Infof("Background update checker started (interval: %s)", svc.Interval())
+}

--- a/internal/api/core/update_checker_test.go
+++ b/internal/api/core/update_checker_test.go
@@ -1,0 +1,129 @@
+package core
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/update"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// countingChecker is a stub update.Checker for the API bootstrap wiring tests.
+// It records how many times the latest version was queried and never touches
+// the network, keeping the bootstrap tests hermetic.
+type countingChecker struct {
+	mu      sync.Mutex
+	calls   int
+	version *update.VersionInfo
+}
+
+func (c *countingChecker) CheckLatestVersion(_ context.Context) (*update.VersionInfo, error) {
+	c.mu.Lock()
+	c.calls++
+	c.mu.Unlock()
+	if c.version == nil {
+		return &update.VersionInfo{Version: "v0.0.0", TagName: "v0.0.0"}, nil
+	}
+	return c.version, nil
+}
+
+func (c *countingChecker) callsCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+// newCheckerConfig builds a config with the given version-check flag. The
+// interval is set to 24h so the bootstrap's ticker (derived from config) never
+// fires during a test — only the one-shot startup check is observable, which
+// is exactly the wiring these tests assert.
+func newCheckerConfig(enabled bool) *config.Config {
+	cfg := &config.Config{}
+	cfg.System.VersionCheckEnabled = enabled
+	cfg.System.VersionCheckIntervalHours = 24
+	return cfg
+}
+
+// newCheckerRuntime returns a minimal APIRuntime suitable for exercising
+// startUpdateChecker. startUpdateChecker only touches rt.ServerCtx() (and
+// rt.Shutdown() cancels it), so a bare APIDeps is sufficient and avoids
+// standing up the full database/scraper stack.
+func newCheckerRuntime(t *testing.T) *APIRuntime {
+	t.Helper()
+	return NewAPIRuntime(&APIDeps{})
+}
+
+// stubOpts returns ServiceOptions that inject the stub checker and isolate the
+// on-disk cache to a temp dir, so the bootstrap never hits the network or the
+// real data directory.
+func stubOpts(t *testing.T, chk *countingChecker) update.ServiceOptions {
+	t.Helper()
+	return update.ServiceOptions{
+		Checker:   chk,
+		StatePath: filepath.Join(t.TempDir(), "update_cache.json"),
+	}
+}
+
+// TestStartUpdateChecker_Disabled_DoesNothing covers AC (d) at the bootstrap
+// seam: a disabled config starts no goroutine and never queries the checker.
+func TestStartUpdateChecker_Disabled_DoesNothing(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	chk := &countingChecker{}
+	rt := newCheckerRuntime(t)
+	defer rt.Shutdown()
+
+	startUpdateChecker(rt, newCheckerConfig(false), stubOpts(t, chk))
+
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 0, chk.callsCount(),
+		"disabled config must not start the update checker")
+}
+
+// TestStartUpdateChecker_Enabled_FiresOneShotAndStopsOnShutdown covers ACs (a)
+// and (c) at the bootstrap seam: with version checks enabled, the one-shot
+// startup check fires immediately (warming the cache), and rt.Shutdown()
+// cancels the server context so the background ticker stops cleanly.
+func TestStartUpdateChecker_Enabled_FiresOneShotAndStopsOnShutdown(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	chk := &countingChecker{}
+	rt := newCheckerRuntime(t)
+
+	startUpdateChecker(rt, newCheckerConfig(true), stubOpts(t, chk))
+
+	// The one-shot check is dispatched at startup and must query the stub
+	// before the first GetStatus read would otherwise hit a nil cache.
+	require.Eventually(t, func() bool { return chk.callsCount() >= 1 }, time.Second, 5*time.Millisecond,
+		"one-shot startup check must fire when version checks are enabled")
+
+	callsBeforeShutdown := chk.callsCount()
+	rt.Shutdown()
+
+	// After shutdown the server context is cancelled, so the ticker (24h
+	// interval) must not produce any further checks.
+	time.Sleep(150 * time.Millisecond)
+	assert.Equal(t, callsBeforeShutdown, chk.callsCount(),
+		"rt.Shutdown must stop the background update checker")
+}
+
+// TestStartUpdateChecker_NilConfigIsSafe asserts the bootstrap gate is nil-safe
+// so a misconfigured caller cannot panic startup.
+func TestStartUpdateChecker_NilConfigIsSafe(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	chk := &countingChecker{}
+	rt := newCheckerRuntime(t)
+	defer rt.Shutdown()
+
+	assert.NotPanics(t, func() {
+		startUpdateChecker(rt, nil, stubOpts(t, chk))
+	})
+	assert.Equal(t, 0, chk.callsCount())
+}

--- a/internal/update/checker.go
+++ b/internal/update/checker.go
@@ -26,10 +26,20 @@ type versionInfo struct {
 	PublishedAt string `json:"published_at"` // ISO8601 timestamp
 }
 
-// checker is the interface for checking version information.
-type checker interface {
-	CheckLatestVersion(ctx context.Context) (*versionInfo, error)
+// VersionInfo is the exported alias for versionInfo, enabling external callers
+// (and tests in other packages) to construct values returned by a stub
+// Checker. It is identical to versionInfo — no copy is made.
+type VersionInfo = versionInfo
+
+// Checker is the interface for checking the latest released version.
+// It is exported so callers can inject a stub via NewServiceWithOptions,
+// avoiding real network calls in hermetic tests.
+type Checker interface {
+	CheckLatestVersion(ctx context.Context) (*VersionInfo, error)
 }
+
+// checker is an alias retaining the original unexported name used internally.
+type checker = Checker
 
 // githubChecker checks versions from GitHub releases.
 type githubChecker struct {

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -27,22 +27,62 @@ type UpdateConfig struct {
 	VersionCheckIntervalHours int
 }
 
-// NewService creates a new update service.
+// NewService creates a new update service with production defaults (the real
+// GitHub checker and the default cache path). Existing callers are unaffected.
 func NewService(cfg UpdateConfig) *service {
+	return NewServiceWithOptions(cfg, ServiceOptions{})
+}
+
+// ServiceOptions carries optional overrides for the update service, enabling
+// hermetic tests (a stub Checker and a temp-dir cache path). Zero-value fields
+// fall back to production defaults, so NewService(cfg) and
+// NewServiceWithOptions(cfg, ServiceOptions{}) are equivalent.
+type ServiceOptions struct {
+	// Checker, if non-nil, replaces the default GitHub release checker. Inject
+	// a stub to avoid real network calls in tests.
+	Checker Checker
+	// StatePath overrides the on-disk update cache location. Use t.TempDir() in
+	// tests to avoid writing to the real data directory.
+	StatePath string
+}
+
+// NewServiceWithOptions creates an update service with the given options. A
+// zero-value opts reproduces NewService behavior exactly, so production callers
+// can keep using NewService while tests inject a stub Checker and a temp-dir
+// StatePath for hermetic, network-free coverage.
+func NewServiceWithOptions(cfg UpdateConfig, opts ServiceOptions) *service {
 	interval := time.Duration(cfg.VersionCheckIntervalHours) * time.Hour
 	if interval <= 0 {
 		interval = defaultCheckInterval
 	}
 
-	store := newStateStore(updateStatePath(), interval)
+	statePath := opts.StatePath
+	if statePath == "" {
+		statePath = updateStatePath()
+	}
+
+	store := newStateStore(statePath, interval)
+
+	chk := opts.Checker
+	if chk == nil {
+		chk = newGitHubChecker("javinizer/Javinizer")
+	}
 
 	return &service{
-		checker:   newGitHubChecker("javinizer/Javinizer"),
+		checker:   chk,
 		store:     store,
-		statePath: updateStatePath(),
+		statePath: statePath,
 		interval:  interval,
 		enabled:   cfg.Enabled,
 	}
+}
+
+// Interval returns the normalized interval between background update checks.
+// Exposed so callers (e.g. the API bootstrap) can start the background ticker
+// with the same interval the service uses for staleness checks, rather than
+// re-deriving (and possibly diverging from) the default-interval logic.
+func (s *service) Interval() time.Duration {
+	return s.interval
 }
 
 // GetStatus returns the current update status.

--- a/internal/update/wiring_test.go
+++ b/internal/update/wiring_test.go
@@ -1,0 +1,164 @@
+package update
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// countingChecker is a stub update.Checker that records how many times the
+// latest version was queried. It returns a fixed version immediately and never
+// touches the network, so tests depending on it are hermetic.
+type countingChecker struct {
+	mu      sync.Mutex
+	calls   int
+	version *versionInfo
+}
+
+func (c *countingChecker) CheckLatestVersion(_ context.Context) (*versionInfo, error) {
+	c.mu.Lock()
+	c.calls++
+	c.mu.Unlock()
+	if c.version == nil {
+		return &versionInfo{Version: "v0.0.0", TagName: "v0.0.0"}, nil
+	}
+	return c.version, nil
+}
+
+func (c *countingChecker) callsCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+// newStubService builds a hermetic service backed by a countingChecker and a
+// temp-dir cache path, so tests neither hit the network nor write to the real
+// data directory.
+func newStubService(t *testing.T, enabled bool) (*service, *countingChecker) {
+	t.Helper()
+	chk := &countingChecker{}
+	svc := NewServiceWithOptions(UpdateConfig{
+		Enabled:                   enabled,
+		VersionCheckIntervalHours: 24,
+	}, ServiceOptions{
+		Checker:   chk,
+		StatePath: filepath.Join(t.TempDir(), "update_cache.json"),
+	})
+	return svc, chk
+}
+
+// TestNewServiceWithOptions_ZeroOptsMatchesNewService verifies the injection
+// seam is backward-compatible: a zero-value ServiceOptions reproduces the
+// production constructor exactly (same interval, cache path, enabled flag, and
+// a non-nil real GitHub checker).
+func TestNewServiceWithOptions_ZeroOptsMatchesNewService(t *testing.T) {
+	cfg := UpdateConfig{Enabled: true, VersionCheckIntervalHours: 24}
+	s1 := NewService(cfg)
+	s2 := NewServiceWithOptions(cfg, ServiceOptions{})
+
+	assert.Equal(t, s1.interval, s2.interval)
+	assert.Equal(t, s1.statePath, s2.statePath)
+	assert.Equal(t, s1.enabled, s2.enabled)
+	assert.NotNil(t, s1.checker)
+	assert.NotNil(t, s2.checker)
+}
+
+// TestNewServiceWithOptions_InjectsCheckerAndStatePath verifies the injected
+// checker is actually used by ForceCheck and that state is written to the
+// overridden temp-dir path (not the real data directory).
+func TestNewServiceWithOptions_InjectsCheckerAndStatePath(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "update_cache.json")
+	chk := &countingChecker{version: &versionInfo{Version: "v9.9.9", TagName: "v9.9.9"}}
+	svc := NewServiceWithOptions(UpdateConfig{Enabled: true, VersionCheckIntervalHours: 24}, ServiceOptions{
+		Checker:   chk,
+		StatePath: statePath,
+	})
+
+	assert.Equal(t, statePath, svc.statePath)
+
+	state, err := svc.ForceCheck(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, "v9.9.9", state.Version)
+	assert.Equal(t, 1, chk.callsCount(), "injected checker must be used")
+
+	// State must be persisted to the overridden temp path, proving tests do
+	// not touch the real on-disk cache.
+	_, err = os.Stat(statePath)
+	assert.NoError(t, err, "update cache written to temp StatePath")
+}
+
+// TestService_BackgroundCheck_OneShotFiresWithStub covers AC (a): the one-shot
+// startup check fires and queries the injected stub, with no real network.
+func TestService_BackgroundCheck_OneShotFiresWithStub(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	svc, chk := newStubService(t, true)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go svc.BackgroundCheck(ctx)
+
+	require.Eventually(t, func() bool { return chk.callsCount() >= 1 }, time.Second, 5*time.Millisecond,
+		"one-shot BackgroundCheck must query the stub")
+}
+
+// TestService_StartBackgroundCheck_StubTickerFiresOnInterval covers AC (b): the
+// background ticker queries the stub on each tick. StartBackgroundCheck does
+// not fire an immediate check, so every observed call corresponds to a tick.
+func TestService_StartBackgroundCheck_StubTickerFiresOnInterval(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	svc, chk := newStubService(t, true)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	svc.StartBackgroundCheck(ctx, 30*time.Millisecond)
+
+	require.Eventually(t, func() bool { return chk.callsCount() >= 3 }, 2*time.Second, 10*time.Millisecond,
+		"background ticker must fire multiple times on interval")
+}
+
+// TestService_StartBackgroundCheck_StubStopsOnCancel covers AC (c): after the
+// context is cancelled, no further checks fire and the ticker goroutine exits.
+func TestService_StartBackgroundCheck_StubStopsOnCancel(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	svc, chk := newStubService(t, true)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	svc.StartBackgroundCheck(ctx, 20*time.Millisecond)
+
+	require.Eventually(t, func() bool { return chk.callsCount() >= 2 }, time.Second, 10*time.Millisecond,
+		"ticker must fire before cancellation")
+
+	callsBeforeCancel := chk.callsCount()
+	cancel()
+
+	// Wait several tick periods; no new calls must arrive after cancellation.
+	time.Sleep(120 * time.Millisecond)
+	assert.Equal(t, callsBeforeCancel, chk.callsCount(),
+		"no further checks after context cancel")
+}
+
+// TestService_StartBackgroundCheck_StubDisabledNoCalls covers AC (d): when the
+// service is disabled, StartBackgroundCheck starts no goroutine and never
+// queries the checker.
+func TestService_StartBackgroundCheck_StubDisabledNoCalls(t *testing.T) {
+	svc, chk := newStubService(t, false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	svc.StartBackgroundCheck(ctx, 20*time.Millisecond)
+
+	time.Sleep(120 * time.Millisecond)
+	assert.Equal(t, 0, chk.callsCount(),
+		"disabled service must not start the background checker")
+}


### PR DESCRIPTION
## Summary

The self-update subsystem had three compounding gaps that made it largely inert on fresh installs and during normal runs (issue #39, raised in [PR #35 discussion](https://github.com/javinizer/javinizer-go/pull/35#discussion_r3482983624)):

1. **`StartBackgroundCheck` had zero production callers** — implemented and tested but only invoked from test files.
2. **No startup check** — the cache was never warmed before the first `GetStatus` read.
3. **`GetStatus` nil-state skip** returns `UpdateSourceNone` immediately for fresh installs. This is intentional (making `GetStatus` side-effectful would break the read-only `javinizer info` command and hermetic tests), so the fix is to **warm the cache at startup** rather than mutate `GetStatus`.

## Changes

### 1. Checker-injection seam (`internal/update`)
- Exported the `Checker` interface and added a `VersionInfo = versionInfo` alias so external callers/tests can construct stub return values.
- Added `NewServiceWithOptions(cfg, ServiceOptions{Checker, StatePath})` — an explicit-options constructor matching the project `NewWithOptions` convention. A zero-value `ServiceOptions` reproduces `NewService` exactly, so `NewService(cfg)` now delegates and existing callers (`info`, `version`, `api/version`) are unchanged.
- Added `Interval()` accessor so the bootstrap can start the ticker with the service's normalized interval (no duplicated default-interval logic).

### 2. Wire `StartBackgroundCheck` at API server start (`internal/api/core`)
- New `startUpdateChecker(rt, cfg, opts)` helper, called from `bootstrapAPIDeps`.
- **Gated** on `cfg.System.VersionCheckEnabled` — when disabled, no goroutine starts and no network/cache writes occur.
- Fires a **one-shot `go svc.BackgroundCheck(ctx)`** at startup to warm the cache before the first `GetStatus` read (the nil-state skip becomes benign).
- Starts `StartBackgroundCheck(ctx, svc.Interval())` for periodic refresh.
- Both are bound to **`rt.ServerCtx()`**, which `rt.Shutdown()` cancels — so the background ticker and any in-flight one-shot stop cleanly on server shutdown (no naked goroutine, no leak). The existing `run()` already defers `rt.Shutdown()`.

### `GetStatus` is untouched
It remains a pure read-only path (no side effects, no network). The fix is purely additive warming at startup.

## Tests (hermetic — no real network, `t.TempDir()` cache paths)

`internal/update/wiring_test.go`:
- `TestNewServiceWithOptions_ZeroOptsMatchesNewService` / `_InjectsCheckerAndStatePath` — seam coverage.
- `TestService_BackgroundCheck_OneShotFiresWithStub` — AC (a) one-shot fires.
- `TestService_StartBackgroundCheck_StubTickerFiresOnInterval` — AC (b) ticker fires on interval.
- `TestService_StartBackgroundCheck_StubStopsOnCancel` — AC (c) stops cleanly on ctx cancel (goleak-verified).
- `TestService_StartBackgroundCheck_StubDisabledNoCalls` — AC (d) nothing starts when disabled.

`internal/api/core/update_checker_test.go`:
- `TestStartUpdateChecker_Disabled_DoesNothing` — bootstrap gate (AC d).
- `TestStartUpdateChecker_Enabled_FiresOneShotAndStopsOnShutdown` — one-shot fires + clean `rt.Shutdown()` (ACs a, c).
- `TestStartUpdateChecker_NilConfigIsSafe` — nil-safety.

## Verification (from worktree)
- `gofmt -l .` → empty
- `go build ./...` → ok
- `go vet ./internal/update/... ./internal/api/core/... ./cmd/javinizer/...` → clean
- `go test ./internal/update/... ./internal/api/core/... ./cmd/javinizer/...` → all PASS
- `go test ./...` → full suite green (no FAIL)
- `make coverage-check` → PASSED (89.01% line coverage, ≥ 75% required)
- Re-ran the two named tests unmodified: `TestPrintUpdateStatus_NeverChecked` and `TestRunInfo_WriteFailures_Exhaustive` → PASS (they exercise the `info` command path, which is untouched by this change).

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic background version checking during app startup when enabled.
  * Version checks warm the cache on startup and then run periodically using the configured interval.

* **Bug Fixes**
  * Improved shutdown behavior so background version checks stop cleanly when the server stops.
  * Version checking is now safely skipped when disabled or not configured, avoiding unnecessary work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->