### PR TITLE
fix(config,frontend): WebUI Output/NFO settings broken by nested JSON

### DIFF
--- a/internal/config/nfo_json.go
+++ b/internal/config/nfo_json.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"encoding/json"
+)
+
+// NFOConfig groups its settings into named sub-structs (Feature, Format,
+// Extra) using yaml.",inline" so the YAML layout stays flat under "nfo:"
+// (nfo.enabled, nfo.first_name_order, …) while the Go type system provides
+// named access groups (n.Feature.Enabled, n.Format.FirstNameOrder, …).
+//
+// yaml.",inline" flattens the YAML representation, but encoding/json does NOT
+// inline named fields — only embedded (anonymous) fields are inlined.
+// Without these methods the JSON wire format would nest the groups
+// ({"Feature": {...}, "Format": {...}, "Extra": {...}}), which mismatches the
+// flat YAML layout and the frontend's flat NFOConfig type. The result was that
+// every nfo.* field (enabled, first_name_order, actress_language_ja,
+// unknown_actress_mode, …) deserialized to undefined on the WebUI, leaving NFO
+// checkboxes unchecked regardless of config.yaml and silently dropping saves.
+//
+// MarshalJSON/UnmarshalJSON collapse the three sub-structs into a single flat
+// object that matches the YAML layout and the frontend contract. The Go API
+// (n.Feature.*, n.Format.*, n.Extra.*) is unchanged.
+
+// MarshalJSON flattens the three NFO sub-structs into one JSON object.
+func (n NFOConfig) MarshalJSON() ([]byte, error) {
+	type flat struct {
+		NFOFeatureConfig
+		NFOFormatConfig
+		NFOExtraConfig
+	}
+	return json.Marshal(flat{
+		NFOFeatureConfig: n.Feature,
+		NFOFormatConfig:  n.Format,
+		NFOExtraConfig:   n.Extra,
+	})
+}
+
+// UnmarshalJSON accepts the flat JSON shape emitted by MarshalJSON (and used
+// by the WebUI). It also tolerates the legacy nested shape
+// ({"Feature": {...}, …}) for backward compatibility. Each sub-struct's JSON
+// tags are distinct, so unmarshaling the same flat bytes into every sub-struct
+// populates only that group's fields.
+func (n *NFOConfig) UnmarshalJSON(data []byte) error {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return err
+	}
+
+	if _, nested := probe["Feature"]; nested {
+		type nestedForm struct {
+			Feature NFOFeatureConfig `json:"Feature"`
+			Format  NFOFormatConfig  `json:"Format"`
+			Extra   NFOExtraConfig   `json:"Extra"`
+		}
+		var v nestedForm
+		if err := json.Unmarshal(data, &v); err != nil {
+			return err
+		}
+		*n = NFOConfig(v)
+		return nil
+	}
+
+	if err := json.Unmarshal(data, &n.Feature); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &n.Format); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &n.Extra); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/config/output_json.go
+++ b/internal/config/output_json.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"encoding/json"
+)
+
+// OutputConfig groups its settings into named sub-structs using yaml:",inline"
+// so the YAML format stays flat (output.folder_format, output.download_cover,
+// …) while the Go type system provides named access groups
+// (cfg.Output.Template.FolderFormat, cfg.Output.Download.DownloadCover, …).
+//
+// yaml.",inline" flattens the YAML representation, but encoding/json does NOT
+// inline named fields — only embedded (anonymous) fields are inlined. Without
+// these methods the JSON wire format would nest the groups
+// ({"Template": {...}, "Download": {...}, …}), which mismatches both the flat
+// YAML layout and the frontend's flat OutputConfig type. The result was that
+// output.download_* (and every other output field) deserialized to undefined
+// on the WebUI, leaving download checkboxes unchecked and breaking saves.
+//
+// MarshalJSON/UnmarshalJSON collapse the four sub-structs into a single flat
+// object that matches the YAML layout and the frontend contract. The Go API
+// (cfg.Output.Template.*, cfg.Output.Download.*) is unchanged.
+
+// MarshalJSON flattens the four output sub-structs into one JSON object.
+func (o OutputConfig) MarshalJSON() ([]byte, error) {
+	type flat struct {
+		OutputTemplateConfig
+		OutputOperationConfig
+		OutputMediaFormatConfig
+		OutputDownloadConfig
+	}
+	return json.Marshal(flat{
+		OutputTemplateConfig:    o.Template,
+		OutputOperationConfig:   o.Operation,
+		OutputMediaFormatConfig: o.MediaFormat,
+		OutputDownloadConfig:    o.Download,
+	})
+}
+
+// UnmarshalJSON accepts the flat JSON shape emitted by MarshalJSON (and used
+// by the WebUI). It also tolerates the legacy nested shape
+// ({"Template": {...}, …}) for backward compatibility with any cached client
+// payloads. Each sub-struct's JSON tags are distinct, so unmarshaling the same
+// flat bytes into every sub-struct populates only that group's fields.
+func (o *OutputConfig) UnmarshalJSON(data []byte) error {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return err
+	}
+
+	if _, nested := probe["Template"]; nested {
+		type nestedForm struct {
+			Template    OutputTemplateConfig    `json:"Template"`
+			Operation   OutputOperationConfig   `json:"Operation"`
+			MediaFormat OutputMediaFormatConfig `json:"MediaFormat"`
+			Download    OutputDownloadConfig    `json:"Download"`
+		}
+		var n nestedForm
+		if err := json.Unmarshal(data, &n); err != nil {
+			return err
+		}
+		*o = OutputConfig(n)
+		return nil
+	}
+
+	if err := json.Unmarshal(data, &o.Template); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &o.Operation); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &o.MediaFormat); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &o.Download); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/config/output_json.go
+++ b/internal/config/output_json.go
@@ -63,6 +63,20 @@ func (o *OutputConfig) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	// Legacy alias: "delimiter" was the pre-rename key for actress_delimiter
+	// (still accepted in YAML via LegacyDelimiter + normalize). json:"-" keeps
+	// LegacyDelimiter out of JSON entirely, so without this remap a JSON
+	// payload carrying the legacy key would be silently dropped. Honor it
+	// only when the canonical actress_delimiter is absent so an explicit
+	// canonical value always wins (and a stray legacy "" cannot wipe it).
+	if _, hasCanonical := probe["actress_delimiter"]; !hasCanonical {
+		if raw, hasLegacy := probe["delimiter"]; hasLegacy {
+			probe["actress_delimiter"] = raw
+			delete(probe, "delimiter")
+			data, _ = json.Marshal(probe)
+		}
+	}
+
 	if err := json.Unmarshal(data, &o.Template); err != nil {
 		return err
 	}

