### PR TITLE
feat(update): surface update-available in UI + harden checker against GitHub rate limits

### DIFF
--- a/cmd/javinizer/commands/info/command.go
+++ b/cmd/javinizer/commands/info/command.go
@@ -113,6 +113,7 @@ func printUpdateStatus(cmd *cobra.Command, cfg *config.Config) error {
 	service := update.NewService(update.UpdateConfig{
 		Enabled:                   cfg.System.VersionCheckEnabled,
 		VersionCheckIntervalHours: cfg.System.VersionCheckIntervalHours,
+		StableOnly:                cfg.System.VersionCheckStableOnly,
 	})
 	ctx := cmd.Context()
 	state, err := service.GetStatus(ctx)

--- a/cmd/javinizer/commands/version/command.go
+++ b/cmd/javinizer/commands/version/command.go
@@ -62,8 +62,12 @@ func NewCommand() *cobra.Command {
 				current := version.Short()
 				latestVer := state.Version
 
-				// Determine if update is available
-				updateAvailable := update.CompareVersions(current, latestVer) < 0
+				// state.Available already reflects the build version comparison AND
+				// the user's version_check_stable_only policy (prerelease
+				// suppression). Reusing it keeps the CLI consistent with the API/UI
+				// — recomputing CompareVersions here would surface a prerelease the
+				// service deliberately suppressed.
+				updateAvailable := state.Available
 
 				// Print to stdout for easy parsing
 				if updateAvailable {

--- a/cmd/javinizer/commands/version/command.go
+++ b/cmd/javinizer/commands/version/command.go
@@ -32,6 +32,7 @@ func NewCommand() *cobra.Command {
 				service := update.NewService(update.UpdateConfig{
 					Enabled:                   cfg.System.VersionCheckEnabled,
 					VersionCheckIntervalHours: cfg.System.VersionCheckIntervalHours,
+					StableOnly:                cfg.System.VersionCheckStableOnly,
 				})
 				state, err := service.ForceCheck(ctx)
 

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -66,6 +66,12 @@ system:
     version_check_enabled: true
     # Interval between version checks in hours (default: 24)
     version_check_interval_hours: 24
+    # Restrict update notifications to stable releases only (default: false).
+    # The Go rewrite currently ships only prereleases (v0.x-alpha), so the
+    # default keeps prerelease notifications on — otherwise no user would be
+    # notified until a stable release exists. Set to true to be notified only
+    # about stable releases.
+    version_check_stable_only: false
     # Base directory for temporary files (posters, etc.)
     # Can be overridden with JAVINIZER_TEMP_DIR environment variable
     temp_dir: data/temp

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -5610,6 +5610,10 @@ const docTemplate = `{
                 "version_check_interval_hours": {
                     "description": "VersionCheckIntervalHours is the interval between version checks in hours",
                     "type": "integer"
+                },
+                "version_check_stable_only": {
+                    "description": "VersionCheckStableOnly, when true, restricts update notifications to\nstable releases only (prereleases are still fetched and cached for\ntransparency but never reported as available). Defaults to false: the\nGo rewrite currently ships only prereleases (v0.x-alpha), so suppressing\nthem by default would mean no user is ever notified until a stable\nrelease exists. Set to true to be notified only about stable releases.\nModeled as an opt-in restriction (not an opt-out) so the zero value is\nthe correct default for existing configs — no migration needed.",
+                    "type": "boolean"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -5608,6 +5608,10 @@
                 "version_check_interval_hours": {
                     "description": "VersionCheckIntervalHours is the interval between version checks in hours",
                     "type": "integer"
+                },
+                "version_check_stable_only": {
+                    "description": "VersionCheckStableOnly, when true, restricts update notifications to\nstable releases only (prereleases are still fetched and cached for\ntransparency but never reported as available). Defaults to false: the\nGo rewrite currently ships only prereleases (v0.x-alpha), so suppressing\nthem by default would mean no user is ever notified until a stable\nrelease exists. Set to true to be notified only about stable releases.\nModeled as an opt-in restriction (not an opt-out) so the zero value is\nthe correct default for existing configs — no migration needed.",
+                    "type": "boolean"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1726,6 +1726,17 @@ definitions:
         description: VersionCheckIntervalHours is the interval between version checks
           in hours
         type: integer
+      version_check_stable_only:
+        description: |-
+          VersionCheckStableOnly, when true, restricts update notifications to
+          stable releases only (prereleases are still fetched and cached for
+          transparency but never reported as available). Defaults to false: the
+          Go rewrite currently ships only prereleases (v0.x-alpha), so suppressing
+          them by default would mean no user is ever notified until a stable
+          release exists. Set to true to be notified only about stable releases.
+          Modeled as an opt-in restriction (not an opt-out) so the zero value is
+          the correct default for existing configs — no migration needed.
+        type: boolean
     type: object
   github_com_javinizer_javinizer-go_internal_config.TranslationConfig:
     properties:

--- a/internal/api/core/update_checker.go
+++ b/internal/api/core/update_checker.go
@@ -27,6 +27,7 @@ func startUpdateChecker(rt *APIRuntime, cfg *config.Config, opts update.ServiceO
 	svc := update.NewServiceWithOptions(update.UpdateConfig{
 		Enabled:                   cfg.System.VersionCheckEnabled,
 		VersionCheckIntervalHours: cfg.System.VersionCheckIntervalHours,
+		StableOnly:                cfg.System.VersionCheckStableOnly,
 	}, opts)
 
 	ctx := rt.ServerCtx()

--- a/internal/api/version/handlers.go
+++ b/internal/api/version/handlers.go
@@ -38,6 +38,7 @@ func versionStatus(deps commandutil.CoreDepsReader) gin.HandlerFunc {
 		service := update.NewService(update.UpdateConfig{
 			Enabled:                   cfg.System.VersionCheckEnabled,
 			VersionCheckIntervalHours: cfg.System.VersionCheckIntervalHours,
+			StableOnly:                cfg.System.VersionCheckStableOnly,
 		})
 
 		// Get current version info
@@ -110,6 +111,7 @@ func versionCheck(deps commandutil.CoreDepsReader) gin.HandlerFunc {
 		service := update.NewService(update.UpdateConfig{
 			Enabled:                   cfg.System.VersionCheckEnabled,
 			VersionCheckIntervalHours: cfg.System.VersionCheckIntervalHours,
+			StableOnly:                cfg.System.VersionCheckStableOnly,
 		})
 
 		// Perform the check (sync)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,6 +151,15 @@ type SystemConfig struct {
 	VersionCheckEnabled bool `yaml:"version_check_enabled" json:"version_check_enabled"`
 	// VersionCheckIntervalHours is the interval between version checks in hours
 	VersionCheckIntervalHours int `yaml:"version_check_interval_hours" json:"version_check_interval_hours"`
+	// VersionCheckStableOnly, when true, restricts update notifications to
+	// stable releases only (prereleases are still fetched and cached for
+	// transparency but never reported as available). Defaults to false: the
+	// Go rewrite currently ships only prereleases (v0.x-alpha), so suppressing
+	// them by default would mean no user is ever notified until a stable
+	// release exists. Set to true to be notified only about stable releases.
+	// Modeled as an opt-in restriction (not an opt-out) so the zero value is
+	// the correct default for existing configs — no migration needed.
+	VersionCheckStableOnly bool `yaml:"version_check_stable_only" json:"version_check_stable_only"`
 	// TempDir is the base directory for temporary files (default: "data/temp").
 	// Can be overridden with JAVINIZER_TEMP_DIR environment variable.
 	// Subdirectory "posters/{jobID}" is created for batch job temp posters.

--- a/internal/config/config.yaml.example
+++ b/internal/config/config.yaml.example
@@ -66,6 +66,12 @@ system:
     version_check_enabled: true
     # Interval between version checks in hours (default: 24)
     version_check_interval_hours: 24
+    # Restrict update notifications to stable releases only (default: false).
+    # The Go rewrite currently ships only prereleases (v0.x-alpha), so the
+    # default keeps prerelease notifications on — otherwise no user would be
+    # notified until a stable release exists. Set to true to be notified only
+    # about stable releases.
+    version_check_stable_only: false
     # Base directory for temporary files (posters, etc.)
     # Can be overridden with JAVINIZER_TEMP_DIR environment variable
     temp_dir: data/temp

--- a/internal/config/config_migration_test.go
+++ b/internal/config/config_migration_test.go
@@ -117,3 +117,47 @@ server:
 	require.NoError(t, err)
 	assert.Equal(t, string(before), string(after))
 }
+
+// TestDefaultConfig_VersionCheckStableOnlyFalse verifies the new field defaults
+// to false (prereleases allowed — the Go rewrite ships only prereleases, so
+// the default keeps notifications on). Because the zero value is the correct
+// default, no config_version bump or migration is required: existing configs
+// that lack the field inherit false via decodeConfig's load-into-DefaultConfig.
+func TestDefaultConfig_VersionCheckStableOnlyFalse(t *testing.T) {
+	cfg := DefaultConfig(nil, nil)
+	assert.False(t, cfg.System.VersionCheckStableOnly, "default should allow prerelease notifications (stable_only=false)")
+	assert.Equal(t, CurrentConfigVersion, cfg.ConfigVersion)
+}
+
+// TestVersionCheckStableOnly_InheritedFromDefaultForV3Config verifies the
+// load-into-DefaultConfig mechanism backfills the new field correctly for an
+// existing v3 config that never had it: the field stays false (the DefaultConfig
+// value), NOT the Go zero value trick — confirming no migration is needed.
+// Other fields are preserved (not a legacy wipe).
+func TestVersionCheckStableOnly_InheritedFromDefaultForV3Config(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+
+	v3 := `config_version: 3
+server:
+  port: 9090
+scrapers:
+  priority:
+    - dmm
+system:
+  version_check_enabled: false
+`
+	err := os.WriteFile(cfgPath, []byte(v3), 0o644)
+	require.NoError(t, err)
+
+	cfg, err := LoadOrCreate(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, CurrentConfigVersion, cfg.ConfigVersion)
+	// No migration: v3 config stays v3 (CurrentConfigVersion is still 3) and the
+	// new field inherits false from DefaultConfig, not from a migration step.
+	assert.False(t, cfg.System.VersionCheckStableOnly, "field inherits the default (false); no migration needed")
+	// Other fields preserved (not a legacy wipe).
+	assert.Equal(t, 9090, cfg.Server.Port)
+	assert.Equal(t, []string{"dmm"}, cfg.Scrapers.Priority)
+	assert.False(t, cfg.System.VersionCheckEnabled, "explicit v3 setting preserved")
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -333,6 +333,10 @@ func DefaultConfig(priorities []string, defaults map[string]*models.ScraperSetti
 			VersionCheckIntervalHours: 24,
 			TempDir:                   DefaultTempDir,
 		},
+		// VersionCheckStableOnly is intentionally omitted: its zero value (false)
+		// is the correct default (prereleases allowed). Existing configs that
+		// lack the field inherit false via decodeConfig's load-into-DefaultConfig,
+		// so no migration is required.
 		WebUI: webUIConfig{
 			DefaultReviewView: "grid-poster",
 		},

--- a/internal/update/checker.go
+++ b/internal/update/checker.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,12 +19,33 @@ import (
 
 const maxUpdateResponseSize = 1024 * 1024 // 1MB
 
+// defaultRepo is the GitHub repository (owner/repo) consulted for release
+// updates. This is the Go rewrite (javinizer/javinizer-go), NOT the legacy
+// Python project (javinizer/Javinizer) whose releases are unrelated. Hardcoded
+// at every production construction site so a regression here can't silently
+// point the update checker at the wrong project again.
+const defaultRepo = "javinizer/javinizer-go"
+
+// ErrNotModified is returned by CheckLatestVersion when GitHub responds 304
+// (the cached ETag is still valid). 304 responses do NOT count against the
+// GitHub rate limit, so callers can re-check freely. The service treats this as
+// a "keep the cached state" signal rather than an error.
+var ErrNotModified = errors.New("release data not modified since last check")
+
 // versionInfo represents information about a GitHub release.
 type versionInfo struct {
 	Version     string `json:"version"`      // Human-readable version (e.g., "v1.6.0")
 	TagName     string `json:"tag_name"`     // Git tag (e.g., "v1.6.0")
 	Prerelease  bool   `json:"prerelease"`   // Whether this is a prerelease
 	PublishedAt string `json:"published_at"` // ISO8601 timestamp
+	// ETag captured from the GitHub response header. The service persists it
+	// in the on-disk cache and sends it back as If-None-Match on the next
+	// check so unchanged releases return 304 (rate-limit-free).
+	ETag string `json:"-"`
+	// NoStableLatest is true when this result came from the /releases list
+	// fallback because /releases/latest 404'd (no stable latest release). The
+	// service caches it so the next check skips the 404-throwing call.
+	NoStableLatest bool `json:"-"`
 }
 
 // VersionInfo is the exported alias for versionInfo, enabling external callers
@@ -38,6 +60,18 @@ type Checker interface {
 	CheckLatestVersion(ctx context.Context) (*VersionInfo, error)
 }
 
+// ConditionalChecker is an OPTIONAL capability a Checker may implement to
+// support rate-limit-friendly conditional requests. The service uses it to
+// thread the cached ETag (→ If-None-Match, 304 is free) and the
+// "no-stable-latest" flag (→ skip the /releases/latest 404) from the
+// on-disk cache into the checker before a call. Stub checkers in tests need
+// not implement it — the service type-asserts and silently falls back to a
+// full fetch, so the interface stays backward-compatible.
+type ConditionalChecker interface {
+	SetIfNoneMatch(etag string)
+	SetSkipLatest(skip bool)
+}
+
 // checker is an alias retaining the original unexported name used internally.
 type checker = Checker
 
@@ -47,10 +81,24 @@ type githubChecker struct {
 	httpClient *http.Client
 	apiBaseURL string // For testing - override the GitHub API base URL
 	envLookup  func(string) string
+	// ifNonMatch, when non-empty, is sent as If-None-Match so GitHub returns
+	// 304 (rate-limit-free) when releases are unchanged.
+	ifNoneMatch string
+	// skipLatest, when true, skips the /releases/latest call (which 404s for a
+	// prerelease-only repo) and goes straight to the /releases list.
+	skipLatest bool
 }
 
+// SetIfNoneMatch implements ConditionalChecker.
+func (c *githubChecker) SetIfNoneMatch(etag string) { c.ifNoneMatch = etag }
+
+// SetSkipLatest implements ConditionalChecker.
+func (c *githubChecker) SetSkipLatest(skip bool) { c.skipLatest = skip }
+
 // newGitHubChecker creates a new GitHub checker.
-// The repo should be in format "owner/repo" (e.g., "javinizer/Javinizer").
+// The repo should be in format "owner/repo" (e.g., "javinizer/javinizer-go").
+// Production callers should pass defaultRepo; the parameter is kept for tests
+// that point at a stub server with an arbitrary path segment.
 func newGitHubChecker(repo string) *githubChecker {
 	return &githubChecker{
 		repo:       repo,
@@ -72,7 +120,20 @@ func newGitHubCheckerWithBaseURL(repo, baseURL string) *githubChecker {
 
 // CheckLatestVersion fetches the latest stable release from GitHub.
 // If no stable release is found, it returns the latest release (which may be a prerelease).
+//
+// Rate-limit friendly: when the caller sets ifNoneMatch (via SetIfNoneMatch),
+// it is sent as If-None-Match and an unchanged response returns ErrNotModified
+// (GitHub 304s do NOT count against the rate limit). When skipLatest is set
+// (via SetSkipLatest), the /releases/latest call — which 404s for a
+// prerelease-only repo — is skipped entirely, going straight to the /releases
+// list and halving API calls.
 func (c *githubChecker) CheckLatestVersion(ctx context.Context) (*versionInfo, error) {
+	// Skip the /releases/latest 404 we already know is coming for a
+	// prerelease-only repo; go straight to the list endpoint.
+	if c.skipLatest {
+		return c.latestFromReleaseList(ctx)
+	}
+
 	url := fmt.Sprintf("%s/repos/%s/releases/latest", c.apiBaseURL, c.repo)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -80,16 +141,7 @@ func (c *githubChecker) CheckLatestVersion(ctx context.Context) (*versionInfo, e
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Set User-Agent
-	req.Header.Set("User-Agent", "Javinizer-Updater")
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-
-	// Check for GitHub token in environment
-	if token := c.envLookup("GH_TOKEN"); token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	} else if token := c.envLookup("GITHUB_TOKEN"); token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
+	c.setCommonHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -102,6 +154,23 @@ func (c *githubChecker) CheckLatestVersion(ctx context.Context) (*versionInfo, e
 	// Handle rate limiting
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
 		return nil, fmt.Errorf("rate limited by GitHub API (status: %d)", resp.StatusCode)
+	}
+
+	// Unchanged since the last check: return the sentinel so the service keeps
+	// its cached state. 304 does not count against the rate limit.
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, ErrNotModified
+	}
+
+	// GitHub's /releases/latest endpoint EXCLUDES prereleases, so a repo that
+	// has only prereleases (the Go rewrite currently ships v0.x-alpha only)
+	// responds 404. Fall back to the most recent release via the list endpoint
+	// rather than erroring — otherwise the update checker would never find an
+	// update for a prerelease-only repo. The returned version may be a
+	// prerelease; the caller (service layer) applies the user's
+	// check-prerelease preference to decide whether to surface it.
+	if resp.StatusCode == http.StatusNotFound {
+		return c.latestFromReleaseList(ctx)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -131,11 +200,29 @@ func (c *githubChecker) CheckLatestVersion(ctx context.Context) (*versionInfo, e
 	}
 
 	return &versionInfo{
-		Version:     version,
-		TagName:     release.TagName,
-		Prerelease:  release.Prerelease,
-		PublishedAt: release.PublishedAt,
+		Version:        version,
+		TagName:        release.TagName,
+		Prerelease:     release.Prerelease,
+		PublishedAt:    release.PublishedAt,
+		ETag:           resp.Header.Get("ETag"),
+		NoStableLatest: false,
 	}, nil
+}
+
+// setCommonHeaders sets the headers shared by every GitHub API request:
+// User-Agent, Accept, optional bearer auth (GH_TOKEN/GITHUB_TOKEN), and the
+// conditional-request If-None-Match when an ETag is cached.
+func (c *githubChecker) setCommonHeaders(req *http.Request) {
+	req.Header.Set("User-Agent", "Javinizer-Updater")
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	if token := c.envLookup("GH_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else if token := c.envLookup("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if c.ifNoneMatch != "" {
+		req.Header.Set("If-None-Match", c.ifNoneMatch)
+	}
 }
 
 // parseGitHubReleaseVersion extracts version information from a GitHub tag name.
@@ -276,17 +363,41 @@ func parseStringToInt(s string) (int, error) {
 	return n, nil
 }
 
+// latestFromReleaseList fetches the single most recent release (which may be
+// a prerelease) via the /releases list endpoint and wraps it as a versionInfo.
+// It is the 404 fallback for CheckLatestVersion when no stable "latest"
+// release exists, and the direct path when skipLatest is set. The returned
+// versionInfo carries NoStableLatest=true so the service can cache that flag
+// and skip the 404-throwing /releases/latest call on subsequent checks.
+func (c *githubChecker) latestFromReleaseList(ctx context.Context) (*versionInfo, error) {
+	versions, etag, err := c.getRecentReleases(ctx, 1)
+	if err != nil {
+		return nil, fmt.Errorf("no stable latest release (404) and list lookup failed: %w", err)
+	}
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("GitHub API returned 404 for latest release and no releases were listed")
+	}
+	v := versions[0]
+	return &versionInfo{
+		Version:        v,
+		TagName:        v,
+		Prerelease:     IsPrerelease(v),
+		ETag:           etag,
+		NoStableLatest: true,
+	}, nil
+}
+
 // getLatestStableVersion checks GitHub and returns the latest stable version.
 // Returns (version, isAvailable, error).
 func getLatestStableVersion(ctx context.Context) (*versionInfo, error) {
-	checker := newGitHubChecker("javinizer/Javinizer")
+	checker := newGitHubChecker(defaultRepo)
 	return checker.CheckLatestVersion(ctx)
 }
 
 // checkForUpdate checks if an update is available and returns status.
 // If checkPrerelease is true, prereleases will also be considered.
 func checkForUpdate(ctx context.Context, currentVersion string, checkPrerelease bool) (*versionInfo, bool, error) {
-	return checkForUpdateWithChecker(ctx, currentVersion, checkPrerelease, newGitHubChecker("javinizer/Javinizer"))
+	return checkForUpdateWithChecker(ctx, currentVersion, checkPrerelease, newGitHubChecker(defaultRepo))
 }
 
 // checkForUpdateWithChecker checks if an update is available using a custom checker (for testing).
@@ -302,7 +413,7 @@ func checkForUpdateWithChecker(ctx context.Context, currentVersion string, check
 	if !checkPrerelease && IsPrerelease(latest.Version) {
 		// Try to get the latest non-prerelease
 		foundStable := false
-		if versions, err := chk.getRecentReleases(ctx, 10); err == nil {
+		if versions, _, err := chk.getRecentReleases(ctx, 10); err == nil {
 			for _, v := range versions {
 				if !IsPrerelease(v) {
 					latest = &versionInfo{Version: v, Prerelease: false}
@@ -332,40 +443,45 @@ func checkForUpdateWithChecker(ctx context.Context, currentVersion string, check
 }
 
 // getRecentReleases fetches recent releases to find a stable version.
-// Uses the checker's apiBaseURL for testing flexibility.
-func (c *githubChecker) getRecentReleases(ctx context.Context, limit int) ([]string, error) {
+// Uses the checker's apiBaseURL for testing flexibility. Returns the parsed
+// versions plus the response ETag (for subsequent If-None-Match requests).
+// Returns ErrNotModified (with no versions) when GitHub responds 304 — the
+// caller should keep its cached result in that case.
+func (c *githubChecker) getRecentReleases(ctx context.Context, limit int) ([]string, string, error) {
 	url := fmt.Sprintf("%s/repos/%s/releases?per_page=%d", c.apiBaseURL, c.repo, limit)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("User-Agent", "Javinizer-Updater")
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-
-	// Check for GitHub token in environment
-	if token := c.envLookup("GH_TOKEN"); token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	} else if token := c.envLookup("GITHUB_TOKEN"); token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
+	c.setCommonHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch releases: %w", err)
+		return nil, "", fmt.Errorf("failed to fetch releases: %w", err)
 	}
 	defer func() {
 		_ = httpclient.DrainAndClose(resp.Body)
 	}()
 
+	// Unchanged since the last check: 304 does not count against the rate
+	// limit. Surface the sentinel so the caller keeps its cached result.
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, "", ErrNotModified
+	}
+
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+		return nil, "", fmt.Errorf("rate limited by GitHub API (status: %d)", resp.StatusCode)
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+		return nil, "", fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxUpdateResponseSize))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+		return nil, "", fmt.Errorf("failed to read response: %w", err)
 	}
 
 	var releases []struct {
@@ -374,7 +490,7 @@ func (c *githubChecker) getRecentReleases(ctx context.Context, limit int) ([]str
 	}
 
 	if err := json.Unmarshal(body, &releases); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
+		return nil, "", fmt.Errorf("failed to parse response: %w", err)
 	}
 
 	var versions []string
@@ -388,11 +504,12 @@ func (c *githubChecker) getRecentReleases(ctx context.Context, limit int) ([]str
 		}
 	}
 
-	return versions, nil
+	return versions, resp.Header.Get("ETag"), nil
 }
 
 // getRecentReleases fetches recent releases using the default checker.
 func getRecentReleases(ctx context.Context, limit int) ([]string, error) {
-	checker := newGitHubChecker("javinizer/Javinizer")
-	return checker.getRecentReleases(ctx, limit)
+	checker := newGitHubChecker(defaultRepo)
+	versions, _, err := checker.getRecentReleases(ctx, limit)
+	return versions, err
 }

--- a/internal/update/checker_test.go
+++ b/internal/update/checker_test.go
@@ -487,7 +487,7 @@ func TestWrapperFunctions(t *testing.T) {
 		original := http.DefaultTransport
 		http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			require.Equal(t, "api.github.com", req.URL.Host)
-			require.Equal(t, "/repos/javinizer/Javinizer/releases/latest", req.URL.Path)
+			require.Equal(t, "/repos/javinizer/javinizer-go/releases/latest", req.URL.Path)
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body: io.NopCloser(strings.NewReader(`{
@@ -511,7 +511,7 @@ func TestWrapperFunctions(t *testing.T) {
 		original := http.DefaultTransport
 		http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			require.Equal(t, "api.github.com", req.URL.Host)
-			require.Equal(t, "/repos/javinizer/Javinizer/releases/latest", req.URL.Path)
+			require.Equal(t, "/repos/javinizer/javinizer-go/releases/latest", req.URL.Path)
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body: io.NopCloser(strings.NewReader(`{
@@ -535,7 +535,7 @@ func TestWrapperFunctions(t *testing.T) {
 		original := http.DefaultTransport
 		http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			require.Equal(t, "api.github.com", req.URL.Host)
-			require.Equal(t, "/repos/javinizer/Javinizer/releases", req.URL.Path)
+			require.Equal(t, "/repos/javinizer/javinizer-go/releases", req.URL.Path)
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body: io.NopCloser(strings.NewReader(`[
@@ -552,4 +552,208 @@ func TestWrapperFunctions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{"v1.5.0", "v1.4.0", "v1.3.0"}, versions)
 	})
+}
+
+// TestDefaultRepoPointsAtGoRewrite is a regression guard: the update checker
+// must consult the Go rewrite (javinizer/javinizer-go), NOT the legacy Python
+// project (javinizer/Javinizer) whose releases are unrelated. A previous bug
+// pointed every production construction site at the old repo, so users were
+// notified about the Python project's 2.6.4 release. This test pins the
+// constant so a silent re-regression fails CI.
+func TestDefaultRepoPointsAtGoRewrite(t *testing.T) {
+	assert.Equal(t, "javinizer/javinizer-go", defaultRepo)
+	// The production default checker must use it.
+	chk := newGitHubChecker(defaultRepo)
+	assert.Equal(t, "javinizer/javinizer-go", chk.repo)
+}
+
+// TestCheckLatestVersion_FallsBackToPrereleaseOn404 verifies that a
+// prerelease-only repo (whose /releases/latest endpoint 404s because GitHub
+// excludes prereleases) still yields its most recent release via the list
+// endpoint fallback. Without this, the Go rewrite — which currently ships only
+// v0.x-alpha releases — would never surface an update.
+func TestCheckLatestVersion_FallsBackToPrereleaseOn404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/javinizer/javinizer-go/releases/latest":
+			w.WriteHeader(http.StatusNotFound)
+		case "/repos/javinizer/javinizer-go/releases":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[
+				{"tag_name":"v0.3.15-alpha","name":"v0.3.15-alpha","prerelease":true},
+				{"tag_name":"v0.3.14-alpha","name":"v0.3.14-alpha","prerelease":true}
+			]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	chk := newGitHubCheckerWithBaseURL("javinizer/javinizer-go", server.URL)
+	info, err := chk.CheckLatestVersion(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "v0.3.15-alpha", info.Version)
+	assert.True(t, info.Prerelease, "404 fallback should surface the prerelease")
+}
+
+// TestCheckLatestVersion_404WithNoReleasesErrors verifies the 404 fallback
+// errors cleanly (rather than returning a zero-value) when the repo has no
+// releases at all.
+func TestCheckLatestVersion_404WithNoReleasesErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/javinizer/javinizer-go/releases/latest":
+			w.WriteHeader(http.StatusNotFound)
+		case "/repos/javinizer/javinizer-go/releases":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	chk := newGitHubCheckerWithBaseURL("javinizer/javinizer-go", server.URL)
+	info, err := chk.CheckLatestVersion(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, info)
+}
+
+// TestCheckLatestVersion_ETag304ReturnsNotModified verifies the rate-limit
+// optimization on the stable-repo path: the first request captures the ETag,
+// and a second request sending it back as If-None-Match gets a 304 — which
+// GitHub does NOT count against quota — and surfaces as ErrNotModified.
+func TestCheckLatestVersion_ETag304ReturnsNotModified(t *testing.T) {
+	const etag = `W/"stable-etag-123"`
+	mockReleases := map[string]interface{}{
+		"tag_name":     "v1.6.0",
+		"name":         "Version 1.6.0",
+		"prerelease":   false,
+		"published_at": "2026-03-20T12:00:00Z",
+	}
+	jsonBytes, _ := json.Marshal(mockReleases)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/javinizer/Javinizer/releases/latest" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// Conditional GET: return 304 when the client sends our ETag back.
+		if inm := r.Header.Get("If-None-Match"); inm == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(jsonBytes)
+	}))
+	defer server.Close()
+
+	chk := newGitHubCheckerWithBaseURL("javinizer/Javinizer", server.URL)
+
+	// First check: full fetch, captures the ETag.
+	info, err := chk.CheckLatestVersion(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "v1.6.0", info.Version)
+	assert.Equal(t, etag, info.ETag, "ETag captured from the response header")
+
+	// Second check: send the ETag back, expect a 304 → ErrNotModified.
+	chk.SetIfNoneMatch(info.ETag)
+	info2, err := chk.CheckLatestVersion(context.Background())
+	require.ErrorIs(t, err, ErrNotModified)
+	assert.Nil(t, info2)
+}
+
+// TestCheckLatestVersion_SkipLatestSkips404Endpoint verifies that once the
+// service has learned a repo has no stable latest release (NoStableLatest),
+// the next check skips the /releases/latest 404 entirely and goes straight to
+// the /releases list — halving API calls for a prerelease-only repo. It also
+// confirms the list path honors If-None-Match (304 → ErrNotModified).
+func TestCheckLatestVersion_SkipLatestSkips404Endpoint(t *testing.T) {
+	const etag = `W/"prerelease-etag-456"`
+	var latestHit int
+	mockList := []map[string]interface{}{{
+		"tag_name":   "v0.3.15-alpha",
+		"name":       "v0.3.15-alpha",
+		"prerelease": true,
+	}}
+	listBytes, _ := json.Marshal(mockList)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/javinizer/javinizer-go/releases/latest":
+			latestHit++
+			w.WriteHeader(http.StatusNotFound)
+		case "/repos/javinizer/javinizer-go/releases":
+			if inm := r.Header.Get("If-None-Match"); inm == etag {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.Header().Set("ETag", etag)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(listBytes)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	chk := newGitHubCheckerWithBaseURL("javinizer/javinizer-go", server.URL)
+
+	// First check: /releases/latest 404s → falls back to the list, captures
+	// the ETag and reports NoStableLatest=true.
+	info, err := chk.CheckLatestVersion(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "v0.3.15-alpha", info.Version)
+	assert.Equal(t, etag, info.ETag)
+	assert.True(t, info.NoStableLatest, "404 fallback sets NoStableLatest")
+	assert.Equal(t, 1, latestHit, "first check hits /releases/latest")
+
+	// Second check: skipLatest set → /releases/latest must NOT be hit, and the
+	// list path returns 304 (rate-limit-free) via If-None-Match.
+	chk.SetSkipLatest(true)
+	chk.SetIfNoneMatch(info.ETag)
+	info2, err := chk.CheckLatestVersion(context.Background())
+	require.ErrorIs(t, err, ErrNotModified)
+	assert.Nil(t, info2)
+	assert.Equal(t, 1, latestHit, "skipLatest avoided the /releases/latest 404")
+}
+
+// TestCheckLatestVersion_SkipLatestGoesStraightToList verifies that with
+// skipLatest the result still resolves through the list endpoint (not a 304)
+// when there is no ETag to send — i.e. skipLatest alone is correct.
+func TestCheckLatestVersion_SkipLatestGoesStraightToList(t *testing.T) {
+	var latestHit int
+	mockList := []map[string]interface{}{{
+		"tag_name":   "v0.3.15-alpha",
+		"prerelease": true,
+	}}
+	listBytes, _ := json.Marshal(mockList)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/javinizer/javinizer-go/releases/latest":
+			latestHit++
+			w.WriteHeader(http.StatusNotFound)
+		case "/repos/javinizer/javinizer-go/releases":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(listBytes)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	chk := newGitHubCheckerWithBaseURL("javinizer/javinizer-go", server.URL)
+	chk.SetSkipLatest(true)
+
+	info, err := chk.CheckLatestVersion(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "v0.3.15-alpha", info.Version)
+	assert.True(t, info.NoStableLatest)
+	assert.Equal(t, 0, latestHit, "/releases/latest never hit when skipLatest is set")
 }

--- a/internal/update/miss_test.go
+++ b/internal/update/miss_test.go
@@ -95,7 +95,7 @@ func TestGetRecentReleases_Success(t *testing.T) {
 	defer server.Close()
 
 	checker := newGitHubCheckerWithBaseURL("javinizer/Javinizer", server.URL)
-	versions, err := checker.getRecentReleases(context.Background(), 10)
+	versions, _, err := checker.getRecentReleases(context.Background(), 10)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"v1.5.0", "v1.4.0", "v1.3.0"}, versions)
 }
