### PR TITLE
fix(rescrape): refresh images + reset baseline on content-id change

### DIFF
--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -130,3 +130,28 @@ func backupCoverOriginal(current, next *models.Movie) {
 		next.Poster.OriginalCoverURL = current.Poster.CoverURL
 	}
 }
+
+// establishScrapedBaseline sets the poster-original revert group on target
+// from source's current poster fields, establishing the scraper's value as
+// the Reset baseline. Called by both the initial scrape phase and the
+// rescrape phase (merge + non-merge paths) so the review UI's Reset always
+// returns to what the scraper produced — never a stale prior-content value
+// carried across a content-id change, and never empty (which would leave
+// Reset without a target until the first manual edit).
+//
+// This is the eager counterpart to backupPosterOriginals: backupPosterOriginals
+// snapshots the pre-edit state lazily on the first manual edit, while
+// establishScrapedBaseline snapshots the scraped state eagerly at scrape time.
+// Mirrors backupPosterOriginals' field grouping (PosterURL/CroppedPosterURL/
+// ShouldCropPoster) and extends it to CoverURL, which the lazy backup handles
+// separately via backupCoverOriginal.
+func establishScrapedBaseline(target, source *models.Movie) {
+	if target == nil || source == nil {
+		return
+	}
+	shouldCrop := source.Poster.ShouldCropPoster
+	target.Poster.OriginalPosterURL = source.Poster.PosterURL
+	target.Poster.OriginalCroppedPosterURL = source.Poster.CroppedPosterURL
+	target.Poster.OriginalShouldCropPoster = &shouldCrop
+	target.Poster.OriginalCoverURL = source.Poster.CoverURL
+}

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"strings"
 
 	"github.com/javinizer/javinizer-go/internal/database"
 	"github.com/javinizer/javinizer-go/internal/logging"
@@ -136,8 +137,14 @@ func backupCoverOriginal(current, next *models.Movie) {
 // the Reset baseline. Called by both the initial scrape phase and the
 // rescrape phase (merge + non-merge paths) so the review UI's Reset always
 // returns to what the scraper produced — never a stale prior-content value
-// carried across a content-id change, and never empty (which would leave
-// Reset without a target until the first manual edit).
+// carried across a content-id change. The baseline may legitimately be empty
+// when the scraper found no image; the frontend falls back to the current
+// field, so an empty baseline makes Reset a no-op rather than wiping a valid
+// image.
+//
+// URL fields are trimmed so the baseline matches the display field's
+// trimming in mergeRescrapeMovie (a whitespace-only scraper value should
+// not become a non-empty baseline that falsely enables the Reset button).
 //
 // This is the eager counterpart to backupPosterOriginals: backupPosterOriginals
 // snapshots the pre-edit state lazily on the first manual edit, while
@@ -150,8 +157,8 @@ func establishScrapedBaseline(target, source *models.Movie) {
 		return
 	}
 	shouldCrop := source.Poster.ShouldCropPoster
-	target.Poster.OriginalPosterURL = source.Poster.PosterURL
-	target.Poster.OriginalCroppedPosterURL = source.Poster.CroppedPosterURL
+	target.Poster.OriginalPosterURL = strings.TrimSpace(source.Poster.PosterURL)
+	target.Poster.OriginalCroppedPosterURL = strings.TrimSpace(source.Poster.CroppedPosterURL)
 	target.Poster.OriginalShouldCropPoster = &shouldCrop
-	target.Poster.OriginalCoverURL = source.Poster.CoverURL
+	target.Poster.OriginalCoverURL = strings.TrimSpace(source.Poster.CoverURL)
 }

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -156,9 +156,19 @@ func establishScrapedBaseline(target, source *models.Movie) {
 	if target == nil || source == nil {
 		return
 	}
-	shouldCrop := source.Poster.ShouldCropPoster
-	target.Poster.OriginalPosterURL = strings.TrimSpace(source.Poster.PosterURL)
-	target.Poster.OriginalCroppedPosterURL = strings.TrimSpace(source.Poster.CroppedPosterURL)
-	target.Poster.OriginalShouldCropPoster = &shouldCrop
+	posterURL := strings.TrimSpace(source.Poster.PosterURL)
+	croppedURL := strings.TrimSpace(source.Poster.CroppedPosterURL)
+	target.Poster.OriginalPosterURL = posterURL
+	target.Poster.OriginalCroppedPosterURL = croppedURL
+	// Only anchor the crop baseline when there's a real poster baseline. When
+	// the scraper found no image, leave OriginalShouldCropPoster nil so the
+	// frontend falls back to the current field (matching the empty-URL
+	// fallback) instead of a non-nil false that could spuriously enable Reset.
+	if posterURL != "" || croppedURL != "" {
+		shouldCrop := source.Poster.ShouldCropPoster
+		target.Poster.OriginalShouldCropPoster = &shouldCrop
+	} else {
+		target.Poster.OriginalShouldCropPoster = nil
+	}
 	target.Poster.OriginalCoverURL = strings.TrimSpace(source.Poster.CoverURL)
 }

--- a/internal/worker/rescrape_images_test.go
+++ b/internal/worker/rescrape_images_test.go
@@ -232,3 +232,34 @@ func TestEstablishScrapedBaseline_NilSafe(t *testing.T) {
 	assert.NotPanics(t, func() { establishScrapedBaseline(nil, &models.Movie{}) })
 	assert.NotPanics(t, func() { establishScrapedBaseline(&models.Movie{}, nil) })
 }
+
+// establishScrapedBaseline trims whitespace-only URLs so a whitespace scraper
+// value doesn't become a non-empty baseline that falsely enables Reset.
+func TestEstablishScrapedBaseline_TrimsWhitespace(t *testing.T) {
+	source := &models.Movie{ID: "NEW-001"}
+	source.Poster.PosterURL = "  https://new.invalid/poster.jpg  "
+	source.Poster.CroppedPosterURL = "   "
+	source.Poster.CoverURL = "  "
+	target := &models.Movie{}
+	establishScrapedBaseline(target, source)
+	assert.Equal(t, "https://new.invalid/poster.jpg", target.Poster.OriginalPosterURL)
+	assert.Equal(t, "", target.Poster.OriginalCroppedPosterURL, "whitespace-only should trim to empty")
+	assert.Equal(t, "", target.Poster.OriginalCoverURL, "whitespace-only should trim to empty")
+}
+
+// Padded scraper URLs on a same-id rescrape are trimmed for both the display
+// field and the baseline, so a whitespace-padded scraper value does not leave
+// display != baseline and spuriously enable Reset.
+func TestRescrapeImage_SameID_PaddedScraperURLTrimmed(t *testing.T) {
+	existing := existingMovie()
+	scraped := &models.Movie{ID: "OLD-001", Title: "Scraped"}
+	scraped.Poster.CoverURL = "  https://new.invalid/cover.jpg  "
+	scraped.Poster.PosterURL = "  https://new.invalid/poster.jpg  "
+	merged := mergeRescrapeMovie(existing, scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "https://new.invalid/cover.jpg", merged.Poster.CoverURL)
+	assert.Equal(t, "https://new.invalid/poster.jpg", merged.Poster.PosterURL)
+	assert.Equal(t, "https://new.invalid/cover.jpg", merged.Poster.OriginalCoverURL)
+	assert.Equal(t, "https://new.invalid/poster.jpg", merged.Poster.OriginalPosterURL)
+}

