### PR TITLE
fix(dmm): restore director + rating extraction after DMM markup migration

### DIFF
--- a/internal/scraper/dmm/dmm_test.go
+++ b/internal/scraper/dmm/dmm_test.go
@@ -847,6 +847,20 @@ func TestExtractRating_OldSite(t *testing.T) {
 			expectedVotes: 100,
 		},
 		{
+			name:          "new dcd-review format",
+			html:          `<html><head></head><body><div class="dcd-review__points"><p class="dcd-review__average">平均評価<strong>4.5</strong></p><p class="dcd-review__evaluates">総評価数<strong>2</strong>（1件のコメント）</p></div></body></html>`,
+			expectNil:     false,
+			expectedScore: 9.0, // 4.5 * 2 = 9.0
+			expectedVotes: 2,
+		},
+		{
+			name:          "hybrid new score + legacy votes fallback",
+			html:          `<html><head></head><body><p class="dcd-review__average">平均評価<strong>4.5</strong></p><p class="d-review__evaluates">評価数: <strong>100</strong></p></body></html>`,
+			expectNil:     false,
+			expectedScore: 9.0, // 4.5 * 2 = 9.0
+			expectedVotes: 100,
+		},
+		{
 			name:      "no rating",
 			html:      `<html><body>No rating</body></html>`,
 			expectNil: true,
@@ -974,6 +988,30 @@ func TestExtractDirector_EdgeCases(t *testing.T) {
 			html:        `<a href="?director=123">  Director Name  </a>`,
 			expected:    "Director Name",
 			description: "Should clean whitespace from director name",
+		},
+		{
+			name:        "Director with new path-based href",
+			html:        `<a href="/mono/dvd/-/list/=/article=director/id=102296/">マサルパンサー</a>`,
+			expected:    "マサルパンサー",
+			description: "Should extract director from new DMM path-based href (article=director/id=)",
+		},
+		{
+			name:        "Director in new table-row format with 監督 label",
+			html:        `<table><tr><td>監督：</td><td><a href="/mono/dvd/-/list/=/article=director/id=102296/">マサルパンサー</a></td></tr></table>`,
+			expected:    "マサルパンサー",
+			description: "Should extract director from new DMM table format with 監督 label",
+		},
+		{
+			name:        "breadcrumb article=directory does not false-match director",
+			html:        `<a href="/mono/dvd/-/list/=/article=directory/id=5/">メーカー</a>`,
+			expected:    "",
+			description: "article=directory/id= (breadcrumb) must not match the article=director/id= selector",
+		},
+		{
+			name:        "mixed old and new director links — first in DOM wins",
+			html:        `<a href="?director=123">Old Director</a><a href="/mono/dvd/-/list/=/article=director/id=456/">New Director</a>`,
+			expected:    "Old Director",
+			description: "goquery returns combined-selector matches in document order; first match wins",
 		},
 		{
 			name:        "No director",

--- a/internal/scraper/dmm/parse_html.go
+++ b/internal/scraper/dmm/parse_html.go
@@ -17,7 +17,6 @@ import (
 var (
 	dateRegex      = regexp.MustCompile(`\d{4}/\d{2}/\d{2}`)
 	runtimeRegex   = regexp.MustCompile(`(\d{2,3})\s?(?:minutes|分)`)
-	directorRegex  = regexp.MustCompile(`<a.*?href="[^"]*\?director=(\d+)".*?>([^<]+)</a>`)
 	seriesRegex    = regexp.MustCompile(`<a href="(?:/digital/videoa/|(?:/en)?/mono/dvd/)-/list/=/article=series/id=\d*/"[^>]*?>(.*)</a></td>`)
 	ratingRegex    = regexp.MustCompile(`<strong>(.*)\s?(?:points|点)</strong>`)
 	votesRegex     = regexp.MustCompile(`<p class="d-review__evaluates">.*?<strong>(\d+)</strong>`)
@@ -260,13 +259,13 @@ func (s *scraper) extractRuntime(doc *goquery.Document) int {
 }
 
 func (s *scraper) extractDirector(doc *goquery.Document) string {
-	html, _ := doc.Html()
-	matches := directorRegex.FindStringSubmatch(html)
-
-	if len(matches) > 2 {
-		return scraperutil.CleanString(matches[2])
-	}
-	return ""
+	var director string
+	doc.Find("a[href*='?director='], a[href*='/article=director/id=']").Each(func(i int, sel *goquery.Selection) {
+		if director == "" {
+			director = scraperutil.CleanString(sel.Text())
+		}
+	})
+	return director
 }
 
 func (s *scraper) extractMaker(doc *goquery.Document, isNewSite bool) string {
@@ -319,40 +318,43 @@ func (s *scraper) extractRating(doc *goquery.Document, isNewSite bool) *models.R
 		return nil
 	}
 
-	html, _ := doc.Html()
-	matches := ratingRegex.FindStringSubmatch(html)
-
-	if len(matches) > 1 {
-		ratingStr := matches[1]
-
-		ratingMap := map[string]float64{
-			"One":   1.0,
-			"Two":   2.0,
-			"Three": 3.0,
-			"Four":  4.0,
-			"Five":  5.0,
+	var rating float64
+	if scoreSel := doc.Find(".dcd-review__average strong").First(); scoreSel.Length() > 0 {
+		rating, _ = strconv.ParseFloat(strings.TrimSpace(scoreSel.Text()), 64)
+	} else {
+		html, _ := doc.Html()
+		if matches := ratingRegex.FindStringSubmatch(html); len(matches) > 1 {
+			ratingStr := matches[1]
+			ratingMap := map[string]float64{
+				"One":   1.0,
+				"Two":   2.0,
+				"Three": 3.0,
+				"Four":  4.0,
+				"Five":  5.0,
+			}
+			if val, exists := ratingMap[ratingStr]; exists {
+				rating = val
+			} else {
+				rating, _ = strconv.ParseFloat(ratingStr, 64)
+			}
 		}
+	}
+	rating = rating * 2
 
-		rating := 0.0
-		if val, exists := ratingMap[ratingStr]; exists {
-			rating = val
-		} else {
-			rating, _ = strconv.ParseFloat(ratingStr, 64)
-		}
-
-		rating = rating * 2
-
-		votesMatches := votesRegex.FindStringSubmatch(html)
-		votes := 0
-		if len(votesMatches) > 1 {
+	var votes int
+	if votesSel := doc.Find(".dcd-review__evaluates strong").First(); votesSel.Length() > 0 {
+		votes, _ = strconv.Atoi(strings.TrimSpace(votesSel.Text()))
+	} else {
+		html, _ := doc.Html()
+		if votesMatches := votesRegex.FindStringSubmatch(html); len(votesMatches) > 1 {
 			votes, _ = strconv.Atoi(votesMatches[1])
 		}
+	}
 
-		if rating > 0 || votes > 0 {
-			return &models.Rating{
-				Score: rating,
-				Votes: votes,
-			}
+	if rating > 0 || votes > 0 {
+		return &models.Rating{
+			Score: rating,
+			Votes: votes,
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

DMM migrated its detail-page markup, breaking two extractors that only matched the old formats — **every** DMM title returned an empty `Director` and a nil `Rating`.

### Director
`extractDirector` used a regex matching only the old query-string format `<a href="?director=123">`. DMM moved to path-based `<a href="/mono/dvd/-/list/=/article=director/id=102296/">`. The sibling extractors (`extractMaker`/`extractLabel`) already handled both formats via goquery; `extractDirector` was missed.

**Fix**: `extractDirector` now uses goquery matching both `?director=` and `/article=director/id=` (mirroring `extractMaker`/`extractLabel`). Removed the now-unused `directorRegex`.

### Rating
`ratingRegex` (`<strong>X 点</strong>`) and `votesRegex` (`d-review__evaluates`) matched only the old format. DMM moved to `<p class="dcd-review__average"><strong>4.5</strong>` (score) + `<p class="dcd-review__evaluates"><strong>2</strong>` (votes).

**Fix**: `extractRating` tries the new `dcd-review__*` classes first, falling back to the legacy regexes for backward compat. Preserves the `×2` (1-5→1-10) conversion, the `One/Two/…/Five` word map, and the `rating>0||votes>0` nil guard.

### Rating scale
The `×2` (out-of-10) is intentionally kept **hardcoded**, not configurable. This matches the original PowerShell `Get-DmmRating` (`# Multiply the rating value by 2 to conform to 1-10 rating standard`) and the codebase convention — `models.Movie` validates `RatingScore` 0-10 and the NFO writer hardcodes `max="10"`.

## Verification
- ✅ End-to-end: `scrape ABW-102 -s dmm` → `Director: マサルパンサー` + `Rating: 9.0/10 (2 votes)` (was empty)
- ✅ `go vet` + `gofmt` clean; full DMM package tests pass
- ✅ Code-reviewed by swarm worker (KeenOtter) — no blockers/majors; added the 3 regression tests it flagged (breadcrumb non-match, mixed old/new link order, hybrid rating fallback)

## Test coverage added
- New path-based director href + table-row format with `監督` label
- Breadcrumb `article=directory` does not false-match the `article=director` selector
- Mixed old + new director links — first-in-DOM wins
- New `dcd-review` rating format
- Hybrid new-score + legacy-votes fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of director information on older pages, making results more reliable when the primary metadata format is unavailable.
  * Updated rating parsing to better detect review scores and vote counts, with fallback handling for pages that use alternate text formats.
  * Reduced cases where ratings or director details could be missing due to page layout differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->