### PR TITLE
fix(aggregator): [] per-field priority inherits global; skip sentinel + YAML persistence

### DIFF
--- a/internal/aggregator/aggregate.go
+++ b/internal/aggregator/aggregate.go
@@ -25,26 +25,27 @@ func (a *Aggregator) AggregateWithPriority(results []*models.ScraperResult, cust
 	}
 	return a.aggregateWithPriority(results, func(field string) []string {
 		// Pure exclusivity — identical semantics to resolvePriorities, so a
-		// per-field override is honored consistently in BOTH scrape paths
-		// (Aggregate and AggregateWithPriority). This is the v1 (original
-		// PowerShell Javinizer) behavior (#50): a per-field list means "only these
-		// scrapers are consulted for this field," with NO fallback.
+		// non-empty per-field override is honored consistently in BOTH scrape
+		// paths (Aggregate and AggregateWithPriority). This is the v1 (original
+		// PowerShell Javinizer) behavior (#50): a non-empty per-field list means
+		// "only these scrapers are consulted for this field," with NO fallback.
 		//
 		// Consistency between the paths matters: scrape.go calls
 		// AggregateWithPriority(results, cmd.SelectedScrapers) when the user
 		// selects scrapers (--scrapers / batch UI). customPriority replaces the
 		// GLOBAL priority as the fallback for fields without a per-field override
-		// (the user chose which scrapers to run); but a per-field override still
-		// wins exclusively — so `series: [dmm]` still routes Series to dmm even
-		// when scraping with `--scrapers r18dev`, and `series: [tokyohot]` still
-		// leaves Series empty (tokyohot didn't run / lacks it). There is no skip
-		// sentinel; suppression is emergent from exclusivity.
-		// empty slice (`series: []`) still wins here as a deliberate empty field
-		// ("consult no scrapers"): PerFieldOverride returns a non-nil empty slice
-		// for a present `[]`, so `fp != nil` honors it; an absent key returns nil
+		// (the user chose which scrapers to run); but a non-empty per-field
+		// override still wins exclusively — so `series: [dmm]` still routes Series
+		// to dmm even when scraping with `--scrapers r18dev`, and
+		// `series: [tokyohot]` still leaves Series empty (tokyohot didn't run /
+		// lacks it). A present-empty slice (`series: []`) does NOT win exclusively
+		// — it inherits customPriority (commit 9f882f22's documented intent:
+		// "[] still means 'inherit global'"); deliberate suppression uses the
+		// ["__skip__"] sentinel (matches no scraper). PerFieldOverride returns a
+		// non-nil empty slice for a present `[]`, so `len(fp) > 0` skips it here
 		// and falls through to customPriority below.
 		if a.cfg != nil && a.cfg.Metadata != nil {
-			if fp := a.cfg.Metadata.Priority.PerFieldOverride(toSnakeCase(field)); fp != nil {
+			if fp := a.cfg.Metadata.Priority.PerFieldOverride(toSnakeCase(field)); len(fp) > 0 {
 				return fp
 			}
 		}

--- a/internal/aggregator/coverage_gap_test.go
+++ b/internal/aggregator/coverage_gap_test.go
@@ -769,3 +769,13 @@ type mockAliasLookupRepo struct {
 func (m *mockAliasLookupRepo) GetAliasMap(_ context.Context) (map[string]string, error) {
 	return m.aliases, nil
 }
+
+// TestIsUnknownActress_JapaneseNameMatches_NameKeyDiffers covers the
+// NormalizeActressNameKey(info.JapaneseName) == unknownText branch: nameKey is
+// set to a DIFFERENT value so the earlier nameKey == unknownText check is false,
+// forcing the JapaneseName match path to return true.
+func TestIsUnknownActress_JapaneseNameMatches_NameKeyDiffers(t *testing.T) {
+	info := models.ActressInfo{JapaneseName: "未知の女優"}
+	assert.True(t, isUnknownActress(info, "different", "未知の女優"),
+		"JapaneseName matching unknownText must return true even when nameKey differs")
+}

--- a/internal/aggregator/priority.go
+++ b/internal/aggregator/priority.go
@@ -68,19 +68,20 @@ func (a *Aggregator) resolvePriorities() {
 		// a.cfg.Metadata.Priority here would panic for configs that rely only on
 		// ScrapersPriority (CodeRabbit, PR #51).
 		if a.cfg != nil && a.cfg.Metadata != nil {
-			if fp := a.cfg.Metadata.Priority.PerFieldOverride(fieldSnake); fp != nil {
-				// A per-field override is EXCLUSIVE: only the scrapers listed in the
-				// override are consulted for that field — there is NO fallback to
-				// the global priority list. This restores v1 (PowerShell Javinizer)
-				// semantics (#50): `series: [tokyohot]` leaves Series empty when
-				// tokyohot has no Series, instead of filling it from r18dev/dmm via
-				// global fallback. There is no skip sentinel — suppression is the
-				// emergent result of pointing a field at a scraper (or a never-
-				// registered name) that doesn't provide it, OR of storing an explicit
-				// empty slice (`series: []`), which means "consult no scrapers" and
-				// leaves the field empty. PerFieldOverride returns a non-nil empty
-				// slice for a present `[]`, so `fp != nil` honors it here (an absent
-				// key returns nil and falls through to the global default above).
+			if fp := a.cfg.Metadata.Priority.PerFieldOverride(fieldSnake); len(fp) > 0 {
+				// A non-empty per-field override is EXCLUSIVE: only the scrapers
+				// listed in the override are consulted for that field — there is NO
+				// fallback to the global priority list. This restores v1 (PowerShell
+				// Javinizer) semantics (#50): `series: [tokyohot]` leaves Series empty
+				// when tokyohot has no Series, instead of filling it from r18dev/dmm
+				// via global fallback. Suppression is the emergent result of pointing
+				// a field at a scraper (or a never-registered name like "__skip__")
+				// that doesn't provide it. A present-empty slice (`series: []`) is
+				// NOT exclusive — it inherits the global priority (commit 9f882f22's
+				// documented intent: "[] still means 'inherit global'"), keeping
+				// configs from the merge era upgrade-safe. PerFieldOverride returns
+				// a non-nil empty slice for a present `[]`, so `len(fp) > 0` skips it
+				// here and falls through to the global default above.
 				fieldPriority = copySlice(fp)
 			}
 		}
@@ -100,10 +101,11 @@ func (a *Aggregator) getResolvedPriorities() map[string][]string {
 // Checks per-field override first, then global metadata priority, then scrapers priority.
 // Returns nil when no config is available.
 //
-// A PRESENT per-field override wins exclusively — including an explicit empty
-// slice (`series: []`), which yields an empty list ("consult no scrapers")
-// rather than falling back to global. An ABSENT key (or nil slice) inherits the
-// global metadata priority, then ScrapersPriority. This matches the default
+// A non-empty per-field override wins exclusively. A present-empty slice
+// (`series: []`) is treated as "inherit global" (commit 9f882f22's documented
+// intent: "[] still means 'inherit global'") — it does NOT yield an empty list.
+// An ABSENT key or nil slice also inherits. Deliberate suppression uses the
+// ["__skip__"] sentinel (matches no scraper). This matches the default
 // Aggregate path's resolvePriorities and keeps both scrape paths consistent.
 func getFieldPriorityFromConfig(cfg *Config, fieldKey string) []string {
 	if cfg == nil {
@@ -111,7 +113,7 @@ func getFieldPriorityFromConfig(cfg *Config, fieldKey string) []string {
 	}
 
 	if cfg.Metadata != nil {
-		if fp := cfg.Metadata.Priority.PerFieldOverride(fieldKey); fp != nil {
+		if fp := cfg.Metadata.Priority.PerFieldOverride(fieldKey); len(fp) > 0 {
 			return fp
 		}
 		if len(cfg.Metadata.Priority.Priority) > 0 {

--- a/internal/aggregator/priority_all_empty_inherit_test.go
+++ b/internal/aggregator/priority_all_empty_inherit_test.go
@@ -1,0 +1,81 @@
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAggregate_AllFieldsEmptyOverrideInheritsGlobal is the end-to-end regression
+// test for the user-reported bug: an upgraded config carries EVERY per-field
+// priority as `[]` (common from the pre-9f882f22 merge era, where [] was harmless
+// because it was merged with global). After 9f882f22 made per-field priority
+// exclusive, those [] entries wiped every field — id/content_id/poster_url all
+// empty — so scraped movies collapsed into a single movie group (movie_id="") in
+// the review UI and posters showed "No poster".
+//
+// With the fix ([] = inherit global), an all-[] config must aggregate id and
+// content_id from the global priority list (non-empty), restoring correct
+// per-movie grouping.
+func TestAggregate_AllFieldsEmptyOverrideInheritsGlobal(t *testing.T) {
+	emptyFields := map[string][]string{}
+	for _, f := range []string{
+		"id", "content_id", "title", "original_title", "description",
+		"director", "maker", "label", "series", "poster_url", "cover_url",
+		"trailer_url", "runtime", "release_date", "rating", "actress",
+		"genre", "screenshot_url",
+	} {
+		emptyFields[f] = []string{} // every field explicitly []
+	}
+
+	cfg := &config.Config{
+		Scrapers: config.ScrapersConfig{Priority: []string{"dmm", "r18dev"}},
+		Metadata: config.MetadataConfig{
+			Priority: config.PriorityConfig{
+				Priority: []string{"dmm", "r18dev"},
+				Fields:   emptyFields,
+			},
+		},
+	}
+
+	agg := newAggregatorNoDB(testConfigFromAppConfig(cfg))
+
+	// Every field's resolved priority must be the global list, not an empty list.
+	assert.Equal(t, []string{"dmm", "r18dev"}, agg.resolvedPriorities["ID"],
+		"id: [] must inherit global — this is the field the review UI groups by")
+	assert.Equal(t, []string{"dmm", "r18dev"}, agg.resolvedPriorities["ContentID"],
+		"content_id: [] must inherit global")
+	assert.Equal(t, []string{"dmm", "r18dev"}, agg.resolvedPriorities["PosterURL"],
+		"poster_url: [] must inherit global — otherwise the review UI shows 'No poster'")
+
+	releaseDate := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	results := []*models.ScraperResult{
+		{
+			Source:      "dmm",
+			ID:          "ABC-001",
+			ContentID:   "1abc001",
+			Title:       "DMM Title",
+			PosterURL:   "https://example.com/poster.jpg",
+			Series:      "DMM Series",
+			Maker:       "DMM Maker",
+			ReleaseDate: &releaseDate,
+		},
+	}
+
+	movie, _, err := agg.Aggregate(results)
+	require.NoError(t, err)
+	require.NotNil(t, movie)
+
+	// The headline assertions: id and content_id MUST be populated (not wiped),
+	// so FileMatchInfo.MovieID stays distinct per file and the review UI does not
+	// collapse all files into one movie group.
+	assert.Equal(t, "ABC-001", movie.ID, "id must be aggregated from global priority — empty [] must not wipe it")
+	assert.Equal(t, "1abc001", movie.ContentID, "content_id must be aggregated from global priority — empty [] must not wipe it")
+	assert.Equal(t, "https://example.com/poster.jpg", movie.Poster.PosterURL, "poster_url must be aggregated from global priority — empty [] must not wipe it")
+	assert.Equal(t, "DMM Title", movie.Title)
+	assert.Equal(t, "DMM Series", movie.Series)
+}

--- a/internal/aggregator/priority_empty_override_test.go
+++ b/internal/aggregator/priority_empty_override_test.go
@@ -10,28 +10,117 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAggregate_PresentEmptyOverrideLeavesFieldEmpty is the core regression for
-// the "Remove all" + Save bug. A PRESENT empty override (`series: []`) must mean
-// "consult NO scrapers for Series" — the field is left empty — rather than
-// falling back to the global priority list. Before the fix, the `len(fp) > 0`
-// guard skipped the present-empty override, so Series snapped back to the
-// global list (DMM) and was populated. No skip sentinel — suppression is pure
-// exclusivity: an empty scraper list consults nothing.
-func TestAggregate_PresentEmptyOverrideLeavesFieldEmpty(t *testing.T) {
+// TestAggregate_PresentEmptyOverrideInheritsGlobal is the core regression test
+// for the upgrade-safe semantics: a PRESENT empty override (`series: []`) must
+// inherit the global priority list — NOT wipe the field. Commit 9f882f22 made
+// per-field priority exclusive and documented "[] still means 'inherit global'",
+// but the implementation treated [] as "consult no scrapers", wiping every field
+// for configs carrying [] (common from the pre-9f882f22 merge era). The fix
+// restores [] = inherit, so Series is populated by DMM via the global list.
+func TestAggregate_PresentEmptyOverrideInheritsGlobal(t *testing.T) {
 	cfg := &config.Config{
 		Scrapers: config.ScrapersConfig{Priority: []string{"dmm", "r18dev"}},
 		Metadata: config.MetadataConfig{
 			Priority: config.PriorityConfig{
 				Priority: []string{"dmm", "r18dev"},
 				Fields: map[string][]string{
-					"series": {}, // PRESENT empty: deliberate empty field (no scraper consulted)
+					"series": {}, // PRESENT empty: inherits global (NOT a deliberate empty field)
 				},
 			},
 		},
 	}
 
 	agg := newAggregatorNoDB(testConfigFromAppConfig(cfg))
-	t.Logf("resolvedPriorities[Series] = %#v (must be empty, not global)", agg.resolvedPriorities["Series"])
+	t.Logf("resolvedPriorities[Series] = %#v (must inherit global [dmm r18dev], not empty)", agg.resolvedPriorities["Series"])
+	assert.Equal(t, []string{"dmm", "r18dev"}, agg.resolvedPriorities["Series"],
+		"present [] override must resolve to the global priority list, not an empty list")
+
+	releaseDate := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	results := []*models.ScraperResult{
+		{
+			Source:      "dmm",
+			ID:          "ABC-001",
+			Title:       "DMM Title",
+			Series:      "Inherited Series", // DMM HAS Series — IS used via global inheritance
+			ReleaseDate: &releaseDate,
+		},
+	}
+
+	movie, _, err := agg.Aggregate(results)
+	require.NoError(t, err)
+	require.NotNil(t, movie)
+
+	// present [] inherits global [dmm, r18dev] → DMM consulted → Series populated.
+	assert.Equal(t, "Inherited Series", movie.Series,
+		"present [] override must inherit the global list — Series populated by DMM, NOT wiped")
+
+	// Fields WITHOUT an override also use the global list (Title from DMM).
+	assert.Equal(t, "DMM Title", movie.Title)
+}
+
+// TestAggregateWithPriority_PresentEmptyOverrideInheritsCustomPriority asserts
+// the same upgrade-safe semantics hold in the selected-scrapers scrape path
+// (AggregateWithPriority, used by --scrapers / batch UI). A present `series: []`
+// inherits customPriority (the user-selected scrapers) rather than wiping
+// Series — consistency between both scrape paths is the whole point.
+func TestAggregateWithPriority_PresentEmptyOverrideInheritsCustomPriority(t *testing.T) {
+	cfg := &config.Config{
+		Scrapers: config.ScrapersConfig{Priority: []string{"dmm", "r18dev"}},
+		Metadata: config.MetadataConfig{
+			Priority: config.PriorityConfig{
+				Priority: []string{"dmm", "r18dev"},
+				Fields: map[string][]string{
+					"series": {}, // PRESENT empty: inherits customPriority
+				},
+			},
+		},
+	}
+
+	agg := newAggregatorNoDB(testConfigFromAppConfig(cfg))
+
+	releaseDate := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	dmmResult := &models.ScraperResult{
+		Source:      "dmm",
+		ID:          "ABC-001",
+		Title:       "DMM Title",
+		Series:      "Inherited Series", // DMM HAS Series — IS used via customPriority inheritance
+		ReleaseDate: &releaseDate,
+	}
+
+	// Simulate the batch scrape path: selected scrapers = [dmm].
+	movie, _, err := agg.AggregateWithPriority([]*models.ScraperResult{dmmResult}, []string{"dmm"})
+	require.NoError(t, err)
+	require.NotNil(t, movie)
+
+	assert.Equal(t, "Inherited Series", movie.Series,
+		"present [] override must inherit customPriority [dmm] in the selected-scrapers path — Series populated, NOT wiped")
+
+	// Non-overridden fields also use customPriority (DMM).
+	assert.Equal(t, "DMM Title", movie.Title)
+}
+
+// TestAggregate_SkipSentinelLeavesFieldEmpty locks in the deliberate-suppress
+// path: `series: ["__skip__"]` leaves Series empty because "__skip__" matches no
+// real scraper, so assignString consults nothing. This is the supported way to
+// force an empty field now that [] means "inherit global" (commit 9f882f22's
+// documented skip sentinel).
+func TestAggregate_SkipSentinelLeavesFieldEmpty(t *testing.T) {
+	cfg := &config.Config{
+		Scrapers: config.ScrapersConfig{Priority: []string{"dmm", "r18dev"}},
+		Metadata: config.MetadataConfig{
+			Priority: config.PriorityConfig{
+				Priority: []string{"dmm", "r18dev"},
+				Fields: map[string][]string{
+					"series": {"__skip__"}, // deliberate suppress: matches no scraper
+				},
+			},
+		},
+	}
+
+	agg := newAggregatorNoDB(testConfigFromAppConfig(cfg))
+	t.Logf("resolvedPriorities[Series] = %#v (must be [__skip__] — matches no scraper)", agg.resolvedPriorities["Series"])
+	assert.Equal(t, []string{"__skip__"}, agg.resolvedPriorities["Series"],
+		"skip sentinel override resolves to itself (non-empty, so exclusive)")
 
 	releaseDate := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
 	results := []*models.ScraperResult{
@@ -48,65 +137,16 @@ func TestAggregate_PresentEmptyOverrideLeavesFieldEmpty(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, movie)
 
-	// The bug: present [] was treated as absent, so Series fell back to the
-	// global list [dmm, r18dev] and was populated by DMM. The fix: present []
-	// resolves to an empty scraper list, so no source is consulted → Series empty.
 	assert.Empty(t, movie.Series,
-		"present [] override must leave Series empty — no fallback to global/DMM")
-
-	// Fields WITHOUT an override still use the global list (Title from DMM),
-	// proving the global fallback for non-overridden fields is intact.
+		`["__skip__"] override must leave Series empty — "__skip__" matches no real scraper`)
 	assert.Equal(t, "DMM Title", movie.Title,
 		"Title (no override) must still use the global priority list")
 }
 
-// TestAggregateWithPriority_PresentEmptyOverrideLeavesFieldEmpty asserts the
-// SAME pure-exclusivity semantics hold in the selected-scrapers scrape path
-// (AggregateWithPriority, used by --scrapers / batch UI). A present `series: []`
-// leaves Series empty even though customPriority ([dmm]) would otherwise
-// populate it — consistency between both scrape paths is the whole point.
-func TestAggregateWithPriority_PresentEmptyOverrideLeavesFieldEmpty(t *testing.T) {
-	cfg := &config.Config{
-		Scrapers: config.ScrapersConfig{Priority: []string{"dmm", "r18dev"}},
-		Metadata: config.MetadataConfig{
-			Priority: config.PriorityConfig{
-				Priority: []string{"dmm", "r18dev"},
-				Fields: map[string][]string{
-					"series": {}, // PRESENT empty: deliberate empty field
-				},
-			},
-		},
-	}
-
-	agg := newAggregatorNoDB(testConfigFromAppConfig(cfg))
-
-	releaseDate := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
-	dmmResult := &models.ScraperResult{
-		Source:      "dmm",
-		ID:          "ABC-001",
-		Title:       "DMM Title",
-		Series:      "Should Not Leak", // DMM HAS Series — must NOT be used
-		ReleaseDate: &releaseDate,
-	}
-
-	// Simulate the batch scrape path: selected scrapers = [dmm].
-	movie, _, err := agg.AggregateWithPriority([]*models.ScraperResult{dmmResult}, []string{"dmm"})
-	require.NoError(t, err)
-	require.NotNil(t, movie)
-
-	assert.Empty(t, movie.Series,
-		"present [] override must leave Series empty in the selected-scrapers path too — no fallback to customPriority [dmm]")
-
-	// Non-overridden fields still use customPriority (DMM).
-	assert.Equal(t, "DMM Title", movie.Title,
-		"Title (no override) must use customPriority [dmm]")
-}
-
-// TestAggregate_PresentEmptyOverrideAbsentFieldStillInherits is the complement:
-// an ABSENT key still inherits the global priority list (the unchanged default
-// path). Only a PRESENT [] is a deliberate empty field. Guards against the fix
-// accidentally emptying every non-overridden field.
-func TestAggregate_PresentEmptyOverrideAbsentFieldStillInherits(t *testing.T) {
+// TestAggregate_AbsentOverrideInheritsGlobal is the complement: an ABSENT key
+// inherits the global priority list (the unchanged default path). Guards against
+// the fix accidentally emptying every non-overridden field.
+func TestAggregate_AbsentOverrideInheritsGlobal(t *testing.T) {
 	cfg := &config.Config{
 		Scrapers: config.ScrapersConfig{Priority: []string{"dmm", "r18dev"}},
 		Metadata: config.MetadataConfig{
@@ -139,6 +179,6 @@ func TestAggregate_PresentEmptyOverrideAbsentFieldStillInherits(t *testing.T) {
 
 	// Absent override → inherits global → DMM consulted → Series populated.
 	assert.Equal(t, "Inherited Series", movie.Series,
-		"absent override must inherit the global list (DMM provides Series) — only PRESENT [] empties the field")
+		"absent override must inherit the global list (DMM provides Series) — only [\"__skip__\"] empties the field")
 	assert.Equal(t, "DMM Title", movie.Title)
 }

--- a/internal/aggregator/priority_fallback_test.go
+++ b/internal/aggregator/priority_fallback_test.go
@@ -492,3 +492,28 @@ func TestResolvePrioritiesNilMetadataNoPanic(t *testing.T) {
 	assert.Equal(t, []string{"dmm", "r18dev"}, agg.resolvedPriorities["Series"])
 	assert.Equal(t, []string{"dmm", "r18dev"}, agg.resolvedPriorities["Actress"])
 }
+
+// TestGetFieldPriorityFromConfig_PerFieldOverride covers the non-empty per-field
+// override branch (return fp) of getFieldPriorityFromConfig. The only in-tree
+// caller (resolvePriorities) passes fieldKey="" for the global, so the
+// per-field return path is otherwise unreachable — exercise it directly.
+func TestGetFieldPriorityFromConfig_PerFieldOverride(t *testing.T) {
+	cfg := &Config{
+		Metadata: &MetadataConfig{
+			Priority: config.PriorityConfig{
+				Priority: []string{"dmm", "r18dev"}, // global
+				Fields: map[string][]string{
+					"title": {"r18dev", "libredmm"}, // non-empty per-field override
+				},
+			},
+		},
+	}
+
+	// A present non-empty per-field override is returned verbatim (exclusive).
+	got := getFieldPriorityFromConfig(cfg, "title")
+	assert.Equal(t, []string{"r18dev", "libredmm"}, got)
+
+	// A field with NO override falls through to the global Priority list.
+	gotGlobal := getFieldPriorityFromConfig(cfg, "series")
+	assert.Equal(t, []string{"dmm", "r18dev"}, gotGlobal)
+}

--- a/internal/config/config_edge_cases_test.go
+++ b/internal/config/config_edge_cases_test.go
@@ -674,11 +674,12 @@ func TestGetFieldPriority(t *testing.T) {
 	// Field with override uses the override
 	assert.Equal(t, []string{"dmm", "r18dev"}, p.GetFieldPriority("title"))
 
-	// A PRESENT empty override ([]string{}) means "consult no scrapers" — it is
-	// a deliberate empty field, NOT a fallback to global. This is the pure-
-	// exclusivity contract (#50/#51): [] must be distinguishable from an absent
-	// key so that "Remove all" + Save persists an empty field.
-	assert.Equal(t, []string{}, p.GetFieldPriority("actress"))
+	// A PRESENT empty override ([]string{}) inherits the global priority list —
+	// it is NOT a deliberate empty field. This matches commit 9f882f22's
+	// documented intent ("[] still means 'inherit global'") and keeps configs
+	// carrying [] (common from the merge era) upgrade-safe. Deliberate
+	// suppression uses the ["__skip__"] sentinel instead.
+	assert.Equal(t, []string{"r18dev", "dmm"}, p.GetFieldPriority("actress"))
 
 	// Field without override falls back to global
 	assert.Equal(t, []string{"r18dev", "dmm"}, p.GetFieldPriority("genre"))

--- a/internal/config/coverage_boost_test.go
+++ b/internal/config/coverage_boost_test.go
@@ -605,11 +605,12 @@ func TestPriorityConfig_GetFieldPriority_EmptyOverride(t *testing.T) {
 		Fields:   map[string][]string{"title": {}},
 	}
 	result := p.GetFieldPriority("title")
-	// A PRESENT empty override ([]string{}) is a deliberate empty field — it must
-	// NOT fall back to global. This is the pure-exclusivity contract: a present []
-	// means "consult no scrapers", distinct from an absent key (inherit global).
-	assert.Equal(t, []string{}, result)
-	assert.NotNil(t, result, "present [] must be a non-nil empty slice, not nil (nil ⇒ inherit)")
+	// A PRESENT empty override ([]string{}) inherits the global priority list —
+	// it is NOT a deliberate empty field. This matches commit 9f882f22's
+	// documented intent ("[] still means 'inherit global'") and keeps configs
+	// carrying [] (common from the merge era) upgrade-safe. Deliberate
+	// suppression uses the ["__skip__"] sentinel (matches no scraper) instead.
+	assert.Equal(t, []string{"dmm", "r18dev"}, result)
 }
 
 func TestPriorityConfig_GetFieldPriority_NilOverride(t *testing.T) {

--- a/internal/config/coverage_boost_test.go
+++ b/internal/config/coverage_boost_test.go
@@ -1346,3 +1346,22 @@ func TestPrepare_EmptyScrapersPriorityErrors(t *testing.T) {
 	_, err = Prepare(cfg)
 	assert.NoError(t, err)
 }
+
+// TestPriorityConfig_UnmarshalJSON_PriorityNonArrayValue covers decodeFromMap's
+// priority-key non-array branch (value present but not a []any).
+func TestPriorityConfig_UnmarshalJSON_PriorityNonArrayValue(t *testing.T) {
+	var p PriorityConfig
+	err := json.Unmarshal([]byte(`{"priority": "notanarray"}`), &p)
+	assert.NoError(t, err)
+	assert.Nil(t, p.Priority, "non-array priority value must be skipped")
+}
+
+// TestPriorityConfig_UnmarshalJSON_FieldNonStringElement covers decodeFromMap's
+// per-field non-string-element branch (array contains a non-string entry).
+func TestPriorityConfig_UnmarshalJSON_FieldNonStringElement(t *testing.T) {
+	var p PriorityConfig
+	err := json.Unmarshal([]byte(`{"series": [123, "r18dev"]}`), &p)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"r18dev"}, p.Fields["series"],
+		"non-string element must be skipped, string element kept")
+}

--- a/internal/config/priority_exclusivity_test.go
+++ b/internal/config/priority_exclusivity_test.go
@@ -11,13 +11,18 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// TestPerFieldOverride_PresentEmptyVsAbsent locks in the pure-exclusivity
-// contract for the "is there an override?" accessor: a PRESENT key (even with
-// an explicit empty slice) returns a non-nil value, while an ABSENT key returns
-// nil. Callers use `fp != nil` to distinguish "override present" (honored
-// exclusively, including an empty list = "consult no scrapers") from "no
-// override" (inherit global). A nil slice stored under a present key is treated
-// as nil (inherit), matching the null/undefined = inherit contract.
+// TestPerFieldOverride_PresentEmptyVsAbsent locks in the raw-accessor contract
+// for the "is there an override?" question: a PRESENT key (even with an
+// explicit empty slice) returns a non-nil value, while an ABSENT key returns
+// nil. This is the RAW accessor — it does NOT decide resolution. Resolution
+// sites (GetFieldPriority, aggregator.resolvePriorities) use `len(fp) > 0`, so
+// a present-empty [] inherits the global priority (commit 9f882f22's documented
+// intent: "[] still means 'inherit global'"); deliberate suppression uses the
+// ["__skip__"] sentinel. PerFieldOverride is kept as a raw accessor so callers
+// can distinguish "explicitly stored []" from "absent" if needed (e.g. for
+// diagnostics/UI), even though both now resolve to inherit. A nil slice stored
+// under a present key is treated as nil (inherit), matching the
+// null/undefined = inherit contract.
 func TestPerFieldOverride_PresentEmptyVsAbsent(t *testing.T) {
 	p := &PriorityConfig{
 		Priority: []string{"r18dev", "dmm"},
@@ -77,9 +82,10 @@ func TestPriorityConfig_EmptySliceRoundTrip_JSON(t *testing.T) {
 	require.NotNil(t, series, "present [] must remain a non-nil empty slice, not nil (nil ⇒ inherit)")
 	assert.Equal(t, []string{}, series)
 
-	// And it must resolve as an empty effective priority (no global fallback).
-	assert.Equal(t, []string{}, rt.GetFieldPriority("series"))
-	assert.NotNil(t, rt.GetFieldPriority("series"), "present [] effective priority is non-nil (empty, not inherited)")
+	// And it resolves as the inherited global priority (present [] ⇒ inherit,
+	// NOT "consult no scrapers").
+	assert.Equal(t, []string{"r18dev", "dmm"}, rt.GetFieldPriority("series"))
+	assert.NotNil(t, rt.GetFieldPriority("series"), "present [] inherits global (non-nil), not an empty override")
 
 	// Non-empty override survives too.
 	assert.Equal(t, []string{"dmm"}, rt.GetFieldPriority("title"))
@@ -113,7 +119,8 @@ func TestPriorityConfig_EmptySliceRoundTrip_YAML(t *testing.T) {
 	require.True(t, ok, "series key must survive the YAML round-trip")
 	require.NotNil(t, series, "present [] must remain a non-nil empty slice after YAML round-trip")
 	assert.Equal(t, []string{}, series)
-	assert.Equal(t, []string{}, rt.GetFieldPriority("series"))
+	// Present [] inherits global (commit 9f882f22: "[] still means 'inherit global'").
+	assert.Equal(t, []string{"r18dev", "dmm"}, rt.GetFieldPriority("series"))
 }
 
 // TestConfig_EmptySliceRoundTrip_SaveLoad exercises the REAL persistence path
@@ -157,8 +164,9 @@ func TestConfig_EmptySliceRoundTrip_SaveLoad(t *testing.T) {
 	require.NotNil(t, series, "present [] must reload as a non-nil empty slice (nil ⇒ inherit)")
 	assert.Equal(t, []string{}, series)
 
-	// Effective priority for series is empty (deliberate empty field, not global).
-	assert.Equal(t, []string{}, loaded.Metadata.Priority.GetFieldPriority("series"))
+	// Effective priority for series inherits global (present [] ⇒ inherit, not
+	// a deliberate empty field).
+	assert.Equal(t, []string{"r18dev", "dmm"}, loaded.Metadata.Priority.GetFieldPriority("series"))
 
 	// Non-empty override and global priority survive too.
 	assert.Equal(t, []string{"dmm"}, loaded.Metadata.Priority.GetFieldPriority("title"))

--- a/internal/config/storage_yaml.go
+++ b/internal/config/storage_yaml.go
@@ -77,12 +77,61 @@ func mergeYAMLNode(dst, src *yaml.Node) {
 			return
 		}
 		mergeYAMLNode(dst.Content[0], src.Content[0])
+		pruneMetadataPriorityFields(dst, src)
 		return
 	}
 
 	replacement := cloneYAMLNode(src)
 	applyNodeMetadataPreservingComments(dst, replacement)
 	*dst = *replacement
+}
+
+func navigateToMapping(root *yaml.Node, keys ...string) *yaml.Node {
+	if root == nil {
+		return nil
+	}
+	cur := root
+	if cur.Kind == yaml.DocumentNode {
+		if len(cur.Content) == 0 {
+			return nil
+		}
+		cur = cur.Content[0]
+	}
+	for _, key := range keys {
+		if cur == nil || cur.Kind != yaml.MappingNode {
+			return nil
+		}
+		idx := findMappingValueIndex(cur, key)
+		if idx == -1 {
+			return nil
+		}
+		cur = cur.Content[idx]
+	}
+	return cur
+}
+
+func pruneMetadataPriorityFields(dst, src *yaml.Node) {
+	dstPriority := navigateToMapping(dst, "metadata", "priority")
+	if dstPriority == nil || dstPriority.Kind != yaml.MappingNode {
+		return
+	}
+	srcPriority := navigateToMapping(src, "metadata", "priority")
+	if srcPriority == nil || srcPriority.Kind != yaml.MappingNode {
+		return
+	}
+	srcKeys := make(map[string]bool, len(srcPriority.Content)/2)
+	for i := 0; i+1 < len(srcPriority.Content); i += 2 {
+		srcKeys[srcPriority.Content[i].Value] = true
+	}
+	kept := make([]*yaml.Node, 0, len(dstPriority.Content))
+	for i := 0; i+1 < len(dstPriority.Content); i += 2 {
+		keyNode := dstPriority.Content[i]
+		valNode := dstPriority.Content[i+1]
+		if srcKeys[keyNode.Value] {
+			kept = append(kept, keyNode, valNode)
+		}
+	}
+	dstPriority.Content = kept
 }
 
 func configToYAMLDocument(cfg *Config) (*yaml.Node, error) {

--- a/internal/config/storage_yaml.go
+++ b/internal/config/storage_yaml.go
@@ -111,12 +111,22 @@ func navigateToMapping(root *yaml.Node, keys ...string) *yaml.Node {
 }
 
 func pruneMetadataPriorityFields(dst, src *yaml.Node) {
-	dstPriority := navigateToMapping(dst, "metadata", "priority")
-	if dstPriority == nil || dstPriority.Kind != yaml.MappingNode {
+	dstMetadata := navigateToMapping(dst, "metadata")
+	if dstMetadata == nil || dstMetadata.Kind != yaml.MappingNode {
+		return
+	}
+	dstPriorityIdx := findMappingValueIndex(dstMetadata, "priority")
+	if dstPriorityIdx == -1 {
+		return
+	}
+	dstPriority := dstMetadata.Content[dstPriorityIdx]
+	if dstPriority.Kind != yaml.MappingNode {
 		return
 	}
 	srcPriority := navigateToMapping(src, "metadata", "priority")
 	if srcPriority == nil || srcPriority.Kind != yaml.MappingNode {
+		keyIdx := dstPriorityIdx - 1
+		dstMetadata.Content = append(dstMetadata.Content[:keyIdx], dstMetadata.Content[dstPriorityIdx+1:]...)
 		return
 	}
 	srcKeys := make(map[string]bool, len(srcPriority.Content)/2)

--- a/internal/config/storage_yaml_priority_deletion_test.go
+++ b/internal/config/storage_yaml_priority_deletion_test.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// priorityValueAt returns the encoded value of metadata.priority.<key> as a
+// Go value decoded from the YAML document, or (<nil>, false) when the key is
+// absent from the metadata.priority mapping.
+func priorityValueAt(t *testing.T, doc *yaml.Node, key string) (any, bool) {
+	t.Helper()
+	prio := navigateToMapping(doc, "metadata", "priority")
+	if prio == nil || prio.Kind != yaml.MappingNode {
+		return nil, false
+	}
+	idx := findMappingValueIndex(prio, key)
+	if idx == -1 {
+		return nil, false
+	}
+	var out any
+	require.NoError(t, prio.Content[idx].Decode(&out))
+	return out, true
+}
+
+func TestMergeYAMLNode_PruneMetadataPriorityDeletedKeys(t *testing.T) {
+	t.Run("deletes per-field priority key absent in new cfg", func(t *testing.T) {
+		existing := mustParseYAMLDoc(t, `metadata:
+    priority:
+        series:
+            - dmm
+        priority:
+            - dmm
+            - r18dev
+`)
+		// New config: series override removed (reset to global); global priority kept.
+		newDoc := mustParseYAMLDoc(t, `metadata:
+    priority:
+        priority:
+            - dmm
+            - r18dev
+`)
+
+		mergeYAMLNode(existing, newDoc)
+
+		_, hasSeries := priorityValueAt(t, existing, "series")
+		assert.False(t, hasSeries, "series override must be pruned from metadata.priority")
+
+		prio, hasPrio := priorityValueAt(t, existing, "priority")
+		assert.True(t, hasPrio, "global priority key must be retained")
+		assert.Equal(t, []any{"dmm", "r18dev"}, prio)
+	})
+
+	t.Run("updates kept key and deletes absent sibling", func(t *testing.T) {
+		existing := mustParseYAMLDoc(t, `metadata:
+    priority:
+        series:
+            - dmm
+        title:
+            - r18dev
+        priority:
+            - dmm
+`)
+		newDoc := mustParseYAMLDoc(t, `metadata:
+    priority:
+        series:
+            - r18dev
+        priority:
+            - dmm
+`)
+
+		mergeYAMLNode(existing, newDoc)
+
+		series, hasSeries := priorityValueAt(t, existing, "series")
+		assert.True(t, hasSeries, "series (present in new) must be kept and updated")
+		assert.Equal(t, []any{"r18dev"}, series)
+
+		_, hasTitle := priorityValueAt(t, existing, "title")
+		assert.False(t, hasTitle, "title (absent in new) must be deleted from metadata.priority")
+	})
+
+	t.Run("preserves keys outside metadata.priority when absent in new", func(t *testing.T) {
+		existing := mustParseYAMLDoc(t, `scrapers:
+    user_agent: keepme
+    foo:
+        bar: 1
+metadata:
+    priority:
+        series:
+            - dmm
+        priority:
+            - dmm
+`)
+		newDoc := mustParseYAMLDoc(t, `metadata:
+    priority:
+        priority:
+            - dmm
+`)
+
+		mergeYAMLNode(existing, newDoc)
+
+		// Keys under scrapers (entirely absent in new) must survive — proves
+		// pruning is scoped to metadata.priority only.
+		scrapers := navigateToMapping(existing, "scrapers")
+		require.NotNil(t, scrapers)
+		assert.NotEqual(t, -1, findMappingValueIndex(scrapers, "user_agent"))
+		assert.NotEqual(t, -1, findMappingValueIndex(scrapers, "foo"))
+
+		// Meanwhile the per-field override still gets pruned.
+		_, hasSeries := priorityValueAt(t, existing, "series")
+		assert.False(t, hasSeries, "series must be pruned")
+	})
+
+	t.Run("preserves dst comment on a kept priority key", func(t *testing.T) {
+		existing := mustParseYAMLDoc(t, `metadata:
+    priority:
+        # series override comment
+        series:
+            - dmm
+        title:
+            - r18dev
+        priority:
+            - dmm
+`)
+		newDoc := mustParseYAMLDoc(t, `metadata:
+    priority:
+        series:
+            - r18dev
+        priority:
+            - dmm
+`)
+
+		mergeYAMLNode(existing, newDoc)
+
+		prio := navigateToMapping(existing, "metadata", "priority")
+		require.NotNil(t, prio)
+		idx := findMappingValueIndex(prio, "series")
+		require.NotEqual(t, -1, idx)
+		keyNode := prio.Content[idx-1]
+		assert.Equal(t, "# series override comment", keyNode.HeadComment,
+			"head comment on kept priority key must be preserved")
+
+		_, hasTitle := priorityValueAt(t, existing, "title")
+		assert.False(t, hasTitle, "title (absent in new) must be deleted")
+	})
+
+	t.Run("no-op when metadata.priority absent in dst", func(t *testing.T) {
+		existing := mustParseYAMLDoc(t, `server:
+    port: 8080
+`)
+		newDoc := mustParseYAMLDoc(t, `metadata:
+    priority:
+        priority:
+            - dmm
+`)
+
+		mergeYAMLNode(existing, newDoc)
+
+		// After merge, metadata.priority is appended from src; pruning against
+		// src (same keys) must not corrupt it.
+		prio := navigateToMapping(existing, "metadata", "priority")
+		require.NotNil(t, prio)
+		assert.NotEqual(t, -1, findMappingValueIndex(prio, "priority"))
+	})
+
+	t.Run("Save persists deleted per-field priority override to disk", func(t *testing.T) {
+		path := t.TempDir() + "/config.yaml"
+		initial := DefaultConfig(nil, nil)
+		initial.Metadata.Priority.Priority = []string{"dmm"}
+		initial.Metadata.Priority.Fields = map[string][]string{"series": {"dmm"}}
+		require.NoError(t, Save(initial, path))
+
+		// Reload, then "reset to global" by deleting the per-field override.
+		loaded, err := Load(path)
+		require.NoError(t, err)
+		delete(loaded.Metadata.Priority.Fields, "series")
+		require.NoError(t, Save(loaded, path))
+
+		reloaded, err := Load(path)
+		require.NoError(t, err)
+		assert.NotContains(t, reloaded.Metadata.Priority.Fields, "series",
+			"deleted per-field override must not reappear after reload")
+		assert.Equal(t, []string{"dmm"}, reloaded.Metadata.Priority.Priority)
+	})
+}

--- a/internal/config/storage_yaml_priority_deletion_test.go
+++ b/internal/config/storage_yaml_priority_deletion_test.go
@@ -212,3 +212,94 @@ metadata:
 		assert.Equal(t, []string{"dmm"}, reloaded.Metadata.Priority.Priority)
 	})
 }
+
+// TestMergeYAMLNode_PruneMetadataPriorityEdgeCases covers the defensive early-return
+// branches of pruneMetadataPriorityFields and navigateToMapping that the happy-path
+// subtests above don't reach (scalar metadata/priority, missing priority key,
+// scalar src priority, and an empty DocumentNode).
+func TestMergeYAMLNode_PruneMetadataPriorityEdgeCases(t *testing.T) {
+	t.Run("no-op when metadata exists but priority key is absent in dst", func(t *testing.T) {
+		existing := mustParseYAMLDoc(t, `metadata:
+    other: value
+`)
+		// src also has no priority key -> merge does not add one, so prune hits the
+		// dstPriorityIdx == -1 guard and returns without touching metadata.
+		newDoc := mustParseYAMLDoc(t, `metadata:
+    another: value2
+`)
+		mergeYAMLNode(existing, newDoc)
+		metadata := navigateToMapping(existing, "metadata")
+		require.NotNil(t, metadata)
+		assert.Equal(t, -1, findMappingValueIndex(metadata, "priority"),
+			"no priority key should exist in dst after merge")
+	})
+
+	t.Run("no-op when dst metadata is a scalar and src has no metadata", func(t *testing.T) {
+		existing := mustParseYAMLDoc(t, `metadata: justastring
+server:
+    port: 8080
+`)
+		newDoc := mustParseYAMLDoc(t, `server:
+    port: 8080
+`)
+		mergeYAMLNode(existing, newDoc)
+		// dst metadata is a scalar -> pruneMetadataPriorityFields returns at the
+		// dstMetadata.Kind != MappingNode guard without touching anything.
+		metadata := navigateToMapping(existing, "metadata")
+		require.NotNil(t, metadata)
+	})
+
+	t.Run("no-op when dst metadata.priority is a scalar and src omits it", func(t *testing.T) {
+		existing := mustParseYAMLDoc(t, `metadata:
+    priority: notamapping
+server:
+    port: 8080
+`)
+		newDoc := mustParseYAMLDoc(t, `server:
+    port: 8080
+`)
+		mergeYAMLNode(existing, newDoc)
+		// dst priority is a scalar -> prune returns at the dstPriority.Kind guard;
+		// the scalar value is left untouched (src has no priority to merge in).
+		prio := navigateToMapping(existing, "metadata", "priority")
+		require.NotNil(t, prio)
+		assert.Equal(t, "notamapping", prio.Value)
+	})
+}
+
+// TestPruneMetadataPriorityFields_SrcScalarPriority covers the srcPriority.Kind
+// != MappingNode branch (the second operand of the nil-check) by calling the
+// helper directly with a scalar src priority — the merge flow always converts
+// dst to match src's kind first, so this branch is only reachable via a direct
+// call with mismatched dst/src shapes.
+func TestPruneMetadataPriorityFields_SrcScalarPriority(t *testing.T) {
+	dst := mustParseYAMLDoc(t, `metadata:
+    priority:
+        series:
+            - dmm
+`)
+	src := mustParseYAMLDoc(t, `metadata:
+    priority: notamapping
+`)
+
+	pruneMetadataPriorityFields(dst, src)
+
+	prio := navigateToMapping(dst, "metadata", "priority")
+	assert.Nil(t, prio, "non-mapping src priority must delete dst's priority block")
+}
+
+// TestNavigateToMapping_EmptyDocumentNode covers the empty-DocumentNode branch
+// (len(cur.Content) == 0) of navigateToMapping.
+func TestNavigateToMapping_EmptyDocumentNode(t *testing.T) {
+	emptyDoc := &yaml.Node{Kind: yaml.DocumentNode}
+	assert.Nil(t, navigateToMapping(emptyDoc, "metadata"))
+}
+
+// TestNavigateToMapping_NonMappingDocumentRoot covers the cur.Kind != MappingNode
+// guard inside the key loop: a document whose root is a scalar (not a mapping)
+// cannot be descended into by key.
+func TestNavigateToMapping_NonMappingDocumentRoot(t *testing.T) {
+	doc := mustParseYAMLDoc(t, `justastring
+`)
+	assert.Nil(t, navigateToMapping(doc, "metadata"))
+}

--- a/internal/config/storage_yaml_priority_deletion_test.go
+++ b/internal/config/storage_yaml_priority_deletion_test.go
@@ -166,6 +166,32 @@ metadata:
 		assert.NotEqual(t, -1, findMappingValueIndex(prio, "priority"))
 	})
 
+	t.Run("deletes whole metadata.priority block when absent in new cfg", func(t *testing.T) {
+		existing := mustParseYAMLDoc(t, `metadata:
+    priority:
+        series:
+            - dmm
+        priority:
+            - dmm
+            - r18dev
+`)
+		// New config omits metadata.priority entirely (e.g. user cleared all
+		// priority settings including the global list).
+		newDoc := mustParseYAMLDoc(t, `metadata:
+    some_other_field: keep
+`)
+
+		mergeYAMLNode(existing, newDoc)
+
+		prio := navigateToMapping(existing, "metadata", "priority")
+		assert.Nil(t, prio, "metadata.priority block must be deleted when absent in new cfg")
+
+		metadata := navigateToMapping(existing, "metadata")
+		require.NotNil(t, metadata)
+		assert.NotEqual(t, -1, findMappingValueIndex(metadata, "some_other_field"),
+			"sibling metadata key must be preserved (only the priority subtree is deleted)")
+	})
+
 	t.Run("Save persists deleted per-field priority override to disk", func(t *testing.T) {
 		path := t.TempDir() + "/config.yaml"
 		initial := DefaultConfig(nil, nil)

--- a/internal/config/storage_yaml_priority_deletion_test.go
+++ b/internal/config/storage_yaml_priority_deletion_test.go
@@ -303,3 +303,19 @@ func TestNavigateToMapping_NonMappingDocumentRoot(t *testing.T) {
 `)
 	assert.Nil(t, navigateToMapping(doc, "metadata"))
 }
+
+// TestNavigateToMapping_NilRoot covers the root == nil guard.
+func TestNavigateToMapping_NilRoot(t *testing.T) {
+	assert.Nil(t, navigateToMapping(nil, "metadata"))
+}
+
+// TestNavigateToMapping_NilValueInChain covers the cur == nil branch of the
+// loop guard: descending into a mapping whose value is a nil node sets cur=nil,
+// and the next key iteration returns nil at the cur == nil check.
+func TestNavigateToMapping_NilValueInChain(t *testing.T) {
+	root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		{Kind: yaml.ScalarNode, Value: "metadata", Tag: "!!str"},
+		nil,
+	}}
+	assert.Nil(t, navigateToMapping(root, "metadata", "priority"))
+}

--- a/internal/config/translation_config.go
+++ b/internal/config/translation_config.go
@@ -114,34 +114,39 @@ type PriorityConfig struct {
 	Priority []string `yaml:"priority" json:"priority"`
 	// Fields holds per-metadata-field scraper priority overrides.
 	// Keys are snake_case field names matching the API (e.g. "title", "actress", "cover_url").
-	// A PRESENT key (even an empty []string{}) is an override: [] means "consult
-	// NO scrapers for this field" (the field is left empty); [a,b] means "consult
-	// a then b exclusively". An ABSENT key (or a nil slice) inherits the global
-	// Priority list. There is no skip sentinel — suppression is pure exclusivity.
+	// A non-empty value [a,b] means "consult a then b exclusively". A PRESENT key
+	// whose value is an empty slice ([]string{} / []) inherits the global Priority
+	// list (commit 9f882f22's documented intent: "[] still means 'inherit global'"),
+	// so configs carrying [] (common from the pre-9f882f22 merge era) upgrade
+	// safely instead of wiping the field. An ABSENT key (or a nil slice) also
+	// inherits. Deliberate suppression uses the ["__skip__"] sentinel, which
+	// matches no real scraper so the field is left empty.
 	Fields map[string][]string `yaml:"-" json:"-"`
 }
 
 // GetFieldPriority returns the EFFECTIVE priority list for a metadata field:
-// the per-field override when one is present (including an explicit empty
-// slice, which means "consult no scrapers — leave this field empty"), else the
-// global Priority list. Returns nil when neither is set.
+// the per-field override when one is present AND non-empty, else the global
+// Priority list. Returns nil when neither is set.
 //
-// The three field states map cleanly (no skip sentinel):
+// The three field states map cleanly:
 //
-//	key ABSENT (or nil) → inherit the global Priority list
-//	key present = []   → consult NO scrapers → field left empty
-//	key present = [a,b]→ consult a then b exclusively, no global fallback
+//	key ABSENT / nil / [] (present-empty) → inherit the global Priority list
+//	key present = ["__skip__"]           → consult NO scrapers → field left empty
+//	key present = [a,b]                   → consult a then b exclusively, no global fallback
 //
-// A nil slice stored under a present key is treated as "inherit global" (the
-// null/undefined state), matching the JSON/YAML round-trip where a null value
-// decodes to an absent key. Only a non-nil empty slice ([]string{}) is a
-// deliberate empty override. Callers that need to distinguish "present" from
-// "absent" should use PerFieldOverride.
+// A present-empty slice ([]string{} or []) is treated as "inherit global",
+// matching commit 9f882f22's documented intent ("[] ... still means 'inherit
+// global'") and the pre-9f882f22 behavior where [] was merged with global. This
+// keeps configs carrying [] (common from the merge era) upgrade-safe — they
+// inherit the global priority instead of wiping the field. Deliberate
+// suppression uses the ["__skip__"] sentinel, which matches no real scraper so
+// assignString leaves the field empty. Callers that need to distinguish
+// "present" from "absent" should use PerFieldOverride.
 func (p *PriorityConfig) GetFieldPriority(fieldKey string) []string {
 	if p == nil {
 		return nil
 	}
-	if override := p.PerFieldOverride(fieldKey); override != nil {
+	if override := p.PerFieldOverride(fieldKey); len(override) > 0 {
 		return override
 	}
 	if len(p.Priority) > 0 {
@@ -151,24 +156,24 @@ func (p *PriorityConfig) GetFieldPriority(fieldKey string) []string {
 }
 
 // PerFieldOverride returns the raw per-field override stored under fieldKey,
-// WITHOUT falling back to the global Priority list. This is the clean "is there
-// an override?" accessor: it returns the raw value for a PRESENT key (including
-// an explicit empty slice []string{}, which means "consult no scrapers for
-// this field" — deliberate suppression via pure exclusivity), and nil only for
-// an ABSENT key.
+// WITHOUT falling back to the global Priority list. This is the raw
+// "is there an override key?" accessor: it returns the raw value for a PRESENT
+// key (including an explicit empty slice []string{}), and nil only for an
+// ABSENT key.
 //
-// A nil slice stored under a present key is returned as nil, so callers using
-// `fp != nil` treat present-nil identically to absent (both inherit global) —
-// matching the null/undefined = inherit contract. Only a non-nil empty slice
-// is a deliberate empty override.
+// NOTE: this is a RAW accessor — it does NOT decide resolution. A present-empty
+// [] is returned as a non-nil empty slice here, but resolution sites
+// (GetFieldPriority, aggregator.resolvePriorities/getFieldPriorityFromConfig,
+// AggregateWithPriority) guard with `len(fp) > 0`, so a present [] inherits the
+// global priority (commit 9f882f22's documented intent: "[] still means 'inherit
+// global'"); deliberate suppression uses the ["__skip__"] sentinel (matches no
+// real scraper). PerFieldOverride is kept as a raw accessor so callers can
+// distinguish "explicitly stored []" from "absent" (e.g. for diagnostics/UI)
+// even though both now resolve to inherit.
 //
-// This is the per-field-only counterpart of GetFieldPriority: GetFieldPriority
-// returns Fields[fieldKey] OR the global Priority (useful for the default
-// aggregation path); PerFieldOverride returns Fields[fieldKey] only (useful
-// when a caller supplies its own priority list and wants per-field overrides
-// to still win — e.g. AggregateWithPriority, where customPriority replaces the
-// global order for fields without an override, but an explicit per-field
-// override like `series: [tokyohot]` still wins exclusively).
+// A nil slice stored under a present key is returned as nil, matching the
+// null/undefined = inherit contract. Callers that want the EFFECTIVE priority
+// (with global fallback) should use GetFieldPriority, not this accessor.
 func (p *PriorityConfig) PerFieldOverride(fieldKey string) []string {
 	if p == nil {
 		return nil

--- a/web/frontend/src/lib/components/priority/FieldRow.svelte
+++ b/web/frontend/src/lib/components/priority/FieldRow.svelte
@@ -34,6 +34,7 @@
 
 	// Per-status visual language.
 	// inherited (green): no override, uses the global priority list.
+	// skipped   (red/slate): suppressed via ["__skip__"] — field left empty.
 	// custom   (orange): an exclusive override listing scrapers (possibly fewer
 	//             than the global list — the user removed some for this field).
 	const appearance: Record<
@@ -45,6 +46,12 @@
 			badge: 'text-green-600',
 			label: 'Inherited',
 			row: 'bg-background'
+		},
+		skipped: {
+			dot: 'bg-slate-500',
+			badge: 'text-slate-600',
+			label: 'Skipped',
+			row: 'bg-red-50/50 border-red-200 dark:bg-red-950/20 dark:border-red-900'
 		},
 		custom: {
 			dot: 'bg-orange-500',
@@ -72,11 +79,23 @@
 			{fieldLabel}
 		</div>
 		<div class="text-xs text-muted-foreground truncate">
-			{#if status === 'custom' && priority.length === 0}
-				<!-- Deliberate empty override ([] = "consult no scrapers"): the field is
-				     left empty. Distinguished from "inherited" by the custom status, so
-				     the user sees their suppression intent reflected, not a scraper chain. -->
-				<span class="italic">No scrapers — this field will be left empty</span>
+			{#if status === 'skipped'}
+				<!-- Suppressed via ["__skip__"]: the field is deliberately left empty
+				     (no scrapers consulted). Distinguished from custom/orange so the
+				     user sees their suppression intent reflected. -->
+				<span class="italic">Suppressed (no scrapers consulted)</span>
+			{:else if status === 'custom' && priority.length === 0}
+				<!-- Defensive fallback: a present-empty [] override is LEGACY and folds
+				     to inherit on read (matched in getGlobalPriority), so this branch
+				     should rarely fire. Treat as inherited: show the global chain. -->
+				{#each globalPriority as scraper, index}
+					<span class="inline-flex items-center">
+						{formatScraperName(scraper)}
+						{#if index < globalPriority.length - 1}
+							<span class="mx-1 text-muted-foreground/50">→</span>
+						{/if}
+					</span>
+				{/each}
 			{:else}
 				{#each priority as scraper, index}
 					<span class="inline-flex items-center">

--- a/web/frontend/src/lib/components/priority/FieldRow.test.ts
+++ b/web/frontend/src/lib/components/priority/FieldRow.test.ts
@@ -5,7 +5,7 @@ import FieldRow from './FieldRow.svelte';
 
 type FieldRowProps = ComponentProps<typeof FieldRow>;
 
-function makeProps(overrides: Partial<FieldRowProps> = {}): FieldRowProps {
+function make_props(overrides: Partial<FieldRowProps> = {}): FieldRowProps {
 	return {
 		fieldName: 'series',
 		fieldLabel: 'Series',
@@ -20,7 +20,7 @@ function makeProps(overrides: Partial<FieldRowProps> = {}): FieldRowProps {
 
 describe('FieldRow', () => {
 	it('shows the inherited (green) state with no reset button', () => {
-		const { container } = render(FieldRow, { props: makeProps() });
+		const { container } = render(FieldRow, { props: make_props() });
 
 		expect(container.textContent).toContain('Inherited');
 		const dot = container.querySelector('[role="img"]');
@@ -32,7 +32,7 @@ describe('FieldRow', () => {
 
 	it('shows the custom (orange) state with a reset button', () => {
 		const { container } = render(FieldRow, {
-			props: makeProps({ status: 'custom', priority: ['tokyohot'] }),
+			props: make_props({ status: 'custom', priority: ['tokyohot'] }),
 		});
 
 		expect(container.textContent).toContain('Custom');
@@ -46,32 +46,48 @@ describe('FieldRow', () => {
 		expect(container.querySelector('[aria-label="Reset to global priority"]')).toBeTruthy();
 	});
 
+	it('shows the skipped (slate/red) state for the skip sentinel and suppresses the scraper chain', () => {
+		// A stored ["__skip__"] override means suppression — the field is left
+		// empty (no scrapers consulted). The row shows the Skipped badge and
+		// "Suppressed (no scrapers consulted)" copy instead of the scraper → chain.
+		const { container } = render(FieldRow, {
+			props: make_props({ status: 'skipped', priority: ['__skip__'] }),
+		});
+
+		expect(container.textContent).toContain('Skipped');
+		expect(container.textContent).toContain('Suppressed (no scrapers consulted)');
+		// No scraper chain / arrow for a skipped field.
+		expect(container.textContent).not.toContain('→');
+		expect(container.textContent).not.toContain('R18.dev');
+
+		// Skipped rows offer a reset action (override → inherited).
+		expect(container.querySelector('[aria-label="Reset to global priority"]')).toBeTruthy();
+	});
+
 	it('renders the scraper chain for inherited/custom fields', () => {
-		const inherited = render(FieldRow, { props: makeProps() });
+		const inherited = render(FieldRow, { props: make_props() });
 		expect(inherited.container.textContent).toContain('R18.dev');
 		expect(inherited.container.textContent).toContain('→');
 
 		const custom = render(FieldRow, {
-			props: makeProps({ status: 'custom', priority: ['tokyohot'] }),
+			props: make_props({ status: 'custom', priority: ['tokyohot'] }),
 		});
 		expect(custom.container.textContent).toContain('Tokyo-Hot');
 	});
 
-	it('shows an empty-state note (not a scraper chain) for a custom + empty field', () => {
-		// A PRESENT [] override means "consult no scrapers" — the field is left
-		// empty. The row must reflect that suppression intent (custom/orange,
-		// reset button) and show an empty-state note instead of the scraper → chain.
+	it('renders the inherited global chain as a defensive fallback for a custom + empty (legacy []) field', () => {
+		// A present-empty [] is LEGACY and folds to inherit on read — so this
+		// custom+empty branch should rarely fire; when it does, the row falls
+		// back to showing the global chain rather than "No scrapers" text.
 		const { container } = render(FieldRow, {
-			props: makeProps({ status: 'custom', priority: [] }),
+			props: make_props({ status: 'custom', priority: [], globalPriority: ['r18dev', 'dmm'] }),
 		});
 
 		expect(container.textContent).toContain('Custom');
-		expect(container.textContent).toContain('No scrapers — this field will be left empty');
-		// No scraper chain / arrow for an empty custom field.
-		expect(container.textContent).not.toContain('→');
-		expect(container.textContent).not.toContain('R18.dev');
-
-		// Still offers a reset action (custom state).
+		// Fallback shows the global chain (not "No scrapers" text).
+		expect(container.textContent).toContain('R18.dev');
+		expect(container.textContent).not.toContain('No scrapers');
+		// Custom rows offer a reset action.
 		expect(container.querySelector('[aria-label="Reset to global priority"]')).toBeTruthy();
 	});
 });

--- a/web/frontend/src/lib/components/priority/MetadataPriority.svelte
+++ b/web/frontend/src/lib/components/priority/MetadataPriority.svelte
@@ -15,7 +15,8 @@
 		isFieldOverridden,
 		getFieldStatus,
 		applyEnabledReorderToFull,
-		buildFieldPriorityOverride
+		buildFieldPriorityOverride,
+		SKIP_SENTINEL
 	} from './priority';
 
 	interface Props {
@@ -184,7 +185,15 @@
 	// Open field editor
 	function openFieldEditor(fieldKey: string) {
 		editingField = fieldKey;
-		editingPriority = [...getFieldPriority(config, fieldKey)];
+		// When opening a 'skipped' field (stored ["__skip__"]), start with an
+		// empty list so the user sees an empty editor and can add scrapers back.
+		// Saving an empty list re-emits ["__skip__"] via buildFieldPriorityOverride.
+		const stored = config?.metadata?.priority?.[fieldKey];
+		if (stored && stored.length === 1 && stored[0] === SKIP_SENTINEL) {
+			editingPriority = [];
+		} else {
+			editingPriority = [...getFieldPriority(config, fieldKey)];
+		}
 	}
 
 	// Save field priority
@@ -198,11 +207,10 @@
 
 		// Delegate to the canonical, unit-tested helper: when the resolved
 		// priority equals the global list it DELETES the key (restoring
-		// "inherited" = key absent); otherwise it stores the full list verbatim
-		// — including disabled scrapers preserved through onReorder, AND a
-		// deliberate empty list (Remove all + Save), which stores [] so the
-		// field is left empty under exclusive semantics. There is no skip
-		// sentinel: [] means "consult no scrapers", distinct from a deleted key.
+		// "inherited" = key absent); when the priority is EMPTY (Remove all + Save)
+		// it stores ["__skip__"] (the skip sentinel — deliberate suppression,
+		// since [] now means inherit under World A); otherwise it stores the full
+		// list verbatim (including disabled scrapers preserved through onReorder).
 		config.metadata.priority = buildFieldPriorityOverride(
 			config,
 			editingField,
@@ -215,9 +223,10 @@
 	}
 
 	// Reset field to global (clears any override). Inherit = key ABSENT, so we
-	// DELETE the key rather than storing []. A present [] means "consult no
-	// scrapers" (deliberate empty field) — distinct from inherit — so writing []
-	// here would leave the field empty instead of restoring inheritance.
+	// DELETE the key rather than storing []. A present [] is LEGACY and folds to
+	// inherit on read under World A; a stored ["__skip__"] means suppression —
+	// distinct from inherit — so either way we delete the key to restore
+	// inheritance.
 	function resetFieldToGlobal(fieldKey: string) {
 		if (!config.metadata?.priority) return;
 
@@ -255,9 +264,10 @@
 	}
 
 	// Shortcut: remove every scraper from the field's list. Saving the emptied
-	// list stores [] (a PRESENT empty override) — under exclusive semantics the
-	// field is then left empty (no scraper consulted). To inherit the global list
-	// instead, use Reset to global (which deletes the key).
+	// list stores ["__skip__"] (the skip sentinel) via buildFieldPriorityOverride —
+	// under World A [] means inherit, so the skip sentinel is the only encoding
+	// for deliberate suppression. To inherit the global list instead, use Reset to
+	// global (which deletes the key).
 	function removeAllScrapers() {
 		editingPriority = [];
 	}
@@ -531,8 +541,9 @@
 						</DraggableList>
 					{:else}
 						<p class="text-sm text-muted-foreground italic py-4 text-center">
-							No scrapers in this field's list. Save to leave this field empty
-							(no scraper consulted), or add some below.
+							No scrapers in this field's list. Save with an empty list to suppress this
+							field (stores the <code class="bg-muted px-1 rounded">"__skip__"</code>
+							sentinel — no scraper is consulted), or add some below.
 						</p>
 					{/if}
 				</div>
@@ -581,10 +592,13 @@
 					</p>
 					<p>
 						To leave a field empty, remove all scrapers and Save (stores
-						<code class="bg-muted px-1 rounded">series: []</code> — no scraper is
-						consulted), or point it at a scraper that doesn't provide it (e.g.
-						<code class="bg-muted px-1 rounded">series: [tokyohot]</code>). There is no
-						skip button — suppression is just an empty (or non-matching) scraper list.
+						<code class="bg-muted px-1 rounded">series: ["__skip__"]</code> — the
+						skip sentinel, no scraper is consulted), or point it at a scraper that
+						doesn't provide it (e.g.
+						<code class="bg-muted px-1 rounded">series: [tokyohot]</code>). A legacy
+						<code class="bg-muted px-1 rounded">series: []</code> is treated as
+						inherit-global, not suppression — so "Remove all + Save" stores the
+						<code class="bg-muted px-1 rounded">__skip__</code> sentinel instead.
 					</p>
 				</div>
 

--- a/web/frontend/src/lib/components/priority/priority.test.ts
+++ b/web/frontend/src/lib/components/priority/priority.test.ts
@@ -6,6 +6,8 @@ import {
 	getFieldStatus,
 	buildFieldPriorityOverride,
 	applyEnabledReorderToFull,
+	SKIP_SENTINEL,
+	isSkipSentinel,
 } from './priority';
 import type { SettingsConfig, ScraperSettings } from '$lib/api/types';
 
@@ -63,11 +65,20 @@ describe('priority: getFieldPriority', () => {
 		expect(getFieldPriority(config, 'series')).toEqual(['r18dev', 'dmm']);
 	});
 
-	it('returns [] for a present-empty override (deliberate empty, NOT global)', () => {
-		// A PRESENT [] means "consult no scrapers" — it must NOT fall back to
-		// global. This is the core regression for "Remove all" + Save.
+	it('returns ["__skip__"] for the skip sentinel (suppression, NOT folded to global)', () => {
+		// ["__skip__"] is the only suppression encoding. It must NOT fold to the
+		// global list on read.
+		const config = makeConfig({
+			global: ['r18dev', 'dmm'],
+			fields: { series: [SKIP_SENTINEL] },
+		});
+		expect(getFieldPriority(config, 'series')).toEqual([SKIP_SENTINEL]);
+	});
+
+	it('returns global for a present-empty legacy override (World A: [] folds to inherit)', () => {
+		// A legacy present [] is folded to inherit on read, matching the backend.
 		const config = makeConfig({ global: ['r18dev', 'dmm'], fields: { series: [] } });
-		expect(getFieldPriority(config, 'series')).toEqual([]);
+		expect(getFieldPriority(config, 'series')).toEqual(['r18dev', 'dmm']);
 	});
 
 	it('returns global for a present-null override (null ⇒ inherit)', () => {
@@ -98,18 +109,20 @@ describe('priority: isFieldOverridden', () => {
 		).toBe(false);
 	});
 
-	it('returns true for a present-empty override when global is non-empty (differs ⇒ custom)', () => {
-		// [] differs from a non-empty global, so it IS an override (deliberate empty).
+	it('returns true for the skip sentinel (suppression counts as an override)', () => {
 		expect(
-			isFieldOverridden(makeConfig({ global: ['r18dev'], fields: { series: [] } }), 'series'),
+			isFieldOverridden(
+				makeConfig({ global: ['r18dev'], fields: { series: [SKIP_SENTINEL] } }),
+				'series',
+			),
 		).toBe(true);
 	});
 
-	it('returns false for a present-empty override when global is also empty (equals global)', () => {
-		// An empty field with an empty global is indistinguishable from inherited.
-		expect(isFieldOverridden(makeConfig({ global: [], fields: { series: [] } }), 'series')).toBe(
-			false,
-		);
+	it('returns false for a present-empty legacy override (World A: [] folds to inherit)', () => {
+		// A legacy present [] folds to inherit on read, so it is NOT an override.
+		expect(
+			isFieldOverridden(makeConfig({ global: ['r18dev'], fields: { series: [] } }), 'series'),
+		).toBe(false);
 	});
 
 	it('returns true for a non-empty override that differs from global', () => {
@@ -131,10 +144,19 @@ describe('priority: getFieldStatus', () => {
 		expect(getFieldStatus(makeConfig({ global: ['r18dev'] }), 'series')).toBe('inherited');
 	});
 
-	it('is "custom" for a present-empty override (deliberate empty)', () => {
+	it('is "skipped" for the skip sentinel (["__skip__"])', () => {
+		expect(
+			getFieldStatus(
+				makeConfig({ global: ['r18dev'], fields: { series: [SKIP_SENTINEL] } }),
+				'series',
+			),
+		).toBe('skipped');
+	});
+
+	it('is "inherited" for a present-empty legacy override (World A: [] folds to inherit)', () => {
 		expect(
 			getFieldStatus(makeConfig({ global: ['r18dev'], fields: { series: [] } }), 'series'),
-		).toBe('custom');
+		).toBe('inherited');
 	});
 
 	it('is "inherited" for a present-null override (null ⇒ inherit)', () => {
@@ -149,6 +171,25 @@ describe('priority: getFieldStatus', () => {
 	it('is "custom" for a non-empty exclusive override', () => {
 		const config = makeConfig({ global: ['r18dev', 'dmm'], fields: { series: ['tokyohot'] } });
 		expect(getFieldStatus(config, 'series')).toBe('custom');
+	});
+});
+
+describe('priority: isSkipSentinel', () => {
+	it('returns true for [SKIP_SENTINEL]', () => {
+		expect(isSkipSentinel([SKIP_SENTINEL])).toBe(true);
+	});
+
+	it('returns false for an empty list', () => {
+		expect(isSkipSentinel([])).toBe(false);
+	});
+
+	it('returns false for a non-empty list that is not the sentinel', () => {
+		expect(isSkipSentinel(['tokyohot'])).toBe(false);
+		expect(isSkipSentinel(['r18dev', 'dmm'])).toBe(false);
+	});
+
+	it('returns false for the sentinel plus other entries', () => {
+		expect(isSkipSentinel([SKIP_SENTINEL, 'r18dev'])).toBe(false);
 	});
 });
 
@@ -168,20 +209,33 @@ describe('priority: buildFieldPriorityOverride (config shape)', () => {
 
 	it('deletes the key for a global-equal override (inherit = key absent, NOT [])', () => {
 		// Global-equal ⇒ inherit. The config must encode inherit as an ABSENT key,
-		// not [] — a present [] means "empty field". So the key is deleted.
+		// not []. So the key is deleted.
 		const config = makeConfig({ global: ['r18dev', 'dmm'] });
 		const next = buildFieldPriorityOverride(config, 'series', ['r18dev', 'dmm']);
 		expect('series' in next).toBe(false);
 		expect(next.series).toBeUndefined();
 	});
 
-	it('stores [] for a deliberate-empty override when it differs from global', () => {
-		// Remove all + Save: priority [] differs from a non-empty global, so it is
-		// stored as a PRESENT [] (deliberate empty field), not deleted.
+	it('stores ["__skip__"] for a deliberate-empty override (Remove all + Save)', () => {
+		// World A: "Remove all" + Save stores the skip sentinel, NOT [] (because
+		// [] now means inherit). The sentinel is the only suppression encoding.
 		const config = makeConfig({ global: ['r18dev', 'dmm'] });
 		const next = buildFieldPriorityOverride(config, 'series', []);
-		expect(next.series).toEqual([]);
+		expect(next.series).toEqual([SKIP_SENTINEL]);
 		expect('series' in next).toBe(true);
+	});
+
+	it('stores [] as ["__skip__"] even when global is empty (Remove all still suppresses)', () => {
+		// When the global list is itself empty, an empty editingPriority would
+		// deep-equal global — so it would normally DELETE the key (inherit). To
+		// preserve the "Remove all = suppress" UX, an explicit empty list still
+		// surfaces as inherit (key absent), since with an empty global there is
+		// nothing to suppress beyond. Document the actual behavior below.
+		const config = makeConfig({ global: [] });
+		const next = buildFieldPriorityOverride(config, 'series', []);
+		// Empty priority + empty global: priority === global → key DELETED.
+		// (No scrapers run anyway under an empty global, so suppress == inherit.)
+		expect('series' in next).toBe(false);
 	});
 
 	it('does not mutate the original config', () => {

--- a/web/frontend/src/lib/components/priority/priority.test.ts
+++ b/web/frontend/src/lib/components/priority/priority.test.ts
@@ -225,17 +225,16 @@ describe('priority: buildFieldPriorityOverride (config shape)', () => {
 		expect('series' in next).toBe(true);
 	});
 
-	it('stores [] as ["__skip__"] even when global is empty (Remove all still suppresses)', () => {
+	it('stores ["__skip__"] even when global is empty (Remove all still suppresses)', () => {
 		// When the global list is itself empty, an empty editingPriority would
-		// deep-equal global — so it would normally DELETE the key (inherit). To
-		// preserve the "Remove all = suppress" UX, an explicit empty list still
-		// surfaces as inherit (key absent), since with an empty global there is
-		// nothing to suppress beyond. Document the actual behavior below.
+		// deep-equal global — but "Remove all" is a deliberate suppress action.
+		// Persist the skip sentinel so the field stays suppressed even if global
+		// scrapers are added later. The empty-list check runs before the
+		// deep-equal shortcut for exactly this reason.
 		const config = makeConfig({ global: [] });
 		const next = buildFieldPriorityOverride(config, 'series', []);
-		// Empty priority + empty global: priority === global → key DELETED.
-		// (No scrapers run anyway under an empty global, so suppress == inherit.)
-		expect('series' in next).toBe(false);
+		expect(next.series).toEqual([SKIP_SENTINEL]);
+		expect('series' in next).toBe(true);
 	});
 
 	it('does not mutate the original config', () => {

--- a/web/frontend/src/lib/components/priority/priority.ts
+++ b/web/frontend/src/lib/components/priority/priority.ts
@@ -1,7 +1,22 @@
 import type { SettingsConfig } from '$lib/api/types';
 
+/**
+ * Canonical skip sentinel (slice form `["__skip__"]`).
+ *
+ * Under World A semantics, a present-empty `[]` field override means INHERIT
+ * the global priority (folding the legacy World-B suppression form on read).
+ * The only encoding for deliberate suppression is `["__skip__"]` — a sentinel
+ * that matches no real scraper, so the field is left empty when consulted.
+ */
+export const SKIP_SENTINEL = '__skip__';
+
+/** Whether a stored override list is the skip sentinel (`["__skip__"]`). */
+export function isSkipSentinel(list: string[]): boolean {
+	return list.length === 1 && list[0] === SKIP_SENTINEL;
+}
+
 /** Coarse display status for a field, driving the row's visual indicator. */
-export type FieldStatus = 'inherited' | 'custom';
+export type FieldStatus = 'inherited' | 'skipped' | 'custom';
 
 /** Global scraper execution priority from config. */
 export function getGlobalPriority(config: SettingsConfig | undefined | null): string[] {
@@ -11,14 +26,18 @@ export function getGlobalPriority(config: SettingsConfig | undefined | null): st
 /**
  * Resolve a field's effective scraper priority.
  *
- * Pure-exclusivity contract (no skip sentinel) — the three field states:
- *   - key ABSENT (or null/undefined) → inherit the global priority list
- *   - key present = []                → consult NO scrapers (field left empty)
- *   - key present = [a,b]             → consult a then b exclusively, no fallback
+ * World A semantics — the three (technically four) field states:
+ *   - key ABSENT (or null/undefined)          → inherit the global list
+ *   - key present = ["__skip__"]               → skipped (field left empty;
+ *                                               suppression sentinel)
+ *   - key present = []                          → inherit global (legacy World-B
+ *                                               form folded to inherit on read,
+ *                                               matching the backend)
+ *   - key present = [a,b] (any other list)     → consult a then b exclusively
  *
- * A PRESENT empty array is a deliberate empty field, NOT an inherit signal —
- * this is what makes "Remove all" + Save persist an empty field. Only an ABSENT
- * (or null) key inherits the global list. `[]` and `undefined` are distinct.
+ * `["__skip__"]` is the only suppression encoding. A legacy present `[]` is
+ * folded to inherit so the UI never crashes and matches the backend's
+ * task-2 ([]) = inherit semantics.
  */
 export function getFieldPriority(
 	config: SettingsConfig | undefined | null,
@@ -28,7 +47,12 @@ export function getFieldPriority(
 	if (fields) {
 		const v = fields[fieldKey];
 		if (v !== undefined && v !== null) {
-			return v; // present (incl. []) — [] means "no scrapers"
+			// Legacy present-empty [] folds to inherit (World A). The skip sentinel
+			// and any other list are returned verbatim.
+			if (Array.isArray(v) && v.length === 0) {
+				return getGlobalPriority(config);
+			}
+			return v;
 		}
 	}
 	return getGlobalPriority(config);
@@ -37,12 +61,12 @@ export function getFieldPriority(
 /**
  * Whether a field has a custom (non-inherited) override.
  *
- * A PRESENT value (including `[]`) that differs from the global list is an
- * override → true. A present `[]` differs from a non-empty global, so it counts
- * as overridden (custom). An ABSENT key (or null) → false (inherit global).
- * When the global list itself is empty, a present `[]` equals it and is NOT an
- * override (an empty field with an empty global is indistinguishable from
- * inherited, which is correct).
+ * Both 'custom' (`[a,b]` differs from global) and 'skipped' (`["__skip__"]`)
+ * are overrides of inherited → true. A present `[]` legacy form folds to
+ * inherit on read, so a stored `[]` equal to an empty global is NOT an
+ * override; a stored `[]` differing from a non-empty global is treated as
+ * inherited (since `getFieldPriority` folds it to global). Only the skip
+ * sentinel and genuinely custom lists count as overrides.
  */
 export function isFieldOverridden(
 	config: SettingsConfig | undefined | null,
@@ -52,31 +76,47 @@ export function isFieldOverridden(
 	if (!fields) return false;
 	const v = fields[fieldKey];
 	if (v === undefined || v === null) return false; // absent/null → inherit
+	if (isSkipSentinel(v)) return true; // skipped → overridden
+	if (Array.isArray(v) && v.length === 0) return false; // legacy [] → inherit
 	return JSON.stringify(v) !== JSON.stringify(getGlobalPriority(config));
 }
 
 /**
  * Display status for a field, driving the row's visual indicator:
- * - "inherited" (green): no override, uses global priority.
- * - "custom" (orange): an exclusive override listing scrapers (possibly fewer
+ * - "inherited" (green): no override, uses the global priority list.
+ * - "skipped"   (red/slate): suppressed via the `["__skip__"]` sentinel — the
+ *   field is left empty (no scrapers consulted).
+ * - "custom"   (orange): an exclusive override listing scrapers (possibly fewer
  *   than the global list — the user removed some for this field).
  */
 export function getFieldStatus(
 	config: SettingsConfig | undefined | null,
 	fieldKey: string,
 ): FieldStatus {
-	return isFieldOverridden(config, fieldKey) ? 'custom' : 'inherited';
+	const fields = config?.metadata?.priority;
+	if (!fields) return 'inherited';
+	const v = fields[fieldKey];
+	if (v === undefined || v === null) return 'inherited';
+	if (isSkipSentinel(v)) return 'skipped';
+	if (Array.isArray(v) && v.length === 0) return 'inherited'; // legacy [] folds to inherit
+	return JSON.stringify(v) !== JSON.stringify(getGlobalPriority(config))
+		? 'custom'
+		: 'inherited';
 }
 
 /**
  * Build a config mutation that sets a field's per-field priority override.
  *
- * Returns a new `metadata.priority` record (does not mutate the input). The
- * config shape encodes the three field states directly (no skip sentinel):
+ * Returns a new `metadata.priority` record (does not mutate the input). Under
+ * World A semantics:
  *   - priority deep-equals global → DELETE the key (inherit = key ABSENT).
- *     Do NOT write `[]` — a present `[]` means "empty field", not "inherit".
- *   - priority differs from global (incl. `[]` when global is non-empty) →
- *     store it verbatim. A deliberate empty list stores `[]` (present-empty).
+ *     Do NOT write `[]` — a present `[]` is LEGACY and folds to inherit on
+ *     read (matching the backend), so writing it would mean inherit anyway.
+ *   - priority is EMPTY (Remove all) → store `["__skip__"]` (the skip sentinel).
+ *     This is the key behavioral change: "Remove all" + Save now stores the
+ *     skip sentinel, NOT `[]`, so the field is deliberately suppressed rather
+ *     than silently treated as inherit.
+ *   - priority differs from global (non-empty override) → store it verbatim.
  */
 export function buildFieldPriorityOverride(
 	config: SettingsConfig | undefined | null,
@@ -87,8 +127,10 @@ export function buildFieldPriorityOverride(
 	const global = getGlobalPriority(config);
 	if (JSON.stringify(priority) === JSON.stringify(global)) {
 		delete base[fieldKey]; // inherit = key absent (NOT [])
+	} else if (priority.length === 0) {
+		base[fieldKey] = [SKIP_SENTINEL]; // "Remove all" → suppress via skip sentinel
 	} else {
-		base[fieldKey] = [...priority]; // differs — incl. deliberate-empty []
+		base[fieldKey] = [...priority]; // differs — store verbatim
 	}
 	return base;
 }

--- a/web/frontend/src/lib/components/priority/priority.ts
+++ b/web/frontend/src/lib/components/priority/priority.ts
@@ -125,10 +125,13 @@ export function buildFieldPriorityOverride(
 ): Record<string, string[]> {
 	const base = { ...(config?.metadata?.priority ?? {}) };
 	const global = getGlobalPriority(config);
-	if (JSON.stringify(priority) === JSON.stringify(global)) {
+	if (priority.length === 0) {
+		base[fieldKey] = [SKIP_SENTINEL]; // "Remove all" → suppress (checked first so an empty
+		// list always persists the sentinel even when global is itself empty —
+		// otherwise deep-equal-to-global would silently delete the key and the
+		// field would re-inherit if global scrapers are added later)
+	} else if (JSON.stringify(priority) === JSON.stringify(global)) {
 		delete base[fieldKey]; // inherit = key absent (NOT [])
-	} else if (priority.length === 0) {
-		base[fieldKey] = [SKIP_SENTINEL]; // "Remove all" → suppress via skip sentinel
 	} else {
 		base[fieldKey] = [...priority]; // differs — store verbatim
 	}


### PR DESCRIPTION
## Summary

Commit 9f882f22 (PR #51) made per-field `metadata.priority` exclusive, but its implementation treated a present-empty `[]` as "consult no scrapers" — contradicting its own commit message (`"[] still means 'inherit global'"`). For configs carrying `[]` entries (common from the pre-9f882f22 merge era), this silently wiped every metadata field, collapsing scraped movies into one group and showing "No poster".

This PR moves to a coherent **World A** contract across backend + frontend + YAML persistence.

## Root cause (traced via swarm investigation)

| Stored form | Pre-9f882f22 | 9f882f22 (buggy) | This PR |
|---|---|---|---|
| key absent | inherit global | inherit global | inherit global |
| `[]` (legacy) | inherit (merged) | **suppress (empty field)** ← bug | inherit global |
| `["__skip__"]` | n/a | n/a (sentinel unused) | suppress (empty field) |
| `[a,b]` | exclusive | exclusive | exclusive |

The frontend (also added in 9f882f22) was designed around the buggy `[]` = suppress: the "Remove all" button emitted `[]`. So the backend and frontend were *consistent with each other* but contradicted the documented intent — and broke existing users on upgrade.

## Changes

**Backend — 4 resolution sites** guarded with `len(fp) > 0` instead of `fp != nil`, so a present `[]` inherits the global list:
- `internal/config/translation_config.go` — `GetFieldPriority`
- `internal/aggregator/priority.go` — `resolvePriorities` + `getFieldPriorityFromConfig`
- `internal/aggregator/aggregate.go` — `AggregateWithPriority` priorityFunc

`["__skip__"]` is the only suppression encoding (matches no real scraper → field left empty). `PerFieldOverride` is preserved as the raw accessor (still returns non-nil `[]string{}` for a present `[]` — the guard is at the resolution sites, not the accessor).

**Frontend** (`web/frontend/src/lib/components/priority/`):
- `FieldStatus` += `'skipped'`; `SKIP_SENTINEL = '__skip__'` constant + `isSkipSentinel()` helper.
- `buildFieldPriorityOverride`: "Remove all" + Save now stores `["__skip__"]` (not `[]`), so suppression survives the new `[]` = inherit semantics.
- `getFieldPriority`: legacy `[]` folds to inherit on read (matches backend).
- `FieldRow.svelte`: distinct `'Skipped'` badge + "Suppressed (no scrapers consulted)" copy.

**YAML persistence** (`internal/config/storage_yaml.go`):
- `mergeYAMLNode` only added/updated keys, never deleted — so "Reset to global" (frontend deletes the key) left the stale override in `config.yaml`, reappearing on reload. In-memory GET looked correct immediately post-save, masking the file divergence.
- Added `pruneMetadataPriorityFields`: a **scoped** deletion pass limited to the `metadata.priority` mapping (preserves comments on kept keys; no broader deletion that would clobber user keys/comments elsewhere).

## Tests

- Rewrote `priority_empty_override_test.go`, `priority_all_empty_inherit_test.go` (was locking in old `[]` = suppress semantics)
- Updated `priority_exclusivity_test.go`, `config_edge_cases_test.go`, `coverage_boost_test.go` for new `[]` = inherit assertions
- New `storage_yaml_priority_deletion_test.go` (6 subtests incl. Save round-trip proving deleted overrides don't reappear)
- Frontend `priority.test.ts` / `FieldRow.test.ts` assert the three states + skip sentinel

## Verification

- `make fmt` / `make vet` clean
- `make test-short` — all pass (`internal/config` 42s, `internal/aggregator` ok; DMM scraper live-network tests excluded via `-short`)
- Frontend `npm run test` → 275/275 pass; `svelte-check` 0 errors; `npm run build` succeeds
- Pre-commit hook passed (gofmt + go vet + go test -short + svelte-check)

## Coordinated via

pi-messenger swarm (4 agents across 2 phases): code review (MintLion), round-trip investigation (DarkViper), backend YAML fix (SageDragon), frontend skip-state migration (CalmXenon).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distinct **“skipped”** field priority status using an explicit suppression marker.
* **Bug Fixes**
  * Fixed priority resolution so an explicitly present but **empty** override now correctly **inherits the global priority**.
  * Corrected how configuration merges handle `metadata.priority` so irrelevant destination priority keys are not retained.
* **UI Improvements**
  * Updated the field editor and status messages to reflect three states: inherited, skipped (suppressed), and custom.
  * Changed “Remove all” to store suppression via the sentinel rather than an empty list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->