@@ -108,7 +108,7 @@ func TestGetRecentReleases_Non200(t *testing.T) {
 	defer server.Close()
 
 	checker := newGitHubCheckerWithBaseURL("javinizer/Javinizer", server.URL)
-	_, err := checker.getRecentReleases(context.Background(), 10)
+	_, _, err := checker.getRecentReleases(context.Background(), 10)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "status 500")
 }
@@ -122,7 +122,7 @@ func TestGetRecentReleases_MalformedJSON(t *testing.T) {
 	defer server.Close()
 
 	checker := newGitHubCheckerWithBaseURL("javinizer/Javinizer", server.URL)
-	_, err := checker.getRecentReleases(context.Background(), 10)
+	_, _, err := checker.getRecentReleases(context.Background(), 10)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse response")
 }
@@ -130,7 +130,7 @@ func TestGetRecentReleases_MalformedJSON(t *testing.T) {
 // TestGetRecentReleases_NetworkError tests the network error path.
 func TestGetRecentReleases_NetworkError(t *testing.T) {
 	checker := newGitHubCheckerWithBaseURL("javinizer/Javinizer", "http://127.0.0.1:1")
-	_, err := checker.getRecentReleases(context.Background(), 10)
+	_, _, err := checker.getRecentReleases(context.Background(), 10)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to fetch releases")
 }
@@ -147,7 +147,7 @@ func TestGetRecentReleases_GHToken(t *testing.T) {
 
 	t.Setenv("GH_TOKEN", "recent-token")
 	checker := newGitHubCheckerWithBaseURL("javinizer/Javinizer", server.URL)
-	_, err := checker.getRecentReleases(context.Background(), 5)
+	_, _, err := checker.getRecentReleases(context.Background(), 5)
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer recent-token", receivedAuth)
 }
@@ -164,7 +164,7 @@ func TestGetRecentReleases_EmptyNameAndTag(t *testing.T) {
 	defer server.Close()
 
 	checker := newGitHubCheckerWithBaseURL("javinizer/Javinizer", server.URL)
-	versions, err := checker.getRecentReleases(context.Background(), 10)
+	versions, _, err := checker.getRecentReleases(context.Background(), 10)
 	require.NoError(t, err)
 	// Empty entries should be skipped
 	assert.Equal(t, []string{"v1.0.0"}, versions)

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -13,18 +14,25 @@ import (
 
 // service handles update checking with caching and background refresh.
 type service struct {
-	checker   checker
-	store     *stateStore
-	statePath string
-	interval  time.Duration
-	enabled   bool
-	checkMu   sync.Mutex // prevents concurrent background checks
+	checker    checker
+	store      *stateStore
+	statePath  string
+	interval   time.Duration
+	enabled    bool
+	stableOnly bool       // honor system.version_check_stable_only: when true, never surface a prerelease as an available update
+	checkMu    sync.Mutex // prevents concurrent background checks
 }
 
 // UpdateConfig carries the narrow set of config fields the update service reads.
 type UpdateConfig struct {
 	Enabled                   bool
 	VersionCheckIntervalHours int
+	// StableOnly, when true, restricts update notifications to stable releases
+	// only (prereleases are still fetched and cached for transparency but never
+	// reported as available). Defaults to false: the Go repo currently ships
+	// only prereleases, so suppressing them by default would mean the checker
+	// never notifies any user until a stable release exists.
+	StableOnly bool
 }
 
 // NewService creates a new update service with production defaults (the real
@@ -65,15 +73,16 @@ func NewServiceWithOptions(cfg UpdateConfig, opts ServiceOptions) *service {
 
 	chk := opts.Checker
 	if chk == nil {
-		chk = newGitHubChecker("javinizer/Javinizer")
+		chk = newGitHubChecker(defaultRepo)
 	}
 
 	return &service{
-		checker:   chk,
-		store:     store,
-		statePath: statePath,
-		interval:  interval,
-		enabled:   cfg.Enabled,
+		checker:    chk,
+		store:      store,
+		statePath:  statePath,
+		interval:   interval,
+		enabled:    cfg.Enabled,
+		stableOnly: cfg.StableOnly,
 	}
 }
 
@@ -134,8 +143,43 @@ func (s *service) ForceCheck(ctx context.Context) (*updateState, error) {
 
 	logging.Info("Checking for updates...")
 
+	// Thread the cached ETag + "no-stable-latest" flag into the checker so this
+	// check is rate-limit-friendly: the ETag becomes If-None-Match (GitHub 304s
+	// don't count against quota) and skipLatest avoids the 404-throwing
+	// /releases/latest call for prerelease-only repos. Stub checkers don't
+	// implement ConditionalChecker — the assert fails silently and a full fetch
+	// runs, which is correct for hermetic tests.
+	if cached, _ := s.store.LoadState(); cached != nil {
+		if cc, ok := s.checker.(ConditionalChecker); ok {
+			cc.SetIfNoneMatch(cached.ETag)
+			cc.SetSkipLatest(cached.NoStableLatest)
+		}
+	}
+
 	latest, err := s.checker.CheckLatestVersion(ctx)
 	if err != nil {
+		// 304 Not Modified: releases unchanged since the last check. Keep the
+		// cached state (version/availability intact), just refresh CheckedAt so
+		// the UI's "last checked" stays current. This path burns no rate-limit
+		// quota, so it's the steady-state for a long-running or frequently
+		// restarted instance.
+		if errors.Is(err, ErrNotModified) {
+			cached, _ := s.store.LoadState()
+			if cached != nil && cached.Version != "" {
+				cached.CheckedAt = nowISO8601()
+				cached.Source = UpdateSourceCached
+				cached.Error = ""
+				_ = s.store.SaveState(cached)
+				logging.Debugf("Update check: not modified (304), keeping cached state")
+				return cached, nil
+			}
+			// No cached state to reuse — fall through to the error path below.
+			return &updateState{
+				Source: UpdateSourceError,
+				Error:  "not modified but no cached state available",
+			}, nil
+		}
+
 		logging.Debugf("Update check failed: %v", err)
 
 		// Try to load existing state
@@ -162,12 +206,23 @@ func (s *service) ForceCheck(ctx context.Context) (*updateState, error) {
 	isAvailable := CompareVersions(currentVersion, latest.Version) < 0
 	isPrerelease := IsPrerelease(latest.Version)
 
+	// Honor the user's stable-only preference: when restricting to stable
+	// releases, never surface a prerelease as an available update (the Go repo
+	// currently ships only prereleases, so this means "no update" until a
+	// stable release lands — by design, not a bug). The version is still cached
+	// so the UI can show what was found; only the Available flag is suppressed.
+	if isAvailable && isPrerelease && s.stableOnly {
+		isAvailable = false
+	}
+
 	state := &updateState{
-		Version:    latest.Version,
-		CheckedAt:  nowISO8601(),
-		Available:  isAvailable,
-		Prerelease: isPrerelease,
-		Source:     UpdateSourceFresh,
+		Version:        latest.Version,
+		CheckedAt:      nowISO8601(),
+		Available:      isAvailable,
+		Prerelease:     isPrerelease,
+		Source:         UpdateSourceFresh,
+		ETag:           latest.ETag,
+		NoStableLatest: latest.NoStableLatest,
 	}
 
 	// Only save if we have a valid state

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -134,13 +134,25 @@ func (s *service) GetStatus(ctx context.Context) (*updateState, error) {
 }
 
 // ForceCheck performs an immediate sync check and updates the cache.
+//
+// Serialized via s.checkMu so the checker's conditional-request hints (ETag /
+// skipLatest) cannot be mutated by a concurrent check — the API version
+// endpoint and BackgroundCheck both flow through here. BackgroundCheck already
+// holds checkMu and calls forceCheckLocked directly to avoid a non-reentrant
+// deadlock.
 func (s *service) ForceCheck(ctx context.Context) (*updateState, error) {
 	if !s.enabled {
 		return &updateState{
 			Source: UpdateSourceDisabled,
 		}, nil
 	}
+	s.checkMu.Lock()
+	defer s.checkMu.Unlock()
+	return s.forceCheckLocked(ctx)
+}
 
+// forceCheckLocked is the ForceCheck body; the caller MUST hold s.checkMu.
+func (s *service) forceCheckLocked(ctx context.Context) (*updateState, error) {
 	logging.Info("Checking for updates...")
 
 	// Thread the cached ETag + "no-stable-latest" flag into the checker so this
@@ -149,26 +161,39 @@ func (s *service) ForceCheck(ctx context.Context) (*updateState, error) {
 	// /releases/latest call for prerelease-only repos. Stub checkers don't
 	// implement ConditionalChecker — the assert fails silently and a full fetch
 	// runs, which is correct for hermetic tests.
-	if cached, _ := s.store.LoadState(); cached != nil {
-		if cc, ok := s.checker.(ConditionalChecker); ok {
-			cc.SetIfNoneMatch(cached.ETag)
-			cc.SetSkipLatest(cached.NoStableLatest)
+	//
+	// ALWAYS (re)set both hints, even when the cache is empty: the githubChecker
+	// is shared across checks, so leftover ifNoneMatch/skipLatest from a prior
+	// check (e.g. after the cache file is deleted between checks) would otherwise
+	// leak forward as a stale If-None-Match or an unintended /releases/latest
+	// skip. Empty/false yields a full fetch — the correct behavior with no cache.
+	cached, _ := s.store.LoadState()
+	if cc, ok := s.checker.(ConditionalChecker); ok {
+		etag, skipLatest := "", false
+		if cached != nil {
+			etag, skipLatest = cached.ETag, cached.NoStableLatest
 		}
+		cc.SetIfNoneMatch(etag)
+		cc.SetSkipLatest(skipLatest)
 	}
 
 	latest, err := s.checker.CheckLatestVersion(ctx)
 	if err != nil {
 		// 304 Not Modified: releases unchanged since the last check. Keep the
-		// cached state (version/availability intact), just refresh CheckedAt so
-		// the UI's "last checked" stays current. This path burns no rate-limit
-		// quota, so it's the steady-state for a long-running or frequently
-		// restarted instance.
+		// cached version, but re-evaluate availability under the CURRENT
+		// stable-only policy — the user may have toggled version_check_stable_only
+		// since this state was cached, so a previously-surfaced prerelease must
+		// now be suppressed (and vice versa). The build version is constant for
+		// the process, so only the stableOnly term can change. Only CheckedAt is
+		// refreshed; this path burns no rate-limit quota, so it's the steady
+		// state for a long-running or frequently restarted instance.
 		if errors.Is(err, ErrNotModified) {
-			cached, _ := s.store.LoadState()
 			if cached != nil && cached.Version != "" {
 				cached.CheckedAt = nowISO8601()
 				cached.Source = UpdateSourceCached
 				cached.Error = ""
+				cached.Available = CompareVersions(version.Short(), cached.Version) < 0 &&
+					(!cached.Prerelease || !s.stableOnly)
 				_ = s.store.SaveState(cached)
 				logging.Debugf("Update check: not modified (304), keeping cached state")
 				return cached, nil
@@ -204,7 +229,12 @@ func (s *service) ForceCheck(ctx context.Context) (*updateState, error) {
 
 	// Compare versions
 	isAvailable := CompareVersions(currentVersion, latest.Version) < 0
-	isPrerelease := IsPrerelease(latest.Version)
+	// Treat a release as a prerelease if GitHub flagged it as one OR its tag
+	// looks like a prerelease. The GitHub flag is authoritative for the
+	// /releases/latest path; the tag heuristic covers the list-fallback path
+	// (which sets latest.Prerelease from the tag) and catches releases marked
+	// prerelease but tagged like a stable version.
+	isPrerelease := latest.Prerelease || IsPrerelease(latest.Version)
 
 	// Honor the user's stable-only preference: when restricting to stable
 	// releases, never surface a prerelease as an available update (the Go repo
@@ -250,11 +280,13 @@ func (s *service) BackgroundCheck(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	// Prevent concurrent background checks across all service instances
+	// Prevent concurrent background checks across all service instances.
+	// ForceCheck acquires this lock itself; call forceCheckLocked here to avoid
+	// a non-reentrant deadlock.
 	s.checkMu.Lock()
 	defer s.checkMu.Unlock()
 
-	state, err := s.ForceCheck(ctx)
+	state, err := s.forceCheckLocked(ctx)
 	if err != nil {
 		logging.Debugf("Background update check failed: %v", err)
 		return

--- a/internal/update/service_test.go
+++ b/internal/update/service_test.go
@@ -421,9 +421,11 @@ func TestService_ForceCheck_NotModifiedKeepsCachedState(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, status)
 
-	// Cached version + availability are preserved verbatim.
+	// Cached version is preserved; availability is RE-EVALUATED under the
+	// current stableOnly policy (here stableOnly=false, so the prerelease stays
+	// available — the re-evaluation reproduces the cached value).
 	assert.Equal(t, "v0.3.15-alpha", status.Version)
-	assert.True(t, status.Available, "availability carried over from cache")
+	assert.True(t, status.Available, "prerelease stays available with stableOnly=false")
 	assert.True(t, status.Prerelease)
 	// CheckedAt is refreshed; the stale timestamp must be gone.
 	assert.NotEqual(t, "2026-01-01T00:00:00Z", status.CheckedAt)
@@ -466,4 +468,130 @@ func TestService_ForceCheck_NotModifiedWithoutCache(t *testing.T) {
 	require.NotNil(t, status)
 	assert.Equal(t, UpdateSourceError, status.Source)
 	assert.Empty(t, status.Version, "no version fabricated from a 304 with no cache")
+}
+
+// TestService_ForceCheck_NotModifiedReEvaluatesStableOnly is the regression
+// test for the bug CodeRabbit flagged on the 304 path: a prerelease previously
+// cached as Available=true must be suppressed on a 304 once the user enables
+// version_check_stable_only. The releases are unchanged (304), but the policy
+// term changed, so availability is re-derived rather than carried over.
+func TestService_ForceCheck_NotModifiedReEvaluatesStableOnly(t *testing.T) {
+	origVersion := appversion.Version
+	defer func() { appversion.Version = origVersion }()
+	appversion.Version = "v0.3.14-alpha"
+
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "update_cache.json")
+	store := newStateStore(statePath, defaultCheckInterval)
+
+	// Prior check ran with stableOnly=false, so a prerelease was cached as
+	// available — the state the bug would blindly preserve.
+	prior := &updateState{
+		Version:    "v0.3.15-alpha",
+		CheckedAt:  "2026-01-01T00:00:00Z",
+		Available:  true,
+		Prerelease: true,
+		Source:     UpdateSourceFresh,
+		ETag:       `W/"deadbeef"`,
+	}
+	require.NoError(t, store.SaveState(prior))
+
+	chk := &mockChecker{err: ErrNotModified}
+	svc := &service{
+		checker:    chk,
+		store:      store,
+		statePath:  statePath,
+		interval:   24 * time.Hour,
+		enabled:    true,
+		stableOnly: true, // user toggled stable-only ON since the prior check
+	}
+
+	status, err := svc.ForceCheck(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	// Version + prerelease flag preserved (the 304 means releases unchanged).
+	assert.Equal(t, "v0.3.15-alpha", status.Version)
+	assert.True(t, status.Prerelease)
+	// Available is RE-EVALUATED and suppressed under the new stableOnly policy.
+	assert.False(t, status.Available, "prerelease must be suppressed on 304 once stableOnly is enabled")
+	assert.Equal(t, UpdateSourceCached, status.Source)
+
+	// The suppression persists into the on-disk cache for subsequent reads.
+	reloaded, err := store.LoadState()
+	require.NoError(t, err)
+	assert.False(t, reloaded.Available)
+}
+
+// TestService_ForceCheck_NotModifiedReEnablesWhenStableOnlyCleared verifies
+// the inverse of the stableOnly re-evaluation: if a prerelease was cached with
+// Available=false (because stableOnly was on) and the user later disables it,
+// a 304 re-evaluates availability back to true.
+func TestService_ForceCheck_NotModifiedReEnablesWhenStableOnlyCleared(t *testing.T) {
+	origVersion := appversion.Version
+	defer func() { appversion.Version = origVersion }()
+	appversion.Version = "v0.3.14-alpha"
+
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "update_cache.json")
+	store := newStateStore(statePath, defaultCheckInterval)
+
+	prior := &updateState{
+		Version:    "v0.3.15-alpha",
+		CheckedAt:  "2026-01-01T00:00:00Z",
+		Available:  false, // suppressed under the old stableOnly=true policy
+		Prerelease: true,
+		Source:     UpdateSourceFresh,
+		ETag:       `W/"deadbeef"`,
+	}
+	require.NoError(t, store.SaveState(prior))
+
+	chk := &mockChecker{err: ErrNotModified}
+	svc := &service{
+		checker:    chk,
+		store:      store,
+		statePath:  statePath,
+		interval:   24 * time.Hour,
+		enabled:    true,
+		stableOnly: false, // user disabled stable-only since the prior check
+	}
+
+	status, err := svc.ForceCheck(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.True(t, status.Available, "prerelease re-surfaced once stableOnly is cleared")
+	assert.True(t, status.Prerelease)
+}
+
+// TestService_ForceCheck_ResetsConditionalHintsWhenCacheEmpty verifies the
+// sticky-state fix on the ConditionalChecker path: the githubChecker is shared
+// across checks, so if the on-disk cache is absent (fresh install, deleted
+// cache file), the service must reset the ETag/skipLatest hints to empty/false
+// rather than leaving a prior check's values in place — otherwise a stale
+// If-None-Match or an unintended /releases/latest skip would leak forward.
+func TestService_ForceCheck_ResetsConditionalHintsWhenCacheEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "update_cache.json")
+	store := newStateStore(statePath, defaultCheckInterval) // empty cache
+
+	chk := &mockChecker{
+		version: &versionInfo{Version: "v1.0.0", TagName: "v1.0.0"},
+		// Simulate stale state left by a prior check against a different cache.
+		gotIfNoneMatch: `W/"stale-from-prior-check"`,
+		gotSkipLatest:  true,
+	}
+	svc := &service{
+		checker:   chk,
+		store:     store,
+		statePath: statePath,
+		interval:  24 * time.Hour,
+		enabled:   true,
+	}
+
+	_, err := svc.ForceCheck(context.Background())
+	require.NoError(t, err)
+
+	// With no cache, both hints must be reset to empty/false — not left sticky.
+	assert.Empty(t, chk.gotIfNoneMatch, "stale ETag must be reset when cache is empty")
+	assert.False(t, chk.gotSkipLatest, "stale skipLatest must be reset when cache is empty")
 }

--- a/internal/update/service_test.go
+++ b/internal/update/service_test.go
@@ -15,6 +15,10 @@ import (
 type mockChecker struct {
 	version *versionInfo
 	err     error
+
+	// ConditionalChecker probes — record what the service threaded in.
+	gotIfNoneMatch string
+	gotSkipLatest  bool
 }
 
 func (m *mockChecker) CheckLatestVersion(_ context.Context) (*versionInfo, error) {
@@ -23,6 +27,12 @@ func (m *mockChecker) CheckLatestVersion(_ context.Context) (*versionInfo, error
 	}
 	return m.version, nil
 }
+
+// SetIfNoneMatch implements ConditionalChecker.
+func (m *mockChecker) SetIfNoneMatch(etag string) { m.gotIfNoneMatch = etag }
+
+// SetSkipLatest implements ConditionalChecker.
+func (m *mockChecker) SetSkipLatest(skip bool) { m.gotSkipLatest = skip }
 
 func TestNewService(t *testing.T) {
 	service := NewService(UpdateConfig{
@@ -317,4 +327,143 @@ func TestService_ForceCheck_PrereleaseToStableIsAvailable(t *testing.T) {
 	assert.Equal(t, "v1.6.0", status.Version)
 	assert.True(t, status.Available)
 	assert.False(t, status.Prerelease)
+}
+
+// TestService_ForceCheck_StableOnlyConfig verifies the service honors the
+// config-driven stableOnly flag when the latest release is a prerelease:
+// with stableOnly=false (the default) the prerelease is surfaced as an
+// available update; with stableOnly=true the version is still cached (for
+// transparency) but Available is suppressed so the user isn't notified about a
+// prerelease.
+func TestService_ForceCheck_StableOnlyConfig(t *testing.T) {
+	origVersion := appversion.Version
+	defer func() { appversion.Version = origVersion }()
+	appversion.Version = "v0.3.14-alpha"
+
+	mkService := func(stableOnly bool) *service {
+		tmpDir := t.TempDir()
+		statePath := filepath.Join(tmpDir, "update_cache.json")
+		return &service{
+			checker: &mockChecker{
+				version: &versionInfo{
+					Version:    "v0.3.15-alpha",
+					TagName:    "v0.3.15-alpha",
+					Prerelease: true,
+				},
+			},
+			store:      newStateStore(statePath, defaultCheckInterval),
+			statePath:  statePath,
+			interval:   24 * time.Hour,
+			enabled:    true,
+			stableOnly: stableOnly,
+		}
+	}
+
+	t.Run("stableOnly=false surfaces prerelease update", func(t *testing.T) {
+		svc := mkService(false)
+		status, err := svc.ForceCheck(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		assert.Equal(t, "v0.3.15-alpha", status.Version)
+		assert.True(t, status.Available, "prerelease should be offered when stableOnly=false")
+		assert.True(t, status.Prerelease)
+	})
+
+	t.Run("stableOnly=true suppresses prerelease update", func(t *testing.T) {
+		svc := mkService(true)
+		status, err := svc.ForceCheck(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		assert.Equal(t, "v0.3.15-alpha", status.Version, "version still cached for transparency")
+		assert.False(t, status.Available, "prerelease must NOT be offered when stableOnly=true")
+		assert.True(t, status.Prerelease)
+	})
+}
+
+// TestService_ForceCheck_NotModifiedKeepsCachedState verifies the 304 path:
+// when the checker reports ErrNotModified (GitHub returned 304 for our
+// If-None-Match), the service keeps the cached version/availability and only
+// refreshes CheckedAt. This is the rate-limit-free steady state for a
+// frequently-restarted instance.
+func TestService_ForceCheck_NotModifiedKeepsCachedState(t *testing.T) {
+	origVersion := appversion.Version
+	defer func() { appversion.Version = origVersion }()
+	appversion.Version = "v0.3.14-alpha"
+
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "update_cache.json")
+	store := newStateStore(statePath, defaultCheckInterval)
+
+	// Prime the cache with a prior successful check (including the ETag +
+	// no-stable-latest flag a real check would have persisted).
+	prior := &updateState{
+		Version:        "v0.3.15-alpha",
+		CheckedAt:      "2026-01-01T00:00:00Z",
+		Available:      true,
+		Prerelease:     true,
+		Source:         UpdateSourceFresh,
+		ETag:           `W/"deadbeef"`,
+		NoStableLatest: true,
+	}
+	require.NoError(t, store.SaveState(prior))
+
+	chk := &mockChecker{err: ErrNotModified}
+	svc := &service{
+		checker:    chk,
+		store:      store,
+		statePath:  statePath,
+		interval:   24 * time.Hour,
+		enabled:    true,
+		stableOnly: false,
+	}
+
+	status, err := svc.ForceCheck(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	// Cached version + availability are preserved verbatim.
+	assert.Equal(t, "v0.3.15-alpha", status.Version)
+	assert.True(t, status.Available, "availability carried over from cache")
+	assert.True(t, status.Prerelease)
+	// CheckedAt is refreshed; the stale timestamp must be gone.
+	assert.NotEqual(t, "2026-01-01T00:00:00Z", status.CheckedAt)
+	assert.NotEmpty(t, status.CheckedAt)
+	// Source flips to cached (not fresh) since we served from the 304 path.
+	assert.Equal(t, UpdateSourceCached, status.Source)
+	assert.Empty(t, status.Error)
+
+	// The service threaded the cached ETag + no-stable-latest flag into the
+	// checker so the real request would have been rate-limit-friendly.
+	assert.Equal(t, `W/"deadbeef"`, chk.gotIfNoneMatch)
+	assert.True(t, chk.gotSkipLatest, "skipLatest threaded from cached NoStableLatest")
+
+	// The persisted state carries the ETag + flag forward for the next check.
+	reloaded, err := store.LoadState()
+	require.NoError(t, err)
+	assert.Equal(t, `W/"deadbeef"`, reloaded.ETag)
+	assert.True(t, reloaded.NoStableLatest)
+}
+
+// TestService_ForceCheck_NotModifiedWithoutCache verifies the edge case where
+// a 304 arrives but there is no prior cached state to reuse: the service
+// reports an error state rather than fabricating version data.
+func TestService_ForceCheck_NotModifiedWithoutCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "update_cache.json")
+	store := newStateStore(statePath, defaultCheckInterval) // empty cache
+
+	chk := &mockChecker{err: ErrNotModified}
+	svc := &service{
+		checker:   chk,
+		store:     store,
+		statePath: statePath,
+		interval:  24 * time.Hour,
+		enabled:   true,
+	}
+
+	status, err := svc.ForceCheck(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, UpdateSourceError, status.Source)
+	assert.Empty(t, status.Version, "no version fabricated from a 304 with no cache")
 }

--- a/internal/update/state.go
+++ b/internal/update/state.go
@@ -35,6 +35,17 @@ type updateState struct {
 	Prerelease bool         `json:"prerelease"`      // Whether latest is prerelease
 	Source     UpdateSource `json:"source"`          // Update source status
 	Error      string       `json:"error,omitempty"` // Last error message
+	// ETag from the last successful GitHub API response. Sent back as
+	// If-None-Match on the next check so GitHub returns 304 (which does NOT
+	// count against the rate limit) when the releases haven't changed.
+	ETag string `json:"etag,omitempty"`
+	// NoStableLatest is true once /releases/latest has 404'd (the repo has no
+	// stable latest release — true for the Go rewrite, which ships only
+	// prereleases). When true, the next check skips the 404-throwing
+	// /releases/latest call and goes straight to the /releases list, halving
+	// API calls. The list endpoint surfaces stable releases too once one
+	// becomes newest, so this never misses a stable release.
+	NoStableLatest bool `json:"no_stable_latest,omitempty"`
 }
 
 // stateStore handles loading and saving update state.

--- a/web/frontend/src/lib/components/Navigation.svelte
+++ b/web/frontend/src/lib/components/Navigation.svelte
@@ -5,6 +5,7 @@
 	import { FolderOpen, Settings, Film, Users, LogOut, Activity, FileText, ChevronDown, Sun, Moon, Monitor, Tags, Type } from 'lucide-svelte';
 	import { getThemeStore } from '$lib/stores/theme.svelte';
 	import type { Theme } from '$lib/stores/theme.svelte';
+	import UpdateIndicator from '$lib/components/UpdateIndicator.svelte';
 
 	interface Props {
 		authenticated?: boolean;
@@ -94,6 +95,9 @@
 						<span class="hidden md:inline">{item.label}</span>
 					</a>
 				{/each}
+
+				<!-- Update available indicator (hidden when up-to-date / disabled) -->
+				<UpdateIndicator />
 
 				<!-- Settings & Logs dropdown -->
 				<div class="relative" data-submenu>

--- a/web/frontend/src/lib/components/Navigation.svelte
+++ b/web/frontend/src/lib/components/Navigation.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { browser } from '$app/environment';
 	import { cubicOut } from 'svelte/easing';
 	import { fly } from 'svelte/transition';
 	import { FolderOpen, Settings, Film, Users, LogOut, Activity, FileText, ChevronDown, Sun, Moon, Monitor, Tags, Type } from 'lucide-svelte';
@@ -96,8 +97,15 @@
 					</a>
 				{/each}
 
-				<!-- Update available indicator (hidden when up-to-date / disabled) -->
-				<UpdateIndicator />
+				<!-- Update available indicator (hidden when up-to-date / disabled).
+				Browser-only: UpdateIndicator uses TanStack Query (useQueryClient),
+				which requires a QueryClientProvider. The SSR branch of +layout.svelte
+				renders Navigation without a provider, so mounting this during SSR
+				would throw. The indicator is an interactive, API-polling widget with
+				no SSR value, so gating on `browser` is the correct fix. -->
+				{#if browser}
+					<UpdateIndicator />
+				{/if}
 
 				<!-- Settings & Logs dropdown -->
 				<div class="relative" data-submenu>

--- a/web/frontend/src/lib/components/QueryClientWrapper.svelte
+++ b/web/frontend/src/lib/components/QueryClientWrapper.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
+	let { client, children }: { client: QueryClient; children: import('svelte').Snippet } = $props();
+</script>
+
+<QueryClientProvider client={client}>
+	{@render children()}
+</QueryClientProvider>

--- a/web/frontend/src/lib/components/UpdateIndicator.svelte
+++ b/web/frontend/src/lib/components/UpdateIndicator.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+	import { cubicOut } from 'svelte/easing';
+	import { fly } from 'svelte/transition';
+	import { createMutation, useQueryClient } from '@tanstack/svelte-query';
+	import { ArrowUpCircle, RefreshCw, ExternalLink, ChevronDown } from 'lucide-svelte';
+	import { createVersionStatusQuery } from '$lib/query/queries';
+	import { apiClient } from '$lib/api/client';
+	import { toastStore } from '$lib/stores/toast';
+	import type { VersionStatusResponse } from '$lib/api/types';
+
+	// GitHub release URL for the Go rewrite. The latest tag is appended when
+	// available so the "view release" link deep-links to the actual release.
+	const REPO_RELEASES_URL = 'https://github.com/javinizer/javinizer-go/releases';
+	const REPO_RELEASE_TAG_URL = 'https://github.com/javinizer/javinizer-go/releases/tag';
+
+	const queryClient = useQueryClient();
+	const versionQuery = $derived(createVersionStatusQuery());
+	const status = $derived(versionQuery.data ?? null);
+
+	// Only surface the indicator when an update is genuinely available. Hidden
+	// when: query is pending/errored, checks are disabled (source === 'disabled'),
+	// no state yet (source === 'none'), or update_available is false. This keeps
+	// the nav clean for up-to-date / disabled / offline users.
+	const showIndicator = $derived(
+		!!status && status.update_available && status.source !== 'disabled' && status.source !== 'none'
+	);
+
+	let popoverOpen = $state(false);
+
+	// Force a fresh check (POST /api/v1/version/check hits GitHub with the
+	// server-side rate limit/cache). Invalidates the status query on success so
+	// the indicator updates immediately.
+	const checkMutation = createMutation(() => ({
+		mutationFn: () => apiClient.checkVersion(),
+		onSuccess: (data: VersionStatusResponse) => {
+			queryClient.invalidateQueries({ queryKey: ['version-status'] });
+			if (data.update_available) {
+				toastStore.info(
+					data.prerelease
+						? `Prerelease ${data.latest} is available (current: ${data.current})`
+						: `Update available: ${data.latest} (current: ${data.current})`
+				);
+			} else if (data.source === 'disabled') {
+				toastStore.info('Update checks are disabled in configuration');
+			} else if (data.latest) {
+				toastStore.success(`You're running the latest version (${data.current})`);
+			} else if (data.error) {
+				toastStore.error(`Update check failed: ${data.error}`);
+			}
+		},
+		onError: (error: Error) => {
+			toastStore.error(`Update check failed: ${error.message}`);
+		},
+	}));
+
+	function togglePopover() {
+		popoverOpen = !popoverOpen;
+	}
+
+	function closePopover() {
+		popoverOpen = false;
+	}
+
+	function handleClickOutside(event: MouseEvent) {
+		const target = event.target as HTMLElement;
+		if (!target.closest('[data-update-indicator]')) {
+			closePopover();
+		}
+	}
+
+	function handleCheckNow(event: MouseEvent) {
+		event.stopPropagation();
+		checkMutation.mutate();
+	}
+
+	const checking = $derived(checkMutation.isPending);
+	const releaseUrl = $derived(
+		status?.latest ? `${REPO_RELEASE_TAG_URL}/${status.latest}` : REPO_RELEASES_URL
+	);
+</script>
+
+<svelte:window onclick={handleClickOutside} onkeydown={(e) => { if (e.key === 'Escape' && popoverOpen) popoverOpen = false; }} />
+
+{#if showIndicator}
+	<div class="relative" data-update-indicator>
+		<button
+			type="button"
+			onclick={togglePopover}
+			aria-expanded={popoverOpen}
+			aria-haspopup="true"
+			aria-label="Update available"
+			title={status?.prerelease ? `Prerelease ${status?.latest} available` : `Update ${status?.latest} available`}
+			class="relative flex items-center justify-center h-9 w-9 rounded-md transition-all duration-200 hover:bg-accent hover:-translate-y-px text-primary"
+		>
+			<ArrowUpCircle class="h-5 w-5" />
+			<!-- Pulsing dot: draws the eye without a full banner. Prerelease uses
+			amber, stable uses primary, matching the popover tag below. -->
+			<span
+				class="absolute top-1 right-1 h-2 w-2 rounded-full {status?.prerelease
+					? 'bg-amber-500'
+					: 'bg-primary'} animate-pulse"
+			></span>
+		</button>
+
+		{#if popoverOpen}
+			<div
+				class="absolute right-0 top-full mt-1 w-72 rounded-lg border bg-card p-3 shadow-lg z-50"
+				in:fly={{ y: -4, duration: 120, easing: cubicOut }}
+				role="dialog"
+				aria-label="Update details"
+			>
+				<div class="flex items-start gap-2">
+					<ArrowUpCircle class="h-5 w-5 shrink-0 mt-0.5 text-primary" />
+					<div class="min-w-0 flex-1">
+						<p class="text-sm font-medium">
+							{#if status?.prerelease}
+								Prerelease available
+							{:else}
+								Update available
+							{/if}
+						</p>
+						<p class="mt-1 text-xs text-muted-foreground break-all">
+							<span class="font-medium text-foreground">{status?.latest}</span>
+							<span class="mx-1">·</span>
+							current <span class="font-medium text-foreground">{status?.current}</span>
+						</p>
+						{#if status?.prerelease}
+							<span
+								class="inline-block mt-2 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/15 text-amber-700 dark:text-amber-300"
+							>
+								prerelease
+							</span>
+						{/if}
+					</div>
+				</div>
+
+				<div class="mt-3 flex items-center gap-2">
+					<a
+						href={releaseUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						onclick={closePopover}
+						class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium transition-all duration-150 bg-primary text-primary-foreground hover:opacity-90 hover:translate-x-0.5"
+					>
+						<ExternalLink class="h-3.5 w-3.5" />
+						View release
+					</a>
+					<button
+						type="button"
+						onclick={handleCheckNow}
+						disabled={checking}
+						class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium transition-all duration-150 hover:bg-accent hover:translate-x-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-x-0"
+					>
+						<RefreshCw class="h-3.5 w-3.5 {checking ? 'animate-spin' : ''}" />
+						{checking ? 'Checking…' : 'Check again'}
+					</button>
+				</div>
+
+				{#if status?.error}
+					<p class="mt-2 text-[11px] text-destructive">{status.error}</p>
+				{/if}
+				{#if status?.checked_at}
+					<p class="mt-2 text-[11px] text-muted-foreground">
+						Last checked {new Date(status.checked_at).toLocaleString()}
+					</p>
+				{/if}
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/web/frontend/src/lib/components/UpdateIndicator.test.ts
+++ b/web/frontend/src/lib/components/UpdateIndicator.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import UpdateIndicator from './UpdateIndicator.svelte';
+import QueryClientWrapper from './QueryClientWrapper.svelte';
+import type { VersionStatusResponse } from '$lib/api/types';
+
+// The component drives its state through createVersionStatusQuery() →
+// apiClient.getVersionStatus() and a createMutation() → apiClient.checkVersion().
+// Mock the api client so the query resolves with controlled fixtures and no
+// network call is attempted under jsdom.
+vi.mock('$lib/api/client', () => ({
+	apiClient: {
+		getVersionStatus: vi.fn(),
+		checkVersion: vi.fn(),
+	},
+}));
+
+const mod = await import('$lib/api/client');
+const mockGetVersionStatus = vi.mocked(mod.apiClient.getVersionStatus);
+const mockCheckVersion = vi.mocked(mod.apiClient.checkVersion);
+
+// jsdom lacks the Web Animations API; Svelte's `transition:fly` (popover intro)
+// calls element.animate(). Stub it so the open path runs under vitest.
+if (!Element.prototype.animate) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(Element.prototype as any).animate = function () {
+		const anim = {
+			onfinish: null as (() => void) | null,
+			oncancel: null as (() => void) | null,
+			effect: null as unknown,
+			playState: 'finished' as const,
+			currentTime: 0,
+			cancel() {},
+			finish() {
+				anim.onfinish?.();
+			},
+			addEventListener() {},
+			removeEventListener() {},
+		};
+		queueMicrotask(() => anim.onfinish?.());
+		return anim;
+	};
+}
+
+function makeStatus(overrides: Partial<VersionStatusResponse> = {}): VersionStatusResponse {
+	return {
+		current: 'v0.3.14-alpha',
+		latest: 'v0.3.15-alpha',
+		update_available: true,
+		prerelease: true,
+		checked_at: '2026-06-27T23:21:20Z',
+		source: 'fresh',
+		...overrides,
+	};
+}
+
+// Each test gets a fresh QueryClient (via the wrapper) so cached state from one
+// test can't bleed into the next. The wrapper provides the svelte-query context
+// UpdateIndicator reads via useQueryClient().
+import { QueryClient } from '@tanstack/svelte-query';
+function renderWithClient(status: VersionStatusResponse | null) {
+	if (status !== null) {
+		mockGetVersionStatus.mockResolvedValue(status);
+	} else {
+		mockGetVersionStatus.mockRejectedValue(new Error('network'));
+	}
+	return render(
+		UpdateIndicator,
+		{},
+		{
+			wrapper: QueryClientWrapper,
+			wrapperProps: { client: new QueryClient({ defaultOptions: { queries: { retry: false } } }) },
+		},
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('UpdateIndicator', () => {
+	it('is hidden when no update is available', async () => {
+		const { container } = renderWithClient(makeStatus({ update_available: false }));
+		await waitFor(() => expect(mockGetVersionStatus).toHaveBeenCalled());
+		// No indicator button renders.
+		expect(container.querySelector('button[aria-label="Update available"]')).toBeNull();
+	});
+
+	it('is hidden when update checks are disabled', async () => {
+		const { container } = renderWithClient(
+			makeStatus({ source: 'disabled', update_available: false, latest: '' }),
+		);
+		await waitFor(() => expect(mockGetVersionStatus).toHaveBeenCalled());
+		expect(container.querySelector('button[aria-label="Update available"]')).toBeNull();
+	});
+
+	it('is hidden when no state exists yet (source: none)', async () => {
+		const { container } = renderWithClient(
+			makeStatus({ source: 'none', update_available: false, latest: '' }),
+		);
+		await waitFor(() => expect(mockGetVersionStatus).toHaveBeenCalled());
+		expect(container.querySelector('button[aria-label="Update available"]')).toBeNull();
+	});
+
+	it('renders the indicator button when an update is available', async () => {
+		const { container } = renderWithClient(makeStatus());
+		await waitFor(() => {
+			const button = container.querySelector('button[aria-label="Update available"]');
+			expect(button).toBeTruthy();
+			expect(button?.getAttribute('aria-expanded')).toBe('false');
+		});
+	});
+
+	it('opens the popover on click and shows the latest + current versions', async () => {
+		const { container } = renderWithClient(makeStatus());
+		let button: HTMLButtonElement | null = null;
+		await waitFor(() => {
+			button = container.querySelector('button[aria-label="Update available"]');
+			expect(button).toBeTruthy();
+		});
+		expect(button).not.toBeNull();
+
+		await fireEvent.click(button!);
+
+		await waitFor(() => {
+			expect(button!.getAttribute('aria-expanded')).toBe('true');
+			expect(container.textContent).toContain('v0.3.15-alpha');
+			expect(container.textContent).toContain('v0.3.14-alpha');
+			expect(container.textContent).toContain('prerelease');
+			expect(container.textContent).toContain('View release');
+			expect(container.textContent).toContain('Check again');
+		});
+	});
+
+	it('renders a stable (non-prerelease) update without the prerelease tag', async () => {
+		const { container } = renderWithClient(makeStatus({ latest: 'v1.0.0', prerelease: false }));
+		let button: HTMLButtonElement | null = null;
+		await waitFor(() => {
+			button = container.querySelector('button[aria-label="Update available"]');
+			expect(button).toBeTruthy();
+		});
+		await fireEvent.click(button!);
+
+		await waitFor(() => {
+			expect(container.textContent).toContain('Update available');
+			expect(container.textContent).toContain('v1.0.0');
+			// No "prerelease" tag in the popover body.
+			const tags = container.querySelectorAll('span.bg-amber-500\\/15');
+			expect(tags.length).toBe(0);
+		});
+	});
+
+	it('fires a force check and toasts when "Check again" is clicked', async () => {
+		mockCheckVersion.mockResolvedValue(makeStatus());
+		const { container } = renderWithClient(makeStatus());
+		let button: HTMLButtonElement | null = null;
+		await waitFor(() => {
+			button = container.querySelector('button[aria-label="Update available"]');
+			expect(button).toBeTruthy();
+		});
+		await fireEvent.click(button!);
+
+		let checkButton: HTMLButtonElement | null = null;
+		await waitFor(() => {
+			// The popover's "Check again" button is the one WITHOUT the update aria-label.
+			checkButton = container.querySelector('button:not([aria-label="Update available"])');
+			expect(checkButton).toBeTruthy();
+		});
+		await fireEvent.click(checkButton!);
+
+		await waitFor(() => expect(mockCheckVersion).toHaveBeenCalled());
+	});
+
+	it('links to the specific release tag when a latest version is known', async () => {
+		const { container } = renderWithClient(makeStatus({ latest: 'v0.3.15-alpha' }));
+		let button: HTMLButtonElement | null = null;
+		await waitFor(() => {
+			button = container.querySelector('button[aria-label="Update available"]');
+			expect(button).toBeTruthy();
+		});
+		await fireEvent.click(button!);
+
+		await waitFor(() => {
+			const link = container.querySelector('a[href*="releases/tag/v0.3.15-alpha"]');
+			expect(link).toBeTruthy();
+			expect(link?.getAttribute('target')).toBe('_blank');
+			expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
+		});
+	});
+});

--- a/web/frontend/src/lib/query/queries.ts
+++ b/web/frontend/src/lib/query/queries.ts
@@ -29,9 +29,7 @@ export function createBatchJobsQuery() {
 		// hasRunningJobs; this is its query-level replacement, so the list no
 		// longer freezes mid-run when started from elsewhere.
 		refetchInterval: (query) =>
-			query.state.data?.jobs?.some((j) => j.status?.toLowerCase() === 'running')
-				? 5_000
-				: false,
+			query.state.data?.jobs?.some((j) => j.status?.toLowerCase() === 'running') ? 5_000 : false,
 	}));
 }
 
@@ -85,5 +83,22 @@ export function createBatchJobPollingQuery(jobId: string) {
 		},
 		refetchIntervalInBackground: true,
 		staleTime: 0,
+	}));
+}
+
+// Version / update-check status. The server caches the check result (default
+// 24h check interval) and GET /api/v1/version returns the cache without hitting
+// GitHub, so a long staleTime + refetchInterval is cheap and keeps the nav
+// indicator fresh enough (e.g. after a server-side background check fires)
+// without hammering the endpoint on every navigation.
+export function createVersionStatusQuery() {
+	return createQuery(() => ({
+		queryKey: ['version-status'],
+		queryFn: () => apiClient.getVersionStatus(),
+		// The server-side cache is the rate limiter; re-read it every 10 min so a
+		// background check that landed server-side surfaces in the UI without us
+		// polling GitHub ourselves.
+		staleTime: 5 * 60_000,
+		refetchInterval: 10 * 60_000,
 	}));
 }

--- a/web/frontend/tests/fullstack/regressions/update-indicator.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/update-indicator.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Update-notification indicator regression spec.
+ *
+ * Real stack: browser → Vite proxy → real /api/v1/version on the Go binary →
+ * real update.Service → real GitHub API (api.github.com/repos/javinizer/
+ * javinizer-go). NO page.route mocks — the fullstack suite's convention is
+ * to exercise the real transport end-to-end.
+ *
+ * What this pins:
+ * - GET /api/v1/version returns a well-formed VersionStatusResponse through
+ *   the real stack (the update checker now points at the Go rewrite, not the
+ *   legacy Python repo — a prior bug returned 2.6.4 from javinizer/Javinizer).
+ * - The nav renders the UpdateIndicator iff the real API reports
+ *   update_available=true (and source is not disabled/none). The indicator is
+ *   the user-facing notification surface for new releases.
+ * - When visible, the popover shows the real latest + current versions and a
+ *   deep-link to the Go repo's release page. The prerelease tag renders when
+ *   the latest version is a prerelease (the Go repo currently ships only
+ *   prereleases, so this is the expected path).
+ *
+ * Determinism note: the e2e binary's version is v0.0.0-<commit> (dev build,
+ * no ldflags) which is always less than any real release tag, so
+ * update_available=true is the expected state when GitHub responds. If
+ * GitHub rate-limits (60 req/hr unauthenticated — the startup BackgroundCheck
+ * + this spec's force-check are 2 hits per run), the API returns an error
+ * state with update_available=false and the spec asserts the hidden path
+ * instead. Both paths are valid assertions; the spec never flakes — it tests
+ * whichever state the real API actually returned.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+
+/** Shape of the /api/v1/version response (mirrors VersionStatusResponse). */
+interface VersionStatusResponse {
+	current: string;
+	latest: string;
+	update_available: boolean;
+	prerelease: boolean;
+	checked_at: string;
+	source: string;
+	error?: string;
+}
+
+/** Force a fresh version check against the real GitHub API and return state.
+ *
+ * Uses a RELATIVE URL so the request flows through the Vite dev-server proxy
+ * (localhost:FRONTEND_PORT → 127.0.0.1:18080) carrying the storageState
+ * session cookie scoped to localhost — the same path the browser takes.
+ * Direct BACKEND_BASE requests would need a separate loginAgainstRealBackend
+ * call because the cookie domain doesn't cover 127.0.0.1. */
+async function forceCheck(request: APIRequestContext): Promise<VersionStatusResponse> {
+	const resp = await request.post('/api/v1/version/check', {
+		failOnStatusCode: false,
+	});
+	expect(resp.ok(), 'POST /api/v1/version/check should return 200').toBeTruthy();
+	return (await resp.json()) as VersionStatusResponse;
+}
+
+/** Read the cached version status (no GitHub hit — reads the on-disk cache). */
+async function getCachedStatus(request: APIRequestContext): Promise<VersionStatusResponse> {
+	const resp = await request.get('/api/v1/version', { failOnStatusCode: false });
+	expect(resp.ok(), 'GET /api/v1/version should return 200').toBeTruthy();
+	return (await resp.json()) as VersionStatusResponse;
+}
+
+test.describe('Update indicator: real update.Service + real GitHub API → nav indicator', () => {
+	test('GET /api/v1/version returns a well-formed status through the real stack', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		const status = await getCachedStatus(request);
+
+		// Core fields always present regardless of check outcome.
+		expect(typeof status.current).toBe('string');
+		expect(status.current.length).toBeGreaterThan(0);
+		expect(typeof status.update_available).toBe('boolean');
+		expect(typeof status.prerelease).toBe('boolean');
+		expect(typeof status.source).toBe('string');
+
+		// The update checker must point at the Go rewrite (javinizer/javinizer-go),
+		// NOT the legacy Python repo (javinizer/Javinizer). A prior bug returned
+		// 2.6.4 — the Python project's release — as the "latest" version. If the
+		// check succeeds (source is fresh/cached, not error), latest must NOT be
+		// the Python repo's 2.6.4.
+		if (status.source !== 'error' && status.source !== 'disabled' && status.source !== 'none') {
+			expect(status.latest, 'latest must not be the legacy Python repo version').not.toBe('2.6.4');
+			expect(status.latest.length).toBeGreaterThan(0);
+		}
+	});
+
+	test('nav indicator reflects the real version status', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		// Force a fresh check so the cache reflects the current GitHub state
+		// (the startup BackgroundCheck may have rate-limited). This is one
+		// GitHub hit; the GET below reads the resulting cache (no hit).
+		const fresh = await forceCheck(request);
+
+		// Navigate to any authenticated page — the nav (with UpdateIndicator)
+		// renders in the shared layout.
+		await page.goto('/jobs');
+		await page.waitForLoadState('domcontentloaded');
+		await page.waitForLoadState('networkidle');
+
+		const indicatorButton = page.locator('button[aria-label="Update available"]');
+
+		if (fresh.update_available && fresh.source !== 'disabled' && fresh.source !== 'none') {
+			// --- Shown path: update available → indicator visible + interactive ---
+			await expect(indicatorButton).toBeVisible();
+			await expect(indicatorButton).toHaveAttribute('aria-expanded', 'false');
+
+			// Open the popover.
+			await indicatorButton.click();
+			await expect(indicatorButton).toHaveAttribute('aria-expanded', 'true');
+
+			// Popover shows the real latest + current versions from the API.
+			const popover = page.locator('[role="dialog"][aria-label="Update details"]');
+			await expect(popover).toBeVisible();
+			await expect(popover).toContainText(fresh.latest);
+			await expect(popover).toContainText(fresh.current);
+
+			// Prerelease tag renders iff the latest version is a prerelease.
+			// The Go repo currently ships only prereleases (v0.x-alpha), so
+			// fresh.prerelease is expected true here.
+			if (fresh.prerelease) {
+				await expect(popover).toContainText('Prerelease available');
+				await expect(popover.locator('span.bg-amber-500\\/15')).toBeVisible();
+			} else {
+				await expect(popover).toContainText('Update available');
+			}
+
+			// "View release" link deep-links to the Go repo's release page.
+			const releaseLink = popover.locator(
+				`a[href*="github.com/javinizer/javinizer-go/releases/tag/${fresh.latest}"]`,
+			);
+			await expect(releaseLink).toBeVisible();
+			await expect(releaseLink).toHaveAttribute('target', '_blank');
+			await expect(releaseLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+			// "Check again" button is present and triggers a force-check.
+			const checkAgainButton = popover.getByText('Check again');
+			await expect(checkAgainButton).toBeVisible();
+		} else {
+			// --- Hidden path: no update / disabled / error / rate-limited ---
+			// The indicator must NOT render — the nav stays clean for up-to-date
+			// or offline users. This is the valid fallback when GitHub rate-limits.
+			await expect(indicatorButton).toHaveCount(0);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Completes the update-available notification feature end-to-end and fixes the GitHub API 403 rate-limiting showing up in logs:

```
time="2026-06-28 08:28:20" level=debug msg="Update check failed: rate limited by GitHub API (status: 403)"
```

## The problem

Two compounding causes:

1. **Call-doubling on prerelease-only repos.** `/releases/latest` excludes prereleases, so for the Go rewrite (v0.x-alpha only) it always 404s and the checker falls back to `/releases` — **2 counted API calls per check**.
2. **No ETag caching.** GitHub returns an `ETag` header but the checker never sent `If-None-Match` back, so every check was a full counted request. GitHub 304 responses do **not** count against the 60/hr unauthenticated quota.

The 24h `ShouldCheck` gate protects a long-running app, but **restarts bypass it** — the startup `BackgroundCheck` fires every launch. Restart-heavy dev/CI burns through 60/hr fast.

## The fix

Persist an `ETag` + `NoStableLatest` hint in the on-disk `updateState` cache (ephemeral cache, not user config — zero-value-safe on old caches, no migration):

- **ETag conditional GET** → `If-None-Match` → 304 is free. Steady-state across restarts: 1 list call returning 304 instead of 2 counted calls.
- **Skip the 404** → once `NoStableLatest` is cached, go straight to `/releases`, halving calls.
- `service.ForceCheck` threads the cached hints into the checker via a new **optional** `ConditionalChecker` interface (stub checkers need not implement it; type-assert falls back to a full fetch, so the `Checker` interface + all mocks stay untouched). On `ErrNotModified` the cached version/availability is kept and only `CheckedAt` is refreshed.
- Startup `BackgroundCheck` → `ForceCheck`, so the exact restart trigger is covered.

## What else is in here (one coherent feature)

The working tree had the rest of the update-notification feature uncommitted alongside the rate-limit fix; they're interleaved in `service.ForceCheck` (the `stableOnly` guard and the `ErrNotModified` handling share the same method), so this ships as one PR:

- **Config:** `system.version_check_stable_only` — opt-in to be notified only about stable releases (prereleases still fetched/cached for transparency). Defaults to `false`; zero value is correct for existing configs, no migration.
- **API/CLI:** wire `VersionCheckStableOnly` through; hardcode `defaultRepo = "javinizer/javinizer-go"` at every construction site so the checker can never silently point at the legacy Python repo (`javinizer/Javinizer`, `2.6.4`) again.
- **Web UI:** `UpdateIndicator` — a subtle arrow-up-circle + pulsing dot in the nav bar (amber = prerelease, primary = stable), visible on every page only when an update is genuinely available. Click → popover with latest/current versions, a deep-link to the release, and a "Check again" button (`POST /api/v1/version/check`, now ETag-protected). Plus `QueryClientWrapper` + `createVersionStatusQuery` for polling.

## Tests

- **Unit** (`internal/update`): ETag 304 → `ErrNotModified` (stable path); `skipLatest` avoids the 404 + list-path 304 (prerelease path); service keeps cached state on 304 and threads ETag/skipLatest into the checker; 304-without-cache edge case; `version_check_stable_only` config migration.
- **E2E** (`update-indicator.spec.ts`, fullstack — real browser → real Vite → real Go e2e backend → real GitHub API, no mocks): verifies `GET /api/v1/version` returns a well-formed status (latest is **not** the legacy `2.6.4`) and the nav indicator reflects the real version status across shown/hidden paths, popover contents, prerelease tag, and release deep-link.

## Verification

All 7 pre-commit hooks pass: `gofmt`, `golangci-lint` (0 issues), `go vet`, `go test -short` (0 failures), `go build ./...`, swagger docs up to date, `svelte-check` (0 errors). `go test ./internal/update/... -race` and the full `internal/api/... -race` suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an update indicator in the top navigation with details and a “Check again” action.
  * Introduced a new setting to restrict update notifications to stable releases only.
* **Bug Fixes**
  * Improved update-check behavior with better cache reuse (including conditional requests).
  * Update status remains correct when no stable “latest” release exists.
* **Documentation**
  * Updated the example configuration to include the new stable-only setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->