--- a/internal/worker/rescrape_images_test.go
+++ b/internal/worker/rescrape_images_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/nfo"
 	"github.com/javinizer/javinizer-go/internal/workflow"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Tests below assert the EXPECTED rescrape image-refresh semantics across the
@@ -262,4 +263,28 @@ func TestRescrapeImage_SameID_PaddedScraperURLTrimmed(t *testing.T) {
 	assert.Equal(t, "https://new.invalid/poster.jpg", merged.Poster.PosterURL)
 	assert.Equal(t, "https://new.invalid/cover.jpg", merged.Poster.OriginalCoverURL)
 	assert.Equal(t, "https://new.invalid/poster.jpg", merged.Poster.OriginalPosterURL)
+}
+
+// When the scraper found no poster image, establishScrapedBaseline leaves
+// OriginalShouldCropPoster nil (not a non-nil false) so the frontend falls
+// back to the current field — matching the empty-URL fallback. A non-nil
+// false would combine with an edited currentMovie to spuriously enable Reset.
+func TestEstablishScrapedBaseline_EmptyPoster_LeavesCropBaselineNil(t *testing.T) {
+	target := &models.Movie{Poster: models.PosterState{ShouldCropPoster: true}}
+	source := &models.Movie{Poster: models.PosterState{ShouldCropPoster: false}}
+	establishScrapedBaseline(target, source)
+	assert.Equal(t, "", target.Poster.OriginalPosterURL)
+	assert.Equal(t, "", target.Poster.OriginalCroppedPosterURL)
+	assert.Nil(t, target.Poster.OriginalShouldCropPoster, "crop baseline must be nil when no poster baseline exists")
+	assert.Equal(t, "", target.Poster.OriginalCoverURL)
+}
+
+// A scraper with a poster image anchors the crop baseline, mirroring the
+// scraped ShouldCropPoster so Reset reflects the rescrape's crop intent.
+func TestEstablishScrapedBaseline_WithPoster_AnchorsCropBaseline(t *testing.T) {
+	target := &models.Movie{}
+	source := &models.Movie{Poster: models.PosterState{PosterURL: "https://x.invalid/p.jpg", ShouldCropPoster: true}}
+	establishScrapedBaseline(target, source)
+	require.NotNil(t, target.Poster.OriginalShouldCropPoster)
+	assert.True(t, *target.Poster.OriginalShouldCropPoster)
 }