--- a/internal/config/output_nfo_json_test.go
+++ b/internal/config/output_nfo_json_test.go
@@ -1,0 +1,267 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOutputConfigMarshalJSON_Flat verifies OutputConfig serializes to a flat
+// JSON object (no Template/Operation/MediaFormat/Download nesting), matching
+// the YAML layout and the frontend OutputConfig type.
+func TestOutputConfigMarshalJSON_Flat(t *testing.T) {
+	o := OutputConfig{
+		Template:    OutputTemplateConfig{FolderFormat: "<ID>", SubfolderFormat: []string{"<ID>"}, ActressDelimiter: ", ", MaxTitleLength: 100},
+		Operation:   OutputOperationConfig{RenameFile: true, SubtitleExtensions: []string{".srt"}},
+		MediaFormat: OutputMediaFormatConfig{PosterFormat: "<ID>-poster.jpg", ScreenshotPadding: 1},
+		Download:    OutputDownloadConfig{DownloadCover: true, DownloadPoster: false, DownloadTimeout: 60},
+	}
+	b, err := json.Marshal(&o)
+	require.NoError(t, err)
+	s := string(b)
+
+	for _, key := range []string{"Template", "Operation", "MediaFormat", "Download"} {
+		assert.NotContains(t, s, "\""+key+"\"", "JSON should not nest group %q", key)
+	}
+	// Decode back and assert on values (robust to Go's HTML escaping of </>).
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &m))
+	for _, key := range []string{"folder_format", "file_format", "actress_delimiter", "max_title_length", "rename_file", "subtitle_extensions", "poster_format", "screenshot_padding", "download_cover", "download_poster", "download_timeout", "subfolder_format"} {
+		assert.Contains(t, m, key, "flat JSON missing key %q", key)
+	}
+	var ff string
+	require.NoError(t, json.Unmarshal(m["folder_format"], &ff))
+	assert.Equal(t, "<ID>", ff)
+	var dc bool
+	require.NoError(t, json.Unmarshal(m["download_cover"], &dc))
+	assert.True(t, dc)
+	var dp bool
+	require.NoError(t, json.Unmarshal(m["download_poster"], &dp))
+	assert.False(t, dp)
+	var sf []string
+	require.NoError(t, json.Unmarshal(m["subfolder_format"], &sf))
+	assert.Equal(t, []string{"<ID>"}, sf)
+}
+
+// TestOutputConfigUnmarshalJSON_Flat verifies the flat JSON shape round-trips
+// back into the grouped sub-struct fields.
+func TestOutputConfigUnmarshalJSON_Flat(t *testing.T) {
+	raw := `{"folder_format":"<ID>","file_format":"<ID>.mp4","actress_delimiter":", ","max_title_length":100,"rename_file":true,"subtitle_extensions":[".srt",".ass"],"poster_format":"<ID>-poster.jpg","screenshot_padding":1,"download_cover":true,"download_poster":false,"download_extrafanart":true,"download_trailer":true,"download_actress":true,"download_timeout":60}`
+	var o OutputConfig
+	require.NoError(t, json.Unmarshal([]byte(raw), &o))
+
+	assert.Equal(t, "<ID>", o.Template.FolderFormat)
+	assert.Equal(t, "<ID>.mp4", o.Template.FileFormat)
+	assert.Equal(t, ", ", o.Template.ActressDelimiter)
+	assert.Equal(t, 100, o.Template.MaxTitleLength)
+	assert.True(t, o.Operation.RenameFile)
+	assert.Equal(t, []string{".srt", ".ass"}, o.Operation.SubtitleExtensions)
+	assert.Equal(t, "<ID>-poster.jpg", o.MediaFormat.PosterFormat)
+	assert.Equal(t, 1, o.MediaFormat.ScreenshotPadding)
+	assert.True(t, o.Download.DownloadCover)
+	assert.False(t, o.Download.DownloadPoster)
+	assert.True(t, o.Download.DownloadExtrafanart)
+	assert.Equal(t, 60, o.Download.DownloadTimeout)
+}
+
+// TestOutputConfigUnmarshalJSON_NestedLegacy verifies the legacy nested shape
+// ({"Template": {...}, ...}) produced before this fix is still accepted.
+func TestOutputConfigUnmarshalJSON_NestedLegacy(t *testing.T) {
+	raw := `{"Template":{"folder_format":"X","actress_delimiter":"; "},"Operation":{"rename_file":false},"MediaFormat":{"poster_format":"p.jpg"},"Download":{"download_cover":false,"download_poster":true,"download_extrafanart":true,"download_trailer":true,"download_actress":true,"download_timeout":30}}`
+	var o OutputConfig
+	require.NoError(t, json.Unmarshal([]byte(raw), &o))
+
+	assert.Equal(t, "X", o.Template.FolderFormat)
+	assert.Equal(t, "; ", o.Template.ActressDelimiter)
+	assert.False(t, o.Operation.RenameFile)
+	assert.Equal(t, "p.jpg", o.MediaFormat.PosterFormat)
+	assert.False(t, o.Download.DownloadCover)
+	assert.True(t, o.Download.DownloadPoster)
+	assert.Equal(t, 30, o.Download.DownloadTimeout)
+}
+
+// TestOutputConfigUnmarshalJSON_LegacyDelimiterAlias verifies the bare legacy
+// "delimiter" key is honored as an alias for actress_delimiter on JSON input,
+// mirroring the YAML LegacyDelimiter behavior. Canonical wins on conflict.
+func TestOutputConfigUnmarshalJSON_LegacyDelimiterAlias(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"legacy-only maps to canonical", `{"delimiter": "; "}`, "; "},
+		{"canonical wins over legacy", `{"delimiter": "; ", "actress_delimiter": ", "}`, ", "},
+		{"canonical-only", `{"actress_delimiter": " / "}`, " / "},
+		{"neither leaves zero value", `{}`, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var o OutputConfig
+			require.NoError(t, json.Unmarshal([]byte(c.raw), &o))
+			assert.Equal(t, c.want, o.Template.ActressDelimiter)
+		})
+	}
+}
+
+// TestOutputConfigMarshalJSON_OmitsLegacyDelimiter verifies MarshalJSON emits
+// only the canonical actress_delimiter, never the legacy key.
+func TestOutputConfigMarshalJSON_OmitsLegacyDelimiter(t *testing.T) {
+	o := OutputConfig{Template: OutputTemplateConfig{ActressDelimiter: ", "}}
+	b, err := json.Marshal(&o)
+	require.NoError(t, err)
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &m))
+	assert.Contains(t, m, "actress_delimiter")
+	assert.NotContains(t, m, "delimiter")
+}
+
+// TestOutputConfigJSON_RoundTrip verifies marshal→unmarshal preserves all
+// fields across the four sub-structs.
+func TestOutputConfigJSON_RoundTrip(t *testing.T) {
+	original := OutputConfig{
+		Template:    OutputTemplateConfig{FolderFormat: "<ID>", FileFormat: "<ID>.mp4", SubfolderFormat: []string{"<ID>"}, ActressDelimiter: ", ", MaxTitleLength: 100, MaxPathLength: 240, FirstNameOrder: true, ActressLanguageJA: false},
+		Operation:   OutputOperationConfig{OperationMode: "move", RenameFile: true, AllowRevert: false, GroupActress: true, GroupActressName: "@Group", MoveSubtitles: true, SubtitleExtensions: []string{".srt", ".ass"}},
+		MediaFormat: OutputMediaFormatConfig{PosterFormat: "<ID>-poster.jpg", MaxPosterHeight: 0, FanartFormat: "<ID>-fanart.jpg", TrailerFormat: "<ID>-trailer.mp4", ScreenshotFormat: "fanart<INDEX>.jpg", ScreenshotFolder: "extrafanart", ScreenshotPadding: 1, ActressFolder: ".actors", ActressFormat: "<ACTORNAME>.jpg"},
+		Download:    OutputDownloadConfig{DownloadCover: true, DownloadPoster: true, DownloadExtrafanart: false, DownloadTrailer: true, DownloadActress: false, DownloadTimeout: 90},
+	}
+	b, err := json.Marshal(&original)
+	require.NoError(t, err)
+	var restored OutputConfig
+	require.NoError(t, json.Unmarshal(b, &restored))
+
+	assert.Equal(t, original.Template, restored.Template)
+	assert.Equal(t, original.Operation, restored.Operation)
+	assert.Equal(t, original.MediaFormat, restored.MediaFormat)
+	assert.Equal(t, original.Download, restored.Download)
+}
+
+// TestOutputConfigUnmarshalJSON_InvalidJSON verifies malformed input errors.
+func TestOutputConfigUnmarshalJSON_InvalidJSON(t *testing.T) {
+	var o OutputConfig
+	err := json.Unmarshal([]byte("{not json"), &o)
+	assert.Error(t, err)
+}
+
+// TestNFOConfigMarshalJSON_Flat verifies NFOConfig serializes to a flat JSON
+// object (no Feature/Format/Extra nesting), matching the frontend NFOConfig.
+func TestNFOConfigMarshalJSON_Flat(t *testing.T) {
+	n := NFOConfig{
+		Feature: NFOFeatureConfig{Enabled: true, PerFile: false, IncludeFanart: true, IncludeTrailer: false, IncludeStreamDetails: true, IncludeOriginalPath: false, ActressAsTag: true, AddGenericRole: false, AltNameRole: true},
+		Format:  NFOFormatConfig{DisplayTitle: "<TITLE>", FilenameTemplate: "<ID>.nfo", FirstNameOrder: true, ActressLanguageJA: false, RatingSource: "r18dev", Tagline: "tl", UnknownActressMode: "skip", UnknownActressText: "Unknown"},
+		Extra:   NFOExtraConfig{Tag: []string{"a", "b"}, Credits: []string{"c"}},
+	}
+	b, err := json.Marshal(&n)
+	require.NoError(t, err)
+	s := string(b)
+
+	for _, key := range []string{"Feature", "Format", "Extra"} {
+		assert.NotContains(t, s, "\""+key+"\"", "JSON should not nest group %q", key)
+	}
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &m))
+	for _, key := range []string{"enabled", "first_name_order", "unknown_actress_mode", "tag", "credits", "include_fanart", "actress_as_tag", "alt_name_role", "display_title", "filename_template"} {
+		assert.Contains(t, m, key, "flat JSON missing key %q", key)
+	}
+	var en bool
+	require.NoError(t, json.Unmarshal(m["enabled"], &en))
+	assert.True(t, en)
+	var fno bool
+	require.NoError(t, json.Unmarshal(m["first_name_order"], &fno))
+	assert.True(t, fno)
+	var uam string
+	require.NoError(t, json.Unmarshal(m["unknown_actress_mode"], &uam))
+	assert.Equal(t, "skip", uam)
+	var tag []string
+	require.NoError(t, json.Unmarshal(m["tag"], &tag))
+	assert.Equal(t, []string{"a", "b"}, tag)
+	var credits []string
+	require.NoError(t, json.Unmarshal(m["credits"], &credits))
+	assert.Equal(t, []string{"c"}, credits)
+}
+
+// TestNFOConfigUnmarshalJSON_Flat verifies the flat JSON shape round-trips
+// back into the grouped sub-struct fields.
+func TestNFOConfigUnmarshalJSON_Flat(t *testing.T) {
+	raw := `{"enabled":true,"per_file":false,"include_fanart":true,"include_trailer":false,"include_stream_details":true,"include_originalpath":false,"actress_as_tag":true,"add_generic_role":false,"alt_name_role":true,"display_title":"<TITLE>","filename_template":"<ID>.nfo","first_name_order":true,"actress_language_ja":false,"rating_source":"r18dev","tagline":"tl","unknown_actress_mode":"skip","unknown_actress_text":"Unknown","tag":["a","b"],"credits":["c"]}`
+	var n NFOConfig
+	require.NoError(t, json.Unmarshal([]byte(raw), &n))
+
+	assert.True(t, n.Feature.Enabled)
+	assert.False(t, n.Feature.PerFile)
+	assert.True(t, n.Feature.IncludeFanart)
+	assert.True(t, n.Feature.IncludeStreamDetails)
+	assert.True(t, n.Feature.ActressAsTag)
+	assert.True(t, n.Feature.AltNameRole)
+	assert.Equal(t, "<TITLE>", n.Format.DisplayTitle)
+	assert.Equal(t, "<ID>.nfo", n.Format.FilenameTemplate)
+	assert.True(t, n.Format.FirstNameOrder)
+	assert.Equal(t, "r18dev", n.Format.RatingSource)
+	assert.Equal(t, "skip", string(n.Format.UnknownActressMode))
+	assert.Equal(t, "Unknown", n.Format.UnknownActressText)
+	assert.Equal(t, []string{"a", "b"}, n.Extra.Tag)
+	assert.Equal(t, []string{"c"}, n.Extra.Credits)
+}
+
+// TestNFOConfigUnmarshalJSON_NestedLegacy verifies the legacy nested shape
+// ({"Feature": {...}, ...}) is still accepted.
+func TestNFOConfigUnmarshalJSON_NestedLegacy(t *testing.T) {
+	raw := `{"Feature":{"enabled":false,"per_file":true},"Format":{"first_name_order":false,"unknown_actress_mode":"fallback","unknown_actress_text":"N/A"},"Extra":{"tag":["x"]}}`
+	var n NFOConfig
+	require.NoError(t, json.Unmarshal([]byte(raw), &n))
+
+	assert.False(t, n.Feature.Enabled)
+	assert.True(t, n.Feature.PerFile)
+	assert.False(t, n.Format.FirstNameOrder)
+	assert.Equal(t, "fallback", string(n.Format.UnknownActressMode))
+	assert.Equal(t, "N/A", n.Format.UnknownActressText)
+	assert.Equal(t, []string{"x"}, n.Extra.Tag)
+}
+
+// TestNFOConfigJSON_RoundTrip verifies marshal→unmarshal preserves all fields.
+func TestNFOConfigJSON_RoundTrip(t *testing.T) {
+	original := NFOConfig{
+		Feature: NFOFeatureConfig{Enabled: true, PerFile: true, IncludeFanart: false, IncludeTrailer: true, IncludeStreamDetails: true, IncludeOriginalPath: true, ActressAsTag: false, AddGenericRole: true, AltNameRole: false},
+		Format:  NFOFormatConfig{DisplayTitle: "<TITLE>", FilenameTemplate: "<ID>.nfo", FirstNameOrder: false, ActressLanguageJA: true, RatingSource: "dmm", Tagline: "", UnknownActressMode: "fallback", UnknownActressText: "Unknown Actress"},
+		Extra:   NFOExtraConfig{Tag: []string{"tag1", "tag2"}, Credits: []string{"dir", "studio"}},
+	}
+	b, err := json.Marshal(&original)
+	require.NoError(t, err)
+	var restored NFOConfig
+	require.NoError(t, json.Unmarshal(b, &restored))
+
+	assert.Equal(t, original.Feature, restored.Feature)
+	assert.Equal(t, original.Format, restored.Format)
+	assert.Equal(t, original.Extra, restored.Extra)
+}
+
+// TestNFOConfigUnmarshalJSON_InvalidJSON verifies malformed input errors.
+func TestNFOConfigUnmarshalJSON_InvalidJSON(t *testing.T) {
+	var n NFOConfig
+	err := json.Unmarshal([]byte("}bad json{"), &n)
+	assert.Error(t, err)
+}
+
+// TestNFOConfigUnmarshalJSON_NullArrays verifies null array fields decode to
+// nil slices without error (backend serializes empty tag/credits as null).
+func TestNFOConfigUnmarshalJSON_NullArrays(t *testing.T) {
+	raw := `{"enabled":true,"tag":null,"credits":null}`
+	var n NFOConfig
+	require.NoError(t, json.Unmarshal([]byte(raw), &n))
+	assert.True(t, n.Feature.Enabled)
+	assert.Nil(t, n.Extra.Tag)
+	assert.Nil(t, n.Extra.Credits)
+}
+
+// TestOutputConfigMarshalJSON_DoesNotEmitLegacyDelimiterField ensures the
+// json:"-" LegacyDelimiter field never appears in output (belt-and-suspenders
+// alongside TestOutputConfigMarshalJSON_OmitsLegacyDelimiter).
+func TestOutputConfigMarshalJSON_DoesNotEmitLegacyDelimiterField(t *testing.T) {
+	o := OutputConfig{Template: OutputTemplateConfig{LegacyDelimiter: "legacy", ActressDelimiter: "canonical"}}
+	b, err := json.Marshal(&o)
+	require.NoError(t, err)
+	assert.False(t, strings.Contains(string(b), "legacy"), "LegacyDelimiter must not serialize: %s", b)
+	assert.Contains(t, string(b), `"actress_delimiter":"canonical"`)
+}

