### PR TITLE
feat(manual-scrape): per-file ID/URL override + /manual review route

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3545,6 +3545,16 @@ const docTemplate = `{
                     "type": "boolean",
                     "example": false
                 },
+                "manual_inputs": {
+                    "description": "Per-file manual input override keyed by file path; an ID scrapes as that ID (bypasses matcher), a URL scrapes with URL-compatible scrapers",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "example": {
+                        "{\"/path/file.mp4\"": "\"IPX-123\"}"
+                    }
+                },
                 "operation_mode": {
                     "description": "Override config.output.operation_mode: organize, in-place, in-place-norenamefolder, metadata-artwork, preview",
                     "type": "string",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3543,6 +3543,16 @@
                     "type": "boolean",
                     "example": false
                 },
+                "manual_inputs": {
+                    "description": "Per-file manual input override keyed by file path; an ID scrapes as that ID (bypasses matcher), a URL scrapes with URL-compatible scrapers",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "example": {
+                        "{\"/path/file.mp4\"": "\"IPX-123\"}"
+                    }
+                },
                 "operation_mode": {
                     "description": "Override config.output.operation_mode: organize, in-place, in-place-norenamefolder, metadata-artwork, preview",
                     "type": "string",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -292,6 +292,14 @@ definitions:
       force:
         example: false
         type: boolean
+      manual_inputs:
+        additionalProperties:
+          type: string
+        description: Per-file manual input override keyed by file path; an ID scrapes
+          as that ID (bypasses matcher), a URL scrapes with URL-compatible scrapers
+        example:
+          '{"/path/file.mp4"': '"IPX-123"}'
+        type: object
       operation_mode:
         description: 'Override config.output.operation_mode: organize, in-place, in-place-norenamefolder,
           metadata-artwork, preview'

--- a/internal/api/batch/lifecycle.go
+++ b/internal/api/batch/lifecycle.go
@@ -30,6 +30,10 @@ import (
 // @Router /api/v1/batch/scrape [post]
 func batchScrape(rt *core.APIRuntime) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Bound the request body (security F1): a body over 10MB is rejected before
+		// JSON parsing. Mirrors actress/genre handlers; stdlib-enforced.
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 10<<20)
+
 		var req contracts.BatchScrapeRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: err.Error()})
@@ -49,6 +53,14 @@ func batchScrape(rt *core.APIRuntime) gin.HandlerFunc {
 			}
 		}
 
+		// Sanitize + validate per-file manual inputs (scheme, CanHandleURL, length,
+		// count) before starting the job; the sanitized map is what reaches the scrape.
+		sanitizedManualInputs, err := validateAndSanitizeManualInputs(req.ManualInputs, req.Files, deps.GetScraperLister())
+		if err != nil {
+			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: err.Error()})
+			return
+		}
+
 		output, err := StartScrapeUseCase(c.Request.Context(), rt, StartScrapeInput{
 			Files:            req.Files,
 			Destination:      req.Destination,
@@ -60,6 +72,7 @@ func batchScrape(rt *core.APIRuntime) gin.HandlerFunc {
 			SelectedScrapers: req.SelectedScrapers,
 			Strict:           req.Strict,
 			Force:            req.Force,
+			ManualInputs:     sanitizedManualInputs,
 		})
 		if err != nil {
 			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: err.Error()})

--- a/internal/api/batch/manual_input.go
+++ b/internal/api/batch/manual_input.go
@@ -1,0 +1,77 @@
+package batch
+
+import (
+	"fmt"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+// resolveManualInputOverride produces the final per-file RawInputOverride map by
+// propagating each submitted file's manual input to newly-discovered sibling
+// files that share the same matcher MovieID. Co-submitted files (present in
+// submittedFiles) keep their own input and are never overwritten by
+// propagation: propagation targets only files that were discovered by sibling
+// discovery, not files the caller submitted (backend F1). Two submitted files
+// sharing a matcher MovieID with conflicting manual inputs are rejected
+// (backend F2): otherwise map-iteration order would decide which input a
+// shared sibling receives, making the scrape non-deterministic.
+//
+// fileMatchInfo is the metadata returned by discoverSiblingPartsWithMetadata;
+// allFiles is its expanded file list (submitted + discovered).
+func resolveManualInputOverride(
+	submittedFiles []string,
+	manualInputs map[string]string,
+	fileMatchInfo map[string]models.FileMatchInfo,
+	allFiles []string,
+) (map[string]string, error) {
+	if len(manualInputs) == 0 {
+		return manualInputs, nil
+	}
+
+	submitted := make(map[string]bool, len(submittedFiles))
+	for _, f := range submittedFiles {
+		submitted[f] = true
+	}
+
+	// Map each submitter's manual input to the matcher MovieID of its file.
+	movieInput := make(map[string]string)
+	for path, input := range manualInputs {
+		if !submitted[path] {
+			continue
+		}
+		fmi, ok := fileMatchInfo[path]
+		if !ok || fmi.MovieID == "" {
+			continue
+		}
+		if existing, dup := movieInput[fmi.MovieID]; dup && existing != input {
+			return nil, fmt.Errorf("conflicting manual inputs for movie %q: %q vs %q", fmi.MovieID, existing, input)
+		}
+		movieInput[fmi.MovieID] = input
+	}
+
+	// Seed the result with every explicit input (submitters keep their own).
+	result := make(map[string]string, len(manualInputs))
+	for k, v := range manualInputs {
+		result[k] = v
+	}
+
+	// Propagate to discovered siblings (!submitted) sharing a MovieID. Co-submitted
+	// files are skipped so a part the caller submitted is never clobbered.
+	for _, path := range allFiles {
+		if submitted[path] {
+			continue
+		}
+		if _, has := result[path]; has {
+			continue
+		}
+		fmi, ok := fileMatchInfo[path]
+		if !ok || fmi.MovieID == "" {
+			continue
+		}
+		if input, ok := movieInput[fmi.MovieID]; ok {
+			result[path] = input
+		}
+	}
+
+	return result, nil
+}

--- a/internal/api/batch/manual_input.go
+++ b/internal/api/batch/manual_input.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scrape"
 )
 
 // resolveManualInputOverride produces the final per-file RawInputOverride map by
@@ -44,7 +45,7 @@ func resolveManualInputOverride(
 			continue
 		}
 		if existing, dup := movieInput[fmi.MovieID]; dup && existing != input {
-			return nil, fmt.Errorf("conflicting manual inputs for movie %q: %q vs %q", fmi.MovieID, existing, input)
+			return nil, fmt.Errorf("conflicting manual inputs for movie %q: %q vs %q", fmi.MovieID, scrape.RedactURLQuery(existing), scrape.RedactURLQuery(input))
 		}
 		movieInput[fmi.MovieID] = input
 	}

--- a/internal/api/batch/manual_input_race_test.go
+++ b/internal/api/batch/manual_input_race_test.go
@@ -1,0 +1,151 @@
+package batch
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveManualInputOverride_ConcurrentReadSafety asserts the manual-input
+// override resolution is safe under the race detector when many goroutines
+// resolve the same shared inputs concurrently. resolveManualInputOverride is
+// the propagation step on the batch scrape path (usecases.go); it reads
+// submittedFiles, manualInputs, and fileMatchInfo and builds a fresh override
+// map. Inputs are read-only across the call, so concurrent callers must not
+// race on the shared maps/slices and must each observe identical, deterministic
+// results. The discovered-sibling propagation case (the new manual-input path)
+// is included so the race detector exercises the full build path, not just the
+// early-return shortcuts.
+func TestResolveManualInputOverride_ConcurrentReadSafety(t *testing.T) {
+	t.Parallel()
+
+	submitted := []string{"/d/ABC-001-pt1.mp4"}
+	manualInputs := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+	}
+	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+
+	want, err := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	require.NoError(t, err)
+	require.Equal(t, "IPX-999", want["/d/ABC-001-pt1.mp4"])
+	require.Equal(t, "IPX-999", want["/d/ABC-001-pt2.mp4"], "precondition: discovered sibling inherits submitter input")
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				got, gerr := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+				if gerr != nil {
+					t.Errorf("concurrent resolve failed: %v", gerr)
+					return
+				}
+				if !mapsEqual(got, want) {
+					t.Errorf("concurrent resolve diverged: got %v want %v", got, want)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestValidateAndSanitizeManualInputs_ConcurrentReadSafety asserts the
+// manual-input sanitization+validation layer (the 400 gate on the batch create
+// path, lifecycle.go) is race-free and deterministic when many goroutines
+// validate the same shared inputs concurrently. Plain IDs (no scheme) are used
+// so validation passes without a scraper registry, isolating the manual-input
+// data path from external deps.
+func TestValidateAndSanitizeManualInputs_ConcurrentReadSafety(t *testing.T) {
+	t.Parallel()
+
+	files := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4", "/b/SSIS-002.mp4"}
+	rawInputs := map[string]string{
+		"/d/ABC-001-pt1.mp4": "  IPX-999  ",
+		"/b/SSIS-002.mp4":    "SSIS-002",
+	}
+
+	want, err := validateAndSanitizeManualInputs(rawInputs, files, nil)
+	require.NoError(t, err)
+	require.Len(t, want, 2)
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				got, gerr := validateAndSanitizeManualInputs(rawInputs, files, nil)
+				if gerr != nil {
+					t.Errorf("concurrent validate failed: %v", gerr)
+					return
+				}
+				if !mapsEqual(got, want) {
+					t.Errorf("concurrent validate diverged: got %v want %v", got, want)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestResolveManualInputOverride_ConcurrentSharedInputs_NoMutation asserts that
+// concurrent resolution never mutates the shared input maps/slices: a caller
+// must treat its inputs as read-only. This guards the contract the usecase
+// relies on (the same manualInputs/fileMatchInfo feed into the job's
+// FileMatchInfo and RawInputOverride) — if a concurrent resolver mutated them,
+// a later caller or the scrape phase would observe corrupted data.
+func TestResolveManualInputOverride_ConcurrentSharedInputs_NoMutation(t *testing.T) {
+	t.Parallel()
+
+	submitted := []string{"/d/ABC-001-pt1.mp4"}
+	manualInputs := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+	}
+	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+
+	manualSnapshot := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"}
+	fmiSnapshot := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+	}
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				_, _ = resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, manualSnapshot, manualInputs, "shared manualInputs must not be mutated by concurrent resolvers")
+	assert.Equal(t, fmiSnapshot, fileMatchInfo, "shared fileMatchInfo must not be mutated by concurrent resolvers")
+}
+
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || w != v {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/batch/manual_input_test.go
+++ b/internal/api/batch/manual_input_test.go
@@ -62,3 +62,21 @@ func TestResolveManualInputOverride_PropagatesToDiscoveredSibling(t *testing.T) 
 	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt1.mp4"], "submitter keeps its own input")
 	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt2.mp4"], "discovered sibling inherits the submitter's input (same matcher MovieID)")
 }
+
+func TestResolveManualInputOverride_MixedBatchManualAndAuto(t *testing.T) {
+	submitted := []string{"/a/SSIS-001.mp4", "/b/SSIS-002.mp4"}
+	manualInputs := map[string]string{"/a/SSIS-001.mp4": "ABC-123"}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/a/SSIS-001.mp4": fmiFor("/a/SSIS-001.mp4", "SSIS-001", 1),
+		"/b/SSIS-002.mp4": fmiFor("/b/SSIS-002.mp4", "SSIS-002", 1),
+	}
+	allFiles := submitted
+
+	result, err := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 1, "only the manually-input row gets an override; the auto row stays auto (no map entry)")
+	assert.Equal(t, "ABC-123", result["/a/SSIS-001.mp4"], "manual row scrapes as its explicit input")
+	_, hasAuto := result["/b/SSIS-002.mp4"]
+	assert.False(t, hasAuto, "auto row (no input, no matching sibling) is absent from the override map — buildScrapeCmd auto-IDs it from the matcher")
+}

--- a/internal/api/batch/manual_input_test.go
+++ b/internal/api/batch/manual_input_test.go
@@ -1,0 +1,64 @@
+package batch
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fmiFor(path, movieID string, part int) models.FileMatchInfo {
+	return models.FileMatchInfo{Path: path, Name: path, MovieID: movieID, IsMultiPart: true, PartNumber: part}
+}
+
+func TestResolveManualInputOverride_RejectsConflictingInputsForSameMovieID(t *testing.T) {
+	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+	manualInputs := map[string]string{
+		"/d/ABC-001-pt1.mp4": "IPX-111",
+		"/d/ABC-001-pt2.mp4": "IPX-222",
+	}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+	}
+	allFiles := submitted
+
+	_, err := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	require.Error(t, err, "two submitted files sharing a matcher MovieID with conflicting inputs must be rejected (non-deterministic scrape)")
+	assert.Contains(t, err.Error(), "conflicting manual inputs")
+}
+
+func TestResolveManualInputOverride_DoesNotOverwriteCoSubmittedSibling(t *testing.T) {
+	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+	manualInputs := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"} // only pt1 has an input
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+	}
+	allFiles := submitted // no discovered siblings
+
+	result, err := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	require.NoError(t, err)
+	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt1.mp4"], "submitter keeps its own input")
+	_, has := result["/d/ABC-001-pt2.mp4"]
+	assert.False(t, has, "co-submitted pt2 does NOT inherit pt1's input — it stays auto-ID (its own row's choice)")
+}
+
+func TestResolveManualInputOverride_PropagatesToDiscoveredSibling(t *testing.T) {
+	submitted := []string{"/d/ABC-001-pt1.mp4"}
+	manualInputs := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+	}
+	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+
+	result, err := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	require.NoError(t, err)
+	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt1.mp4"], "submitter keeps its own input")
+	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt2.mp4"], "discovered sibling inherits the submitter's input (same matcher MovieID)")
+}

--- a/internal/api/batch/manual_input_validate.go
+++ b/internal/api/batch/manual_input_validate.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/javinizer/javinizer-go/internal/matcher"
 	"github.com/javinizer/javinizer-go/internal/scrape"
@@ -40,7 +41,11 @@ func sanitizeManualInput(input string) string {
 func validateManualURL(input string, registry matcher.URLScraperLister) error {
 	u, err := url.Parse(input)
 	if err != nil {
-		return fmt.Errorf("malformed manual input: %w", err)
+		// url.Parse errors embed the raw input verbatim (e.g.
+		// `parse "https://…?token=secret": …`), which would leak a signed-URL
+		// token into the 400 response. The specific parse detail isn't
+		// actionable for the client, so return a fixed message.
+		return fmt.Errorf("malformed manual input")
 	}
 	if u.Scheme != "" && u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("unsupported URL scheme %q: only http and https are allowed", u.Scheme)
@@ -86,7 +91,7 @@ func validateAndSanitizeManualInputs(
 			return nil, fmt.Errorf("manual_inputs key %q is not in files", path)
 		}
 		sanitized := strings.TrimSpace(sanitizeManualInput(raw))
-		if len(sanitized) > maxManualInputLen {
+		if utf8.RuneCountInString(sanitized) > maxManualInputLen {
 			return nil, fmt.Errorf("manual input for %q exceeds %d characters", path, maxManualInputLen)
 		}
 		if sanitized == "" {

--- a/internal/api/batch/manual_input_validate.go
+++ b/internal/api/batch/manual_input_validate.go
@@ -7,6 +7,7 @@ import (
 	"unicode"
 
 	"github.com/javinizer/javinizer-go/internal/matcher"
+	"github.com/javinizer/javinizer-go/internal/scrape"
 )
 
 const (
@@ -50,7 +51,7 @@ func validateManualURL(input string, registry matcher.URLScraperLister) error {
 			return perr
 		}
 		if !parsed.IsURL {
-			return fmt.Errorf("no enabled scraper can handle URL %q", input)
+			return fmt.Errorf("no enabled scraper can handle URL %q", scrape.RedactURLQuery(input))
 		}
 	}
 	return nil
@@ -84,12 +85,11 @@ func validateAndSanitizeManualInputs(
 		if _, ok := fileSet[path]; !ok {
 			return nil, fmt.Errorf("manual_inputs key %q is not in files", path)
 		}
-		sanitized := sanitizeManualInput(raw)
+		sanitized := strings.TrimSpace(sanitizeManualInput(raw))
 		if len(sanitized) > maxManualInputLen {
 			return nil, fmt.Errorf("manual input for %q exceeds %d characters", path, maxManualInputLen)
 		}
 		if sanitized == "" {
-			result[path] = sanitized
 			continue
 		}
 		if err := validateManualURL(sanitized, registry); err != nil {

--- a/internal/api/batch/manual_input_validate.go
+++ b/internal/api/batch/manual_input_validate.go
@@ -75,8 +75,15 @@ func validateAndSanitizeManualInputs(
 	if len(rawInputs) == 0 {
 		return rawInputs, nil
 	}
+	fileSet := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		fileSet[f] = struct{}{}
+	}
 	result := make(map[string]string, len(rawInputs))
 	for path, raw := range rawInputs {
+		if _, ok := fileSet[path]; !ok {
+			return nil, fmt.Errorf("manual_inputs key %q is not in files", path)
+		}
 		sanitized := sanitizeManualInput(raw)
 		if len(sanitized) > maxManualInputLen {
 			return nil, fmt.Errorf("manual input for %q exceeds %d characters", path, maxManualInputLen)

--- a/internal/api/batch/manual_input_validate.go
+++ b/internal/api/batch/manual_input_validate.go
@@ -1,0 +1,94 @@
+package batch
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"unicode"
+
+	"github.com/javinizer/javinizer-go/internal/matcher"
+)
+
+const (
+	// maxManualInputLen is the per-value character cap for a manual input.
+	// Inputs exceeding this are rejected (400) to bound log/metadata bloat and
+	// parser cost (security F7 / Phase 2 #4).
+	maxManualInputLen = 4096
+)
+
+// sanitizeManualInput strips Unicode format (Cf) and control (Cc) characters
+// from a manual input. Cf covers zero-width/bidi/BOM codepoints; Cc covers
+// NUL/TAB/LF/CR and the rest of the C0 control block. Stripping by unicode
+// category — not a hardcoded codepoint list — survives future additions to
+// those categories (security F7). Visible runes (including ASCII space, which
+// is Zs not Cc) are preserved; edge whitespace is trimmed later by
+// buildScrapeCmd's TrimSpace.
+func sanitizeManualInput(input string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.Is(unicode.Cf, r) || unicode.Is(unicode.Cc, r) {
+			return -1
+		}
+		return r
+	}, input)
+}
+
+// validateManualURL enforces the URL-shaped checks for a single sanitized manual
+// input. A non-http(s) scheme is rejected (Phase 2 #1). Plain IDs (no scheme)
+// pass through — they are never fetched as URLs (security F4). The registry is
+// consumed by the CanHandleURL check added in Phase 2 #2.
+func validateManualURL(input string, registry matcher.URLScraperLister) error {
+	u, err := url.Parse(input)
+	if err != nil {
+		return fmt.Errorf("malformed manual input: %w", err)
+	}
+	if u.Scheme != "" && u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme %q: only http and https are allowed", u.Scheme)
+	}
+	if u.Scheme == "http" || u.Scheme == "https" {
+		parsed, perr := matcher.ParseInput(input, registry)
+		if perr != nil {
+			return perr
+		}
+		if !parsed.IsURL {
+			return fmt.Errorf("no enabled scraper can handle URL %q", input)
+		}
+	}
+	return nil
+}
+
+// validateAndSanitizeManualInputs sanitizes (strips Cf/Cc), validates, and returns
+// the manual-input map for a CREATE batch scrape. It is the 400 layer on top of
+// the existing URL classifier (matcher.ParseInput). Returns a 400-eligible
+// error on: more inputs than files (Phase 2 #4), a per-value length over
+// maxManualInputLen (Phase 2 #4), a non-http(s) URL scheme (Phase 2 #1), or an
+// http(s) URL no enabled scraper CanHandleURLs (Phase 2 #2). The returned map
+// holds the sanitized values so a hidden codepoint that passed validation
+// cannot reach the scrape.
+func validateAndSanitizeManualInputs(
+	rawInputs map[string]string,
+	files []string,
+	registry matcher.URLScraperLister,
+) (map[string]string, error) {
+	if len(rawInputs) > len(files) {
+		return nil, fmt.Errorf("manual_inputs count (%d) exceeds files count (%d)", len(rawInputs), len(files))
+	}
+	if len(rawInputs) == 0 {
+		return rawInputs, nil
+	}
+	result := make(map[string]string, len(rawInputs))
+	for path, raw := range rawInputs {
+		sanitized := sanitizeManualInput(raw)
+		if len(sanitized) > maxManualInputLen {
+			return nil, fmt.Errorf("manual input for %q exceeds %d characters", path, maxManualInputLen)
+		}
+		if sanitized == "" {
+			result[path] = sanitized
+			continue
+		}
+		if err := validateManualURL(sanitized, registry); err != nil {
+			return nil, err
+		}
+		result[path] = sanitized
+	}
+	return result, nil
+}

--- a/internal/api/batch/manual_input_validate_test.go
+++ b/internal/api/batch/manual_input_validate_test.go
@@ -93,3 +93,35 @@ func TestValidateAndSanitizeManualInputs_RejectsKeyNotInFiles(t *testing.T) {
 		})
 	}
 }
+
+// A whitespace-padded URL is trimmed before the scheme/CanHandleURL check, so
+// an unhandleable URL with edge whitespace is rejected (400) just like its
+// trimmed counterpart — previously the leading space made url.Parse return
+// Scheme="" so it took the plain-ID branch and bypassed the check.
+func TestValidateAndSanitizeManualInputs_TrimsBeforeURLValidation(t *testing.T) {
+	raw := map[string]string{"/d/a.mp4": "  https://no-handler.example.com/v/123  "}
+	got, err := validateAndSanitizeManualInputs(raw, []string{"/d/a.mp4"}, nil)
+	require.Error(t, err, "whitespace-padded unhandleable URL must be rejected after trim")
+	assert.Contains(t, err.Error(), "no enabled scraper can handle URL")
+	assert.Nil(t, got)
+}
+
+// Empty-after-trim entries are dropped from the sanitized map (not stored as "")
+// so the override map carries no no-op entries.
+func TestValidateAndSanitizeManualInputs_DropsEmptyAfterTrim(t *testing.T) {
+	raw := map[string]string{"/d/a.mp4": "   "}
+	got, err := validateAndSanitizeManualInputs(raw, []string{"/d/a.mp4"}, nil)
+	require.NoError(t, err)
+	_, present := got["/d/a.mp4"]
+	assert.False(t, present, "empty-after-trim entry should be dropped, not stored as \"\"")
+}
+
+// The "no enabled scraper" 400 error redacts the URL query so a token in the
+// echoed URL is not leaked back to the client.
+func TestValidateManualURL_RedactsQueryInError(t *testing.T) {
+	err := validateManualURL("https://no-handler.example.com/v/123?token=secret", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no enabled scraper can handle URL")
+	assert.NotContains(t, err.Error(), "token=secret", "query token must be redacted from the error")
+	assert.NotContains(t, err.Error(), "secret")
+}

--- a/internal/api/batch/manual_input_validate_test.go
+++ b/internal/api/batch/manual_input_validate_test.go
@@ -55,3 +55,41 @@ func TestValidateAndSanitizeManualInputs_RejectsMoreInputsThanFiles(t *testing.T
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds files count")
 }
+
+func TestValidateAndSanitizeManualInputs_RejectsKeyNotInFiles(t *testing.T) {
+	testCases := []struct {
+		name     string
+		raw      map[string]string
+		files    []string
+		wantErr  bool
+		contains string
+	}{
+		{
+			name:     "orphan key passes count check but is not in files",
+			raw:      map[string]string{"/orphan/path": "IPX-123"},
+			files:    []string{"/real/a.mp4", "/real/b.mp4"},
+			wantErr:  true,
+			contains: "/orphan/path",
+		},
+		{
+			name:    "key in files passes (regression guard)",
+			raw:     map[string]string{"/real/a.mp4": "IPX-123"},
+			files:   []string{"/real/a.mp4", "/real/b.mp4"},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateAndSanitizeManualInputs(tc.raw, tc.files, nil)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.contains)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.raw, got)
+			}
+		})
+	}
+}

--- a/internal/api/batch/manual_input_validate_test.go
+++ b/internal/api/batch/manual_input_validate_test.go
@@ -1,0 +1,57 @@
+package batch
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeManualInput_StripsFormatAndControlChars(t *testing.T) {
+	// Cf (format): zero-width space U+200B, zero-width joiner U+200D, BOM U+FEFF.
+	// Cc (control): NUL \x00, TAB \t, LF \n, CR \r.
+	// Space U+0020 is NOT Cf/Cc (it is Zs) and must be preserved for downstream TrimSpace.
+	t.Run("strips Cf/Cc, preserves visible runes", func(t *testing.T) {
+		got := sanitizeManualInput("IPX\u200B123\u200D\t\n\r\x00\uFEFF")
+		assert.Equal(t, "IPX123", got)
+	})
+
+	t.Run("preserves spaces (TrimSpace is downstream)", func(t *testing.T) {
+		assert.Equal(t, "  IPX-123  ", sanitizeManualInput("  IPX-123  "))
+	})
+}
+
+func TestValidateManualURL_RejectsNonHTTPScheme(t *testing.T) {
+	for _, input := range []string{"file:///etc/passwd", "javascript:alert(1)", "ftp://example.com", "gopher://x"} {
+		err := validateManualURL(input, nil)
+		require.Error(t, err, "non-http(s) scheme %q must be rejected", input)
+		assert.Contains(t, err.Error(), "unsupported URL scheme", input)
+	}
+}
+
+func TestValidateManualURL_RejectsURLNoScraperHandles(t *testing.T) {
+	// nil registry => no scrapers CanHandleURL => an http(s) URL must be rejected.
+	err := validateManualURL("https://no-handler.example.com/video/123", nil)
+	require.Error(t, err, "an http(s) URL no enabled scraper CanHandleURLs must be rejected")
+	assert.Contains(t, err.Error(), "no enabled scraper can handle URL")
+}
+
+func TestValidateManualURL_AcceptsPlainID(t *testing.T) {
+	// A plain ID (no scheme) is never a URL fetch — always accepted.
+	assert.NoError(t, validateManualURL("IPX-123", nil))
+}
+
+func TestValidateAndSanitizeManualInputs_RejectsOverlongValue(t *testing.T) {
+	raw := map[string]string{"/d/a.mp4": strings.Repeat("x", maxManualInputLen+1)}
+	_, err := validateAndSanitizeManualInputs(raw, []string{"/d/a.mp4"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+func TestValidateAndSanitizeManualInputs_RejectsMoreInputsThanFiles(t *testing.T) {
+	raw := map[string]string{"/d/a.mp4": "IPX-1", "/d/b.mp4": "IPX-2"}
+	_, err := validateAndSanitizeManualInputs(raw, []string{"/d/a.mp4"}, nil) // 2 inputs, 1 file
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds files count")
+}

--- a/internal/api/batch/manual_input_validate_test.go
+++ b/internal/api/batch/manual_input_validate_test.go
@@ -125,3 +125,29 @@ func TestValidateManualURL_RedactsQueryInError(t *testing.T) {
 	assert.NotContains(t, err.Error(), "token=secret", "query token must be redacted from the error")
 	assert.NotContains(t, err.Error(), "secret")
 }
+
+// The length cap is a CHARACTER (rune) limit, not a byte limit. A multibyte
+// input (e.g. CJK IDs) at the rune cap must pass even though its byte length
+// exceeds the cap; one rune over must fail.
+func TestValidateAndSanitizeManualInputs_LengthCapIsRuneCount(t *testing.T) {
+	// '中' is 3 bytes; 4096 runes = 12288 bytes, well over the old byte cap.
+	atCap := strings.Repeat("中", maxManualInputLen)     // exactly the cap → pass
+	overCap := strings.Repeat("中", maxManualInputLen+1) // one rune over → fail
+
+	if _, err := validateAndSanitizeManualInputs(map[string]string{"/d/a.mp4": atCap}, []string{"/d/a.mp4"}, nil); err != nil {
+		t.Fatalf("input at the rune cap should pass, got: %v", err)
+	}
+	_, err := validateAndSanitizeManualInputs(map[string]string{"/d/a.mp4": overCap}, []string{"/d/a.mp4"}, nil)
+	require.Error(t, err, "one rune over the cap should fail even though byte length >> cap")
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+// A malformed URL triggering a url.Parse error must not echo the raw input
+// (which may carry a query token) back in the 400.
+func TestValidateManualURL_RedactsParseError(t *testing.T) {
+	// A control char in the host forces url.Parse to fail while keeping a
+	// query-like token; the error must not contain the token.
+	err := validateManualURL("https://exa\tmple.com/v/123?token=secret", nil)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "token=secret", "parse error must not echo the raw query token")
+}

--- a/internal/api/batch/rescrape.go
+++ b/internal/api/batch/rescrape.go
@@ -9,6 +9,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/api/core"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scrape"
 )
 
 // rescrapeBatchMovie godoc
@@ -49,7 +50,7 @@ func rescrapeBatchMovie(rt *core.APIRuntime) gin.HandlerFunc {
 		}
 
 		logging.Infof("Batch rescrape request for job %s, result %s: scrapers=%v, manual_input=%s, force=%v",
-			job.GetID(), resultID, req.SelectedScrapers, req.ManualSearchInput, req.Force)
+			job.GetID(), resultID, req.SelectedScrapers, scrape.RedactURLQuery(req.ManualSearchInput), req.Force)
 
 		// Resolve result by resultID to get movieID and filePath
 		result, filePath, found := job.GetFileResultByResultID(resultID)

--- a/internal/api/batch/usecases.go
+++ b/internal/api/batch/usecases.go
@@ -133,6 +133,7 @@ type StartScrapeInput struct {
 	SelectedScrapers []string
 	Strict           bool
 	Force            bool
+	ManualInputs     map[string]string
 }
 
 // StartScrapeOutput holds the result of starting a batch scrape job.
@@ -153,6 +154,14 @@ func StartScrapeUseCase(
 	if len(allFiles) > len(input.Files) {
 		logging.Infof("Auto-discovered %d sibling files for batch job (original: %d, total: %d)",
 			len(allFiles)-len(input.Files), len(input.Files), len(allFiles))
+	}
+
+	// Resolve manual inputs: propagate each submitter's input to discovered
+	// siblings sharing the matcher MovieID, and reject conflicting inputs across
+	// co-parts of the same movie (handler maps the error to 400).
+	propagatedManualInputs, err := resolveManualInputOverride(input.Files, input.ManualInputs, fileMatchInfoMap, allFiles)
+	if err != nil {
+		return nil, err
 	}
 
 	resolved, err := workflow.ResolveSeamStrings(workflow.SeamStringsInput{
@@ -193,6 +202,7 @@ func StartScrapeUseCase(
 	// otherwise metadata collected earlier in the usecase never reaches the
 	// scrape config.
 	scrapeOpts.FileMatchInfo = matchInfo
+	scrapeOpts.RawInputOverride = propagatedManualInputs
 	// Wire per-file scrape progress hooks so the frontend's messagesByFile
 	// populates during scrape and ProgressModal shows live per-file status.
 	// Restores main's realtime.ProgressAdapter behavior (deleted in this

--- a/internal/api/contracts/batch_types.go
+++ b/internal/api/contracts/batch_types.go
@@ -7,16 +7,17 @@ import (
 
 // BatchScrapeRequest represents a batch scrape request
 type BatchScrapeRequest struct {
-	Files            []string `json:"files" binding:"required"`
-	Strict           bool     `json:"strict" example:"false"`
-	Force            bool     `json:"force" example:"false"`
-	Destination      string   `json:"destination,omitempty" example:"/path/to/output"` // Persisted on job for UI retrieval; required for organize mode, optional for in-place modes
-	Update           bool     `json:"update" example:"false"`                          // Update mode: only create/update metadata files without moving video files
-	SelectedScrapers []string `json:"selected_scrapers,omitempty" example:"r18dev,dmm"`
-	Preset           string   `json:"preset,omitempty" example:"conservative"`        // Merge strategy preset: conservative, gap-fill, aggressive (overrides scalar/array strategies)
-	ScalarStrategy   string   `json:"scalar_strategy,omitempty" example:"prefer-nfo"` // For Update mode: prefer-nfo, prefer-scraper, preserve-existing, fill-missing-only
-	ArrayStrategy    string   `json:"array_strategy,omitempty" example:"merge"`       // For Update mode: merge, replace
-	OperationMode    string   `json:"operation_mode,omitempty" example:"organize"`    // Override config.output.operation_mode: organize, in-place, in-place-norenamefolder, metadata-artwork, preview
+	Files            []string          `json:"files" binding:"required"`
+	Strict           bool              `json:"strict" example:"false"`
+	Force            bool              `json:"force" example:"false"`
+	Destination      string            `json:"destination,omitempty" example:"/path/to/output"` // Persisted on job for UI retrieval; required for organize mode, optional for in-place modes
+	Update           bool              `json:"update" example:"false"`                          // Update mode: only create/update metadata files without moving video files
+	SelectedScrapers []string          `json:"selected_scrapers,omitempty" example:"r18dev,dmm"`
+	Preset           string            `json:"preset,omitempty" example:"conservative"`                            // Merge strategy preset: conservative, gap-fill, aggressive (overrides scalar/array strategies)
+	ScalarStrategy   string            `json:"scalar_strategy,omitempty" example:"prefer-nfo"`                     // For Update mode: prefer-nfo, prefer-scraper, preserve-existing, fill-missing-only
+	ArrayStrategy    string            `json:"array_strategy,omitempty" example:"merge"`                           // For Update mode: merge, replace
+	OperationMode    string            `json:"operation_mode,omitempty" example:"organize"`                        // Override config.output.operation_mode: organize, in-place, in-place-norenamefolder, metadata-artwork, preview
+	ManualInputs     map[string]string `json:"manual_inputs,omitempty" example:"{\"/path/file.mp4\":\"IPX-123\"}"` // Per-file manual input override keyed by file path; an ID scrapes as that ID (bypasses matcher), a URL scrapes with URL-compatible scrapers
 }
 
 // BatchScrapeResponse represents batch scrape response

--- a/internal/api/contracts/types_test.go
+++ b/internal/api/contracts/types_test.go
@@ -112,6 +112,35 @@ func TestOrganizePreviewRequest_OperationMode(t *testing.T) {
 	}
 }
 
+func TestBatchScrapeRequest_ManualInputsOmittedWhenEmpty(t *testing.T) {
+	var req BatchScrapeRequest
+	assert.NoError(t, json.Unmarshal([]byte(`{"files":["/test/a.mp4"]}`), &req))
+	assert.Nil(t, req.ManualInputs)
+
+	req = BatchScrapeRequest{Files: []string{"/test/a.mp4"}}
+	data, err := json.Marshal(req)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "manual_inputs")
+
+	req = BatchScrapeRequest{Files: []string{"/test/a.mp4"}, ManualInputs: map[string]string{}}
+	data, err = json.Marshal(req)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "manual_inputs")
+}
+
+func TestBatchScrapeRequest_ManualInputsRoundTrip(t *testing.T) {
+	req := BatchScrapeRequest{
+		Files:        []string{"/test/a.mp4", "/test/b.mp4"},
+		ManualInputs: map[string]string{"/test/a.mp4": "IPX-123", "/test/b.mp4": "https://example.com/v/456"},
+	}
+	data, err := json.Marshal(req)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"manual_inputs":`)
+	var got BatchScrapeRequest
+	assert.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, req.ManualInputs, got.ManualInputs)
+}
+
 func TestOrganizePreviewResponse_OperationMode(t *testing.T) {
 	resp := OrganizePreviewResponse{
 		FolderName:    "TEST-001",

--- a/internal/api/server/manual_scrape_e2e_test.go
+++ b/internal/api/server/manual_scrape_e2e_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/api/batch"
+	"github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/scraper/e2emock"
+)
+
+type batchScrapeResponse struct {
+	JobID string `json:"job_id"`
+}
+
+type batchJobResponse struct {
+	ID      string                                `json:"id"`
+	Status  string                                `json:"status"`
+	Results map[string]*contracts.BatchFileResult `json:"results"`
+}
+
+func setupManualScrapeE2E(t *testing.T) (*gin.Engine, string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "ABC-123.mp4")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake"), 0o644))
+
+	cfg := &config.Config{
+		Logging: config.LoggingConfig{Level: "error"},
+		Matching: config.MatchingConfig{
+			RegexEnabled: false,
+		},
+		Scrapers: config.ScrapersConfig{
+			Priority: []string{e2emock.Name},
+		},
+		API: config.APIConfig{
+			Security: config.SecurityConfig{
+				AllowedDirectories: []string{tempDir},
+			},
+		},
+		Output: config.OutputConfig{
+			Download: config.OutputDownloadConfig{DownloadTimeout: 2},
+		},
+	}
+
+	deps := testkit.CreateTestDeps(t, cfg, "")
+	deps.CoreDeps.ScraperRegistry.RegisterInstance(&e2emock.Scraper{})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	batch.RegisterRoutes(router.Group(""), testkit.GetTestRuntime(deps))
+	return router, filePath
+}
+
+func TestE2E_ManualScrapeInputFlowsAsMovieID(t *testing.T) {
+	router, filePath := setupManualScrapeE2E(t)
+
+	reqBody, _ := json.Marshal(map[string]any{
+		"files":         []string{filePath},
+		"manual_inputs": map[string]string{filePath: "GOOD-999"},
+	})
+	req := httptest.NewRequest("POST", "/batch/scrape", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, 200, w.Code, "batch scrape with valid manual input should be accepted: %s", w.Body.String())
+
+	var scrapeResp batchScrapeResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &scrapeResp))
+	require.NotEmpty(t, scrapeResp.JobID, "job should be created")
+
+	var jobResp batchJobResponse
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		gReq := httptest.NewRequest("GET", "/batch/"+scrapeResp.JobID+"?include_data=true", nil)
+		gW := httptest.NewRecorder()
+		router.ServeHTTP(gW, gReq)
+		if gW.Code != 200 {
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		require.NoError(t, json.Unmarshal(gW.Body.Bytes(), &jobResp))
+		if r, ok := jobResp.Results[filePath]; ok && r.MovieID != "" {
+			assert.Equal(t, "GOOD-999", r.MovieID, "manual input must flow end-to-end as the scrape MovieID, bypassing the matcher")
+			assert.NotEqual(t, "ABC-123", r.MovieID, "the filename matcher (ABC-123) must be bypassed when a manual input is present")
+			if r.Movie != nil {
+				assert.Equal(t, "GOOD-999", r.Movie.ID, "the mock scraper must be queried with the manual input ID")
+			}
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("scrape result for %s never materialized within 10s (last status=%s, results=%v)", filePath, jobResp.Status, jobResp.Results)
+}
+
+func TestE2E_ManualScrapeOrphanKeyRejected(t *testing.T) {
+	router, filePath := setupManualScrapeE2E(t)
+
+	orphanPath := filepath.Join(filepath.Dir(filePath), "NONEXISTENT-999.mp4")
+	reqBody, _ := json.Marshal(map[string]any{
+		"files":         []string{filePath},
+		"manual_inputs": map[string]string{orphanPath: "GOOD-999"},
+	})
+	req := httptest.NewRequest("POST", "/batch/scrape", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 400, w.Code, "manual_inputs key not present in files must be rejected (task-30 cross-check)")
+	assert.Contains(t, w.Body.String(), "is not in files")
+}

--- a/internal/scrape/redact.go
+++ b/internal/scrape/redact.go
@@ -1,0 +1,31 @@
+package scrape
+
+import "net/url"
+
+// RedactURLQuery strips the query (and fragment) from a URL-shaped raw input
+// before it reaches logs, failure JobEvents, or persisted provenance (security
+// F2 / Phase 2 #6). Query strings may carry tokens; the redacted value keeps
+// only scheme+host+path so a row is still identifiable without leaking secrets.
+//
+// Plain IDs (no scheme/host) round-trip unchanged — a bare string is never a
+// URL fetch (security F4), and url.Parse happily attaches a RawQuery to a
+// schemeless string like "ABC-?123", so the scheme guard prevents redacting
+// part of a plain ID. Inputs with no query are returned unchanged.
+//
+// Exported so the batch rescrape log (and other manual-input log sites) can
+// share the same redaction as resolveScrapeInput's parse-fail fallback.
+func RedactURLQuery(input string) string {
+	if input == "" {
+		return ""
+	}
+	u, err := url.Parse(input)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return input
+	}
+	if u.RawQuery == "" && u.Fragment == "" {
+		return input
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}

--- a/internal/scrape/redact.go
+++ b/internal/scrape/redact.go
@@ -22,9 +22,12 @@ func RedactURLQuery(input string) string {
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return input
 	}
-	if u.RawQuery == "" && u.Fragment == "" {
+	if u.RawQuery == "" && u.Fragment == "" && u.User == nil {
 		return input
 	}
+	// Clear userinfo (user:pass@) as well as query/fragment — a URL carrying
+	// credentials must not leak them into logs or persisted identifiers.
+	u.User = nil
 	u.RawQuery = ""
 	u.Fragment = ""
 	return u.String()

--- a/internal/scrape/redact_test.go
+++ b/internal/scrape/redact_test.go
@@ -19,6 +19,8 @@ func TestRedactURLQuery(t *testing.T) {
 		{"plain ID unchanged (no scheme)", "IPX-123", "IPX-123"},
 		{"plain ID with question mark unchanged (no scheme)", "ABC-?123", "ABC-?123"},
 		{"empty unchanged", "", ""},
+		{"userinfo stripped", "https://user:pass@example.com/v/123?token=secret", "https://example.com/v/123"},
+		{"userinfo stripped even without query", "https://user:pass@example.com/v/123", "https://example.com/v/123"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/scrape/redact_test.go
+++ b/internal/scrape/redact_test.go
@@ -1,0 +1,28 @@
+package scrape
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedactURLQuery(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"http with query stripped", "https://example.com/v/123?token=secret", "https://example.com/v/123"},
+		{"http with query+fragment stripped", "https://example.com/v/123?token=secret#frag", "https://example.com/v/123"},
+		{"http no query unchanged", "https://example.com/v/123", "https://example.com/v/123"},
+		{"query-only host stripped", "https://example.com?token=x", "https://example.com"},
+		{"plain ID unchanged (no scheme)", "IPX-123", "IPX-123"},
+		{"plain ID with question mark unchanged (no scheme)", "ABC-?123", "ABC-?123"},
+		{"empty unchanged", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, RedactURLQuery(c.in))
+		})
+	}
+}