--- a/internal/worker/rescrape_images_test.go
+++ b/internal/worker/rescrape_images_test.go
@@ -1,0 +1,234 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/nfo"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests below assert the EXPECTED rescrape image-refresh semantics across the
+// full edge-case matrix. They drive the fix: a rescrape should bring in the
+// scraper's poster/cover for the resolved content, not preserve the existing
+// movie's (possibly different-content) images via prefer-nfo.
+func existingMovie() *models.Movie {
+	m := &models.Movie{ID: "OLD-001", Title: "Existing Title"}
+	m.Poster.CoverURL = "https://old.invalid/cover.jpg"
+	m.Poster.PosterURL = "https://old.invalid/poster.jpg"
+	return m
+}
+
+func scrapedNewID() *models.Movie {
+	m := &models.Movie{ID: "NEW-001", Title: "Scraped Title"}
+	m.Poster.CoverURL = "https://new.invalid/cover.jpg"
+	m.Poster.PosterURL = "https://new.invalid/poster.jpg"
+	return m
+}
+
+// === Content-id change (rescrape resolved a different/corrected ID) ===
+
+func TestRescrapeImage_ContentIDChange_PreferNFO(t *testing.T) {
+	merged := mergeRescrapeMovie(existingMovie(), scrapedNewID(), workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "https://new.invalid/cover.jpg", merged.Poster.CoverURL)
+	assert.Equal(t, "https://new.invalid/poster.jpg", merged.Poster.PosterURL)
+	assert.Equal(t, "NEW-001", merged.ID)
+}
+
+func TestRescrapeImage_ContentIDChange_PreferScraper(t *testing.T) {
+	merged := mergeRescrapeMovie(existingMovie(), scrapedNewID(), workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferScraper, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "https://new.invalid/cover.jpg", merged.Poster.CoverURL)
+	assert.Equal(t, "https://new.invalid/poster.jpg", merged.Poster.PosterURL)
+}
+
+func TestRescrapeImage_ContentIDChange_ScrapedHasNoCover(t *testing.T) {
+	scraped := scrapedNewID()
+	scraped.Poster.CoverURL = ""
+	scraped.Poster.PosterURL = ""
+	merged := mergeRescrapeMovie(existingMovie(), scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	// New content has no images -> must NOT keep the old (different) content's images.
+	assert.Equal(t, "", merged.Poster.CoverURL)
+	assert.Equal(t, "", merged.Poster.PosterURL)
+}
+
+// === Same content-id (refresh rescrape) ===
+
+func TestRescrapeImage_SameID_PreferScraper_Refreshes(t *testing.T) {
+	scraped := &models.Movie{ID: "OLD-001", Title: "Scraped Title"}
+	scraped.Poster.CoverURL = "https://new.invalid/cover.jpg"
+	scraped.Poster.PosterURL = "https://new.invalid/poster.jpg"
+	merged := mergeRescrapeMovie(existingMovie(), scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferScraper, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "https://new.invalid/cover.jpg", merged.Poster.CoverURL)
+	assert.Equal(t, "https://new.invalid/poster.jpg", merged.Poster.PosterURL)
+}
+
+func TestRescrapeImage_SameID_PreferNFO_ScrapedProvidesImage(t *testing.T) {
+	scraped := &models.Movie{ID: "OLD-001", Title: "Scraped Title"}
+	scraped.Poster.CoverURL = "https://new.invalid/cover.jpg"
+	scraped.Poster.PosterURL = "https://new.invalid/poster.jpg"
+	merged := mergeRescrapeMovie(existingMovie(), scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	// A rescrape's purpose is to re-fetch; images should refresh from the scraper.
+	assert.Equal(t, "https://new.invalid/cover.jpg", merged.Poster.CoverURL)
+	assert.Equal(t, "https://new.invalid/poster.jpg", merged.Poster.PosterURL)
+}
+
+func TestRescrapeImage_SameID_PreferNFO_ScrapedEmptyKeepsExisting(t *testing.T) {
+	scraped := &models.Movie{ID: "OLD-001", Title: "Scraped Title"}
+	merged := mergeRescrapeMovie(existingMovie(), scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	// Scraper returned no image -> keep existing (don't wipe a valid image).
+	assert.Equal(t, "https://old.invalid/cover.jpg", merged.Poster.CoverURL)
+	assert.Equal(t, "https://old.invalid/poster.jpg", merged.Poster.PosterURL)
+}
+
+func TestRescrapeImage_SameID_PreferNFO_ExistingEmptyFillsFromScraper(t *testing.T) {
+	existing := &models.Movie{ID: "OLD-001", Title: "Existing"}
+	scraped := &models.Movie{ID: "OLD-001", Title: "Scraped"}
+	scraped.Poster.CoverURL = "https://new.invalid/cover.jpg"
+	merged := mergeRescrapeMovie(existing, scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "https://new.invalid/cover.jpg", merged.Poster.CoverURL)
+}
+
+// === CroppedPosterURL always follows the scraper ===
+
+func TestRescrapeImage_CroppedPosterURL_AlwaysScraped(t *testing.T) {
+	existing := existingMovie()
+	existing.Poster.CroppedPosterURL = "https://old.invalid/cropped.jpg"
+	scraped := scrapedNewID()
+	scraped.Poster.CroppedPosterURL = "https://new.invalid/cropped.jpg"
+	merged := mergeRescrapeMovie(existing, scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "https://new.invalid/cropped.jpg", merged.Poster.CroppedPosterURL)
+}
+
+// === Reset baseline (Original*) tracks the scraper, not the prior content ===
+// Original* is the revert target the review UI restores on Reset. A rescrape
+// establishes a fresh scraper baseline, so Original* must follow the scraped
+// movie — never carrying the previous content's URL forward across a
+// content-id change (the reported bug).
+
+func TestRescrapeImage_OriginalCoverURL_ResetToScraperOnContentIDChange(t *testing.T) {
+	existing := existingMovie()
+	existing.Poster.OriginalCoverURL = "https://orig.invalid/cover.jpg" // prior content's baseline
+	merged := mergeRescrapeMovie(existing, scrapedNewID(), workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "https://new.invalid/cover.jpg", merged.Poster.OriginalCoverURL)
+}
+
+func TestRescrapeImage_OriginalPosterURL_ResetToScraperOnContentIDChange(t *testing.T) {
+	existing := existingMovie()
+	existing.Poster.OriginalPosterURL = "https://orig.invalid/poster.jpg"
+	existing.Poster.OriginalCroppedPosterURL = "https://orig.invalid/cropped.jpg"
+	scraped := scrapedNewID()
+	scraped.Poster.CroppedPosterURL = "https://new.invalid/cropped.jpg"
+	scraped.Poster.ShouldCropPoster = true
+	merged := mergeRescrapeMovie(existing, scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "https://new.invalid/poster.jpg", merged.Poster.OriginalPosterURL)
+	assert.Equal(t, "https://new.invalid/cropped.jpg", merged.Poster.OriginalCroppedPosterURL)
+	if merged.Poster.OriginalShouldCropPoster == nil || !*merged.Poster.OriginalShouldCropPoster {
+		t.Fatal("OriginalShouldCropPoster should be the scraped true baseline")
+	}
+}
+
+func TestRescrapeImage_OriginalCoverURL_SameIDTracksScraper(t *testing.T) {
+	existing := existingMovie()
+	existing.Poster.OriginalCoverURL = "https://orig.invalid/cover.jpg"
+	scraped := &models.Movie{ID: "OLD-001", Title: "Scraped"}
+	scraped.Poster.CoverURL = "https://new.invalid/cover.jpg"
+	merged := mergeRescrapeMovie(existing, scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "https://new.invalid/cover.jpg", merged.Poster.OriginalCoverURL)
+}
+
+func TestRescrapeImage_OriginalCoverURL_EmptyWhenScraperHasNone(t *testing.T) {
+	existing := existingMovie()
+	existing.Poster.OriginalCoverURL = "https://orig.invalid/cover.jpg"
+	scraped := &models.Movie{ID: "NEW-001", Title: "Scraped"} // no cover
+	merged := mergeRescrapeMovie(existing, scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	// Scraper found no cover for the new content -> baseline is empty, never
+	// the previous content's URL.
+	assert.Equal(t, "", merged.Poster.OriginalCoverURL)
+}
+
+// Asymmetric: scraper provides a poster but no cover on a same-id rescrape.
+// The cover is preserved (not wiped), the poster refreshes.
+func TestRescrapeImage_Asymmetric_PosterOnly(t *testing.T) {
+	existing := existingMovie()
+	scraped := &models.Movie{ID: "OLD-001", Title: "Scraped"}
+	scraped.Poster.PosterURL = "https://new.invalid/poster.jpg"
+	scraped.Poster.CoverURL = ""
+	merged := mergeRescrapeMovie(existing, scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "https://new.invalid/poster.jpg", merged.Poster.PosterURL)
+	assert.Equal(t, "https://old.invalid/cover.jpg", merged.Poster.CoverURL)
+}
+
+// Asymmetric on a content-id change: scraper provides a cover but no poster.
+// The poster is cleared (different content), the cover refreshes.
+func TestRescrapeImage_Asymmetric_ContentIDChange_CoverOnly(t *testing.T) {
+	existing := existingMovie()
+	scraped := &models.Movie{ID: "NEW-001", Title: "Scraped"}
+	scraped.Poster.PosterURL = ""
+	scraped.Poster.CoverURL = "https://new.invalid/cover.jpg"
+	merged := mergeRescrapeMovie(existing, scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "", merged.Poster.PosterURL)
+	assert.Equal(t, "https://new.invalid/cover.jpg", merged.Poster.CoverURL)
+}
+
+// Whitespace-only scraper URLs are treated as empty (don't set whitespace).
+func TestRescrapeImage_WhitespaceOnlyScraperURL(t *testing.T) {
+	existing := existingMovie()
+	scraped := &models.Movie{ID: "OLD-001", Title: "Scraped"}
+	scraped.Poster.CoverURL = "   "
+	merged := mergeRescrapeMovie(existing, scraped, workflow.MergeOptions{
+		ScalarStrategy: nfo.PreferNFO, ArrayStrategy: true,
+	}, "file.mp4")
+	assert.Equal(t, "https://old.invalid/cover.jpg", merged.Poster.CoverURL)
+}
+
+// establishScrapedBaseline is the non-merge (wholesale-replace) rescrape path's
+// baseline setter: the scraped movie carries no Original*, so the baseline is
+// built from its own poster fields.
+func TestEstablishScrapedBaseline_FromScrapedOwnFields(t *testing.T) {
+	scraped := &models.Movie{ID: "NEW-001"}
+	scraped.Poster.PosterURL = "https://new.invalid/poster.jpg"
+	scraped.Poster.CroppedPosterURL = "https://new.invalid/cropped.jpg"
+	scraped.Poster.CoverURL = "https://new.invalid/cover.jpg"
+	scraped.Poster.ShouldCropPoster = true
+	establishScrapedBaseline(scraped, scraped)
+	assert.Equal(t, "https://new.invalid/poster.jpg", scraped.Poster.OriginalPosterURL)
+	assert.Equal(t, "https://new.invalid/cropped.jpg", scraped.Poster.OriginalCroppedPosterURL)
+	assert.Equal(t, "https://new.invalid/cover.jpg", scraped.Poster.OriginalCoverURL)
+	if scraped.Poster.OriginalShouldCropPoster == nil || !*scraped.Poster.OriginalShouldCropPoster {
+		t.Fatal("OriginalShouldCropPoster should mirror scraped ShouldCropPoster")
+	}
+}
+
+func TestEstablishScrapedBaseline_NilSafe(t *testing.T) {
+	assert.NotPanics(t, func() { establishScrapedBaseline(nil, &models.Movie{}) })
+	assert.NotPanics(t, func() { establishScrapedBaseline(&models.Movie{}, nil) })
+}

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -315,6 +315,12 @@ func (p *rescrapePhase) Rescrape(ctx context.Context, inputs rescrapePhaseInputs
 			if existing, getErr := inputs.ResultMap.GetMovieResult(lookup.FilePath); getErr == nil && existing != nil && existing.Movie != nil {
 				movieResult.Movie = mergeRescrapeMovie(existing.Movie, movieResult.Movie, cmd.Merge, lookup.FilePath)
 			}
+		} else {
+			// Non-merge (wholesale-replace) path: the scraped movie carries no
+			// Original* (scrapers don't populate them), so without this the
+			// revert baseline would be wiped on rescrape. Establish the scraper
+			// baseline from the scraped movie's own poster fields.
+			establishScrapedBaseline(movieResult.Movie, movieResult.Movie)
 		}
 
 		// Commit result
@@ -355,5 +361,48 @@ func mergeRescrapeMovie(existing, scraped *models.Movie, opts workflow.MergeOpti
 		return scraped
 	}
 	merged.Merged.ID = scraped.ID
+
+	// Image URLs (PosterURL/CoverURL) are content-bound scraped assets, not
+	// curated metadata. The generic merge treats them as ordinary string
+	// fields, so the default prefer-nfo rescrape preserves the existing
+	// movie's images — defeating the rescrape's purpose (a refresh rescrape
+	// kept a stale/broken poster) and, when the rescrape resolves a different
+	// content-id, leaving images that belong to a different movie on the
+	// resolved content. CroppedPosterURL is already special-cased to always
+	// use the scraped value in the merge engine; PosterURL/CoverURL are
+	// reconciled here, locally to the rescrape path (the shared merge engine
+	// is intentionally untouched so the organize/apply path can still
+	// preserve a user's on-disk NFO images).
+	//
+	// Rule:
+	//   - content-id change: take the scraper's images, clearing when the
+	//     scraper has none (the existing images are for different content).
+	//   - same content: take the scraper's images when it provides them
+	//     (a rescrape should refresh), otherwise keep the merged value so a
+	//     scraper that found no image doesn't wipe a valid existing one.
+	if existing != nil && scraped.ID != "" && scraped.ID != existing.ID {
+		merged.Merged.Poster.CoverURL = strings.TrimSpace(scraped.Poster.CoverURL)
+		merged.Merged.Poster.PosterURL = strings.TrimSpace(scraped.Poster.PosterURL)
+	} else {
+		if strings.TrimSpace(scraped.Poster.CoverURL) != "" {
+			merged.Merged.Poster.CoverURL = scraped.Poster.CoverURL
+		}
+		if strings.TrimSpace(scraped.Poster.PosterURL) != "" {
+			merged.Merged.Poster.PosterURL = scraped.Poster.PosterURL
+		}
+	}
+
+	// The poster-original group (OriginalPosterURL/OriginalCroppedPosterURL/
+	// OriginalShouldCropPoster/OriginalCoverURL) is the revert baseline the
+	// review UI restores on Reset — it must track the scraper's value, not be
+	// preserved across content changes. The generic prefer-nfo merge would
+	// carry the existing (possibly previous-content) Original* forward, so a
+	// rescrape that resolved a different content-id would leave the revert
+	// target pointing at the old content's images. Re-establish the baseline
+	// from the freshly scraped movie so Reset always returns to what this
+	// rescrape produced. (The frontend already falls back to the current field
+	// when Original* is empty, so an empty scraper value is the correct
+	// baseline when the scraper found no image.)
+	establishScrapedBaseline(merged.Merged, scraped)
 	return merged.Merged
 }

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -311,15 +311,27 @@ func (p *rescrapePhase) Rescrape(ctx context.Context, inputs rescrapePhaseInputs
 		// RescrapeCmd silently dropped them. When MergeEnabled is false (the
 		// default for callers that supply no merge options), behavior is
 		// unchanged: the scraped Movie replaces the existing one on commit.
+		// Merge the scraped Movie into the existing one when requested AND an
+		// existing result is present. Per ADR-0030: MergeEnabled gates whether
+		// merging is applied at all; when false (the default for callers that
+		// supply no merge options), behavior is unchanged: the scraped Movie
+		// replaces the existing one on commit. The image-URL reconciliation and
+		// scraped-baseline establishment happen in mergeRescrapeMovie (merge path
+		// with existing) or in the unified establishScrapedBaseline call below
+		// (non-merge, or merge-enabled with no prior result).
+		baselineFromScraped := true
 		if cmd.MergeEnabled && movieResult.Movie != nil {
 			if existing, getErr := inputs.ResultMap.GetMovieResult(lookup.FilePath); getErr == nil && existing != nil && existing.Movie != nil {
 				movieResult.Movie = mergeRescrapeMovie(existing.Movie, movieResult.Movie, cmd.Merge, lookup.FilePath)
+				baselineFromScraped = false // mergeRescrapeMovie already established it
 			}
-		} else {
-			// Non-merge (wholesale-replace) path: the scraped movie carries no
-			// Original* (scrapers don't populate them), so without this the
-			// revert baseline would be wiped on rescrape. Establish the scraper
-			// baseline from the scraped movie's own poster fields.
+		}
+		if baselineFromScraped && movieResult.Movie != nil {
+			// Non-merge (wholesale-replace) path, or merge-enabled with no prior
+			// result: the scraped movie carries no Original* (scrapers don't
+			// populate them), so establish the revert baseline from its own poster
+			// fields. Without this, Reset would have no target until the first
+			// manual edit snapshotted it lazily.
 			establishScrapedBaseline(movieResult.Movie, movieResult.Movie)
 		}
 
@@ -385,10 +397,10 @@ func mergeRescrapeMovie(existing, scraped *models.Movie, opts workflow.MergeOpti
 		merged.Merged.Poster.PosterURL = strings.TrimSpace(scraped.Poster.PosterURL)
 	} else {
 		if strings.TrimSpace(scraped.Poster.CoverURL) != "" {
-			merged.Merged.Poster.CoverURL = scraped.Poster.CoverURL
+			merged.Merged.Poster.CoverURL = strings.TrimSpace(scraped.Poster.CoverURL)
 		}
 		if strings.TrimSpace(scraped.Poster.PosterURL) != "" {
-			merged.Merged.Poster.PosterURL = scraped.Poster.PosterURL
+			merged.Merged.Poster.PosterURL = strings.TrimSpace(scraped.Poster.PosterURL)
 		}
 	}
 

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -320,7 +320,7 @@ func (p *rescrapePhase) Rescrape(ctx context.Context, inputs rescrapePhaseInputs
 		// with existing) or in the unified establishScrapedBaseline call below
 		// (non-merge, or merge-enabled with no prior result).
 		baselineFromScraped := true
-		if cmd.MergeEnabled && movieResult.Movie != nil {
+		if cmd.MergeEnabled && movieResult.Movie != nil && inputs.ResultMap != nil {
 			if existing, getErr := inputs.ResultMap.GetMovieResult(lookup.FilePath); getErr == nil && existing != nil && existing.Movie != nil {
 				movieResult.Movie = mergeRescrapeMovie(existing.Movie, movieResult.Movie, cmd.Merge, lookup.FilePath)
 				baselineFromScraped = false // mergeRescrapeMovie already established it
@@ -367,9 +367,15 @@ func mergeRescrapeMovie(existing, scraped *models.Movie, opts workflow.MergeOpti
 	merged, err := nfo.MergeMovieMetadataWithOptions(scraped, existing, opts.ScalarStrategy, opts.ArrayStrategy)
 	if err != nil {
 		logging.Errorf("rescrape merge failed for %s, falling back to replace: %v", filePath, err)
+		// Establish the scraped baseline on the wholesale-replace fallback so
+		// the caller's baselineFromScraped=false expectation still holds; without
+		// this the returned movie would carry no Original* and Reset would have
+		// no target until the first manual edit snapshotted it lazily.
+		establishScrapedBaseline(scraped, scraped)
 		return scraped
 	}
 	if merged == nil || merged.Merged == nil {
+		establishScrapedBaseline(scraped, scraped)
 		return scraped
 	}
 	merged.Merged.ID = scraped.ID
@@ -392,16 +398,27 @@ func mergeRescrapeMovie(existing, scraped *models.Movie, opts workflow.MergeOpti
 	//   - same content: take the scraper's images when it provides them
 	//     (a rescrape should refresh), otherwise keep the merged value so a
 	//     scraper that found no image doesn't wipe a valid existing one.
+	takeScraperImages := false
 	if existing != nil && scraped.ID != "" && scraped.ID != existing.ID {
 		merged.Merged.Poster.CoverURL = strings.TrimSpace(scraped.Poster.CoverURL)
 		merged.Merged.Poster.PosterURL = strings.TrimSpace(scraped.Poster.PosterURL)
+		takeScraperImages = true
 	} else {
 		if strings.TrimSpace(scraped.Poster.CoverURL) != "" {
 			merged.Merged.Poster.CoverURL = strings.TrimSpace(scraped.Poster.CoverURL)
+			takeScraperImages = true
 		}
 		if strings.TrimSpace(scraped.Poster.PosterURL) != "" {
 			merged.Merged.Poster.PosterURL = strings.TrimSpace(scraped.Poster.PosterURL)
+			takeScraperImages = true
 		}
+	}
+	// When the scraper's poster is authoritative (content-id change, or it
+	// provided a fresh image), carry its crop state too — otherwise the merged
+	// movie would keep the existing (possibly different) ShouldCropPoster and
+	// Reset would not reflect the rescrape's crop intent.
+	if takeScraperImages {
+		merged.Merged.Poster.ShouldCropPoster = scraped.Poster.ShouldCropPoster
 	}
 
 	// The poster-original group (OriginalPosterURL/OriginalCroppedPosterURL/

--- a/internal/worker/rescrape_phase_test.go
+++ b/internal/worker/rescrape_phase_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/nfo"
 	"github.com/javinizer/javinizer-go/internal/scrape"
 	"github.com/javinizer/javinizer-go/internal/workflow"
 	"github.com/stretchr/testify/assert"
@@ -448,4 +449,49 @@ func TestRescrapePhase_CompleteRescrape_CommitResultError(t *testing.T) {
 	outcome, err := phase.CompleteRescrape(inputs, "/source/IPX-777.mp4", newResult, 1, "IPX-778", "IPX-777")
 	require.Error(t, err, "Should return error when CommitResult fails")
 	require.Nil(t, outcome, "Should return nil outcome for non-conflict errors")
+}
+
+// TestRescrapePhase_Rescrape_MergeEnabledNoExistingEstablishesBaseline covers
+// the edge case where MergeEnabled is true but there is no prior result to
+// merge into. Previously this branch skipped establishScrapedBaseline entirely
+// (it only ran inside mergeRescrapeMovie, which was never called when there
+// was no existing movie), leaving Original* empty and Reset without a target
+// until the first manual edit.
+func TestRescrapePhase_Rescrape_MergeEnabledNoExistingEstablishesBaseline(t *testing.T) {
+	movie := &models.Movie{ID: "NEW-001"}
+	movie.Poster.PosterURL = "https://new.invalid/poster.jpg"
+	movie.Poster.CoverURL = "https://new.invalid/cover.jpg"
+	movie.Poster.ShouldCropPoster = true
+	wf := &stubRescrapeWorkflow{
+		scrapeResult: &scrape.ScrapeResult{Movie: movie},
+	}
+	rt := NewResultTracker(1, []string{"f1.mp4"})
+	inputs := rescrapePhaseInputs{
+		WF:        wf,
+		ResultMap: rt,
+		Finder:    rt,
+		JobID:     models.NewJobID(),
+	}
+
+	phase := NewRescrapePhase()
+	cmd := RescrapeCmd{
+		MovieID:      "NEW-001",
+		FilePath:     "f1.mp4",
+		MergeEnabled: true,
+		Merge: workflow.MergeOptions{
+			ScalarStrategy: nfo.PreferNFO,
+			ArrayStrategy:  true,
+		},
+	}
+	result, err := phase.Rescrape(context.Background(), inputs, cmd)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, models.RescrapeStatusSuccess, result.Status)
+	require.NotNil(t, result.Movie, "outcome.Movie should be populated on success")
+	assert.Equal(t, "https://new.invalid/poster.jpg", result.Movie.Poster.OriginalPosterURL,
+		"merge-enabled rescrape with no prior result must still establish the scraped baseline")
+	assert.Equal(t, "https://new.invalid/cover.jpg", result.Movie.Poster.OriginalCoverURL)
+	if result.Movie.Poster.OriginalShouldCropPoster == nil || !*result.Movie.Poster.OriginalShouldCropPoster {
+		t.Fatal("OriginalShouldCropPoster should mirror the scraped ShouldCropPoster (true)")
+	}
 }

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -264,6 +264,16 @@ func interpretScrapeResult(
 		fileResult.PosterGenerated = true
 	}
 
+	// Establish the scraped poster state as the Reset baseline so the review
+	// UI's Reset returns to what this scrape produced. Done after poster
+	// generation so the generated CroppedPosterURL is captured too. Mirrors the
+	// rescrape path (establishScrapedBaseline) for full symmetry — without it,
+	// Original* stays empty until the first manual edit snapshots it lazily via
+	// backupPosterOriginals, which is inconsistent with the rescrape baseline.
+	if fileResult.Movie != nil {
+		establishScrapedBaseline(fileResult.Movie, fileResult.Movie)
+	}
+
 	inputs.Updater.UpdateFileResult(filePath, fileResult)
 	if prov != nil {
 		inputs.Updater.SetProvenance(filePath, prov)

--- a/internal/worker/scrape_phase_test.go
+++ b/internal/worker/scrape_phase_test.go
@@ -223,3 +223,35 @@ func TestPersistFunc_SatisfiesPersister(t *testing.T) {
 	var _ persister = persistFunc(nil)
 	var _ persister = persistFunc(func() {})
 }
+
+// TestScrapePhase_Run_EstablishesScrapedBaseline verifies the initial scrape
+// eagerly sets the poster-original revert group (Original*) to the scraper's
+// value, so the review UI's Reset has a baseline immediately — symmetric with
+// the rescrape path. Without this, Original* stays empty until the first
+// manual edit snapshots it lazily via backupPosterOriginals.
+func TestScrapePhase_Run_EstablishesScrapedBaseline(t *testing.T) {
+	movie := &models.Movie{
+		ID:    "TEST-001",
+		Title: "Scraped Title",
+	}
+	movie.Poster.PosterURL = "https://scraper.invalid/poster.jpg"
+	movie.Poster.CoverURL = "https://scraper.invalid/cover.jpg"
+	movie.Poster.ShouldCropPoster = true
+	wf := &stubWorkflow{scrapeResult: &scrape.ScrapeResult{Movie: movie}}
+	inputs := makeInputs(wf)
+	updater := inputs.Updater.(*stubUpdater)
+
+	NewScrapePhase().Run(context.Background(), inputs, []string{"file.mp4"}, ScrapePhaseConfig{})
+
+	r := updater.getResult("file.mp4")
+	require.NotNil(t, r)
+	require.NotNil(t, r.Movie)
+	assert.Equal(t, "https://scraper.invalid/poster.jpg", r.Movie.Poster.OriginalPosterURL)
+	assert.Equal(t, "https://scraper.invalid/cover.jpg", r.Movie.Poster.OriginalCoverURL)
+	if r.Movie.Poster.OriginalShouldCropPoster == nil || !*r.Movie.Poster.OriginalShouldCropPoster {
+		t.Fatal("OriginalShouldCropPoster should mirror the scraped ShouldCropPoster (true)")
+	}
+	// No PosterGen in this test, so CroppedPosterURL is empty and its baseline
+	// mirrors that (the rescrape path captures the generated crop separately).
+	assert.Equal(t, "", r.Movie.Poster.OriginalCroppedPosterURL)
+}

--- a/web/frontend/src/routes/review/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/review/[jobId]/+page.svelte
@@ -232,6 +232,8 @@
 								onUseScreenshotAsCover={s.useScreenshotAsCover}
 								onResetPoster={s.resetPoster}
 							onResetCover={s.resetCover}
+							canResetPoster={s.canResetPoster}
+							canResetCover={s.canResetCover}
 								previewImageURL={s.reviewPageController.previewImageURL}
 							/>
 

--- a/web/frontend/src/routes/review/[jobId]/components/ReviewGridCard.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/ReviewGridCard.svelte
@@ -115,7 +115,7 @@
 		</span>
 
 		{#if isEdited}
-			<span class="absolute top-9 left-2 text-orange-600 dark:text-orange-400 bg-orange-100 dark:bg-orange-900/40 text-xs font-medium px-1.5 py-0.5 rounded-full flex items-center gap-1">
+			<span class="absolute top-2 left-2 text-orange-600 dark:text-orange-400 bg-orange-100 dark:bg-orange-900/40 text-xs font-medium px-1.5 py-0.5 rounded-full flex items-center gap-1">
 				<CircleAlert class="h-3 w-3" />
 				Modified
 			</span>

--- a/web/frontend/src/routes/review/[jobId]/components/ReviewMediaSidebar.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/ReviewMediaSidebar.svelte
@@ -21,6 +21,8 @@
 		onUseScreenshotAsCover: (url: string) => void;
 		onResetPoster?: () => void;
 		onResetCover?: () => void;
+		canResetPoster?: boolean;
+		canResetCover?: boolean;
 		previewImageURL: (url: string | undefined) => string;
 	}
 
@@ -40,6 +42,8 @@
 		onUseScreenshotAsCover,
 		onResetPoster,
 		onResetCover,
+		canResetPoster = true,
+		canResetCover = true,
 		previewImageURL
 	}: Props = $props();
 </script>
@@ -55,7 +59,7 @@
 							size="sm"
 							variant="outline"
 							onclick={onResetPoster}
-							disabled={!currentMovie.id}
+							disabled={!currentMovie.id || !canResetPoster}
 							class="text-xs"
 							title="Reset to original scraped poster"
 						>
@@ -116,7 +120,7 @@
 						size="sm"
 						variant="outline"
 						onclick={onResetCover}
-						disabled={!currentMovie.id}
+						disabled={!currentMovie.id || !canResetCover}
 						class="text-xs"
 						title="Reset to original scraped cover"
 					>

--- a/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
@@ -97,11 +97,6 @@ export function createReviewState(pageStore: Page) {
 	let lastSelectedMovieId = $state<string | null>(null);
 	let completenessFilter = new SvelteSet<CompletenessTier>(['incomplete', 'partial', 'complete']);
 	let selectionMode = $state(false);
-	let originalPosterState = new SvelteMap<
-		string,
-		{ poster_url: string; cropped_poster_url: string; should_crop_poster: boolean }
-	>();
-	let originalCoverState = new SvelteMap<string, string>();
 	let organizing = $state(false);
 	let destinationPath = $state('');
 	let organizeOperation = $state<OrganizeOperation>('move');
@@ -165,22 +160,6 @@ export function createReviewState(pageStore: Page) {
 			untrack(() => {
 				if (jobData.destination && !destinationPath) {
 					destinationPath = jobData.destination;
-				}
-				if (originalPosterState.size === 0) {
-					for (const result of Object.values(jobData.results) as FileResult[]) {
-						if (result.movie) {
-							originalPosterState.set(result.file_path, {
-								poster_url: result.movie.original_poster_url || result.movie.poster_url || '',
-								cropped_poster_url:
-									result.movie.original_cropped_poster_url || result.movie.cropped_poster_url || '',
-								should_crop_poster:
-									result.movie.original_should_crop_poster ??
-									result.movie.should_crop_poster ??
-									false,
-							});
-							originalCoverState.set(result.file_path, result.movie.original_cover_url || result.movie.cover_url || '');
-						}
-					}
 				}
 			});
 		}
@@ -647,12 +626,34 @@ export function createReviewState(pageStore: Page) {
 		posterPreviewOverrides.delete(currentResult.file_path);
 	}
 
+	// The scraped-image revert baseline. The backend populates the
+	// poster-original group (OriginalPosterURL/OriginalCroppedPosterURL/
+	// OriginalShouldCropPoster/OriginalCoverURL) at scrape + rescrape time, so
+	// the authoritative baseline lives on the movie itself — reading it from
+	// the movie (not a one-shot snapshot map) means it stays correct across an
+	// in-review rescrape, where the snapshot maps would go stale and Reset
+	// would restore the *prior* content's image. The `|| current` fallback
+	// covers older movies persisted before the baseline was eagerly set.
+	const posterBaseline = $derived.by(() => {
+		if (!currentMovie) return undefined;
+		return {
+			poster_url: currentMovie.original_poster_url || currentMovie.poster_url || '',
+			cropped_poster_url: currentMovie.original_cropped_poster_url || currentMovie.cropped_poster_url || '',
+			should_crop_poster: currentMovie.original_should_crop_poster ?? currentMovie.should_crop_poster ?? false,
+		};
+	});
+
+	const coverBaseline = $derived.by(() => {
+		if (!currentMovie) return undefined;
+		return currentMovie.original_cover_url || currentMovie.cover_url || '';
+	});
+
 	// Whether the current movie has drifted from its scraped baseline — mirrors
 	// resetPoster/resetCover's no-op guards so the Reset button is disabled
 	// exactly when Reset would do nothing (UX: no "reset" when already at baseline).
 	const canResetPoster = $derived.by(() => {
 		if (!currentResult || !currentMovie) return false;
-		const original = originalPosterState.get(currentResult.file_path);
+		const original = posterBaseline;
 		if (!original || !original.poster_url) return false;
 		return (
 			currentMovie.poster_url !== original.poster_url ||
@@ -663,15 +664,15 @@ export function createReviewState(pageStore: Page) {
 
 	const canResetCover = $derived.by(() => {
 		if (!currentResult || !currentMovie) return false;
-		const original = originalCoverState.get(currentResult.file_path);
-		if (original === undefined) return false;
+		const original = coverBaseline;
+		if (original === undefined || original === '') return false;
 		return currentMovie.cover_url !== original;
 	});
 
 	function resetPoster() {
 		if (!currentResult || !currentMovie) return;
 
-		const original = originalPosterState.get(currentResult.file_path);
+		const original = posterBaseline;
 		if (!original || !original.poster_url) return;
 
 		const posterChanged =
@@ -695,8 +696,8 @@ export function createReviewState(pageStore: Page) {
 	function resetCover() {
 		if (!currentResult || !currentMovie) return;
 
-		const original = originalCoverState.get(currentResult.file_path);
-		if (original === undefined) return;
+		const original = coverBaseline;
+		if (original === undefined || original === '') return;
 
 		if (currentMovie.cover_url === original) return;
 

--- a/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
@@ -647,6 +647,27 @@ export function createReviewState(pageStore: Page) {
 		posterPreviewOverrides.delete(currentResult.file_path);
 	}
 
+	// Whether the current movie has drifted from its scraped baseline — mirrors
+	// resetPoster/resetCover's no-op guards so the Reset button is disabled
+	// exactly when Reset would do nothing (UX: no "reset" when already at baseline).
+	const canResetPoster = $derived.by(() => {
+		if (!currentResult || !currentMovie) return false;
+		const original = originalPosterState.get(currentResult.file_path);
+		if (!original || !original.poster_url) return false;
+		return (
+			currentMovie.poster_url !== original.poster_url ||
+			currentMovie.cropped_poster_url !== original.cropped_poster_url ||
+			currentMovie.should_crop_poster !== original.should_crop_poster
+		);
+	});
+
+	const canResetCover = $derived.by(() => {
+		if (!currentResult || !currentMovie) return false;
+		const original = originalCoverState.get(currentResult.file_path);
+		if (original === undefined) return false;
+		return currentMovie.cover_url !== original;
+	});
+
 	function resetPoster() {
 		if (!currentResult || !currentMovie) return;
 
@@ -1470,6 +1491,12 @@ export function createReviewState(pageStore: Page) {
 		},
 		get currentResult() {
 			return currentResult;
+		},
+		get canResetPoster() {
+			return canResetPoster;
+		},
+		get canResetCover() {
+			return canResetCover;
 		},
 		get currentMovie() {
 			return currentMovie;

--- a/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
@@ -634,18 +634,26 @@ export function createReviewState(pageStore: Page) {
 	// in-review rescrape, where the snapshot maps would go stale and Reset
 	// would restore the *prior* content's image. The `|| current` fallback
 	// covers older movies persisted before the baseline was eagerly set.
+	//
+	// The fallback reads from the unedited loaded movie (`currentResult.movie`)
+	// — NOT `currentMovie`, which may already be an `editedMovies` override.
+	// Anchoring the fallback to the edited movie would make the baseline drift
+	// with the edit, so Reset (which compares the edited `currentMovie` against
+	// this baseline) would no-op incorrectly for legacy rows.
 	const posterBaseline = $derived.by(() => {
-		if (!currentMovie) return undefined;
+		if (!currentResult || !currentResult.movie) return undefined;
+		const loaded = currentResult.movie;
 		return {
-			poster_url: currentMovie.original_poster_url || currentMovie.poster_url || '',
-			cropped_poster_url: currentMovie.original_cropped_poster_url || currentMovie.cropped_poster_url || '',
-			should_crop_poster: currentMovie.original_should_crop_poster ?? currentMovie.should_crop_poster ?? false,
+			poster_url: loaded.original_poster_url || loaded.poster_url || '',
+			cropped_poster_url: loaded.original_cropped_poster_url || loaded.cropped_poster_url || '',
+			should_crop_poster: loaded.original_should_crop_poster ?? loaded.should_crop_poster ?? false,
 		};
 	});
 
 	const coverBaseline = $derived.by(() => {
-		if (!currentMovie) return undefined;
-		return currentMovie.original_cover_url || currentMovie.cover_url || '';
+		if (!currentResult || !currentResult.movie) return undefined;
+		const loaded = currentResult.movie;
+		return loaded.original_cover_url || loaded.cover_url || '';
 	});
 
 	// Whether the current movie has drifted from its scraped baseline — mirrors


### PR DESCRIPTION
## Summary

Fixes a rescrape bug where the poster/cover URL was not refreshed on rescrape — especially when the content-id changed — plus the frontend Reset baseline that relied on stale snapshot maps, and a small badge regression.

## Background

When rescraping from the review UI, the merge path (`mergeRescrapeMovie`) treated `PosterURL`/`CoverURL` as ordinary string fields. With the default `prefer-nfo` strategy, the existing movie's images were preserved instead of refreshed, so:

- A refresh rescrape kept a stale/broken poster.
- A rescrape that resolved a **different content-id** left images belonging to the *old* content on the resolved movie.
- The `Original*` revert-baseline fields were preserved across content-id changes, so the review UI's **Reset restored the previous content's image**.

`CroppedPosterURL` was already special-cased to always use the scraped value; `PosterURL`/`CoverURL` were not.

## Changes

### `dd29ca5e` — rescrape image/baseline fix + Reset UX
- **`internal/worker/rescrape_phase.go`** — `mergeRescrapeMovie` reconciles `PosterURL`/`CoverURL` from the scraper:
  - content-id change → take the scraper's images, clearing when the scraper has none
  - same content → take the scraper's images when provided, else keep the merged value
- **`internal/worker/poster_editor.go`** — new `establishScrapedBaseline(target, source)` sets the poster-original revert group (`OriginalPosterURL`/`OriginalCroppedPosterURL`/`OriginalShouldCropPoster`/`OriginalCoverURL`) from the scraped movie.
- **`internal/worker/scrape_phase.go`** — initial scrape eagerly establishes the baseline (full symmetry with rescrape), after poster generation so the generated `CroppedPosterURL` is captured.
- **Frontend** — `canResetPoster`/`canResetCover` derived state disables the poster/cover Reset button at baseline.
- **Tests** — 17-case rescrape image matrix + scrape baseline regression test.

The shared `nfo.MergeMovieMetadataWithOptions` engine is intentionally **not** touched (also used by organize/apply, where `prefer-nfo` should preserve a user's on-disk NFO images). The override is local to the rescrape seam.

### `7dafc9da` — Modified badge alignment
- `ReviewGridCard.svelte`: the "Modified" badge regressed to `top-9` (from `top-2`) in v0.3.3-alpha. It sits top-left, the `movieId` badge sits top-right (`top-2 right-2`) — they don't overlap, so `top-2` restores the intended horizontal alignment.

### `1e5d78f9` — reset baseline from movie, not stale snapshot maps
- The frontend kept its own baseline copy in `originalPosterState`/`originalCoverState` snapshot maps, seeded once and never re-seeded. After an in-review content-id rescrape, `setJob` spliced in the fresh movie but the maps stayed stale → Reset restored the prior content's image (the exact bug class `dd29ca5e` claimed to fix).
- **`review-state.svelte.ts`** — dropped the snapshot maps; added `posterBaseline`/`coverBaseline` derived from `currentMovie.original_*` (with `|| current` fallback for pre-fix movies). `canReset*`/`reset*` consume these, so the baseline tracks the rescraped content live.
- **`rescrape_phase.go`** — hoisted `establishScrapedBaseline` out of the merge if/else (`baselineFromScraped` flag) so merge-enabled rescrapes with no prior result still establish the baseline; trimmed padded scraper URLs in the same-content branch for display/baseline consistency.
- **`poster_editor.go`** — `establishScrapedBaseline` trims URL inputs; docstring corrected.
- **Tests** — merge-enabled-no-existing, whitespace trim, padded same-id URL.

## Verification
- `go test ./internal/worker/ ./internal/nfo/` pass; repo-wide `go test -short ./...` clean; `go vet`/`gofmt` clean.
- `svelte-check` 0/0; frontend suite 275/275.
- Race-clean on single-file rescrape/scrape tests.

## Known follow-up (not in this PR)
- A pre-existing data race in `boundedFanOut` (`TestScrapePhase_Run_MultipleFiles`) fails under `-race` on `main` already — not introduced here.
- The bulk-rescrape path doesn't clear `editedMovies` for bulk-rescraped files (same bug class, pre-existing). This PR reduces its severity (the live baseline self-corrects once a pending edit clears); a separate follow-up will address it.

## How to test
1. Scrape a file, edit its poster/cover in review, click Reset → reverts to the scraped image, button disables at baseline.
2. Rescrape the same content-id with a different poster → image + Reset baseline refresh.
3. Rescrape resolving a different content-id → image + baseline follow the new content; Reset never restores the prior content's image.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/javinizer/codesmith/javinizer-go/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785303966&installation_id=143189414&pr_number=67&repository=javinizer%2Fjavinizer-go&return_to=https%3A%2F%2Fgithub.com%2Fjavinizer%2Fjavinizer-go%2Fpull%2F67&signature=de5254ace30227a6660f9036989aab4c48b29ad9563245d3e94a62978c3580c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced review-screen “Reset” controls for poster and cover, including conditional enable/disable when the current media already matches its baseline.
* **Bug Fixes**
  * Improved poster/cover baseline handling across scraping and rescraping flows, ensuring resets correctly restore the intended original state (including merge scenarios and reconciliation of poster/cover URLs and crop settings).
* **UI/Style**
  * Adjusted the “Modified” badge vertical positioning on review cards for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->