--- a/internal/config/output_nfo_json_test.go
+++ b/internal/config/output_nfo_json_test.go
@@ -138,11 +138,42 @@ func TestOutputConfigJSON_RoundTrip(t *testing.T) {
 	assert.Equal(t, original.Download, restored.Download)
 }
 
-// TestOutputConfigUnmarshalJSON_InvalidJSON verifies malformed input errors.
+// TestOutputConfigUnmarshalJSON_InvalidJSON verifies malformed input errors
+// at the top-level probe unmarshal (line 47-48).
 func TestOutputConfigUnmarshalJSON_InvalidJSON(t *testing.T) {
 	var o OutputConfig
 	err := json.Unmarshal([]byte("{not json"), &o)
 	assert.Error(t, err)
+}
+
+// TestOutputConfigUnmarshalJSON_NestedPathError verifies a malformed nested
+// payload (Template present but not an object) errors via the nested branch.
+func TestOutputConfigUnmarshalJSON_NestedPathError(t *testing.T) {
+	var o OutputConfig
+	err := json.Unmarshal([]byte(`{"Template":"not-an-object"}`), &o)
+	assert.Error(t, err)
+}
+
+// TestOutputConfigUnmarshalJSON_FlatSubStructErrors verifies type-mismatched
+// values in each flat sub-struct field surface an error from every per-group
+// unmarshal branch (Template/Operation/MediaFormat/Download).
+func TestOutputConfigUnmarshalJSON_FlatSubStructErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"template field wrong type", `{"max_title_length":"not-int"}`},
+		{"operation field wrong type", `{"rename_file":"not-bool"}`},
+		{"mediaformat field wrong type", `{"screenshot_padding":"not-int"}`},
+		{"download field wrong type", `{"download_timeout":"not-int"}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var o OutputConfig
+			err := json.Unmarshal([]byte(c.raw), &o)
+			assert.Error(t, err)
+		})
+	}
 }
 
 // TestNFOConfigMarshalJSON_Flat verifies NFOConfig serializes to a flat JSON
@@ -237,11 +268,41 @@ func TestNFOConfigJSON_RoundTrip(t *testing.T) {
 	assert.Equal(t, original.Extra, restored.Extra)
 }
 
-// TestNFOConfigUnmarshalJSON_InvalidJSON verifies malformed input errors.
+// TestNFOConfigUnmarshalJSON_InvalidJSON verifies malformed input errors
+// at the top-level probe unmarshal (line 46-47).
 func TestNFOConfigUnmarshalJSON_InvalidJSON(t *testing.T) {
 	var n NFOConfig
 	err := json.Unmarshal([]byte("}bad json{"), &n)
 	assert.Error(t, err)
+}
+
+// TestNFOConfigUnmarshalJSON_NestedPathError verifies a malformed nested
+// payload (Feature present but not an object) errors via the nested branch.
+func TestNFOConfigUnmarshalJSON_NestedPathError(t *testing.T) {
+	var n NFOConfig
+	err := json.Unmarshal([]byte(`{"Feature":"not-an-object"}`), &n)
+	assert.Error(t, err)
+}
+
+// TestNFOConfigUnmarshalJSON_FlatSubStructErrors verifies type-mismatched
+// values in each flat sub-struct field surface an error from every per-group
+// unmarshal branch (Feature/Format/Extra).
+func TestNFOConfigUnmarshalJSON_FlatSubStructErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"feature field wrong type", `{"enabled":"not-bool"}`},
+		{"format field wrong type", `{"first_name_order":"not-bool"}`},
+		{"extra field wrong type", `{"tag":"not-an-array"}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var n NFOConfig
+			err := json.Unmarshal([]byte(c.raw), &n)
+			assert.Error(t, err)
+		})
+	}
 }
 
 // TestNFOConfigUnmarshalJSON_NullArrays verifies null array fields decode to