--- a/internal/scrape/resolve_scrape_input_test.go
+++ b/internal/scrape/resolve_scrape_input_test.go
@@ -1,0 +1,62 @@
+package scrape
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// claimFailScraper claims to handle every URL (CanHandleURL=true) but fails to
+// extract an ID, driving matcher.ParseInput's claimedButFailed path — the
+// parse-fail fallback that resolveScrapeInput routes to cmd.MovieID = RawInput.
+type claimFailScraper struct {
+	name    string
+	enabled bool
+}
+
+func (s *claimFailScraper) Name() string { return s.name }
+func (s *claimFailScraper) Search(context.Context, string) (*models.ScraperResult, error) {
+	return nil, nil
+}
+func (s *claimFailScraper) GetURL(context.Context, string) (string, error) { return "", nil }
+func (s *claimFailScraper) IsEnabled() bool                                { return s.enabled }
+func (s *claimFailScraper) Config() *models.ScraperSettings                { return nil }
+func (s *claimFailScraper) Close() error                                   { return nil }
+func (s *claimFailScraper) CanHandleURL(string) bool                       { return true }
+func (s *claimFailScraper) ExtractIDFromURL(string) (string, error) {
+	return "", errors.New("extraction failed")
+}
+func (s *claimFailScraper) ScrapeURL(context.Context, string) (*models.ScraperResult, error) {
+	return nil, nil
+}
+
+// redactStubResolver satisfies ScraperInstanceResolver with only GetAllInstances
+// populated (the sole method matcher.ParseInput / resolveScrapeInput reads).
+type redactStubResolver struct{ instances []models.Scraper }
+
+func (r *redactStubResolver) GetInstance(string) (models.Scraper, bool) { return nil, false }
+func (r *redactStubResolver) GetInstancesByPriorityForInput([]string, string) []models.Scraper {
+	return r.instances
+}
+func (r *redactStubResolver) GetAllInstances() []models.Scraper { return r.instances }
+func (r *redactStubResolver) Names() []string                   { return nil }
+
+func TestResolveScrapeInput_RedactsQueryOnParseFailFallback(t *testing.T) {
+	registry := &redactStubResolver{instances: []models.Scraper{
+		&claimFailScraper{name: "test", enabled: true},
+	}}
+	cmd := ScrapeCmd{RawInput: "https://example.com/v/123?token=secret"}
+
+	got, err := resolveScrapeInput(context.Background(), cmd, registry, &Config{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/v/123", got.MovieID,
+		"parse-fail fallback MovieID must be query-redacted (security F2)")
+	assert.NotContains(t, got.MovieID, "token=secret")
+	assert.Contains(t, got.ParseWarning, "could not be parsed",
+		"ParseWarning surfaces the parse failure (backend F5 follow-on)")
+}

--- a/internal/scrape/scrape.go
+++ b/internal/scrape/scrape.go
@@ -200,8 +200,8 @@ func resolveScrapeInput(ctx context.Context, cmd ScrapeCmd, registry ScraperInst
 	if cmd.RawInput != "" {
 		parsed, parseErr := matcher.ParseInput(cmd.RawInput, registry)
 		if parseErr != nil {
-			logging.Warnf("[scrape] RawInput parse failed for %q: %v (using as-is for MovieID)", cmd.RawInput, parseErr)
-			cmd.MovieID = cmd.RawInput
+			logging.Warnf("[scrape] RawInput parse failed for %q: %v (using as-is for MovieID)", RedactURLQuery(cmd.RawInput), parseErr)
+			cmd.MovieID = RedactURLQuery(cmd.RawInput)
 			cmd.ParseWarning = fmt.Sprintf("input could not be parsed: %v", parseErr)
 		} else {
 			cmd.MovieID = parsed.ID

--- a/internal/worker/batch_job_interface.go
+++ b/internal/worker/batch_job_interface.go
@@ -537,6 +537,7 @@ type ScrapePhaseConfig struct {
 	Strict           bool              // Strict mode: fail if no results from any scraper
 	Force            bool              // Force refresh: bypass cache and re-scrape
 	MovieIDOverride  map[string]string // Override movie ID per file path (rescrape use case)
+	RawInputOverride map[string]string // Per-file manual input (ID or URL) keyed by file path; takes precedence over the matcher and MovieIDOverride — resolveScrapeInput parses it into MovieID + PriorityOverride
 	PriorityOverride []string          // Reorder scraper priority instead of restricting
 
 	// Job-level config applied before scrape starts

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -152,7 +152,13 @@ func buildScrapeCmd(
 	if raw, ok := cfg.RawInputOverride[filePath]; ok && strings.TrimSpace(raw) != "" {
 		trimmed := strings.TrimSpace(raw)
 		rawInput = trimmed
-		movieID = trimmed
+		// MovieID is surfaced in persisted job state, WebSocket events, and
+		// per-file progress messages. A manual URL may carry a query token
+		// (e.g. ?token=secret); redact it here so the raw URL never reaches
+		// those sinks. RawInput stays unredacted so resolveScrapeInput/ScrapeURL
+		// still see the real URL. RedactURLQuery passes plain IDs through
+		// unchanged, so manual ID inputs are unaffected.
+		movieID = scrape.RedactURLQuery(trimmed)
 		manualURL = isManualURLInput(trimmed)
 	}
 	if movieID == "" {

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -128,6 +128,16 @@ func (p *scrapePhase) Run(ctx context.Context, inputs scrapePhaseInputs, files [
 	inputs.Lifecycle.MarkCompleted()
 }
 
+// isManualURLInput reports whether a manual input looks like an http(s) URL.
+// Mirrors rescrape_phase.go's manual-search URL detection. Post Phase-2
+// validation only http(s) URLs reach the scrape path (non-http schemes and
+// unhandleable URLs are rejected with 400), so this prefix check is a safe
+// proxy for matcher.ParseInput's IsURL at this seam.
+func isManualURLInput(raw string) bool {
+	lower := strings.ToLower(raw)
+	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")
+}
+
 // buildScrapeCmd constructs a scrape.ScrapeCmd for a single file.
 // It resolves the movie ID (from override or matcher), determines scrapers
 // to use, and builds the command.
@@ -137,24 +147,36 @@ func buildScrapeCmd(
 	cfg ScrapePhaseConfig,
 ) scrape.ScrapeCmd {
 	var movieID string
-	if override, ok := cfg.MovieIDOverride[filePath]; ok {
-		movieID = override
-	} else {
-		movieID = ""
-		if inputs.Matcher != nil {
-			movieID = inputs.Matcher.MatchString(filepath.Base(filePath))
-		}
-		if movieID == "" {
-			movieID = filepath.Base(filePath)
-			ext := filepath.Ext(movieID)
-			if ext != "" {
-				movieID = movieID[:len(movieID)-len(ext)]
+	var rawInput string
+	var manualURL bool
+	if raw, ok := cfg.RawInputOverride[filePath]; ok && strings.TrimSpace(raw) != "" {
+		trimmed := strings.TrimSpace(raw)
+		rawInput = trimmed
+		movieID = trimmed
+		manualURL = isManualURLInput(trimmed)
+	}
+	if movieID == "" {
+		if override, ok := cfg.MovieIDOverride[filePath]; ok {
+			movieID = override
+		} else {
+			movieID = ""
+			if inputs.Matcher != nil {
+				movieID = inputs.Matcher.MatchString(filepath.Base(filePath))
+			}
+			if movieID == "" {
+				movieID = filepath.Base(filePath)
+				ext := filepath.Ext(movieID)
+				if ext != "" {
+					movieID = movieID[:len(movieID)-len(ext)]
+				}
 			}
 		}
 	}
 
 	scrapersToUse := cfg.SelectedScrapers
-	if len(scrapersToUse) == 0 && len(cfg.PriorityOverride) > 0 {
+	if manualURL {
+		scrapersToUse = nil
+	} else if len(scrapersToUse) == 0 && len(cfg.PriorityOverride) > 0 {
 		scrapersToUse = cfg.PriorityOverride
 	}
 	if len(scrapersToUse) == 0 {
@@ -163,6 +185,7 @@ func buildScrapeCmd(
 
 	return scrape.ScrapeCmd{
 		MovieID:          movieID,
+		RawInput:         rawInput,
 		ForceRefresh:     cfg.Force,
 		SelectedScrapers: scrapersToUse,
 		PriorityOverride: cfg.PriorityOverride,

--- a/internal/worker/scrape_phase_test.go
+++ b/internal/worker/scrape_phase_test.go
@@ -159,6 +159,70 @@ func makeInputs(wf *stubWorkflow) scrapePhaseInputs {
 	}
 }
 
+func TestBuildScrapeCmd_ManualInputTrimmedForMovieIDAndRawInput(t *testing.T) {
+	const file = "/videos/ABC-001.mp4"
+	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
+
+	cmd := buildScrapeCmd(file, inputs, ScrapePhaseConfig{RawInputOverride: map[string]string{file: "  IPX-123  "}})
+
+	assert.Equal(t, "IPX-123", cmd.MovieID, "MovieID is trimmed so failure JobEvents + row-identity identify the row, not '  IPX-123  '")
+	assert.Equal(t, "IPX-123", cmd.RawInput, "RawInput is trimmed (mirrors rescrape_phase.go:203 queryOverride = TrimSpace(ManualSearchInput))")
+}
+
+func TestBuildScrapeCmd_EmptyOrWhitespaceManualInputIsNoOverride(t *testing.T) {
+	const file = "/videos/ABC-001.mp4"
+	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
+
+	for _, raw := range []string{"", "   ", "\t\n"} {
+		cmd := buildScrapeCmd(file, inputs, ScrapePhaseConfig{RawInputOverride: map[string]string{file: raw}})
+		assert.Equal(t, "ABC-001", cmd.MovieID, "empty/whitespace input %q should be no override (auto-ID from matcher)", raw)
+		assert.Equal(t, "", cmd.RawInput, "empty/whitespace input %q should not set RawInput", raw)
+	}
+}
+
+func TestBuildScrapeCmd_URLInputBypassesBatchGlobalScrapers_IDInputKeepsThem(t *testing.T) {
+	const file = "/videos/ABC-001.mp4"
+	batchGlobal := []string{"r18dev", "dmm"}
+	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
+
+	urlCmd := buildScrapeCmd(file, inputs, ScrapePhaseConfig{
+		SelectedScrapers: batchGlobal,
+		RawInputOverride: map[string]string{file: "https://www.javbus.com/ABC-001"},
+	})
+	assert.Equal(t, "https://www.javbus.com/ABC-001", urlCmd.RawInput)
+	assert.Empty(t, urlCmd.SelectedScrapers, "URL rows bypass the batch-global scraper picker so resolveScrapeInput sets PriorityOverride")
+
+	idCmd := buildScrapeCmd(file, inputs, ScrapePhaseConfig{
+		SelectedScrapers: batchGlobal,
+		RawInputOverride: map[string]string{file: "ABC-001"},
+	})
+	assert.Equal(t, "ABC-001", idCmd.RawInput)
+	assert.Equal(t, batchGlobal, idCmd.SelectedScrapers, "ID rows keep the batch-global scrapers so resolveScrapeInput reorders them")
+}
+
+func TestBuildScrapeCmd_NoManualInputAutoIDsFromMatcher(t *testing.T) {
+	const file = "/videos/ABC-001.mp4"
+	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
+	cfg := ScrapePhaseConfig{}
+
+	cmd := buildScrapeCmd(file, inputs, cfg)
+
+	assert.Equal(t, "ABC-001", cmd.MovieID, "no manual input: the matcher result is used as the MovieID")
+	assert.Equal(t, "", cmd.RawInput, "no manual input: RawInput stays empty so resolveScrapeInput is a no-op")
+}
+
+func TestBuildScrapeCmd_ManualInputUsedAsIDBypassingMatcher(t *testing.T) {
+	const file = "/videos/MANUAL-123.mp4"
+	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "MATCHED-001"}}
+	cfg := ScrapePhaseConfig{RawInputOverride: map[string]string{file: "MANUAL-123"}}
+
+	cmd := buildScrapeCmd(file, inputs, cfg)
+
+	assert.Equal(t, "MANUAL-123", cmd.MovieID, "manual input is used as the MovieID, not the matcher result")
+	assert.Equal(t, "MANUAL-123", cmd.RawInput, "RawInput carries the manual input so resolveScrapeInput parses it downstream")
+	assert.NotEqual(t, "MATCHED-001", cmd.MovieID, "the filename matcher is bypassed when a manual input is present")
+}
+
 func TestScrapePhase_Run_Success(t *testing.T) {
 	wf := &stubWorkflow{scrapeResult: makeScrapeResult("TEST-001")}
 	inputs := makeInputs(wf)

--- a/internal/worker/scrape_phase_test.go
+++ b/internal/worker/scrape_phase_test.go
@@ -118,7 +118,19 @@ type stubWorkflow struct {
 }
 
 func (s *stubWorkflow) Scrape(_ context.Context, _ scrape.ScrapeCmd, _ scrape.ProgressFunc) (*scrape.ScrapeResult, *workflow.OrchestrationMeta, error) {
-	return s.scrapeResult, nil, s.scrapeErr
+	if s.scrapeResult == nil {
+		return nil, nil, s.scrapeErr
+	}
+	// Return a fresh copy per call so concurrent scrape workers (MaxWorkers>1)
+	// don't share a Movie pointer — establishScrapedBaseline writes to
+	// fileResult.Movie's Original* fields and would race under -race if two
+	// goroutines received the same pointer.
+	clone := *s.scrapeResult
+	if s.scrapeResult.Movie != nil {
+		movieClone := *s.scrapeResult.Movie
+		clone.Movie = &movieClone
+	}
+	return &clone, nil, s.scrapeErr
 }
 
 func (s *stubWorkflow) Apply(_ context.Context, _ workflow.ApplyCmd, _ scrape.ProgressFunc) (*workflow.ApplyResult, error) {
@@ -198,6 +210,36 @@ func TestBuildScrapeCmd_URLInputBypassesBatchGlobalScrapers_IDInputKeepsThem(t *
 	})
 	assert.Equal(t, "ABC-001", idCmd.RawInput)
 	assert.Equal(t, batchGlobal, idCmd.SelectedScrapers, "ID rows keep the batch-global scrapers so resolveScrapeInput reorders them")
+}
+
+// A manual URL input carrying a query token must be redacted from cmd.MovieID
+// (which surfaces in persisted job state, WebSocket events, and progress
+// messages) while cmd.RawInput keeps the raw URL so resolveScrapeInput/ScrapeURL
+// still see it. Regression guard for the buildScrapeCmd redaction seam.
+func TestBuildScrapeCmd_ManualURLInput_RedactsQueryFromMovieID(t *testing.T) {
+	const file = "/videos/ABC-001.mp4"
+	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
+
+	cmd := buildScrapeCmd(file, inputs, ScrapePhaseConfig{
+		RawInputOverride: map[string]string{file: "https://www.javbus.com/ABC-001?token=secret&sig=abc"},
+	})
+
+	assert.Equal(t, "https://www.javbus.com/ABC-001", cmd.MovieID, "MovieID must strip the query/fragment so tokens don't leak to persisted state/events")
+	assert.Equal(t, "https://www.javbus.com/ABC-001?token=secret&sig=abc", cmd.RawInput, "RawInput must stay unredacted so the scraper receives the real URL")
+	assert.Empty(t, cmd.SelectedScrapers, "URL rows bypass the batch-global scraper picker")
+}
+
+// A manual ID input is unaffected by redaction — RedactURLQuery passes plain
+// IDs (no scheme/host) through unchanged.
+func TestBuildScrapeCmd_ManualIDInput_RedactionIsNoOp(t *testing.T) {
+	const file = "/videos/ABC-001.mp4"
+	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
+
+	cmd := buildScrapeCmd(file, inputs, ScrapePhaseConfig{
+		RawInputOverride: map[string]string{file: "IPX-123"},
+	})
+	assert.Equal(t, "IPX-123", cmd.MovieID)
+	assert.Equal(t, "IPX-123", cmd.RawInput)
 }
 
 func TestBuildScrapeCmd_NoManualInputAutoIDsFromMatcher(t *testing.T) {

--- a/web/frontend/src/lib/api/types.test.ts
+++ b/web/frontend/src/lib/api/types.test.ts
@@ -21,6 +21,7 @@ import type {
 	TranslationConfig,
 	TranslationFieldsConfig,
 	ProxyProfile,
+	BatchScrapeRequest,
 } from './types';
 
 describe('types.ts has no unnecessary any', () => {
@@ -147,5 +148,29 @@ describe('types.ts has no unnecessary any', () => {
 		expect(nfo.enabled).toBe(true);
 		expect(metadata.translation?.provider).toBe('openai');
 		expect(db.type).toBe('sqlite');
+	});
+});
+
+describe('BatchScrapeRequest.manual_inputs wire contract', () => {
+	it('serializes per-file manual inputs under the snake_case manual_inputs key', () => {
+		const req: BatchScrapeRequest = {
+			files: ['/test/a.mp4', '/test/b.mp4'],
+			strict: false,
+			force: false,
+			manual_inputs: { '/test/a.mp4': 'IPX-123', '/test/b.mp4': 'https://example.com/v/456' },
+		};
+		const wire = JSON.stringify(req);
+		expect(wire).toContain('"manual_inputs"');
+		expect(wire).toContain('IPX-123');
+		const back = JSON.parse(wire) as BatchScrapeRequest;
+		expect(back.manual_inputs).toEqual({
+			'/test/a.mp4': 'IPX-123',
+			'/test/b.mp4': 'https://example.com/v/456',
+		});
+	});
+
+	it('omits manual_inputs when not set (existing callers unaffected)', () => {
+		const req: BatchScrapeRequest = { files: ['/test/a.mp4'], strict: false, force: false };
+		expect(JSON.stringify(req)).not.toContain('manual_inputs');
 	});
 });

--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -78,6 +78,7 @@ export interface BatchScrapeRequest {
 		| 'merge-arrays';
 	array_strategy?: 'merge' | 'replace';
 	operation_mode?: OperationMode; // Per-request override of config operation_mode
+	manual_inputs?: Record<string, string>; // Per-file manual input override keyed by file path; an ID scrapes as that ID (bypasses matcher), a URL scrapes with URL-compatible scrapers
 }
 
 export interface RescrapeRequest {

--- a/web/frontend/src/lib/stores/manual-inputs-session.ts
+++ b/web/frontend/src/lib/stores/manual-inputs-session.ts
@@ -1,23 +1,56 @@
-// Shared sessionStorage helpers for per-row manual inputs (D4b). Keyed by file
-// path so a Back round-trip to /browse preserves them; /browse "Clear All" and
-// /manual successful submit both clear the entry.
-export const MANUAL_INPUTS_KEY = 'javinizer_manual_inputs';
+// Shared sessionStorage helpers for per-row manual inputs (D4b). Persisted
+// entries are scoped to a batchKey derived from the file set, so a later
+// manual-scrape session can't silently reuse overrides from an abandoned
+// session when the same path reappears in a different batch. A back
+// round-trip to /browse preserves inputs for the SAME file set; /browse
+// "Clear All" and /manual successful submit both clear the batch's entry.
+export const MANUAL_INPUTS_KEY_PREFIX = 'javinizer_manual_inputs';
 
-export function loadManualInputs(): Record<string, string> {
+// batchKeyFromFiles derives a stable key from a file set so two sessions for
+// the same files share overrides, while a different batch can't reuse them.
+// This is a sessionStorage namespace, not a security boundary — a simple
+// non-crypto hash suffices.
+export function batchKeyFromFiles(files: string[]): string {
+	const sorted = [...files].sort();
+	let h = 0;
+	for (const f of sorted) {
+		for (let i = 0; i < f.length; i++) h = (Math.imul(31, h) + f.charCodeAt(i)) | 0;
+		h = Math.imul(31, h) | 0; // separator between paths
+	}
+	return (h >>> 0).toString(36);
+}
+
+function keyFor(batchKey: string): string {
+	return `${MANUAL_INPUTS_KEY_PREFIX}:${batchKey}`;
+}
+
+export function loadManualInputs(batchKey: string): Record<string, string> {
 	if (typeof sessionStorage === 'undefined') return {};
 	try {
-		return JSON.parse(sessionStorage.getItem(MANUAL_INPUTS_KEY) ?? '{}') as Record<string, string>;
+		return JSON.parse(sessionStorage.getItem(keyFor(batchKey)) ?? '{}') as Record<string, string>;
 	} catch {
 		return {};
 	}
 }
 
-export function persistManualInputs(map: Record<string, string>): void {
+export function persistManualInputs(batchKey: string, map: Record<string, string>): void {
 	if (typeof sessionStorage === 'undefined') return;
-	if (Object.keys(map).length > 0) sessionStorage.setItem(MANUAL_INPUTS_KEY, JSON.stringify(map));
-	else sessionStorage.removeItem(MANUAL_INPUTS_KEY);
+	const key = keyFor(batchKey);
+	if (Object.keys(map).length > 0) sessionStorage.setItem(key, JSON.stringify(map));
+	else sessionStorage.removeItem(key);
 }
 
-export function clearManualInputs(): void {
-	if (typeof sessionStorage !== 'undefined') sessionStorage.removeItem(MANUAL_INPUTS_KEY);
+// clearManualInputs drops a single batch's entry when given a batchKey, or all
+// manual-input entries when called without one (used by /browse "Clear All",
+// which discards the selection and any associated overrides).
+export function clearManualInputs(batchKey?: string): void {
+	if (typeof sessionStorage === 'undefined') return;
+	if (batchKey !== undefined) {
+		sessionStorage.removeItem(keyFor(batchKey));
+		return;
+	}
+	for (let i = sessionStorage.length - 1; i >= 0; i--) {
+		const k = sessionStorage.key(i);
+		if (k && k.startsWith(`${MANUAL_INPUTS_KEY_PREFIX}:`)) sessionStorage.removeItem(k);
+	}
 }

--- a/web/frontend/src/lib/stores/manual-inputs-session.ts
+++ b/web/frontend/src/lib/stores/manual-inputs-session.ts
@@ -1,0 +1,23 @@
+// Shared sessionStorage helpers for per-row manual inputs (D4b). Keyed by file
+// path so a Back round-trip to /browse preserves them; /browse "Clear All" and
+// /manual successful submit both clear the entry.
+export const MANUAL_INPUTS_KEY = 'javinizer_manual_inputs';
+
+export function loadManualInputs(): Record<string, string> {
+	if (typeof sessionStorage === 'undefined') return {};
+	try {
+		return JSON.parse(sessionStorage.getItem(MANUAL_INPUTS_KEY) ?? '{}') as Record<string, string>;
+	} catch {
+		return {};
+	}
+}
+
+export function persistManualInputs(map: Record<string, string>): void {
+	if (typeof sessionStorage === 'undefined') return;
+	if (Object.keys(map).length > 0) sessionStorage.setItem(MANUAL_INPUTS_KEY, JSON.stringify(map));
+	else sessionStorage.removeItem(MANUAL_INPUTS_KEY);
+}
+
+export function clearManualInputs(): void {
+	if (typeof sessionStorage !== 'undefined') sessionStorage.removeItem(MANUAL_INPUTS_KEY);
+}

--- a/web/frontend/src/lib/stores/pending-scrape.svelte.ts
+++ b/web/frontend/src/lib/stores/pending-scrape.svelte.ts
@@ -1,0 +1,78 @@
+import type { OperationMode } from '$lib/api/types';
+
+export type BrowseMode = 'scrape' | 'update';
+
+export type ScalarStrategy = 'prefer-nfo' | 'prefer-scraper' | 'preserve-existing' | 'fill-missing-only';
+export type ArrayStrategy = 'merge' | 'replace';
+
+// PendingScrape is the D4 snapshot carried from /browse to /manual: the
+// inherited globals needed to rebuild the BatchScrapeRequest. It carries the
+// DERIVED effectiveOperationMode + isInPlaceImplied (not the raw override) and
+// both browseMode + update (SageEagle must-fix #4: one ambiguous operationMode
+// can't reconstruct update:true, which would drop preset/strategies on /manual).
+// selectedScrapers is carried but only honored when showScraperSelector is true.
+export interface PendingScrape {
+	files: string[];
+	browseMode: BrowseMode;
+	update: boolean;
+	effectiveOperationMode: OperationMode;
+	isInPlaceImplied: boolean;
+	showScraperSelector: boolean;
+	destination: string;
+	selectedScrapers: string[];
+	force: boolean;
+	preset?: 'conservative' | 'gap-fill' | 'aggressive';
+	scalarStrategy?: ScalarStrategy;
+	arrayStrategy?: ArrayStrategy;
+}
+
+const STORAGE_KEY = 'javinizer_pending_scrape';
+
+// Module singleton (mirrors background-job.svelte.ts). On a page refresh the
+// module re-evaluates and state resets to null; getPendingScrape then hydrates
+// from sessionStorage so the /manual tracer survives the refresh.
+let state: PendingScrape | null = $state(null);
+
+function hydrate(): PendingScrape | null {
+	if (typeof sessionStorage === 'undefined') return null;
+	const raw = sessionStorage.getItem(STORAGE_KEY);
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as PendingScrape;
+	} catch {
+		sessionStorage.removeItem(STORAGE_KEY);
+		return null;
+	}
+}
+
+// buildPendingScrapeSnapshot derives the D4 snapshot from /browse state for
+// setPendingScrape before goto('/manual'). update is ALWAYS derived from
+// browseMode (SageEagle must-fix #4: one ambiguous operationMode can't
+// reconstruct update:true, which would drop preset/strategies on /manual),
+// so the caller never passes it.
+export function buildPendingScrapeSnapshot(
+	input: Omit<PendingScrape, 'update'>
+): PendingScrape {
+	return { ...input, update: input.browseMode === 'update' };
+}
+
+export function getPendingScrape(): PendingScrape | null {
+	if (state === null) {
+		state = hydrate();
+	}
+	return state;
+}
+
+export function setPendingScrape(snapshot: PendingScrape): void {
+	state = snapshot;
+	if (typeof sessionStorage !== 'undefined') {
+		sessionStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+	}
+}
+
+export function clearPendingScrape(): void {
+	state = null;
+	if (typeof sessionStorage !== 'undefined') {
+		sessionStorage.removeItem(STORAGE_KEY);
+	}
+}

--- a/web/frontend/src/lib/stores/pending-scrape.test.ts
+++ b/web/frontend/src/lib/stores/pending-scrape.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { PendingScrape } from './pending-scrape.svelte';
+
+function makeSnapshot(overrides: Partial<PendingScrape> = {}): PendingScrape {
+	return {
+		files: ['/a.mp4', '/b.mp4'],
+		browseMode: 'scrape',
+		update: false,
+		effectiveOperationMode: 'organize',
+		isInPlaceImplied: false,
+		showScraperSelector: true,
+		destination: '/out',
+		selectedScrapers: ['javdb', 'r18dev'],
+		force: true,
+		preset: 'gap-fill',
+		scalarStrategy: 'prefer-scraper',
+		arrayStrategy: 'replace',
+		...overrides
+	};
+}
+
+// loadStore returns a FRESH module instance (state re-inits to null) so a test
+// can simulate a page refresh by calling it twice: the first sets + serializes,
+// the second hydrates from sessionStorage.
+async function loadStore() {
+	vi.resetModules();
+	return await import('./pending-scrape.svelte');
+}
+
+describe('buildPendingScrapeSnapshot', () => {
+	it("derives update=true from browseMode 'update' (SageEagle must-fix #4)", async () => {
+		const s = await loadStore();
+		const snap = s.buildPendingScrapeSnapshot({
+			files: ['/a.mp4'],
+			browseMode: 'update',
+			effectiveOperationMode: 'in-place',
+			isInPlaceImplied: false,
+			showScraperSelector: false,
+			destination: '/out',
+			selectedScrapers: [],
+			force: false,
+			preset: 'gap-fill',
+			scalarStrategy: 'prefer-scraper',
+			arrayStrategy: 'replace'
+		});
+		expect(snap.update).toBe(true);
+		expect(snap.browseMode).toBe('update');
+	});
+
+	it("derives update=false from browseMode 'scrape'", async () => {
+		const s = await loadStore();
+		const snap = s.buildPendingScrapeSnapshot({
+			files: ['/a.mp4'],
+			browseMode: 'scrape',
+			effectiveOperationMode: 'organize',
+			isInPlaceImplied: false,
+			showScraperSelector: true,
+			destination: '/out',
+			selectedScrapers: ['javdb'],
+			force: true
+		});
+		expect(snap.update).toBe(false);
+		expect(snap.preset).toBeUndefined();
+	});
+
+	it('round-trips through the store (set snapshot → get)', async () => {
+		const s = await loadStore();
+		const snap = s.buildPendingScrapeSnapshot({
+			files: ['/a.mp4', '/b.mp4'],
+			browseMode: 'scrape',
+			effectiveOperationMode: 'organize',
+			isInPlaceImplied: true,
+			showScraperSelector: false,
+			destination: '/lib',
+			selectedScrapers: [],
+			force: false
+		});
+		s.setPendingScrape(snap);
+		expect(s.getPendingScrape()).toEqual(snap);
+	});
+});
+
+describe('pendingScrape store', () => {
+	beforeEach(() => {
+		if (typeof sessionStorage !== 'undefined') sessionStorage.clear();
+		vi.resetModules();
+	});
+
+	it('set → get returns the snapshot; clear → null (#5)', async () => {
+		const s = await loadStore();
+		const snap = makeSnapshot();
+		s.setPendingScrape(snap);
+		expect(s.getPendingScrape()).toEqual(snap);
+		s.clearPendingScrape();
+		expect(s.getPendingScrape()).toBeNull();
+	});
+
+	it('survives a simulated refresh (serialize on set / hydrate on get from sessionStorage) (#6)', async () => {
+		const before = await loadStore();
+		before.setPendingScrape(makeSnapshot());
+		// Simulate refresh: fresh module instance, in-memory state resets to
+		// null, sessionStorage retains the serialized snapshot.
+		const after = await loadStore();
+		expect(after.getPendingScrape()).toEqual(makeSnapshot());
+	});
+
+	it('clear removes the sessionStorage entry so a refresh does not resurrect (#6b)', async () => {
+		const before = await loadStore();
+		before.setPendingScrape(makeSnapshot());
+		before.clearPendingScrape();
+		const after = await loadStore();
+		expect(after.getPendingScrape()).toBeNull();
+	});
+
+	it('round-trips the full D4 type (#7)', async () => {
+		const s = await loadStore();
+		const snap = makeSnapshot({
+			browseMode: 'update',
+			update: true,
+			effectiveOperationMode: 'in-place-norenamefolder',
+			isInPlaceImplied: true,
+			destination: '/library'
+		});
+		s.setPendingScrape(snap);
+		expect(s.getPendingScrape()).toEqual(snap);
+	});
+
+	it('omits selectedScrapers cleanly when showScraperSelector is false', async () => {
+		const s = await loadStore();
+		const snap = makeSnapshot({ showScraperSelector: false, selectedScrapers: [] });
+		s.setPendingScrape(snap);
+		expect(s.getPendingScrape()).toEqual(snap);
+	});
+});

--- a/web/frontend/src/routes/browse/+page.svelte
+++ b/web/frontend/src/routes/browse/+page.svelte
@@ -343,7 +343,7 @@
 		goto('/manual');
 	}
 
-async function startBatchScrape() {
+	async function startBatchScrape() {
 		if (selectedFiles.length === 0) return;
 
 		const isUpdateMode = operationMode === 'update';

--- a/web/frontend/src/routes/browse/+page.svelte
+++ b/web/frontend/src/routes/browse/+page.svelte
@@ -117,9 +117,9 @@
 		if (scrapeStateHydrated) return;
 		scrapeStateHydrated = true;
 		if (typeof sessionStorage === 'undefined') return;
-		const raw = sessionStorage.getItem(STORAGE_KEY_SCRAPE_STATE);
-		if (!raw) return;
 		try {
+			const raw = sessionStorage.getItem(STORAGE_KEY_SCRAPE_STATE);
+			if (!raw) return;
 			const saved = JSON.parse(raw) as Partial<BrowseScrapeState>;
 			if (Array.isArray(saved.selectedFiles)) selectedFiles = saved.selectedFiles;
 			if (saved.operationMode === 'scrape' || saved.operationMode === 'update') operationMode = saved.operationMode;
@@ -127,9 +127,17 @@
 			if (typeof saved.operationModeOverrideTouched === 'boolean') operationModeOverrideTouched = saved.operationModeOverrideTouched;
 			if (typeof saved.forceRefresh === 'boolean') forceRefresh = saved.forceRefresh;
 			if (typeof saved.showScraperSelector === 'boolean') showScraperSelector = saved.showScraperSelector;
-			if (Array.isArray(saved.selectedScrapers) && saved.selectedScrapers.length > 0) {
+			if (
+				Array.isArray(saved.selectedScrapers) &&
+				saved.selectedScrapers.every((s) => typeof s === 'string')
+			) {
 				selectedScrapers = saved.selectedScrapers;
-				scrapersInitialized = true;
+				// A saved empty array is a deliberate user choice (no scrapers);
+				// only re-run the default “all enabled” initializer when the
+				// saved value is truly absent.
+				if (saved.showScraperSelector || saved.selectedScrapers.length > 0) {
+					scrapersInitialized = true;
+				}
 			}
 			if (saved.selectedPreset !== undefined) selectedPreset = saved.selectedPreset;
 			if (saved.scalarStrategy) scalarStrategy = saved.scalarStrategy;
@@ -154,8 +162,16 @@
 			arrayStrategy,
 			manualScrapeMode
 		};
-		sessionStorage.setItem(STORAGE_KEY_SCRAPE_STATE, JSON.stringify(state));
+		try {
+			sessionStorage.setItem(STORAGE_KEY_SCRAPE_STATE, JSON.stringify(state));
+		} catch {}
 	});
+
+	function clearSelection() {
+		selectedFiles = [];
+		clearPendingScrape();
+		clearManualInputs();
+	}
 
 	function getSettingsOperationMode(): OperationMode {
 		if (config) {
@@ -332,7 +348,7 @@
 				effectiveOperationMode: effectiveOperationMode,
 				isInPlaceImplied: isInPlaceImplied,
 				showScraperSelector: showScraperSelector,
-				destination: destinationPath,
+				destination: operationMode === 'update' ? '' : destinationPath,
 				selectedScrapers: showScraperSelector ? selectedScrapers : [],
 				force: forceRefresh,
 				preset: operationMode === 'update' ? (selectedPreset as 'conservative' | 'gap-fill' | 'aggressive' | undefined) : undefined,
@@ -340,7 +356,7 @@
 				arrayStrategy: operationMode === 'update' ? arrayStrategy : undefined
 			})
 		);
-		goto('/manual');
+		void goto('/manual');
 	}
 
 	async function startBatchScrape() {
@@ -678,9 +694,7 @@
 						<Button
 							variant="ghost"
 							size="sm"
-							onclick={() => {
-								selectedFiles = [];
-							}}
+								onclick={clearSelection}
 						>
 							{#snippet children()}
 								Clear All
@@ -835,7 +849,7 @@
 							{selectedFiles.length} file{selectedFiles.length !== 1 ? 's' : ''} selected
 						</span>
 						<button
-							onclick={() => { selectedFiles = []; clearPendingScrape(); clearManualInputs(); }}
+									onclick={clearSelection}
 							class="text-xs text-muted-foreground hover:text-destructive transition-colors"
 						>
 							(clear)

--- a/web/frontend/src/routes/browse/+page.svelte
+++ b/web/frontend/src/routes/browse/+page.svelte
@@ -13,6 +13,13 @@
 	import { apiClient } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast';
 	import { startJob } from '$lib/stores/background-job.svelte';
+	import { goto } from '$app/navigation';
+	import {
+		setPendingScrape,
+		clearPendingScrape,
+		buildPendingScrapeSnapshot
+	} from '$lib/stores/pending-scrape.svelte';
+	import { clearManualInputs } from '$lib/stores/manual-inputs-session';
 	import { createConfigQuery, createScrapersQuery } from '$lib/query/queries';
 	import { Play, FolderOutput, FolderOpen, FileEdit, FileText, RotateCcw, LoaderCircle, RefreshCw, Settings, ChevronUp, ChevronDown, X, Scan } from 'lucide-svelte';
 	import type { Scraper, FileInfo, Config } from '$lib/api/types';
@@ -82,6 +89,73 @@
 	let showOptionsPanel = $state(false);  // Expandable options panel in sticky bar
 	let operationModeOverride: OperationMode = $state('organize');
 	let operationModeOverrideTouched: boolean = $state(false);
+	let manualScrapeMode: boolean = $state(false);
+
+	// D4: persist /browse scrape state to sessionStorage + hydrate on mount so a
+	// Back round-trip from /manual preserves selection + globals. When hydrated
+	// selectedScrapers is non-empty, scrapersInitialized is locked so the
+	// all-enabled re-init on remount is skipped.
+	const STORAGE_KEY_SCRAPE_STATE = 'javinizer_browse_scrape_state';
+
+	interface BrowseScrapeState {
+		selectedFiles: string[];
+		operationMode: BrowseMode;
+		operationModeOverride: OperationMode;
+		operationModeOverrideTouched: boolean;
+		forceRefresh: boolean;
+		showScraperSelector: boolean;
+		selectedScrapers: string[];
+		selectedPreset: string | undefined;
+		scalarStrategy: ScalarStrategy;
+		arrayStrategy: ArrayStrategy;
+		manualScrapeMode: boolean;
+	}
+
+	let scrapeStateHydrated = $state(false);
+
+	$effect(() => {
+		if (scrapeStateHydrated) return;
+		scrapeStateHydrated = true;
+		if (typeof sessionStorage === 'undefined') return;
+		const raw = sessionStorage.getItem(STORAGE_KEY_SCRAPE_STATE);
+		if (!raw) return;
+		try {
+			const saved = JSON.parse(raw) as Partial<BrowseScrapeState>;
+			if (Array.isArray(saved.selectedFiles)) selectedFiles = saved.selectedFiles;
+			if (saved.operationMode === 'scrape' || saved.operationMode === 'update') operationMode = saved.operationMode;
+			if (saved.operationModeOverride) operationModeOverride = saved.operationModeOverride;
+			if (typeof saved.operationModeOverrideTouched === 'boolean') operationModeOverrideTouched = saved.operationModeOverrideTouched;
+			if (typeof saved.forceRefresh === 'boolean') forceRefresh = saved.forceRefresh;
+			if (typeof saved.showScraperSelector === 'boolean') showScraperSelector = saved.showScraperSelector;
+			if (Array.isArray(saved.selectedScrapers) && saved.selectedScrapers.length > 0) {
+				selectedScrapers = saved.selectedScrapers;
+				scrapersInitialized = true;
+			}
+			if (saved.selectedPreset !== undefined) selectedPreset = saved.selectedPreset;
+			if (saved.scalarStrategy) scalarStrategy = saved.scalarStrategy;
+			if (saved.arrayStrategy) arrayStrategy = saved.arrayStrategy;
+			if (typeof saved.manualScrapeMode === 'boolean') manualScrapeMode = saved.manualScrapeMode;
+		} catch {}
+	});
+
+	$effect(() => {
+		if (!scrapeStateHydrated) return;
+		if (typeof sessionStorage === 'undefined') return;
+		const state: BrowseScrapeState = {
+			selectedFiles,
+			operationMode,
+			operationModeOverride,
+			operationModeOverrideTouched,
+			forceRefresh,
+			showScraperSelector,
+			selectedScrapers,
+			selectedPreset,
+			scalarStrategy,
+			arrayStrategy,
+			manualScrapeMode
+		};
+		sessionStorage.setItem(STORAGE_KEY_SCRAPE_STATE, JSON.stringify(state));
+	});
 
 	function getSettingsOperationMode(): OperationMode {
 		if (config) {
@@ -249,7 +323,27 @@
 		}
 	}
 
-	async function startBatchScrape() {
+	function continueToManual() {
+		if (selectedFiles.length === 0) return;
+		setPendingScrape(
+			buildPendingScrapeSnapshot({
+				files: selectedFiles,
+				browseMode: operationMode,
+				effectiveOperationMode: effectiveOperationMode,
+				isInPlaceImplied: isInPlaceImplied,
+				showScraperSelector: showScraperSelector,
+				destination: destinationPath,
+				selectedScrapers: showScraperSelector ? selectedScrapers : [],
+				force: forceRefresh,
+				preset: operationMode === 'update' ? (selectedPreset as 'conservative' | 'gap-fill' | 'aggressive' | undefined) : undefined,
+				scalarStrategy: operationMode === 'update' ? scalarStrategy : undefined,
+				arrayStrategy: operationMode === 'update' ? arrayStrategy : undefined
+			})
+		);
+		goto('/manual');
+	}
+
+async function startBatchScrape() {
 		if (selectedFiles.length === 0) return;
 
 		const isUpdateMode = operationMode === 'update';
@@ -703,6 +797,20 @@
 						</div>
 					</label>
 
+					<label
+						class="flex items-center gap-3 p-3 rounded-lg border border-border bg-background hover:bg-accent/50 cursor-pointer transition-colors"
+					>
+						<input
+							type="checkbox"
+							bind:checked={manualScrapeMode}
+							class="h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-primary"
+						/>
+						<div class="flex-1">
+							<span class="text-sm font-medium">Manual Scrape</span>
+							<p class="text-xs text-muted-foreground">Review &amp; override IDs/URLs per file before scraping</p>
+						</div>
+					</label>
+
 				</div>
 
 				<!-- Scraper Selector (if enabled) -->
@@ -727,7 +835,7 @@
 							{selectedFiles.length} file{selectedFiles.length !== 1 ? 's' : ''} selected
 						</span>
 						<button
-							onclick={() => selectedFiles = []}
+							onclick={() => { selectedFiles = []; clearPendingScrape(); clearManualInputs(); }}
 							class="text-xs text-muted-foreground hover:text-destructive transition-colors"
 						>
 							(clear)
@@ -789,8 +897,11 @@
 				</Button>
 
 				<!-- Active options indicators -->
-				{#if forceRefresh || showScraperSelector}
+				{#if manualScrapeMode || forceRefresh || showScraperSelector}
 					<div class="hidden sm:flex items-center gap-1 text-xs">
+						{#if manualScrapeMode}
+							<span class="px-2 py-0.5 bg-primary/10 text-primary rounded">Manual</span>
+						{/if}
 						{#if forceRefresh}
 							<span class="px-2 py-0.5 bg-primary/10 text-primary rounded">Force</span>
 						{/if}
@@ -801,16 +912,20 @@
 				{/if}
 
 				<!-- Action button -->
-				<Button onclick={startBatchScrape} disabled={selectedFiles.length === 0 || scraping}>
+				<Button onclick={manualScrapeMode ? continueToManual : startBatchScrape} disabled={selectedFiles.length === 0 || scraping}>
 					{#snippet children()}
-						{#if scraping}
+						{#if manualScrapeMode && !scraping}
+							<FileEdit class="h-4 w-4 mr-2" />
+						{:else if scraping}
 							<LoaderCircle class="h-4 w-4 mr-2 animate-spin" />
 						{:else if operationMode === 'update'}
 							<RefreshCw class="h-4 w-4 mr-2" />
 						{:else}
 							<Play class="h-4 w-4 mr-2" />
 						{/if}
-						{#if scraping}
+						{#if manualScrapeMode && !scraping}
+							Continue to manual review
+						{:else if scraping}
 							Starting...
 						{:else if operationMode === 'update'}
 							Update {selectedFiles.length} File{selectedFiles.length !== 1 ? 's' : ''}

--- a/web/frontend/src/routes/browse/page.test.ts
+++ b/web/frontend/src/routes/browse/page.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterAll, beforeAll } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import { QueryClient } from '@tanstack/svelte-query';
+import QueryClientWrapper from '$lib/components/QueryClientWrapper.svelte';
+import BrowsePage from './+page.svelte';
+import { goto as mockGoto } from '$app/navigation';
+
+// STORAGE_KEY must mirror +page.svelte exactly. A Back round-trip from /manual
+// preserves /browse selection because this snapshot is re-read on mount.
+const STORAGE_KEY_SCRAPE_STATE = 'javinizer_browse_scrape_state';
+
+// This project's jsdom env does not expose localStorage/sessionStorage on the
+// global scope, but +page.svelte reads bare `localStorage`/`sessionStorage`
+// without a typeof guard. Install a minimal Map-backed Storage shim so the
+// component's $effects and the test's seed/read both work.
+function createStorage(): Storage {
+	let store = new Map<string, string>();
+	return {
+		get length() { return store.size; },
+		clear: () => { store.clear(); },
+		getItem: (k: string) => (store.has(k) ? store.get(k) as string : null),
+		key: (i: number) => Array.from(store.keys())[i] ?? null,
+		removeItem: (k: string) => { store.delete(k); },
+		setItem: (k: string, v: string) => { store.set(k, String(v)); }
+	};
+}
+
+const savedSession = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+const savedLocal = (globalThis as { localStorage?: Storage }).localStorage;
+
+beforeAll(() => {
+	(globalThis as { sessionStorage?: Storage }).sessionStorage = createStorage();
+	(globalThis as { localStorage?: Storage }).localStorage = createStorage();
+});
+
+// jsdom lacks the Web Animations API; +page.svelte uses animate:flip and
+// transition:fade/slide on mount-rendered blocks, so polyfill animate().
+const savedAnimate = window.Element.prototype.animate;
+window.Element.prototype.animate = function () {
+	return {
+		onfinish: null as ((this: unknown, ev: AnimationPlaybackEvent) => unknown) | null,
+		oncancel: null as ((this: unknown, ev: AnimationPlaybackEvent) => unknown) | null,
+		cancel() {},
+		finish() {},
+		play() {},
+		pause() {},
+		currentTime: 0
+	} as unknown as Animation;
+};
+
+afterAll(() => {
+	window.Element.prototype.animate = savedAnimate;
+	(globalThis as { sessionStorage?: Storage }).sessionStorage = savedSession;
+	(globalThis as { localStorage?: Storage }).localStorage = savedLocal;
+});
+
+vi.mock('$lib/api/client', () => ({
+	apiClient: {
+		getConfig: vi.fn(),
+		getScrapers: vi.fn(),
+		getCurrentWorkingDirectory: vi.fn(),
+		browse: vi.fn(),
+		batchScrape: vi.fn()
+	}
+}));
+
+vi.mock('$lib/stores/background-job.svelte', () => ({
+	startJob: vi.fn()
+}));
+
+// Spies are created inside the factory (hoisting-safe) and captured below via
+// dynamic import, matching the manual/page.test.ts pattern.
+vi.mock('$lib/stores/pending-scrape.svelte', () => ({
+	setPendingScrape: vi.fn(),
+	clearPendingScrape: vi.fn(),
+	buildPendingScrapeSnapshot: vi.fn((input: Record<string, unknown>) => ({ ...input, update: false }))
+}));
+
+const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+const mod = await import('$lib/api/client');
+const apiClient = vi.mocked(mod.apiClient);
+const pending = await import('$lib/stores/pending-scrape.svelte');
+const pendingSet = vi.mocked(pending.setPendingScrape);
+
+function mockScraper(name: string, enabled = true) {
+	return {
+		name,
+		display_title: name,
+		enabled
+	};
+}
+
+function mockConfig() {
+	return {
+		output: {
+			folder_format: '',
+			file_format: '',
+			subfolder_format: [],
+			operation_mode: 'organize'
+		},
+		api: { security: { allowed_directories: [] } }
+	};
+}
+
+function mockBrowseResponse(path: string) {
+	return {
+		current_path: path,
+		parent_path: '',
+		items: [
+			{ name: 'a.mp4', path: `${path}/a.mp4`, is_dir: false, size: 0, mod_time: '2024-01-01T00:00:00Z' },
+			{ name: 'b.mp4', path: `${path}/b.mp4`, is_dir: false, size: 0, mod_time: '2024-01-01T00:00:00Z' }
+		]
+	};
+}
+
+function renderPage() {
+	return render(BrowsePage, {}, {
+		wrapper: QueryClientWrapper,
+		wrapperProps: { client }
+	});
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	apiClient.getConfig.mockResolvedValue(mockConfig() as never);
+	apiClient.getScrapers.mockResolvedValue([
+		mockScraper('javbus', true),
+		mockScraper('javdb', false)
+	] as never);
+	apiClient.getCurrentWorkingDirectory.mockResolvedValue({ path: '/library' } as never);
+	apiClient.browse.mockResolvedValue(mockBrowseResponse('/library') as never);
+	apiClient.batchScrape.mockResolvedValue({ job_id: 'job-1' } as never);
+	sessionStorage.clear();
+	localStorage.clear();
+});
+
+describe('/browse D4 — sessionStorage hydrate + Manual Scrape checkbox', () => {
+	it('4.5 (P0-5): hydrates selectedFiles + globals from sessionStorage on mount (Back round-trip preserves selection)', async () => {
+		const seed = {
+			selectedFiles: ['/library/kept-a.mp4', '/library/kept-b.mp4'],
+			operationMode: 'scrape',
+			operationModeOverride: 'organize',
+			operationModeOverrideTouched: false,
+			forceRefresh: false,
+			showScraperSelector: true,
+			selectedScrapers: ['javbus'],
+			selectedPreset: undefined,
+			scalarStrategy: 'prefer-nfo',
+			arrayStrategy: 'merge',
+			manualScrapeMode: false
+		};
+		sessionStorage.setItem(STORAGE_KEY_SCRAPE_STATE, JSON.stringify(seed));
+
+		const { findByText, getByText } = renderPage();
+
+		// The hydrate $effect restores selectedFiles, so the "Selected Files"
+		// card renders the pre-seeded paths — a Back round-trip preserves them.
+		await findByText('2 Files Selected for Scraping');
+		expect(getByText('kept-a.mp4')).toBeTruthy();
+		expect(getByText('kept-b.mp4')).toBeTruthy();
+
+		// manualScrapeMode:false ⇒ primary action stays the Scrape path.
+		expect(getByText(/Scrape 2 Files/)).toBeTruthy();
+		expect(pendingSet).not.toHaveBeenCalled();
+	});
+
+	it('4.6 (P1-26): toggling "Manual Scrape" flips the primary action, snapshots manualScrapeMode=true, and goto(\'/manual\')', async () => {
+		// Pre-seed a single selection so the action button is enabled.
+		sessionStorage.setItem(
+			STORAGE_KEY_SCRAPE_STATE,
+			JSON.stringify({
+				selectedFiles: ['/library/pick.mp4'],
+				operationMode: 'scrape',
+				operationModeOverride: 'organize',
+				operationModeOverrideTouched: false,
+				forceRefresh: false,
+				showScraperSelector: false,
+				selectedScrapers: [],
+				selectedPreset: undefined,
+				scalarStrategy: 'prefer-nfo',
+				arrayStrategy: 'merge',
+				manualScrapeMode: false
+			})
+		);
+
+		const { findByText, getByLabelText, getByText, getByRole } = renderPage();
+		await findByText('pick.mp4');
+
+		// Primary action is the Scrape path before toggling.
+		expect(getByText(/Scrape 1 File/)).toBeTruthy();
+
+		// Open the Options panel so the Manual Scrape checkbox is rendered.
+		const optionsBtn = getByRole('button', { name: /Options/ });
+		await fireEvent.click(optionsBtn);
+
+		// Toggle the Manual Scrape checkbox on. Two option checkboxes share the
+		// "Manual Scr..." prefix, so disambiguate by the unique description in the
+		// checkbox's accessible name.
+		const manualCheckbox = getByLabelText(/Review & override IDs/) as HTMLInputElement;
+		expect(manualCheckbox.checked).toBe(false);
+		await fireEvent.click(manualCheckbox);
+		expect(manualCheckbox.checked).toBe(true);
+
+		// (a) Primary action flips to the manual path.
+		expect(getByText('Continue to manual review')).toBeTruthy();
+		// A "Manual" active-option indicator badge appears.
+		expect(getByText('Manual')).toBeTruthy();
+
+		// (b) The persist $event wrote a snapshot with manualScrapeMode=true.
+		const raw = sessionStorage.getItem(STORAGE_KEY_SCRAPE_STATE);
+		expect(raw).not.toBeNull();
+		const snapshot = JSON.parse(raw as string);
+		expect(snapshot.manualScrapeMode).toBe(true);
+		expect(snapshot.selectedFiles).toEqual(['/library/pick.mp4']);
+
+		// (c) Clicking the primary action calls goto('/manual') with a snapshot.
+		const actionBtn = getByText('Continue to manual review');
+		await fireEvent.click(actionBtn);
+		await waitFor(() => expect(pendingSet).toHaveBeenCalledTimes(1));
+		expect(mockGoto).toHaveBeenCalledWith('/manual');
+	});
+});

--- a/web/frontend/src/routes/manual/+page.svelte
+++ b/web/frontend/src/routes/manual/+page.svelte
@@ -17,7 +17,7 @@
 	} from 'lucide-svelte';
 	import { apiClient } from '$lib/api/client';
 	import { startJob } from '$lib/stores/background-job.svelte';
-	import { getPendingScrape, clearPendingScrape } from '$lib/stores/pending-scrape.svelte';
+	import { getPendingScrape, setPendingScrape, clearPendingScrape } from '$lib/stores/pending-scrape.svelte';
 	import type { PendingScrape } from '$lib/stores/pending-scrape.svelte';
 	import {
 		buildManualScrapeRequest,
@@ -142,6 +142,16 @@
 			rows.map((r) => r.filePath)
 		);
 		persistManualInputs(map);
+	});
+
+	// Persist inherited-setting edits (operation mode, destination, scrapers,
+	// force, update/strategy) back to the pending-scrape store so a refresh on
+	// /manual re-hydrates the user's edits, not the original /browse snapshot.
+	// Reads `snapshot` (local $state) and writes to the store (sessionStorage +
+	// module state) — the store's state is not read here, so no loop.
+	$effect(() => {
+		if (!snapshot) return;
+		setPendingScrape(snapshot);
 	});
 
 	function removeRow(idx: number) {

--- a/web/frontend/src/routes/manual/+page.svelte
+++ b/web/frontend/src/routes/manual/+page.svelte
@@ -29,7 +29,8 @@
 	import {
 		loadManualInputs,
 		persistManualInputs,
-		clearManualInputs
+		clearManualInputs,
+		batchKeyFromFiles
 	} from '$lib/stores/manual-inputs-session';
 	import Card from '$lib/components/ui/Card.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
@@ -41,6 +42,9 @@
 
 	let snapshot: PendingScrape | null = $state(null);
 	let rows: ManualRow[] = $state([]);
+	// Fixed at mount from the initial file set so edits/removals don't rekey
+	// the persisted manual inputs mid-session.
+	let batchKey = '';
 	let submitting = $state(false);
 	let errorMsg = $state<string | null>(null);
 	let showScraperModal = $state(false);
@@ -126,22 +130,23 @@
 	onMount(() => {
 		const snap = getPendingScrape();
 		if (!snap) {
-			goto('/browse', { replaceState: true });
+			void goto('/browse', { replaceState: true });
 			return;
 		}
 		snapshot = snap;
-		const stored = loadManualInputs();
+		batchKey = batchKeyFromFiles(snap.files);
+		const stored = loadManualInputs(batchKey);
 		const merged = mergeManualInputs(stored, snap.files);
 		rows = snap.files.map((f) => ({ filePath: f, input: merged[f] ?? '' }));
 	});
 
 	$effect(() => {
-		if (!snapshot) return;
+		if (!snapshot || !batchKey) return;
 		const map = mergeManualInputs(
 			Object.fromEntries(rows.map((r) => [r.filePath, r.input])),
 			rows.map((r) => r.filePath)
 		);
-		persistManualInputs(map);
+		persistManualInputs(batchKey, map);
 	});
 
 	// Persist inherited-setting edits (operation mode, destination, scrapers,
@@ -156,6 +161,12 @@
 
 	function removeRow(idx: number) {
 		rows = rows.filter((_, i) => i !== idx);
+		if (snapshot) {
+			// Keep snapshot.files in sync with the visible rows so refresh
+			// recovery (which rebuilds from snapshot.files) doesn't restore a
+			// removed file, and the persisted pending-scrape stays consistent.
+			snapshot = { ...snapshot, files: rows.map((row) => row.filePath) };
+		}
 	}
 
 	function clearAllOverrides() {
@@ -182,7 +193,7 @@
 			await queryClient.invalidateQueries({ queryKey: ['batch-jobs'] });
 			clearPendingScrape();
 			rows = [];
-			clearManualInputs();
+			clearManualInputs(batchKey);
 		} catch (e) {
 			errorMsg = e instanceof Error ? e.message : 'Failed to start manual scrape';
 		} finally {
@@ -204,7 +215,7 @@
 						Review each file and override its ID or URL before scraping.
 					</p>
 				</div>
-				<Button variant="ghost" size="sm" onclick={() => goto('/browse')}>
+				<Button variant="ghost" size="sm" onclick={() => void goto('/browse')}>
 					{#snippet children()}
 						<ArrowLeft class="h-4 w-4" aria-hidden="true" />
 						Back to browse

--- a/web/frontend/src/routes/manual/+page.svelte
+++ b/web/frontend/src/routes/manual/+page.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { useQueryClient } from '@tanstack/svelte-query';
+	import { apiClient } from '$lib/api/client';
+	import { startJob } from '$lib/stores/background-job.svelte';
+	import { getPendingScrape, clearPendingScrape } from '$lib/stores/pending-scrape.svelte';
+	import type { PendingScrape } from '$lib/stores/pending-scrape.svelte';
+	import {
+		buildManualScrapeRequest,
+		classifyInput,
+		mergeManualInputs
+	} from './logic/build-manual-scrape-request';
+	import type { ManualRow } from './logic/build-manual-scrape-request';
+	import type { BatchScrapeResponse } from '$lib/api/types';
+	import {
+		loadManualInputs,
+		persistManualInputs,
+		clearManualInputs
+	} from '$lib/stores/manual-inputs-session';
+
+	let snapshot: PendingScrape | null = $state(null);
+	let rows: ManualRow[] = $state([]);
+	let submitting = $state(false);
+	let errorMsg = $state<string | null>(null);
+	const queryClient = useQueryClient();
+
+	function badgeLabel(input: string): string {
+		switch (classifyInput(input)) {
+			case 'manual-id':
+				return 'Manual · ID';
+			case 'manual-url':
+				return 'Manual · URL (scraper auto-filtered)';
+			default:
+				return 'Auto';
+		}
+	}
+
+	onMount(() => {
+		const snap = getPendingScrape();
+		if (!snap) {
+			goto('/browse', { replaceState: true });
+			return;
+		}
+		snapshot = snap;
+		const stored = loadManualInputs();
+		const merged = mergeManualInputs(stored, snap.files);
+		rows = snap.files.map((f) => ({ filePath: f, input: merged[f] ?? '' }));
+	});
+
+	// Persist per-row inputs on every change (typing / remove / clear) so a Back
+	// round-trip to /browse preserves them (D4b: merge keyed by path, never
+	// blind-overwrite — re-advance hydrates via mergeManualInputs above).
+	$effect(() => {
+		if (!snapshot) return;
+		const map = mergeManualInputs(
+			Object.fromEntries(rows.map((r) => [r.filePath, r.input])),
+			rows.map((r) => r.filePath)
+		);
+		persistManualInputs(map);
+	});
+
+	function removeRow(idx: number) {
+		rows = rows.filter((_, i) => i !== idx);
+	}
+
+	function clearAllOverrides() {
+		rows = rows.map((r) => ({ ...r, input: '' }));
+	}
+
+	async function submit() {
+		if (!snapshot || submitting) return;
+		submitting = true;
+		errorMsg = null;
+		try {
+			const req = buildManualScrapeRequest(rows, {
+				destination: snapshot.destination.trim() || undefined,
+				operation_mode: snapshot.effectiveOperationMode,
+				selected_scrapers: snapshot.showScraperSelector ? snapshot.selectedScrapers : undefined,
+				force: snapshot.force,
+				preset: snapshot.update ? snapshot.preset : undefined,
+				scalar_strategy: snapshot.update ? snapshot.scalarStrategy : undefined,
+				array_strategy: snapshot.update ? snapshot.arrayStrategy : undefined,
+				update: snapshot.update
+			});
+			const res: BatchScrapeResponse = await apiClient.batchScrape(req);
+			startJob(res.job_id);
+			await queryClient.invalidateQueries({ queryKey: ['batch-jobs'] });
+			clearPendingScrape();
+			rows = [];
+			clearManualInputs();
+		} catch (e) {
+			errorMsg = e instanceof Error ? e.message : 'Failed to start manual scrape';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head><title>Manual Scrape</title></svelte:head>
+
+{#if snapshot}
+	<div class="mx-auto max-w-4xl p-6 space-y-6">
+		<div class="flex items-center justify-between">
+			<h1 class="text-2xl font-semibold">Manual Scrape</h1>
+			<button class="text-sm text-muted-foreground hover:text-foreground" onclick={() => goto('/browse')}>
+				← Back to browse
+			</button>
+		</div>
+
+		<!-- Read-only summary of inherited globals (D6) -->
+		<dl class="rounded-lg border border-border p-4 text-sm space-y-1">
+			<div class="flex justify-between"><dt class="text-muted-foreground">Mode</dt>
+				<dd class="font-medium">{snapshot.update ? 'Update Metadata' : 'Scrape & Organize'}</dd></div>
+			<div class="flex justify-between"><dt class="text-muted-foreground">Operation</dt>
+				<dd class="font-medium">{snapshot.effectiveOperationMode}</dd></div>
+			{#if !snapshot.update}
+				<div class="flex justify-between"><dt class="text-muted-foreground">Destination</dt>
+					<dd class="font-medium">{snapshot.destination || '(in place)'}</dd></div>
+			{/if}
+			<div class="flex justify-between"><dt class="text-muted-foreground">Scrapers</dt>
+				<dd class="font-medium">
+					{#if snapshot.showScraperSelector}{snapshot.selectedScrapers.join(', ')}
+					{:else}All enabled{/if}
+				</dd></div>
+			{#if snapshot.update}
+				<div class="flex justify-between"><dt class="text-muted-foreground">Preset</dt>
+					<dd class="font-medium">{snapshot.preset ?? '—'}</dd></div>
+				<div class="flex justify-between"><dt class="text-muted-foreground">Strategies</dt>
+					<dd class="font-medium">{snapshot.scalarStrategy ?? '—'} / {snapshot.arrayStrategy ?? '—'}</dd></div>
+			{/if}
+			<div class="flex justify-between"><dt class="text-muted-foreground">Force refresh</dt>
+				<dd class="font-medium">{snapshot.force ? 'on' : 'off'}</dd></div>
+		</dl>
+
+		{#if errorMsg}
+			<p class="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">{errorMsg}</p>
+		{/if}
+
+		<div class="space-y-2">
+			<div class="flex items-center justify-between">
+				<h2 class="font-medium">Files ({rows.length})</h2>
+				{#if rows.some((r) => r.input.trim() !== '')}
+					<button class="text-sm text-muted-foreground hover:text-foreground" onclick={clearAllOverrides}>
+						Clear all overrides
+					</button>
+				{/if}
+			</div>
+			{#each rows as row, i (row.filePath)}
+				<div class="flex items-center gap-2 rounded-lg border border-border p-2">
+					<span class="min-w-0 flex-1 truncate text-sm" title={row.filePath}>{row.filePath}</span>
+					<input
+						class="w-64 rounded border border-border px-2 py-1 text-sm"
+						placeholder="Auto — type ID or URL to override"
+						aria-label="Manual input for {row.filePath}"
+						bind:value={row.input}
+					/>
+					<span class="w-44 text-xs text-muted-foreground" role="status" aria-live="polite">
+						{badgeLabel(row.input)}
+					</span>
+					<button
+						class="text-xs text-muted-foreground hover:text-destructive"
+						aria-label="Remove {row.filePath} from batch"
+						onclick={() => removeRow(i)}
+					>Remove from batch</button>
+				</div>
+			{/each}
+		</div>
+
+		<button
+			class="w-full rounded-lg bg-primary px-4 py-2 text-primary-foreground disabled:opacity-50"
+			disabled={submitting || rows.length === 0}
+			onclick={submit}
+		>
+			{submitting ? 'Starting…' : 'Start manual scrape'}
+		</button>
+	</div>
+{/if}

--- a/web/frontend/src/routes/manual/+page.svelte
+++ b/web/frontend/src/routes/manual/+page.svelte
@@ -2,6 +2,19 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { useQueryClient } from '@tanstack/svelte-query';
+	import {
+		ArrowLeft,
+		FileText,
+		Eraser,
+		Trash2,
+		Scan,
+		LoaderCircle,
+		AlertTriangle,
+		Hash,
+		Globe,
+		Sparkles,
+		X
+	} from 'lucide-svelte';
 	import { apiClient } from '$lib/api/client';
 	import { startJob } from '$lib/stores/background-job.svelte';
 	import { getPendingScrape, clearPendingScrape } from '$lib/stores/pending-scrape.svelte';
@@ -18,22 +31,96 @@
 		persistManualInputs,
 		clearManualInputs
 	} from '$lib/stores/manual-inputs-session';
+	import Card from '$lib/components/ui/Card.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ScraperSelector from '$lib/components/ScraperSelector.svelte';
+	import { createScrapersQuery } from '$lib/query/queries';
+	import { portalToBody } from '$lib/actions/portal';
+	import { fade, scale } from 'svelte/transition';
+	import { quintOut } from 'svelte/easing';
 
 	let snapshot: PendingScrape | null = $state(null);
 	let rows: ManualRow[] = $state([]);
 	let submitting = $state(false);
 	let errorMsg = $state<string | null>(null);
+	let showScraperModal = $state(false);
+	let modalSelectedScrapers = $state<string[]>([]);
 	const queryClient = useQueryClient();
+	const scrapersQuery = createScrapersQuery();
+	const enabledScrapers = $derived(
+		(scrapersQuery.data ?? []).filter((s) => s.enabled).map((s) => s.display_title || s.name)
+	);
 
-	function badgeLabel(input: string): string {
+	const overridesCount = $derived(rows.filter((r) => r.input.trim() !== '').length);
+
+	function classifyKind(input: string): 'auto' | 'id' | 'url' {
+		const k = classifyInput(input);
+		if (k === 'manual-id') return 'id';
+		if (k === 'manual-url') return 'url';
+		return 'auto';
+	}
+
+	function badgeClass(input: string): string {
 		switch (classifyInput(input)) {
 			case 'manual-id':
-				return 'Manual · ID';
+				return 'bg-primary/10 text-primary ring-1 ring-primary/20';
 			case 'manual-url':
-				return 'Manual · URL (scraper auto-filtered)';
+				return 'bg-violet-500/10 text-violet-600 dark:text-violet-400 ring-1 ring-violet-500/25';
+			default:
+				return 'bg-muted text-muted-foreground';
+		}
+	}
+
+	function badgeShort(input: string): string {
+		switch (classifyInput(input)) {
+			case 'manual-id':
+				return 'ID';
+			case 'manual-url':
+				return 'URL';
 			default:
 				return 'Auto';
 		}
+	}
+
+	function badgeTitle(input: string): string {
+		switch (classifyInput(input)) {
+			case 'manual-id':
+				return 'Manual ID override — scrapes as this ID, bypassing the matcher';
+			case 'manual-url':
+				return 'Manual URL override — scrapes with URL-compatible scrapers only';
+			default:
+				return 'Auto — ID derived from the filename via the matcher';
+		}
+	}
+
+	function fileParts(path: string): { basename: string; dir: string } {
+		const idx = path.lastIndexOf('/');
+		if (idx < 0) return { basename: path, dir: '' };
+		return { basename: path.slice(idx + 1), dir: path.slice(0, idx) };
+	}
+
+	function openScraperModal() {
+		if (!snapshot) return;
+		modalSelectedScrapers = snapshot.showScraperSelector
+			? [...snapshot.selectedScrapers]
+			: (scrapersQuery.data ?? []).filter((s) => s.enabled).map((s) => s.name);
+		showScraperModal = true;
+	}
+
+	function applyScraperSelection() {
+		if (!snapshot) return;
+		snapshot = {
+			...snapshot,
+			showScraperSelector: true,
+			selectedScrapers: [...modalSelectedScrapers]
+		};
+		showScraperModal = false;
+	}
+
+	function resetScraperSelection() {
+		if (!snapshot) return;
+		snapshot = { ...snapshot, showScraperSelector: false, selectedScrapers: [] };
+		showScraperModal = false;
 	}
 
 	onMount(() => {
@@ -48,9 +135,6 @@
 		rows = snap.files.map((f) => ({ filePath: f, input: merged[f] ?? '' }));
 	});
 
-	// Persist per-row inputs on every change (typing / remove / clear) so a Back
-	// round-trip to /browse preserves them (D4b: merge keyed by path, never
-	// blind-overwrite — re-advance hydrates via mergeManualInputs above).
 	$effect(() => {
 		if (!snapshot) return;
 		const map = mergeManualInputs(
@@ -78,7 +162,7 @@
 				operation_mode: snapshot.effectiveOperationMode,
 				selected_scrapers: snapshot.showScraperSelector ? snapshot.selectedScrapers : undefined,
 				force: snapshot.force,
-				preset: snapshot.update ? snapshot.preset : undefined,
+				preset: snapshot.update ? (snapshot.preset || undefined) : undefined,
 				scalar_strategy: snapshot.update ? snapshot.scalarStrategy : undefined,
 				array_strategy: snapshot.update ? snapshot.arrayStrategy : undefined,
 				update: snapshot.update
@@ -100,79 +184,345 @@
 <svelte:head><title>Manual Scrape</title></svelte:head>
 
 {#if snapshot}
-	<div class="mx-auto max-w-4xl p-6 space-y-6">
-		<div class="flex items-center justify-between">
-			<h1 class="text-2xl font-semibold">Manual Scrape</h1>
-			<button class="text-sm text-muted-foreground hover:text-foreground" onclick={() => goto('/browse')}>
-				← Back to browse
-			</button>
-		</div>
-
-		<!-- Read-only summary of inherited globals (D6) -->
-		<dl class="rounded-lg border border-border p-4 text-sm space-y-1">
-			<div class="flex justify-between"><dt class="text-muted-foreground">Mode</dt>
-				<dd class="font-medium">{snapshot.update ? 'Update Metadata' : 'Scrape & Organize'}</dd></div>
-			<div class="flex justify-between"><dt class="text-muted-foreground">Operation</dt>
-				<dd class="font-medium">{snapshot.effectiveOperationMode}</dd></div>
-			{#if !snapshot.update}
-				<div class="flex justify-between"><dt class="text-muted-foreground">Destination</dt>
-					<dd class="font-medium">{snapshot.destination || '(in place)'}</dd></div>
-			{/if}
-			<div class="flex justify-between"><dt class="text-muted-foreground">Scrapers</dt>
-				<dd class="font-medium">
-					{#if snapshot.showScraperSelector}{snapshot.selectedScrapers.join(', ')}
-					{:else}All enabled{/if}
-				</dd></div>
-			{#if snapshot.update}
-				<div class="flex justify-between"><dt class="text-muted-foreground">Preset</dt>
-					<dd class="font-medium">{snapshot.preset ?? '—'}</dd></div>
-				<div class="flex justify-between"><dt class="text-muted-foreground">Strategies</dt>
-					<dd class="font-medium">{snapshot.scalarStrategy ?? '—'} / {snapshot.arrayStrategy ?? '—'}</dd></div>
-			{/if}
-			<div class="flex justify-between"><dt class="text-muted-foreground">Force refresh</dt>
-				<dd class="font-medium">{snapshot.force ? 'on' : 'off'}</dd></div>
-		</dl>
-
-		{#if errorMsg}
-			<p class="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">{errorMsg}</p>
-		{/if}
-
-		<div class="space-y-2">
-			<div class="flex items-center justify-between">
-				<h2 class="font-medium">Files ({rows.length})</h2>
-				{#if rows.some((r) => r.input.trim() !== '')}
-					<button class="text-sm text-muted-foreground hover:text-foreground" onclick={clearAllOverrides}>
-						Clear all overrides
-					</button>
-				{/if}
-			</div>
-			{#each rows as row, i (row.filePath)}
-				<div class="flex items-center gap-2 rounded-lg border border-border p-2">
-					<span class="min-w-0 flex-1 truncate text-sm" title={row.filePath}>{row.filePath}</span>
-					<input
-						class="w-64 rounded border border-border px-2 py-1 text-sm"
-						placeholder="Auto — type ID or URL to override"
-						aria-label="Manual input for {row.filePath}"
-						bind:value={row.input}
-					/>
-					<span class="w-44 text-xs text-muted-foreground" role="status" aria-live="polite">
-						{badgeLabel(row.input)}
-					</span>
-					<button
-						class="text-xs text-muted-foreground hover:text-destructive"
-						aria-label="Remove {row.filePath} from batch"
-						onclick={() => removeRow(i)}
-					>Remove from batch</button>
+	<div class="container mx-auto px-4 py-8 pb-32">
+		<div class="max-w-7xl mx-auto space-y-8">
+			<!-- Header -->
+			<div class="flex items-start justify-between gap-4">
+				<div>
+					<h1 class="text-3xl font-bold tracking-tight">Manual Scrape</h1>
+					<p class="text-muted-foreground mt-1.5">
+						Review each file and override its ID or URL before scraping.
+					</p>
 				</div>
-			{/each}
-		</div>
+				<Button variant="ghost" size="sm" onclick={() => goto('/browse')}>
+					{#snippet children()}
+						<ArrowLeft class="h-4 w-4" aria-hidden="true" />
+						Back to browse
+					{/snippet}
+				</Button>
+			</div>
 
-		<button
-			class="w-full rounded-lg bg-primary px-4 py-2 text-primary-foreground disabled:opacity-50"
-			disabled={submitting || rows.length === 0}
-			onclick={submit}
-		>
-			{submitting ? 'Starting…' : 'Start manual scrape'}
-		</button>
+			<!-- Inherited settings (read-only) -->
+			<Card class="p-5">
+				<div class="flex items-center gap-2 mb-4">
+					<span class="h-2 w-2 rounded-full bg-primary/60"></span>
+					<h2 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+						Selected Settings
+					</h2>
+				</div>
+				<dl class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-4">
+					<div>
+						<dt class="text-xs text-muted-foreground">Mode</dt>
+						<dd class="mt-0.5">
+							<div class="inline-flex rounded-md border bg-background p-0.5 text-xs">
+								<button type="button" onclick={() => { if (snapshot) snapshot.update = false; }} class="rounded px-2.5 py-1 transition-colors {!snapshot.update ? 'bg-primary text-primary-foreground font-medium' : 'text-muted-foreground hover:text-foreground'}">Scrape &amp; Organize</button>
+								<button type="button" onclick={() => { if (snapshot) snapshot.update = true; }} class="rounded px-2.5 py-1 transition-colors {snapshot.update ? 'bg-primary text-primary-foreground font-medium' : 'text-muted-foreground hover:text-foreground'}">Update Metadata</button>
+							</div>
+						</dd>
+					</div>
+					<div>
+						<dt class="text-xs text-muted-foreground">Operation</dt>
+						<dd class="mt-0.5">
+							<select
+								class="w-full h-8 px-2 text-sm border rounded-md bg-background focus:ring-2 focus:ring-primary focus:border-primary transition-all"
+								bind:value={snapshot.effectiveOperationMode}
+								aria-label="Operation mode"
+							>
+								<option value="organize">Organize</option>
+								<option value="in-place">In place</option>
+								<option value="in-place-norenamefolder">In place (keep folder)</option>
+								<option value="metadata-artwork">Metadata + artwork</option>
+								<option value="preview">Preview</option>
+							</select>
+						</dd>
+					</div>
+					{#if !snapshot.update}
+						<div>
+							<dt class="text-xs text-muted-foreground">Destination</dt>
+							<dd class="mt-0.5">
+								<input
+									type="text"
+									bind:value={snapshot.destination}
+									placeholder="(in place)"
+									class="w-full h-8 px-2 text-sm border rounded-md bg-background focus:ring-2 focus:ring-primary focus:border-primary transition-all font-mono"
+									aria-label="Destination path"
+								/>
+							</dd>
+						</div>
+					{/if}
+					<div class="sm:col-span-2 lg:col-span-3">
+						<dt class="text-xs text-muted-foreground">Scrapers</dt>
+						<dd class="mt-0.5">
+							<button
+								type="button"
+								class="group -m-1 cursor-pointer rounded-md p-1 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+								onclick={openScraperModal}
+								aria-label="Edit scraper selection and order"
+								title="Click to change scraper selection and order"
+							>
+								<div class="flex flex-wrap gap-1.5">
+									{#each (snapshot.showScraperSelector ? snapshot.selectedScrapers : enabledScrapers) as scraper}
+										<span class="rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-foreground transition-colors group-hover:bg-primary/10 group-hover:text-primary">{scraper}</span>
+									{/each}
+									{#if (snapshot.showScraperSelector ? snapshot.selectedScrapers : enabledScrapers).length === 0}
+										<span class="text-sm font-medium">All enabled</span>
+									{/if}
+								</div>
+							</button>
+						</dd>
+					</div>
+					{#if snapshot.update}
+						<div>
+							<dt class="text-xs text-muted-foreground">Preset</dt>
+							<dd class="mt-0.5">
+								<select
+									class="w-full h-8 px-2 text-sm border rounded-md bg-background focus:ring-2 focus:ring-primary focus:border-primary transition-all"
+									bind:value={snapshot.preset}
+									aria-label="Merge preset"
+								>
+									<option value="">None</option>
+									<option value="conservative">Conservative</option>
+									<option value="gap-fill">Gap Fill</option>
+									<option value="aggressive">Aggressive</option>
+								</select>
+							</dd>
+						</div>
+						<div>
+							<dt class="text-xs text-muted-foreground">Strategies</dt>
+							<dd class="mt-0.5 space-y-1">
+								<select
+									class="w-full h-8 px-2 text-sm border rounded-md bg-background focus:ring-2 focus:ring-primary focus:border-primary transition-all"
+									bind:value={snapshot.scalarStrategy}
+									aria-label="Scalar strategy"
+								>
+									<option value="prefer-nfo">Prefer NFO</option>
+									<option value="prefer-scraper">Prefer Scraper</option>
+									<option value="preserve-existing">Preserve Existing</option>
+									<option value="fill-missing-only">Fill Missing Only</option>
+								</select>
+								<select
+									class="w-full h-8 px-2 text-sm border rounded-md bg-background focus:ring-2 focus:ring-primary focus:border-primary transition-all"
+									bind:value={snapshot.arrayStrategy}
+									aria-label="Array strategy"
+								>
+									<option value="merge">Merge</option>
+									<option value="replace">Replace</option>
+								</select>
+							</dd>
+						</div>
+					{/if}
+					<div>
+						<dt class="text-xs text-muted-foreground">Force refresh</dt>
+						<dd class="mt-0.5">
+							<button
+								type="button"
+								role="switch"
+								aria-checked={snapshot.force}
+								onclick={() => { if (snapshot) snapshot.force = !snapshot.force; }}
+								class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring {snapshot.force ? 'bg-primary' : 'bg-muted'}"
+								aria-label="Force refresh"
+							>
+								<span class="inline-block h-4 w-4 transform rounded-full bg-background shadow transition-transform {snapshot.force ? 'translate-x-4' : 'translate-x-0.5'}"></span>
+							</button>
+						</dd>
+					</div>
+				</dl>
+			</Card>
+
+			{#if errorMsg}
+				<Card class="p-4 border-destructive/40 bg-destructive/5">
+					<div class="flex items-start gap-3 text-sm text-destructive">
+						<AlertTriangle class="h-4 w-4 mt-0.5 shrink-0" aria-hidden="true" />
+						<span>{errorMsg}</span>
+					</div>
+				</Card>
+			{/if}
+
+			<!-- File rows -->
+			<section class="space-y-3">
+				<div class="flex items-center justify-between">
+					<h2 class="flex items-center gap-2 font-semibold">
+						<FileText class="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+						<span>Files ({rows.length})</span>
+					</h2>
+					{#if overridesCount > 0}
+						<Button variant="ghost" size="sm" onclick={clearAllOverrides}>
+							{#snippet children()}
+								<Eraser class="h-3.5 w-3.5" aria-hidden="true" />
+								Clear all overrides
+							{/snippet}
+						</Button>
+					{/if}
+				</div>
+
+				{#if rows.length === 0}
+					<Card class="p-8 text-center">
+						<p class="text-sm text-muted-foreground">
+							No files left in this batch. Go back to browse to select again.
+						</p>
+					</Card>
+				{:else}
+					<ul class="space-y-2.5">
+						{#each rows as row, i (row.filePath)}
+							{@const parts = fileParts(row.filePath)}
+							{@const overridden = row.input.trim() !== ''}
+							<li
+								class="row-in flex flex-col gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:border-primary/40 lg:flex-row lg:items-center"
+								style="--i: {i}"
+							>
+								<div class="flex items-center gap-3 min-w-0 flex-1">
+									<span
+										class="grid h-9 w-9 shrink-0 place-items-center rounded-md bg-muted text-muted-foreground"
+									>
+										<FileText class="h-4 w-4" aria-hidden="true" />
+									</span>
+									<span class="min-w-0 flex flex-col">
+										<span class="truncate font-mono text-sm font-medium" title={row.filePath}
+											>{parts.basename}</span
+										>
+										{#if parts.dir}
+											<span class="truncate font-mono text-xs text-muted-foreground" title={parts.dir}
+												>{parts.dir}</span
+											>
+										{/if}
+									</span>
+								</div>
+
+								<div class="flex flex-wrap items-center gap-2 lg:ml-auto">
+									<input
+										class="w-full min-w-[12rem] flex-1 rounded-md border border-input bg-background px-3 py-1 text-sm outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-ring/30 lg:w-64 lg:flex-none {overridden
+											? 'border-primary/50'
+											: ''}"
+										placeholder="Auto — type ID or URL to override"
+										aria-label="Manual input for {row.filePath}"
+										bind:value={row.input}
+									/>
+									<span
+										class="shrink-0 self-stretch rounded-full px-2.5 py-1 text-xs font-medium leading-none flex items-center gap-1 {badgeClass(row.input)}"
+										role="status"
+										aria-live="polite"
+										title={badgeTitle(row.input)}
+									>
+										{#if classifyKind(row.input) === 'id'}
+											<Hash class="h-3 w-3" aria-hidden="true" />
+										{:else if classifyKind(row.input) === 'url'}
+											<Globe class="h-3 w-3" aria-hidden="true" />
+										{:else}
+											<Sparkles class="h-3 w-3" aria-hidden="true" />
+										{/if}
+										{badgeShort(row.input)}
+									</span>
+									<button
+										type="button"
+										class="grid h-8 w-8 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+										aria-label="Remove {row.filePath} from batch"
+										title="Remove from batch"
+										onclick={() => removeRow(i)}
+									>
+										<Trash2 class="h-4 w-4" aria-hidden="true" />
+									</button>
+								</div>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</section>
+
+			<!-- Sticky commit bar -->
+			<div class="sticky bottom-0 z-20">
+				<Card class="flex items-center justify-between gap-4 p-3 shadow-lg">
+					<p class="text-sm text-muted-foreground">
+						<span class="font-medium text-foreground">{rows.length}</span>
+						file{rows.length === 1 ? '' : 's'}
+						{#if overridesCount > 0}
+							· <span class="font-medium text-primary">{overridesCount}</span>
+							override{overridesCount === 1 ? '' : 's'}
+						{/if}
+					</p>
+					<Button variant="default" disabled={submitting || rows.length === 0} onclick={submit}>
+						{#snippet children()}
+							{#if submitting}
+								<LoaderCircle class="h-4 w-4 animate-spin" aria-hidden="true" />
+								Starting…
+							{:else}
+								<Scan class="h-4 w-4" aria-hidden="true" />
+								Start manual scrape
+							{/if}
+						{/snippet}
+					</Button>
+				</Card>
+			</div>
+		</div>
 	</div>
+
+	<!-- Scraper selection + order modal -->
+	{#if showScraperModal}
+		<div
+			class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+			role="presentation"
+			use:portalToBody
+			in:fade|local={{ duration: 140 }}
+			out:fade|local={{ duration: 120 }}
+			onclick={(e) => { if (e.target === e.currentTarget) showScraperModal = false; }}
+			onkeydown={(e) => { if (e.key === 'Escape') showScraperModal = false; }}
+		>
+			<div class="w-full max-w-lg" in:scale|local={{ start: 0.97, duration: 180, easing: quintOut }} out:scale|local={{ start: 1, opacity: 0.7, duration: 130, easing: quintOut }}>
+				<Card class="w-full flex flex-col max-h-[90vh]">
+					<div class="p-6 border-b flex items-center justify-between">
+						<h2 class="text-xl font-bold">Scrapers</h2>
+						<Button variant="ghost" size="icon" onclick={() => (showScraperModal = false)}>
+							{#snippet children()}
+								<X class="h-4 w-4" />
+							{/snippet}
+						</Button>
+					</div>
+					<div class="flex-1 overflow-auto p-6">
+						<p class="text-sm text-muted-foreground mb-4">
+							Select and reorder the scrapers for this scrape. The results will be aggregated according to this order.
+						</p>
+						<ScraperSelector
+							scrapers={scrapersQuery.data ?? []}
+							bind:selected={modalSelectedScrapers}
+							disabled={false}
+						/>
+					</div>
+					<div class="p-6 border-t flex items-center justify-between gap-3">
+						<Button variant="ghost" onclick={resetScraperSelection}>
+							{#snippet children()}Reset to all enabled{/snippet}
+						</Button>
+						<div class="flex gap-3">
+							<Button variant="outline" onclick={() => (showScraperModal = false)}>
+								{#snippet children()}Cancel{/snippet}
+							</Button>
+							<Button onclick={applyScraperSelection}>
+								{#snippet children()}Apply{/snippet}
+							</Button>
+						</div>
+					</div>
+				</Card>
+			</div>
+		</div>
+	{/if}
 {/if}
+
+<style>
+	.row-in {
+		animation: row-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+		animation-delay: calc(var(--i, 0) * 35ms);
+	}
+	@keyframes row-in {
+		from {
+			opacity: 0;
+			transform: translateY(6px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.row-in {
+			animation: none;
+		}
+	}
+</style>

--- a/web/frontend/src/routes/manual/+page.ts
+++ b/web/frontend/src/routes/manual/+page.ts
@@ -1,0 +1,6 @@
+// /manual is a client-only continuation of /browse (D6): the pendingScrape
+// store is a module singleton populated client-side by /browse's "Manual Scrape"
+// action, so the page must not SSR (a server render always sees a null store
+// and would flash/redirect). The null-store redirect is handled in +page.svelte
+// onMount (dodges the server-load footgun of an always-redirect +page.server.ts).
+export const ssr = false;

--- a/web/frontend/src/routes/manual/logic/build-manual-scrape-request.test.ts
+++ b/web/frontend/src/routes/manual/logic/build-manual-scrape-request.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+	buildManualScrapeRequest,
+	classifyInput,
+	mergeManualInputs,
+	type ManualRow,
+	type ManualScrapeOptions
+} from './build-manual-scrape-request';
+import type { BatchScrapeRequest } from '$lib/api/types';
+
+describe('classifyInput', () => {
+	it('classifies empty/whitespace as auto (matcher on basename)', () => {
+		expect(classifyInput('')).toBe('auto');
+		expect(classifyInput('   ')).toBe('auto');
+		expect(classifyInput('\t\n')).toBe('auto');
+	});
+
+	it('classifies http(s) URLs as manual-url (URL-compatible scrapers)', () => {
+		expect(classifyInput('https://example.com/v/123')).toBe('manual-url');
+		expect(classifyInput('http://example.com/v/123')).toBe('manual-url');
+		expect(classifyInput('HTTPS://example.com/v/123')).toBe('manual-url');
+	});
+
+	it('classifies ID-shaped input as manual-id (bypasses matcher)', () => {
+		expect(classifyInput('IPX-123')).toBe('manual-id');
+		expect(classifyInput('abc-001')).toBe('manual-id');
+	});
+
+	it('treats a bare scheme-less string with a query as manual-id (not a URL fetch)', () => {
+		expect(classifyInput('ABC-?123')).toBe('manual-id');
+	});
+});
+
+describe('mergeManualInputs', () => {
+	it('keeps inputs for files still in the batch and drops removed files (D4b)', () => {
+		const stored = { '/a.mp4': 'IPX-1', '/b.mp4': 'IPX-2', '/c.mp4': 'IPX-3' };
+		const merged = mergeManualInputs(stored, ['/a.mp4', '/b.mp4', '/d.mp4']);
+		expect(merged).toEqual({ '/a.mp4': 'IPX-1', '/b.mp4': 'IPX-2' });
+	});
+
+	it('never blind-overwrites: new files get no entry (Auto), existing inputs preserved', () => {
+		const stored = { '/a.mp4': 'IPX-1' };
+		const merged = mergeManualInputs(stored, ['/a.mp4', '/new.mp4']);
+		expect(merged).toEqual({ '/a.mp4': 'IPX-1' });
+		expect('/new.mp4' in merged).toBe(false);
+	});
+
+	it('drops empty/whitespace values so the map only carries real overrides', () => {
+		const stored = { '/a.mp4': 'IPX-1', '/b.mp4': '  ', '/c.mp4': '' };
+		const merged = mergeManualInputs(stored, ['/a.mp4', '/b.mp4', '/c.mp4']);
+		expect(merged).toEqual({ '/a.mp4': 'IPX-1' });
+	});
+});
+
+describe('buildManualScrapeRequest', () => {
+	const opts: ManualScrapeOptions = {
+		destination: '/out',
+		operation_mode: 'organize',
+		selected_scrapers: ['javdb', 'r18dev'],
+		force: true,
+		preset: 'gap-fill',
+		scalar_strategy: 'prefer-scraper',
+		array_strategy: 'replace',
+		update: false
+	};
+
+	it('drops empty/whitespace inputs from manual_inputs (#1)', () => {
+		const rows: ManualRow[] = [
+			{ filePath: '/a.mp4', input: 'IPX-123' },
+			{ filePath: '/b.mp4', input: '' },
+			{ filePath: '/c.mp4', input: '   ' },
+			{ filePath: '/d.mp4', input: 'https://e.com/v/1' }
+		];
+		const req = buildManualScrapeRequest(rows, opts);
+		expect(req.manual_inputs).toEqual({
+			'/a.mp4': 'IPX-123',
+			'/d.mp4': 'https://e.com/v/1'
+		});
+	});
+
+	it('omits manual_inputs entirely when every input is empty (existing callers unaffected)', () => {
+		const rows: ManualRow[] = [
+			{ filePath: '/a.mp4', input: '' },
+			{ filePath: '/b.mp4', input: '  ' }
+		];
+		const req = buildManualScrapeRequest(rows, opts);
+		expect(req.manual_inputs).toBeUndefined();
+		expect(JSON.stringify(req)).not.toContain('manual_inputs');
+	});
+
+	it('builds files[] and manual_inputs from the same rows in one pass so keys ⊆ files (#2)', () => {
+		const rows: ManualRow[] = [
+			{ filePath: '/a.mp4', input: 'IPX-123' },
+			{ filePath: '/b.mp4', input: '' },
+			{ filePath: '/c.mp4', input: 'SSIS-001' }
+		];
+		const req = buildManualScrapeRequest(rows, opts);
+		expect(req.files).toEqual(['/a.mp4', '/b.mp4', '/c.mp4']);
+		for (const key of Object.keys(req.manual_inputs ?? {})) {
+			expect(req.files).toContain(key);
+		}
+	});
+
+	it('trims manual input values', () => {
+		const rows: ManualRow[] = [{ filePath: '/a.mp4', input: '  IPX-123  ' }];
+		const req = buildManualScrapeRequest(rows, opts);
+		expect(req.manual_inputs?.['/a.mp4']).toBe('IPX-123');
+	});
+
+	it('passes inherited opts through unchanged (#4)', () => {
+		const rows: ManualRow[] = [{ filePath: '/a.mp4', input: 'IPX-123' }];
+		const req: BatchScrapeRequest = buildManualScrapeRequest(rows, opts);
+		expect(req.destination).toBe('/out');
+		expect(req.operation_mode).toBe('organize');
+		expect(req.selected_scrapers).toEqual(['javdb', 'r18dev']);
+		expect(req.force).toBe(true);
+		expect(req.preset).toBe('gap-fill');
+		expect(req.scalar_strategy).toBe('prefer-scraper');
+		expect(req.array_strategy).toBe('replace');
+		expect(req.update).toBe(false);
+		expect(req.strict).toBe(false);
+	});
+
+	it('handles an empty rows list (no files, no manual_inputs)', () => {
+		const req = buildManualScrapeRequest([], opts);
+		expect(req.files).toEqual([]);
+		expect(req.manual_inputs).toBeUndefined();
+	});
+});

--- a/web/frontend/src/routes/manual/logic/build-manual-scrape-request.ts
+++ b/web/frontend/src/routes/manual/logic/build-manual-scrape-request.ts
@@ -1,0 +1,84 @@
+import type { BatchScrapeRequest, OperationMode } from '$lib/api/types';
+
+export type InputClass = 'auto' | 'manual-id' | 'manual-url';
+
+export interface ManualRow {
+	filePath: string;
+	input: string;
+}
+
+export interface ManualScrapeOptions {
+	destination?: string;
+	operation_mode?: OperationMode;
+	selected_scrapers?: string[];
+	force?: boolean;
+	preset?: 'conservative' | 'gap-fill' | 'aggressive';
+	scalar_strategy?: BatchScrapeRequest['scalar_strategy'];
+	array_strategy?: BatchScrapeRequest['array_strategy'];
+	update?: boolean;
+}
+
+// classifyInput is a cosmetic hint for the tri-state badge (D5). It is NOT
+// authoritative — backend matcher.ParseInput reclassifies on disagreement
+// (badge says URL but no enabled scraper CanHandleURLs it → 400 via Phase 2 #2
+// or ParseInput reclassifies). Empty/whitespace = Auto (matcher on basename);
+// an http(s) URL = Manual-URL; anything else = Manual-ID.
+export function classifyInput(input: string): InputClass {
+	const trimmed = input.trim();
+	if (trimmed === '') return 'auto';
+	if (/^https?:\/\//i.test(trimmed)) return 'manual-url';
+	return 'manual-id';
+}
+
+// buildManualScrapeRequest builds a BatchScrapeRequest for the /manual route.
+// files[] and manual_inputs are built from the SAME rows[] in one pass, so
+// manual_inputs keys are ⊆ files by construction (F7). Empty/whitespace inputs
+// are dropped from manual_inputs; the map is omitted entirely when no row has
+// a non-empty input (existing callers unaffected). Inherited opts pass through
+// unchanged (#4). strict is always false (matches /browse's startBatchScrape).
+// mergeManualInputs keeps manual inputs for files still in the batch and drops
+// the rest (D4b: never blind-overwrite). New files (absent from stored) get no
+// entry (= Auto); removed files' entries are dropped; empty/whitespace values
+// are dropped so the map only carries real overrides. Callers display
+// `stored[f] ?? ''` per row.
+export function mergeManualInputs(
+	stored: Record<string, string>,
+	files: string[]
+): Record<string, string> {
+	const merged: Record<string, string> = {};
+	for (const f of files) {
+		const v = stored[f];
+		if (v !== undefined && v.trim() !== '') {
+			merged[f] = v;
+		}
+	}
+	return merged;
+}
+
+export function buildManualScrapeRequest(
+	rows: ManualRow[],
+	opts: ManualScrapeOptions
+): BatchScrapeRequest {
+	const files: string[] = [];
+	const manual_inputs: Record<string, string> = {};
+	for (const row of rows) {
+		files.push(row.filePath);
+		const trimmed = row.input.trim();
+		if (trimmed !== '') {
+			manual_inputs[row.filePath] = trimmed;
+		}
+	}
+	return {
+		files,
+		strict: false,
+		force: opts.force ?? false,
+		destination: opts.destination,
+		update: opts.update,
+		selected_scrapers: opts.selected_scrapers,
+		preset: opts.preset,
+		scalar_strategy: opts.scalar_strategy,
+		array_strategy: opts.array_strategy,
+		operation_mode: opts.operation_mode,
+		manual_inputs: Object.keys(manual_inputs).length > 0 ? manual_inputs : undefined
+	};
+}

--- a/web/frontend/src/routes/manual/page.test.ts
+++ b/web/frontend/src/routes/manual/page.test.ts
@@ -53,17 +53,18 @@ beforeEach(() => {
 describe('/manual tracer', () => {
 	it('renders the read-only summary + rows and submits a valid BatchScrapeRequest (#1)', async () => {
 		setPendingScrape(snapshot());
-		const { getByText, getByLabelText, getByRole } = renderPage();
+		const { getByText, getByLabelText, getByRole, getByDisplayValue } = renderPage();
 
 		expect(getByText('Manual Scrape')).toBeTruthy();
 		expect(getByText('Scrape & Organize')).toBeTruthy();
-		expect(getByText('/out')).toBeTruthy();
+		expect(getByDisplayValue('/out')).toBeTruthy();
 		expect(getByText('javdb')).toBeTruthy();
-		expect(getByText('/library/a.mp4')).toBeTruthy();
+		expect(getByText('a.mp4')).toBeTruthy();
+		expect(getByText('/library')).toBeTruthy();
 
 		const input = getByLabelText('Manual input for /library/a.mp4') as HTMLInputElement;
 		await fireEvent.input(input, { target: { value: 'IPX-123' } });
-		expect(getByText('Manual · ID')).toBeTruthy();
+		expect(getByText('ID')).toBeTruthy();
 
 		const submitBtn = getByRole('button', { name: 'Start manual scrape' });
 		await fireEvent.click(submitBtn);
@@ -91,12 +92,12 @@ describe('/manual tracer', () => {
 		);
 	});
 
-	it('badge flips to Manual · URL for an http(s) input', async () => {
+	it('badge flips to URL for an http(s) input', async () => {
 		setPendingScrape(snapshot());
 		const { getByLabelText, getByText } = renderPage();
 		const input = getByLabelText('Manual input for /library/a.mp4') as HTMLInputElement;
 		await fireEvent.input(input, { target: { value: 'https://example.com/v/123' } });
-		expect(getByText('Manual · URL (scraper auto-filtered)')).toBeTruthy();
+		expect(getByText('URL')).toBeTruthy();
 	});
 
 	it('hides preset/strategies in scrape mode and shows them in update mode', async () => {
@@ -116,6 +117,87 @@ describe('/manual tracer', () => {
 			})
 		);
 		const updateRender = renderPage();
-		expect(updateRender.getByText('gap-fill')).toBeTruthy();
+		expect(updateRender.getByDisplayValue('Gap Fill')).toBeTruthy();
+	});
+
+	it('removes the row from the batch and the request when "Remove from batch" is clicked (#4.8a)', async () => {
+		setPendingScrape(snapshot({ files: ['/library/a.mp4', '/library/b.mp4'] }));
+		const { getByRole, getByText, queryByText, queryByLabelText, getByLabelText } = renderPage();
+
+		expect(getByText('a.mp4')).toBeTruthy();
+		expect(getByText('b.mp4')).toBeTruthy();
+		expect(getByText('Files (2)')).toBeTruthy();
+
+		// Give the surviving row a manual override so we can assert it is preserved
+		// in the request while the removed row is dropped entirely.
+		const inputB = getByLabelText('Manual input for /library/b.mp4') as HTMLInputElement;
+		await fireEvent.input(inputB, { target: { value: 'IPX-999' } });
+
+		const removeBtn = getByRole('button', { name: 'Remove /library/a.mp4 from batch' });
+		await fireEvent.click(removeBtn);
+
+		// Row count drops (batch-removal, not a no-op); removed file + its input are
+		// gone, the other row stays.
+		expect(queryByText('a.mp4')).toBeNull();
+		expect(queryByLabelText('Manual input for /library/a.mp4')).toBeNull();
+		expect(getByText('b.mp4')).toBeTruthy();
+		expect(getByLabelText('Manual input for /library/b.mp4')).toBeTruthy();
+		expect(getByText('Files (1)')).toBeTruthy();
+
+		// Submit builds the request from the remaining rows only — the removed file
+		// is absent from both files[] and manual_inputs.
+		await fireEvent.click(getByRole('button', { name: 'Start manual scrape' }));
+		await waitFor(() => expect(mockBatchScrape).toHaveBeenCalledTimes(1));
+		expect(mockBatchScrape).toHaveBeenCalledWith({
+			files: ['/library/b.mp4'],
+			strict: false,
+			force: false,
+			destination: '/out',
+			update: false,
+			selected_scrapers: ['javdb'],
+			operation_mode: 'organize',
+			manual_inputs: { '/library/b.mp4': 'IPX-999' }
+		});
+	});
+
+	it('empties every row input but keeps the rows when "Clear all overrides" is clicked (#4.8b)', async () => {
+		setPendingScrape(snapshot({ files: ['/library/a.mp4', '/library/b.mp4'] }));
+		const { getByRole, getByLabelText, getByText, getAllByText, queryByRole } = renderPage();
+
+		const inputA = getByLabelText('Manual input for /library/a.mp4') as HTMLInputElement;
+		const inputB = getByLabelText('Manual input for /library/b.mp4') as HTMLInputElement;
+		await fireEvent.input(inputA, { target: { value: 'IPX-123' } });
+		await fireEvent.input(inputB, { target: { value: 'https://example.com/v/1' } });
+		expect(inputA.value).toBe('IPX-123');
+		expect(inputB.value).toBe('https://example.com/v/1');
+
+		// The clear button only renders once at least one row has a non-empty override.
+		const clearBtn = getByRole('button', { name: 'Clear all overrides' });
+		await fireEvent.click(clearBtn);
+
+		// Inputs cleared to empty (Auto), rows themselves remain (files[] unchanged).
+		expect((getByLabelText('Manual input for /library/a.mp4') as HTMLInputElement).value).toBe('');
+		expect((getByLabelText('Manual input for /library/b.mp4') as HTMLInputElement).value).toBe('');
+		expect(getByText('a.mp4')).toBeTruthy();
+		expect(getByText('b.mp4')).toBeTruthy();
+		expect(getByText('Files (2)')).toBeTruthy();
+		// Badge reverts to Auto for both rows.
+		expect(getAllByText('Auto')).toHaveLength(2);
+		// The clear button hides again now that no overrides remain.
+		expect(queryByRole('button', { name: 'Clear all overrides' })).toBeNull();
+
+		// Submit still carries every file, with manual_inputs dropped (no overrides).
+		await fireEvent.click(getByRole('button', { name: 'Start manual scrape' }));
+		await waitFor(() => expect(mockBatchScrape).toHaveBeenCalledTimes(1));
+		expect(mockBatchScrape).toHaveBeenCalledWith({
+			files: ['/library/a.mp4', '/library/b.mp4'],
+			strict: false,
+			force: false,
+			destination: '/out',
+			update: false,
+			selected_scrapers: ['javdb'],
+			operation_mode: 'organize',
+			manual_inputs: undefined
+		});
 	});
 });

--- a/web/frontend/src/routes/manual/page.test.ts
+++ b/web/frontend/src/routes/manual/page.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import { QueryClient } from '@tanstack/svelte-query';
+import QueryClientWrapper from '$lib/components/QueryClientWrapper.svelte';
+import { setPendingScrape, clearPendingScrape } from '$lib/stores/pending-scrape.svelte';
+import type { PendingScrape } from '$lib/stores/pending-scrape.svelte';
+import ManualPage from './+page.svelte';
+import { goto as mockGoto } from '$app/navigation';
+
+vi.mock('$lib/api/client', () => ({
+	apiClient: { batchScrape: vi.fn() }
+}));
+vi.mock('$lib/stores/background-job.svelte', () => ({
+	startJob: vi.fn()
+}));
+
+const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+const mod = await import('$lib/api/client');
+const bg = await import('$lib/stores/background-job.svelte');
+const mockBatchScrape = vi.mocked(mod.apiClient.batchScrape);
+const mockStartJob = vi.mocked(bg.startJob);
+const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+function snapshot(overrides: Partial<PendingScrape> = {}): PendingScrape {
+	return {
+		files: ['/library/a.mp4'],
+		browseMode: 'scrape',
+		update: false,
+		effectiveOperationMode: 'organize',
+		isInPlaceImplied: false,
+		showScraperSelector: true,
+		destination: '/out',
+		selectedScrapers: ['javdb'],
+		force: false,
+		...overrides
+	};
+}
+
+function renderPage() {
+	return render(ManualPage, {}, {
+		wrapper: QueryClientWrapper,
+		wrapperProps: { client }
+	});
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockBatchScrape.mockResolvedValue({ job_id: 'job-1' } as never);
+	clearPendingScrape();
+	if (typeof sessionStorage !== 'undefined') sessionStorage.clear();
+});
+
+describe('/manual tracer', () => {
+	it('renders the read-only summary + rows and submits a valid BatchScrapeRequest (#1)', async () => {
+		setPendingScrape(snapshot());
+		const { getByText, getByLabelText, getByRole } = renderPage();
+
+		expect(getByText('Manual Scrape')).toBeTruthy();
+		expect(getByText('Scrape & Organize')).toBeTruthy();
+		expect(getByText('/out')).toBeTruthy();
+		expect(getByText('javdb')).toBeTruthy();
+		expect(getByText('/library/a.mp4')).toBeTruthy();
+
+		const input = getByLabelText('Manual input for /library/a.mp4') as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: 'IPX-123' } });
+		expect(getByText('Manual · ID')).toBeTruthy();
+
+		const submitBtn = getByRole('button', { name: 'Start manual scrape' });
+		await fireEvent.click(submitBtn);
+
+		await waitFor(() => expect(mockBatchScrape).toHaveBeenCalledTimes(1));
+		expect(mockBatchScrape).toHaveBeenCalledWith({
+			files: ['/library/a.mp4'],
+			strict: false,
+			force: false,
+			destination: '/out',
+			update: false,
+			selected_scrapers: ['javdb'],
+			operation_mode: 'organize',
+			manual_inputs: { '/library/a.mp4': 'IPX-123' }
+		});
+		expect(mockStartJob).toHaveBeenCalledWith('job-1');
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['batch-jobs'] });
+		expect(mockGoto).not.toHaveBeenCalled();
+	});
+
+	it('redirects to /browse on direct nav with no pending store (#2)', async () => {
+		renderPage();
+		await waitFor(() =>
+			expect(mockGoto).toHaveBeenCalledWith('/browse', expect.objectContaining({ replaceState: true }))
+		);
+	});
+
+	it('badge flips to Manual · URL for an http(s) input', async () => {
+		setPendingScrape(snapshot());
+		const { getByLabelText, getByText } = renderPage();
+		const input = getByLabelText('Manual input for /library/a.mp4') as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: 'https://example.com/v/123' } });
+		expect(getByText('Manual · URL (scraper auto-filtered)')).toBeTruthy();
+	});
+
+	it('hides preset/strategies in scrape mode and shows them in update mode', async () => {
+		setPendingScrape(snapshot());
+		const scrapeRender = renderPage();
+		expect(scrapeRender.queryByText('Preset')).toBeNull();
+
+		clearPendingScrape();
+		setPendingScrape(
+			snapshot({
+				browseMode: 'update',
+				update: true,
+				effectiveOperationMode: 'in-place',
+				preset: 'gap-fill',
+				scalarStrategy: 'prefer-scraper',
+				arrayStrategy: 'replace'
+			})
+		);
+		const updateRender = renderPage();
+		expect(updateRender.getByText('gap-fill')).toBeTruthy();
+	});
+});

--- a/web/frontend/test/stubs/app/navigation.ts
+++ b/web/frontend/test/stubs/app/navigation.ts
@@ -1,0 +1,13 @@
+import { vi } from 'vitest';
+
+// Minimal $app/navigation stub for component tests (vitest config aliases
+// $app/navigation here). goto is a vi.fn so tests can assert redirects / Back.
+export const goto = vi.fn();
+export const invalidate = vi.fn();
+export const invalidateAll = vi.fn();
+export const prefetch = vi.fn();
+export const beforeNavigate = vi.fn();
+export const afterNavigate = vi.fn();
+export const onNavigate = vi.fn();
+export function applyAction() {}
+export function destroyUrl() {}

--- a/web/frontend/vitest.config.ts
+++ b/web/frontend/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
 		conditions: ['browser'],
 		alias: {
 			$lib: path.resolve(__dirname, 'src/lib'),
+			'$app/navigation': path.resolve(__dirname, 'test/stubs/app/navigation.ts'),
 		},
 	},
 	test: {


### PR DESCRIPTION
## Summary

Adds a manual-scrape flow: from `/browse`, a "Manual Scrape" checkbox advances selected files to a `/manual` refinement page where each row can take a per-file ID or URL override (empty = Auto, derived from the filename via the matcher). The override flows through the batch scrape path to `resolveScrapeInput`, bypassing the matcher for that row and selecting URL-compatible scrapers when the input is a URL. Includes backend validation, redaction, a per-file override propagation pass (co-submitted not clobbered; discovered siblings inherit), and a full frontend store + test suite.

## Background

Issue #58 (pre-scrape manual input). A prior design proposed a dedicated `/scrape` page; this is the revised **hybrid**: `/browse` stays the file-selection page, a checkbox advances to a `/manual` refinement view. Design reviewed in `.planning/swarm-review-manual-view.md`.

## Changes

### Backend
- **`internal/api/batch/manual_input.go`** (new) — `resolveManualInputOverride`: propagates each submitted file's manual input to matcher-discovered sibling parts sharing the same MovieID. Co-submitted files keep their own input (never clobbered); two submitted files with conflicting inputs for a shared MovieID are rejected (determinism). Redacts echoed values in the conflict error.
- **`internal/api/batch/manual_input_validate.go`** (new) — sanitize (strip Unicode Cf/Cc by category, not a hardcoded list) + validate: count > files, orphan key, per-value length cap (4096), non-http(s) scheme, http(s) URL no enabled scraper `CanHandleURL`s. Trims before the scheme/CanHandleURL check; drops empty-after-trim entries. The `CanHandleURL` gate is also an SSRF mitigation — only URLs matching registered scraper domains are accepted. Redacts echoed URLs in 400 errors.
- **`internal/api/batch/lifecycle.go` / `usecases.go` / `rescrape.go`** — wire `ManualInputs` through the create-batch path; add a 10MB `MaxBytesReader` body bound before JSON parse; redact `ManualSearchInput` in the rescrape log.
- **`internal/worker/scrape_phase.go`** — `buildScrapeCmd` reads `cfg.RawInputOverride[filePath]`: non-whitespace override wins over matcher/MovieIDOverride; URL inputs nil out batch-global scrapers so `resolveScrapeInput` sets `PriorityOverride`; ID inputs keep them. **Redacts `cmd.MovieID` via `scrape.RedactURLQuery` for manual inputs** so URL query tokens don't leak into persisted job state, WebSocket events, or progress messages (`RawInput` stays raw so scrapers still see the real URL).
- **`internal/scrape/redact.go`** (new) — `RedactURLQuery`: strips query+fragment from http(s) URLs; passes plain IDs (no scheme/host) through unchanged.
- **`internal/scrape/scrape.go`** — redact the parse-fail fallback `MovieID` + log.
- **`internal/api/contracts/batch_types.go`** — `BatchScrapeRequest.ManualInputs map[string]string` (`manual_inputs,omitempty`).

### Frontend
- **`web/frontend/src/routes/manual/+page.svelte`** (new, 528 lines) — per-file table; `bind:value` edits to inherited settings (operation mode, destination, scrapers, force, strategy) persist back to the `pendingScrape` store via a `$effect` so a refresh rehydrates the user's edits, not the original `/browse` snapshot.
- **`web/frontend/src/routes/browse/+page.svelte`** — "Manual Scrape" checkbox; on continue, snapshot browse state into `pendingScrape` and `goto('/manual')`.
- **`web/frontend/src/routes/manual/logic/build-manual-scrape-request.ts`** (new) — builds the `BatchScrapeRequest` (snake_case), `manual_inputs` keys ⊆ `files`, drops empties.
- **`web/frontend/src/lib/stores/pending-scrape.svelte.ts`** (new) + **`manual-inputs-session.ts`** (new) — sessionStorage-backed singletons with hydration.
- **`web/frontend/src/lib/api/types.ts`** — `manual_inputs?: Record<string, string>`.

### Tests
- Backend: `manual_input_test.go`, `manual_input_validate_test.go`, `manual_input_race_test.go` (32 goroutines × 200 iters under `-race`), `manual_scrape_e2e_test.go` (full HTTP→worker→scraper→result, asserts the manual ID bypasses the matcher end-to-end), `resolve_scrape_input_test.go`, `redact_test.go`, +5 cases in `scrape_phase_test.go` (redaction seam, no-op for plain IDs, trim-before-validate, drop-empty, 400 redaction).
- Frontend: manual page (203 lines), browse page (222 lines), `build-manual-scrape-request`, `pending-scrape`, `types` — 306 total, all green.

### Race fix (pre-existing, carried via rebase)
`TestScrapePhase_Run_MultipleFiles` failed under `-race` (inherited from PR #67): `stubWorkflow.Scrape` returned a shared `Movie` pointer, so concurrent `establishScrapedBaseline` writes raced. Fixed by deep-copying the result per call. The worker race gate (`make test-race`) is now green.

## Verification
- `go test -short ./...` — green
- `go test -race ./internal/worker/` — green (was failing)
- `go vet` / `gofmt` — clean
- `svelte-check` 0/0; `vitest` 306/306; `prettier` clean

## Known follow-ups (deferred)
Captured in `.planning/review/manual-scrape-deferred-followups.md` (gitignored):
- **S1 (security, separate path):** `rescrape_phase.go` single-file rescrape seeds `scrapeCmd.MovieID` from the raw `ManualSearchInput` URL without `RedactURLQuery` — same leak class, pre-existing. Worth a rescrape-path hardening pass (pair with the rescrape validation consistency note).
- Frontend: `/manual` submit doesn't clear `/browse` scrape state (inadvertent re-scrape risk); scraper modal lacks `aria-modal`/focus trap; no AbortController (acceptable); per-keystroke sessionStorage write (negligible now).
- Test: e2e polls with `time.Sleep` (low flake risk); stub shallow-clones slice/map fields (latent, no current test triggers it).
- Docs: swagger `manual_inputs` example malformed (cosmetic).
- Cross-endpoint: rescrape `ManualSearchInput` validation less strict than the new batch path; all usecase errors → 400 (pre-existing).

## How to test
1. `/browse` → select files → check "Manual Scrape" → "Continue to manual review →".
2. On `/manual`, type an ID or URL per row (leave empty for Auto). Edit operation mode / destination / scrapers / force.
3. Submit → batch scrape runs; manual rows use the override (URL rows pick URL-compatible scrapers; ID rows bypass the matcher); auto rows use the matcher.
4. Refresh `/manual` mid-edit → inherited-setting edits persist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual review flow for batch scraping, including a dedicated review page with per-file override inputs.
  * Preserves browse selections and scraper choices when continuing from browse to manual review.
* **Bug Fixes**
  * Manually entered inputs are now trimmed, sanitized, and validated (including URL safety checks) before starting a batch scrape.
  * Added early rejection of oversized request payloads and improved URL query redaction in job state/logging to avoid leaking sensitive data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->