### PR TITLE
fix(ui): refetch image previews on URL change via reactive error state

### DIFF
--- a/web/frontend/src/lib/components/ActressEditor.svelte
+++ b/web/frontend/src/lib/components/ActressEditor.svelte
@@ -30,6 +30,11 @@
 		thumb_url: ''
 	});
 
+	// Whether the thumbnail preview failed to load for the current URL. Reset
+	// whenever the URL changes so a corrected URL re-fetches instead of staying
+	// hidden by a stale onerror (display:none) from a prior failed URL.
+	let thumbPreviewError = $state(false);
+
 	// Autocomplete state
 	let searchQuery = $state('');
 	let searchResults = $state<Actress[]>([]);
@@ -72,6 +77,33 @@
 	$effect(() => {
 		const data = movie.actresses;
 		untrack(() => { actresses = data || []; });
+	});
+
+	// Reset the thumbnail preview error whenever the URL being edited changes
+	// (including when the editor opens on a different actress). Without this,
+	// a previously-failed URL leaves the preview <img> hidden via a stale
+	// onerror display:none, so correcting the URL does not re-fetch.
+	$effect(() => {
+		editingActress.thumb_url;
+		thumbPreviewError = false;
+	});
+
+	// Debounced copy of the thumbnail URL used ONLY for the preview <img src>
+	// and its {#if}/fallback, so rapid typing does not re-fetch per keystroke.
+	// The input stays bound to the live editingActress.thumb_url, and the
+	// error-reset $effect above still tracks the LIVE URL (clears immediately),
+	// so a corrected URL re-fetches once typing pauses.
+	let thumbPreviewSrc = $state('');
+	let thumbDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+	$effect(() => {
+		const url = editingActress.thumb_url;
+		if (thumbDebounceTimer) { clearTimeout(thumbDebounceTimer); thumbDebounceTimer = null; }
+		thumbDebounceTimer = setTimeout(() => {
+			thumbPreviewSrc = url ?? '';
+		}, 250);
+		return () => {
+			if (thumbDebounceTimer) { clearTimeout(thumbDebounceTimer); thumbDebounceTimer = null; }
+		};
 	});
 
 	// Helper to get full name
@@ -443,20 +475,21 @@
 					<div>
 						<span class="text-sm font-medium mb-1 block">Preview</span>
 						<Card class="p-3">