--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -834,7 +834,7 @@ export interface OutputConfig {
 	folder_format: string;
 	file_format: string;
 	subfolder_format: string[];
-	delimiter: string;
+	actress_delimiter: string;
 	max_title_length: number;
 	max_path_length: number;
 	max_poster_height: number;

--- a/web/frontend/src/lib/components/settings/sections/FileMatchingSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/FileMatchingSettingsSection.svelte
@@ -17,7 +17,7 @@
 			<input
 				id="file-extensions"
 				type="text"
-				value={config.file_matching.extensions.join(', ')}
+				value={config.file_matching.extensions?.join(', ') ?? ''}
 				onchange={(e) => {
 					config.file_matching.extensions = e.currentTarget.value
 						.split(',')
@@ -51,7 +51,7 @@
 			<input
 				id="exclude-patterns"
 				type="text"
-				value={config.file_matching.exclude_patterns.join(', ')}
+				value={config.file_matching.exclude_patterns?.join(', ') ?? ''}
 				onchange={(e) => {
 					config.file_matching.exclude_patterns = e.currentTarget.value
 						.split(',')

--- a/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
@@ -87,7 +87,7 @@
 			<input
 				id="subfolder-format"
 				type="text"
-				value={config.output.subfolder_format.join(', ')}
+				value={config.output.subfolder_format?.join(', ') ?? ''}
 				onchange={(e) => {
 					config.output.subfolder_format = e.currentTarget.value
 						.split(',')

--- a/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
@@ -72,7 +72,7 @@
 				<input
 					id="delimiter"
 					type="text"
-					bind:value={config.output.delimiter}
+					bind:value={config.output.actress_delimiter}
 					class={inputClass}
 					placeholder=", "
 				/>


### PR DESCRIPTION
## Summary

Fixes the WebUI **Output** and **NFO** settings sections, which were completely broken: fields showed `undefined` / checkboxes were unchecked regardless of `config.yaml`, and saves were silently dropped.

### Root cause

`OutputConfig` and `NFOConfig` group their fields into named sub-structs using `yaml:",inline"`:

```go
type OutputConfig struct {
    Template    OutputTemplateConfig    `yaml:",inline"`
    Operation   OutputOperationConfig   `yaml:",inline"`
    MediaFormat OutputMediaFormatConfig `yaml:",inline"`
    Download    OutputDownloadConfig    `yaml:",inline"`
}
```

`yaml:",inline"` flattens the **YAML** layout, but Go's `encoding/json` does **not** inline *named* fields — only embedded (anonymous) fields are inlined. So the API serialized these as nested objects (`{"Template": {...}, "Download": {...}}`) while the frontend `OutputConfig`/`NFOConfig` types and every settings component read a **flat** shape (`config.output.download_cover`). The result: all `output.*` and `nfo.*` fields deserialized to `undefined` on the WebUI, and the flat JSON the frontend sent back on save didn't map to the nested struct — so saves were silently lost.

A downstream symptom was the `subfolder_format.join()` crash (`Cannot read properties of undefined (reading 'join')`) in `OutputSettingsSection`.

### Changes (3 commits)

1. **`fix(frontend): guard array .join()`** — Defensive `?.join() ?? ''` guards on the 3 unguarded `.join()` calls in settings sections (`OutputSettingsSection.subfolder_format`, `FileMatchingSettingsSection.extensions` + `exclude_patterns`), matching the convention already used by the other sections. Prevents the crash when a field is `undefined`.

2. **`fix(config): flatten OutputConfig JSON`** — Add `MarshalJSON`/`UnmarshalJSON` to `OutputConfig` that collapse the 4 sub-structs into one flat object matching the YAML layout and frontend contract. `UnmarshalJSON` also accepts the legacy nested shape for backward compatibility. Go API (`cfg.Output.Template.*`, `cfg.Output.Download.*`) unchanged. Fixes the download checkboxes (`download_cover`/`poster`/`extrafanart`), all output fields, and saves.

3. **`fix(config,frontend): flatten NFOConfig JSON + actress_delimiter`** — Same fix for `NFOConfig` (Feature/Format/Extra), which had the identical bug and broke the entire NFO settings section (e.g. `first_name_order: true` showed unchecked). Also fixes a field-name mismatch: `OutputSettingsSection` bound `config.output.delimiter`, but the canonical backend field is `actress_delimiter` (the bare `delimiter` is a YAML-only legacy alias, `json:"-"`), so the delimiter input always showed empty and never saved.

### Verification

- `go test ./internal/config/... ./internal/translation/... ./internal/api/system/...` — all pass
- Full pre-commit suite (golangci-lint, go vet, fast unit tests, build, swagger, **svelte-check** 0 errors, frontend build) — all green
- JSON shape verified flat (`download_cover: true` at top level, no `Template`/`Download`/`Feature`/`Format`/`Extra` keys), round-trips correctly, legacy nested shape still accepted
- No JSON field-name collisions across the flattened sub-structs (33 output fields, 19 NFO fields, all unique)
- Audited the whole config package: only `OutputConfig` and `NFOConfig` use this pattern; no other structs are affected

### Test plan

- [ ] Load the WebUI settings → Output section: download checkboxes reflect `config.yaml` (`download_cover`/`poster`/`extrafanart`), folder/file formats populate, no console crash
- [ ] Change an output setting and save → reload → value persists
- [ ] Settings → NFO section: `first_name_order`, `actress_as_tag`, `unknown_actress_mode`, etc. reflect config and save correctly
- [ ] Actress delimiter input shows the configured value and persists on save



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated output and NFO configuration serialization to support both the current flat JSON format and the legacy nested format for better backward compatibility.
* **Bug Fixes**
  * Updated the settings UI to use the renamed output delimiter field.
  * Prevented runtime errors by safely handling missing file matching and subfolder format values (showing empty fields instead of failing).
  * Ensured legacy delimiter values are mapped to the canonical delimiter key only when the canonical key is not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->