-							{#if editingActress.thumb_url}
+							<!-- Preview hides via {#if}+thumbPreviewError (unmounts the element),
+							     not the HTML [hidden] attr. If changed to hidden=, avoid Tailwind
+							     'block'/'flex' on this <img> — display utilities override [hidden]. -->
+							{#if thumbPreviewSrc && !thumbPreviewError}
 								<img
-									src={editingActress.thumb_url}
+									src={thumbPreviewSrc}
 									alt={getFullName(editingActress) || 'Preview'}
 									class="w-full aspect-2/3 object-cover rounded mb-2"
-									onerror={(e) => {
-										const target = e.currentTarget as HTMLImageElement; target.style.display = 'none';
-									}}
+									onerror={() => { thumbPreviewError = true; }}
 								/>
 							{:else}
 								<div
 									class="w-full aspect-2/3 bg-accent rounded flex items-center justify-center text-sm text-muted-foreground mb-2"
 								>
-									No Thumbnail
+									{thumbPreviewSrc ? 'Unable to load image' : 'No Thumbnail'}
 								</div>
 							{/if}
 							<p class="font-medium text-sm truncate">

--- a/web/frontend/src/lib/components/ActressEditor.svelte
+++ b/web/frontend/src/lib/components/ActressEditor.svelte
@@ -96,10 +96,11 @@
 	let thumbPreviewSrc = $state('');
 	let thumbDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	$effect(() => {
-		const url = editingActress.thumb_url;
+		const url = editingActress.thumb_url ?? '';
 		if (thumbDebounceTimer) { clearTimeout(thumbDebounceTimer); thumbDebounceTimer = null; }
+		thumbPreviewSrc = '';
 		thumbDebounceTimer = setTimeout(() => {
-			thumbPreviewSrc = url ?? '';
+			thumbPreviewSrc = url;
 		}, 250);
 		return () => {
 			if (thumbDebounceTimer) { clearTimeout(thumbDebounceTimer); thumbDebounceTimer = null; }

--- a/web/frontend/src/lib/components/ScreenshotManager.svelte
+++ b/web/frontend/src/lib/components/ScreenshotManager.svelte
@@ -27,6 +27,17 @@
 	let trailerUrl = $state('');
 	let newScreenshotUrl = $state('');
 
+	// Reactive preview-error state — reset when the bound URL changes so a
+	// corrected URL re-fetches instead of staying hidden by a stale onerror
+	// (display:none) from a prior failed URL.
+	let posterPreviewError = $state(false);
+	let coverPreviewError = $state(false);
+	let screenshotErrors = $state<Set<string>>(new Set());
+	// The imgs below hide via the HTML `hidden` attribute (Tailwind preflight
+	// [hidden]{display:none}). Do NOT add `block`/`flex` or other display utility
+	// classes to those imgs — a display utility overrides [hidden] and breaks
+	// error-hiding (the prior inline style.display='none' survived this).
+
 	// Screenshot viewer modal state
 	let showViewer = $state(false);
 	let viewerIndex = $state(0);
@@ -47,6 +58,19 @@
 		coverUrl = movie.cover_url || '';
 		trailerUrl = movie.trailer_url || '';
 	});
+
+	// Reset preview-error state when the bound URL/list changes, so a corrected
+	// URL re-fetches instead of staying hidden by a stale onerror display:none.
+	$effect(() => { posterUrl; displayPosterUrl; posterPreviewError = false; });
+	$effect(() => { coverUrl; coverPreviewError = false; });
+	// Track a derived signature of the screenshot URLs — not the array ref — so
+	// the reset fires only on actual content change. An identical-content
+	// reassignment (e.g. movie-sync handing back a new array with the same URLs)
+	// leaves the signature unchanged, so this effect does not re-run and a
+	// previously-errored img stays hidden (the browser does not re-fetch an
+	// unchanged src, so un-hiding would flash a stale broken-image icon).
+	let screenshotsSignature = $derived(screenshots.join('\u0000'));
+	$effect(() => { screenshotsSignature; screenshotErrors = new Set(); });
 
 	let clearCropState = $state(false);
 
@@ -189,20 +213,16 @@
 								src={posterUrl}
 								alt="Poster"
 								class="absolute h-full"
-								style="right: 0; width: auto; min-width: 211.8%; object-fit: cover; object-position: right center;"
-								onerror={(e) => {
-									const target = e.currentTarget as HTMLImageElement; target.style.display = 'none';
-								}}
+								style="right: 0; width: auto; min-width: 211.8%; object-fit: cover; object-position: right center;" hidden={posterPreviewError}
+								onerror={() => { posterPreviewError = true; }}
 							/>
 						{:else}
 							<!-- Use displayPosterUrl (temp_poster_url if available) or posterUrl directly without cropping -->
 							<img
 								src={displayPosterUrl || posterUrl}
 								alt="Poster"
-								class="w-full h-full object-contain"
-								onerror={(e) => {
-									const target = e.currentTarget as HTMLImageElement; target.style.display = 'none';
-								}}
+								class="w-full h-full object-contain" hidden={posterPreviewError}
+								onerror={() => { posterPreviewError = true; }}
 							/>
 						{/if}
 					</div>
@@ -255,10 +275,8 @@
 							<img
 								src={previewImageURL(coverUrl)}
 								alt="Cover"
-								class="w-full"
-							onerror={(e) => {
-								const target = e.currentTarget as HTMLImageElement; target.style.display = 'none';
-							}}
+								class="w-full" hidden={coverPreviewError}
+							onerror={() => { coverPreviewError = true; }}
 						/>
 					</button>
 				{:else}
@@ -404,10 +422,8 @@
 							<img
 								src={previewImageURL(url)}
 								alt="Screenshot {index + 1}"
-								class="w-full aspect-video object-cover rounded"
-								onerror={(e) => {
-									const target = e.currentTarget as HTMLImageElement; target.style.display = 'none';
-								}}
+								class="w-full aspect-video object-cover rounded" hidden={screenshotErrors.has(url)}
+								onerror={() => { screenshotErrors = new Set([...screenshotErrors, url]); }}
 							/>
 						</button>
 						<div class="mt-2 flex items-center gap-1">

--- a/web/frontend/src/routes/actresses/components/ActressCardsView.svelte
+++ b/web/frontend/src/routes/actresses/components/ActressCardsView.svelte
@@ -28,6 +28,12 @@
 		onRemoveActress: (actress: Actress) => void;
 		deletePending: boolean;
 	} = $props();
+
+	// Reactive per-image error state — reset when the list changes so a
+	// refreshed (same-URL) image re-fetches instead of staying hidden by a
+	// stale onerror display:none from a prior failed load.
+	let actressImgErrors = $state<Set<string | undefined>>(new Set());
+	$effect(() => { actresses; actressImgErrors = new Set(); });
 </script>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -46,13 +52,13 @@
 						/>
 					</div>
 					{#if actress.thumb_url}
+						<!-- [hidden] attr: a Tailwind 'block'/'flex' utility on this <img>
+						     would override [hidden]; keep display utilities off this element -->
 						<img
 							src={actress.thumb_url}
 							alt={getDisplayName(actress)}
-							class="w-20 h-24 rounded object-cover border"
-							onerror={(event) => {
-								(event.currentTarget as HTMLImageElement).style.display = 'none';
-							}}
+							class="w-20 h-24 rounded object-cover border" hidden={actressImgErrors.has(actress.thumb_url)}
+							onerror={() => { actressImgErrors = new Set([...actressImgErrors, actress.thumb_url]); }}
 						/>
 					{:else}
 						<div class="w-20 h-24 rounded border bg-muted flex items-center justify-center text-muted-foreground">

--- a/web/frontend/src/routes/jobs/+page.svelte
+++ b/web/frontend/src/routes/jobs/+page.svelte
@@ -45,6 +45,12 @@
 	let olderThanDays = $state(30);
 	let isCleaningHistory = $state(false);
 	let isCleaningEvents = $state(false);
+
+	// Reactive per-job poster error state — reset when the job list changes
+	// so a refreshed (same-URL) poster re-fetches instead of staying hidden
+	// by a stale onerror display:none from a prior failed load.
+	let posterErrors = $state<Set<string | undefined>>(new Set());
+	$effect(() => { paginatedJobs; posterErrors = new Set(); });
 	let activeFilter = $state<string>('all');
 	let currentPage = $state(1);
 	const pageSize = 10;
@@ -378,13 +384,13 @@
 								<div class="flex items-center p-3 gap-4">
 									{#if poster}
 										<div class="w-20 h-20 flex-shrink-0 bg-muted rounded-md overflow-hidden flex items-center justify-center">
+											<!-- [hidden] attr: a Tailwind 'block'/'flex' utility on this <img>
+											     would override [hidden]; keep display utilities off this element -->
 											<img
 												src={poster}
 												alt=""
-												class="w-full h-full object-cover object-center"
-												onerror={(e) => {
-													(e.target as HTMLImageElement).style.display = 'none';
-												}}
+												class="w-full h-full object-cover object-center" hidden={posterErrors.has(poster)}
+												onerror={() => { posterErrors = new Set([...posterErrors, poster]); }}
 											/>
 										</div>
 									{:else}


### PR DESCRIPTION
## Summary

Broken-image previews across the actress/screenshot/poster UI hid failed images via an **unmanaged `onerror` DOM mutation** (`target.style.display = 'none'`). Because Svelte doesn't track that mutation, it persisted across `src` patches — so when a user corrected an invalid thumbnail URL (e.g. a small character edit), the browser **did** fetch the valid image but it loaded **invisibly** (the stale `display:none` was never reset). Clearing the URL entirely "worked" only because it toggled the `{#if}` and destroyed the `<img>`.

This replaces every such mutation with **reactive error state** that resets when the bound URL/list changes, so a corrected URL re-fetches.

## Changes (4 files)

- **`ActressEditor.svelte`** — `thumbPreviewError` bool + `$effect` reset on URL change + `{#if}` guard (recreates the `<img>` on error→valid) + "Unable to load image" fallback. **+250ms debounced preview src** (input stays live-bound; the error-reset `$effect` still tracks the *live* URL so the error clears immediately).
- **`ScreenshotManager.svelte`** — `posterPreviewError`/`coverPreviewError` bools + `screenshotErrors` Set + `hidden={flag}` on 4 imgs. The grid reset is keyed on a **derived URL signature** (`screenshots.join('\u0000')`) so it only fires on actual content change — not on identical-content reassignment (which previously un-hid an unchanged-src errored image into a stale broken-icon, since the browser doesn't re-fetch an unchanged `src`).
- **`ActressCardsView.svelte`** + **`jobs/+page.svelte`** — `Set<string | undefined>` error state + `hidden={set.has(url)}` + reset on list change. (`Set<string | undefined>` is load-bearing for `ActressCardsView` — TS doesn't preserve property narrowing in nested closures, and `thumb_url` is optional.)

All `hidden={flag}` usages carry a preventive comment: a future Tailwind `block`/`flex` on these imgs would override `[hidden]` (the old inline `style.display` survived this).

## Verification
- `svelte-check` 0 errors / 0 warnings
- `npm run test` → 275/275 pass
- `npm run build` → succeeds

## Review
Independently code-reviewed by 3 swarm workers (all APPROVE, no blockers/majors); the minor findings they raised (grid unchanged-src broken-icon, `[hidden]` override note, rapid-typing flicker) were addressed by 2 follow-up workers — the grid signature fix and the ActressEditor debounce landed here; the ScreenshotManager debounce was intentionally skipped (non-surgical, would risk the fix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image preview handling across actress editing, screenshot previews, actress cards, and the jobs page.
  * Failed thumbnails/posters now hide consistently using state-driven logic and can retry after the associated URL changes.
  * Added clearer fallback messaging to distinguish missing thumbnails from broken images.
  * Reduced unnecessary preview reloads during rapid edits by debouncing thumbnail preview updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->