### PR TITLE
fix(edit): persist actress name edits from review page to DB and NFO

### DIFF
--- a/internal/api/core/bootstrap.go
+++ b/internal/api/core/bootstrap.go
@@ -54,7 +54,7 @@ func bootstrapAPIDeps(cfg *config.Config, configFile string, auth commandutil.Au
 	// OsFs, and APIDeps.Fs was left unset). GetFs() falls back to OsFs when
 	// nil, so this is behavior-preserving for existing callers.
 	fs := afero.NewOsFs()
-	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, sharedEngine, fs)
+	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, sharedEngine, fs, worker.WithActressRepo(repos.ActressRepo))
 	eventEmitter := eventlog.NewEmitter(repos.EventRepo)
 	reverter := history.NewReverter(fs, repos.BatchFileOpRepo)
 

--- a/internal/api/testkit/helpers.go
+++ b/internal/api/testkit/helpers.go
@@ -140,7 +140,7 @@ func CreateTestDeps(t *testing.T, cfg *config.Config, configFile string) *core.A
 	repos := db.Repositories()
 
 	// Initialize job queue with jobRepo for persistence
-	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, nil, nil)
+	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, nil, nil, worker.WithActressRepo(repos.ActressRepo))
 
 	deps := &core.APIDeps{
 		CoreDeps: &commandutil.CoreDeps{

--- a/internal/worker/actress_edit_coverage_test.go
+++ b/internal/worker/actress_edit_coverage_test.go
@@ -1,0 +1,66 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetDepsFromConfig_ActressRepo(t *testing.T) {
+	db := newActressEditTestDB(t)
+	repos := db.Repositories()
+
+	jq := NewJobStore(nil, nil, nil, "", nil, nil)
+	job := jq.CreateJobBatch([]string{"file1.mp4"}, &JobConfig{BatchJobDeps: BatchJobDeps{ActressRepo: repos.ActressRepo}})
+
+	assert.Same(t, repos.ActressRepo, job.deps.ActressRepo,
+		"setDepsFromConfig must wire cfg.ActressRepo into job.deps")
+}
+
+func TestUpdateMovie_ActressRenameError(t *testing.T) {
+	db := newActressEditTestDB(t)
+	repos := db.Repositories()
+
+	// A separately-closed DB backs the actress repo so Update fails, while the
+	// real (open) movieRepo satisfies the gate. The rename loop runs before
+	// movieRepo.Upsert, so the failure aborts UpdateMovie with a wrapped error.
+	badDB := newActressEditTestDB(t)
+	badRepo := badDB.Repositories().ActressRepo
+	require.NoError(t, badDB.Close())
+
+	jq := NewJobStore(nil, nil, repos.MovieRepo, "", nil, nil, WithActressRepo(badRepo))
+	job := jq.CreateJobBatch([]string{"file1.mp4"})
+	job.results.UpdateFileResult("file1.mp4", &MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: "file1.mp4", MovieID: "ABC-001"},
+		Status:        models.JobStatusCompleted,
+		Movie: &models.Movie{ID: "ABC-001", Actresses: []models.Actress{
+			{ID: 1, FirstName: "Yui", JapaneseName: "波多野結衣"},
+		}},
+	})
+
+	ej, ok := jq.GetJobForEdit(job.ID.String())
+	require.True(t, ok)
+
+	err := ej.UpdateMovie(context.Background(), "file1.mp4",
+		&models.Movie{ID: "ABC-001", Actresses: []models.Actress{
+			{ID: 1, FirstName: "Yui-Edited", JapaneseName: "波多野結衣"},
+		}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "persist actress name edit",
+		"a failing actress rename must abort UpdateMovie with a wrapped error")
+}
+
+func TestReconstructBatchJob_ActressRepo(t *testing.T) {
+	db := newActressEditTestDB(t)
+	repos := db.Repositories()
+
+	jq := &JobStore{jobs: make(map[models.JobID]*BatchJob), actressRepo: repos.ActressRepo}
+	dbJob := &models.Job{ID: "recon-actress-1", Status: models.JobStatusCompleted, TotalFiles: 1}
+	reconstructed := jq.reconstructBatchJob(dbJob)
+
+	assert.Same(t, repos.ActressRepo, reconstructed.deps.ActressRepo,
+		"reconstructed jobs must inherit JobStore.actressRepo via wireJobDeps")
+}

--- a/internal/worker/actress_edit_test.go
+++ b/internal/worker/actress_edit_test.go
@@ -1,0 +1,117 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newActressEditTestDB(t *testing.T) *database.DB {
+	t.Helper()
+	cfg := &database.Config{Type: "sqlite", DSN: ":memory:", LogLevel: "error"}
+	db, err := database.New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.RunMigrationsOnStartup(context.Background()))
+	return db
+}
+
+func seedCuratedActress(t *testing.T, repo database.ActressRepositoryInterface) models.Actress {
+	t.Helper()
+	a := &models.Actress{
+		DMMID:        12345,
+		FirstName:    "Yui",
+		LastName:     "Hatano",
+		JapaneseName: "波多野結衣",
+	}
+	require.NoError(t, repo.Create(context.Background(), a))
+	require.NotZero(t, a.ID)
+	return *a
+}
+
+func TestUpdateMovie_ActressRenamesByID(t *testing.T) {
+	t.Run("edited existing actress name persists to DB and in-memory (NFO path)", func(t *testing.T) {
+		db := newActressEditTestDB(t)
+		repos := db.Repositories()
+		curated := seedCuratedActress(t, repos.ActressRepo)
+
+		jq := NewJobStore(nil, nil, repos.MovieRepo, "", nil, nil, WithActressRepo(repos.ActressRepo))
+		job := jq.CreateJobBatch([]string{"file1.mp4"})
+		job.results.UpdateFileResult("file1.mp4", &MovieResult{
+			FileMatchInfo: models.FileMatchInfo{Path: "file1.mp4", MovieID: "ABC-001"},
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "ABC-001", Actresses: []models.Actress{curated}},
+		})
+
+		ej, ok := jq.GetJobForEdit(job.ID.String())
+		require.True(t, ok)
+
+		edited := curated
+		edited.FirstName = "Yui-Edited"
+		require.NoError(t, ej.UpdateMovie(context.Background(), "file1.mp4",
+			&models.Movie{ID: "ABC-001", Actresses: []models.Actress{edited}}))
+
+		got, err := repos.ActressRepo.FindByID(context.Background(), curated.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Yui-Edited", got.FirstName, "actresses table (Actresses page) must reflect the rename")
+
+		result, _ := job.results.GetMovieResult("file1.mp4")
+		require.NotEmpty(t, result.Movie.Actresses)
+		assert.Equal(t, "Yui-Edited", result.Movie.Actresses[0].FirstName,
+			"in-memory movie (NFO generation) must carry the edited name")
+	})
+
+	t.Run("scrape path is untouched: without actressRepo the curated name is preserved", func(t *testing.T) {
+		db := newActressEditTestDB(t)
+		repos := db.Repositories()
+		curated := seedCuratedActress(t, repos.ActressRepo)
+
+		jq := NewJobStore(nil, nil, repos.MovieRepo, "", nil, nil)
+		job := jq.CreateJobBatch([]string{"file1.mp4"})
+		job.results.UpdateFileResult("file1.mp4", &MovieResult{
+			FileMatchInfo: models.FileMatchInfo{Path: "file1.mp4", MovieID: "ABC-001"},
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "ABC-001", Actresses: []models.Actress{curated}},
+		})
+
+		ej, ok := jq.GetJobForEdit(job.ID.String())
+		require.True(t, ok)
+
+		edited := curated
+		edited.FirstName = "Yui-Edited"
+		require.NoError(t, ej.UpdateMovie(context.Background(), "file1.mp4",
+			&models.Movie{ID: "ABC-001", Actresses: []models.Actress{edited}}))
+
+		got, err := repos.ActressRepo.FindByID(context.Background(), curated.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Yui", got.FirstName, "curated actress name must not be clobbered on the scrape/shared path")
+	})
+
+	t.Run("new actress (ID==0) is left to the upserter, not force-renamed", func(t *testing.T) {
+		db := newActressEditTestDB(t)
+		repos := db.Repositories()
+
+		jq := NewJobStore(nil, nil, repos.MovieRepo, "", nil, nil, WithActressRepo(repos.ActressRepo))
+		job := jq.CreateJobBatch([]string{"file1.mp4"})
+		job.results.UpdateFileResult("file1.mp4", &MovieResult{
+			FileMatchInfo: models.FileMatchInfo{Path: "file1.mp4", MovieID: "ABC-001"},
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "ABC-001"},
+		})
+
+		ej, ok := jq.GetJobForEdit(job.ID.String())
+		require.True(t, ok)
+
+		newActress := models.Actress{FirstName: "Rookie", LastName: "Star", JapaneseName: "新人"}
+		require.NoError(t, ej.UpdateMovie(context.Background(), "file1.mp4",
+			&models.Movie{ID: "ABC-001", Actresses: []models.Actress{newActress}}))
+
+		found, err := repos.ActressRepo.FindByFirstNameLastName(context.Background(), "Rookie", "Star")
+		require.NoError(t, err)
+		assert.Equal(t, "Rookie", found.FirstName, "new actress must be created by the upserter, not skipped")
+	})
+}

--- a/internal/worker/actress_edit_test.go
+++ b/internal/worker/actress_edit_test.go
@@ -91,6 +91,34 @@ func TestUpdateMovie_ActressRenamesByID(t *testing.T) {
 		assert.Equal(t, "Yui", got.FirstName, "curated actress name must not be clobbered on the scrape/shared path")
 	})
 
+	t.Run("in-memory-only path (movieRepo nil) does not mutate the DB", func(t *testing.T) {
+		db := newActressEditTestDB(t)
+		repos := db.Repositories()
+		curated := seedCuratedActress(t, repos.ActressRepo)
+
+		// actressRepo is wired but movieRepo is nil: the in-memory-only edit path
+		// must not rename (no DB persistence).
+		jq := NewJobStore(nil, nil, nil, "", nil, nil, WithActressRepo(repos.ActressRepo))
+		job := jq.CreateJobBatch([]string{"file1.mp4"})
+		job.results.UpdateFileResult("file1.mp4", &MovieResult{
+			FileMatchInfo: models.FileMatchInfo{Path: "file1.mp4", MovieID: "ABC-001"},
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "ABC-001", Actresses: []models.Actress{curated}},
+		})
+
+		ej, ok := jq.GetJobForEdit(job.ID.String())
+		require.True(t, ok)
+
+		edited := curated
+		edited.FirstName = "Yui-Edited"
+		require.NoError(t, ej.UpdateMovie(context.Background(), "file1.mp4",
+			&models.Movie{ID: "ABC-001", Actresses: []models.Actress{edited}}))
+
+		got, err := repos.ActressRepo.FindByID(context.Background(), curated.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Yui", got.FirstName, "in-memory-only path must not mutate the actresses table")
+	})
+
 	t.Run("new actress (ID==0) is left to the upserter, not force-renamed", func(t *testing.T) {
 		db := newActressEditTestDB(t)
 		repos := db.Repositories()

--- a/internal/worker/batch_job.go
+++ b/internal/worker/batch_job.go
@@ -32,6 +32,7 @@ type BatchJobDeps struct {
 	BatchCfg        BatchJobConfig                                 // Narrow config fields (replaces *config.Config)
 	BatchFileOpRepo database.BatchFileOperationRepositoryInterface // Batch file operations repository
 	MovieRepo       database.MovieRepositoryInterface              // Movie persistence for batch editing
+	ActressRepo     database.ActressRepositoryInterface            // Actress persistence for explicit review-page edits
 	HistoryRepo     database.HistoryRepositoryInterface            // History repository
 	Emitter         eventlog.EventEmitter                          // Event emission for audit trail
 	PersistFn       func()                                         // Callback to persist job state to database
@@ -159,7 +160,7 @@ func newBatchJob(files []string, jobCfg ...*JobConfig) *BatchJob {
 
 	// Per P-2: wireJobDeps centralizes attachLifecycleCallback, posterEditor,
 	// controller, and PersistFn wiring shared with reconstructBatchJob.
-	wireJobDeps(job, nil, nil)
+	wireJobDeps(job, nil, nil, nil)
 
 	if len(jobCfg) > 0 && jobCfg[0] != nil {
 		cfg := jobCfg[0]

--- a/internal/worker/batch_job_interface.go
+++ b/internal/worker/batch_job_interface.go
@@ -353,6 +353,7 @@ type jobEditorImpl struct {
 	lifecycle    *JobLifecycle
 	posterEditor *PosterEditor
 	movieRepo    database.MovieRepositoryInterface
+	actressRepo  database.ActressRepositoryInterface
 }
 
 func (je *jobEditorImpl) UpdateMovie(ctx context.Context, filePath string, movie *models.Movie) error {
@@ -364,6 +365,23 @@ func (je *jobEditorImpl) UpdateMovie(ctx context.Context, filePath string, movie
 		backupCoverOriginal(current.Movie, movie)
 		return current, nil
 	})
+
+	// Apply explicit actress name edits before the movie upsert. The shared
+	// MovieUpserter only fills missing actress fields, which would discard a
+	// review-page name edit; renaming the record by ID here overwrites it, and
+	// doing so before Upsert makes Upsert's name-based lookup find the renamed
+	// record so the in-memory clone (and NFO generation) carries the edit.
+	if je.actressRepo != nil {
+		for i := range movie.Actresses {
+			a := &movie.Actresses[i]
+			if a.ID == 0 {
+				continue
+			}
+			if err := je.actressRepo.Update(ctx, a); err != nil {
+				return fmt.Errorf("persist actress name edit: %w", err)
+			}
+		}
+	}
 
 	// persist to DB first, then update in-memory. If DB persist
 	// fails, the in-memory state is not updated — no divergence. If DB persist

--- a/internal/worker/batch_job_interface.go
+++ b/internal/worker/batch_job_interface.go
@@ -371,7 +371,9 @@ func (je *jobEditorImpl) UpdateMovie(ctx context.Context, filePath string, movie
 	// review-page name edit; renaming the record by ID here overwrites it, and
 	// doing so before Upsert makes Upsert's name-based lookup find the renamed
 	// record so the in-memory clone (and NFO generation) carries the edit.
-	if je.actressRepo != nil {
+	// Gated on movieRepo so the in-memory-only edit path (no DB persistence)
+	// never mutates the database.
+	if je.actressRepo != nil && je.movieRepo != nil {
 		for i := range movie.Actresses {
 			a := &movie.Actresses[i]
 			if a.ID == 0 {

--- a/internal/worker/job_controller.go
+++ b/internal/worker/job_controller.go
@@ -234,6 +234,9 @@ func (c *jobController) setDepsFromConfig(cfg *JobConfig) {
 		c.job.deps.MovieRepo = cfg.MovieRepo
 		c.job.posterEditor = NewPosterEditor(c.job.resultIndex, c.job.results, cfg.MovieRepo)
 	}
+	if cfg.ActressRepo != nil {
+		c.job.deps.ActressRepo = cfg.ActressRepo
+	}
 	if cfg.HistoryRepo != nil {
 		c.job.deps.HistoryRepo = cfg.HistoryRepo
 	}

--- a/internal/worker/job_store.go
+++ b/internal/worker/job_store.go
@@ -28,6 +28,7 @@ type JobStore struct {
 	jobRepo           database.JobRepositoryInterface
 	batchFileOpRepo   database.BatchFileOperationRepositoryInterface
 	movieRepo         database.MovieRepositoryInterface
+	actressRepo       database.ActressRepositoryInterface
 	persistence       JobPersistencer
 	tempDir           string
 	templateEngine    template.EngineInterface
@@ -58,6 +59,16 @@ type JobStoreOption func(*JobStore)
 func WithPersistence(p JobPersistencer) JobStoreOption {
 	return func(s *JobStore) {
 		s.persistence = p
+	}
+}
+
+// WithActressRepo sets the actress repository used to persist explicit actress
+// name edits made on the review page (rename by primary key). When unset, the
+// edit path skips the overwrite and behaves as before (edits are discarded by
+// the shared upserter's fill-missing merge).
+func WithActressRepo(r database.ActressRepositoryInterface) JobStoreOption {
+	return func(s *JobStore) {
+		s.actressRepo = r
 	}
 }
 
@@ -213,6 +224,7 @@ func buildAdapters(job *BatchJob) *jobAdapters {
 			lifecycle:    job.lifecycle,
 			posterEditor: job.posterEditor,
 			movieRepo:    job.deps.MovieRepo,
+			actressRepo:  job.deps.ActressRepo,
 		},
 	}
 }
@@ -275,6 +287,9 @@ func (s *JobStore) createJob(files []string, jobCfg ...*JobConfig) *BatchJob {
 	}
 	if job.deps.MovieRepo == nil {
 		job.deps.MovieRepo = s.movieRepo
+	}
+	if job.deps.ActressRepo == nil {
+		job.deps.ActressRepo = s.actressRepo
 	}
 
 	s.mu.Lock()

--- a/internal/worker/job_store_persist.go
+++ b/internal/worker/job_store_persist.go
@@ -93,12 +93,15 @@ func (s *JobStore) reconstructResultTracker(dbJob *models.Job) *ResultTracker {
 // (created via getAdapters/buildAdapters) can persist movie edits to the
 // database. Without this, reconstructed jobs have nil MovieRepo and
 // UpdateMovie() silently skips DB persistence.
-func wireJobDeps(job *BatchJob, movieRepo database.MovieRepositoryInterface, persistFn func()) {
+func wireJobDeps(job *BatchJob, movieRepo database.MovieRepositoryInterface, actressRepo database.ActressRepositoryInterface, persistFn func()) {
 	job.attachLifecycleCallback()
 	job.posterEditor = NewPosterEditor(job.resultIndex, job.results, movieRepo)
 	job.controller = newJobController(job)
 	if movieRepo != nil {
 		job.deps.MovieRepo = movieRepo
+	}
+	if actressRepo != nil {
+		job.deps.ActressRepo = actressRepo
 	}
 	if persistFn != nil {
 		job.deps.PersistFn = persistFn
@@ -147,7 +150,7 @@ func (s *JobStore) reconstructBatchJob(dbJob *models.Job) *BatchJob {
 	}
 
 	// Step 3: Wire shared dependencies
-	wireJobDeps(batchJob, s.movieRepo, func() { s.persistence.PersistJob(batchJob) })
+	wireJobDeps(batchJob, s.movieRepo, s.actressRepo, func() { s.persistence.PersistJob(batchJob) })
 
 	// Step 3b: Restore infrastructure deps that are not persisted in the DB
 	// but are required for apply/rescrape phases. These are set on the JobStore

--- a/web/frontend/src/lib/components/ActressEditor.svelte
+++ b/web/frontend/src/lib/components/ActressEditor.svelte
@@ -14,7 +14,7 @@
 	interface Props {
 		movie: Movie;
 		onUpdate: (movie: Movie) => void;
-		onPersistEdits?: () => void;
+		onPersistEdits?: () => void | Promise<void>;
 		actressSources?: Record<string, string>;
 		showFieldSources?: boolean;
 	}
@@ -121,7 +121,7 @@
 
 	function notifyParent() {
 		onUpdate({ ...movie, actresses });
-		onPersistEdits?.();
+		void Promise.resolve(onPersistEdits?.()).catch(() => {});
 	}
 
 	function openAddActress() {

--- a/web/frontend/src/lib/components/ActressEditor.svelte
+++ b/web/frontend/src/lib/components/ActressEditor.svelte
@@ -14,11 +14,12 @@
 	interface Props {
 		movie: Movie;
 		onUpdate: (movie: Movie) => void;
+		onPersistEdits?: () => void;
 		actressSources?: Record<string, string>;
 		showFieldSources?: boolean;
 	}
 
-	let { movie, onUpdate, actressSources, showFieldSources = false }: Props = $props();
+	let { movie, onUpdate, onPersistEdits, actressSources, showFieldSources = false }: Props = $props();
 
 	let actresses = $state<Actress[]>([]);
 	let showEditModal = $state(false);
@@ -120,6 +121,7 @@
 
 	function notifyParent() {
 		onUpdate({ ...movie, actresses });
+		onPersistEdits?.();
 	}
 
 	function openAddActress() {

--- a/web/frontend/src/routes/actresses/stores/actress-store.svelte.ts
+++ b/web/frontend/src/routes/actresses/stores/actress-store.svelte.ts
@@ -70,6 +70,8 @@ export function createActressStore() {
 				toastStore.success('Actress created');
 			}
 			queryClient.invalidateQueries({ queryKey: ['actresses'] });
+			queryClient.invalidateQueries({ queryKey: ['batch-job'] });
+			queryClient.invalidateQueries({ queryKey: ['batch-job-slim'] });
 			resetForm();
 		},
 		onError: (err: Error) => {
@@ -90,6 +92,8 @@ export function createActressStore() {
 				resetForm();
 			}
 			queryClient.invalidateQueries({ queryKey: ['actresses'] });
+			queryClient.invalidateQueries({ queryKey: ['batch-job'] });
+			queryClient.invalidateQueries({ queryKey: ['batch-job-slim'] });
 		},
 		onError: (err: Error) => {
 			toastStore.error(err.message);
@@ -151,6 +155,8 @@ export function createActressStore() {
 			selectedIds = selectedIds.filter((id) => id !== variables.source_id);
 			mergeSourceQueue = mergeSourceQueue.slice(1);
 			queryClient.invalidateQueries({ queryKey: ['actresses'] });
+			queryClient.invalidateQueries({ queryKey: ['batch-job'] });
+			queryClient.invalidateQueries({ queryKey: ['batch-job-slim'] });
 			queryClient.invalidateQueries({ queryKey: ['actress-merge-preview'] });
 			advanceMergeQueue();
 		},

--- a/web/frontend/src/routes/review/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/review/[jobId]/+page.svelte
@@ -284,6 +284,7 @@
 								<ActressEditor
 									movie={s.currentMovie!}
 									onUpdate={s.updateCurrentMovie}
+								onPersistEdits={s.saveAllEdits}
 									actressSources={s.currentResult.actress_sources}
 									showFieldSources={s.showFieldScraperSources}
 								/>

--- a/web/frontend/src/routes/review/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/review/[jobId]/+page.svelte
@@ -171,6 +171,10 @@
 						onClose={() => goto('/browse')}
 						onUpdateAll={s.updateAll}
 						onOrganizeAll={s.organizeAll}
+						onSaveAll={s.saveAllEdits}
+						hasEdits={s.editedMovieCount > 0}
+						editCount={s.editedMovieCount}
+						savingEdits={s.isSavingEdits}
 					/>
 
 					<OrganizeStatusCard

--- a/web/frontend/src/routes/review/[jobId]/components/ReviewHeader.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/ReviewHeader.svelte
@@ -30,7 +30,7 @@
 		onClose: () => void;
 		onUpdateAll: () => void;
 		onOrganizeAll: () => void;
-		onSaveAll: () => void;
+		onSaveAll: () => void | Promise<void>;
 		hasEdits: boolean;
 		editCount: number;
 		savingEdits: boolean;
@@ -135,7 +135,7 @@
 		</div>
 		<div class="h-8 w-px bg-border"></div>
 		{#if hasEdits}
-			<Button onclick={onSaveAll} disabled={savingEdits || organizing} title="Save pending edits to the database">
+			<Button onclick={() => { void Promise.resolve(onSaveAll()).catch(() => {}); }} disabled={savingEdits || organizing} title="Save pending edits to the database">
 				{#snippet children()}
 					{#if savingEdits}
 						<LoaderCircle class="h-4 w-4 mr-2 animate-spin" />

--- a/web/frontend/src/routes/review/[jobId]/components/ReviewHeader.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/ReviewHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/Button.svelte';
-	import { ChevronDown, ChevronUp, Image, LayoutGrid, List, LoaderCircle, Play, RefreshCw, Settings2, X, CheckSquare, Square, Trash2, RotateCcw, MousePointerClick } from 'lucide-svelte';
+	import { ChevronDown, ChevronUp, Image, LayoutGrid, List, LoaderCircle, Play, RefreshCw, Settings2, X, CheckSquare, Square, Trash2, RotateCcw, MousePointerClick, Save } from 'lucide-svelte';
 	import type { CompletenessTier } from '$lib/utils/completeness';
 
 	interface Props {
@@ -30,6 +30,10 @@
 		onClose: () => void;
 		onUpdateAll: () => void;
 		onOrganizeAll: () => void;
+		onSaveAll: () => void;
+		hasEdits: boolean;
+		editCount: number;
+		savingEdits: boolean;
 	}
 
 		let {
@@ -58,7 +62,11 @@
 		onBulkRescrape,
 		onClose,
 		onUpdateAll,
-		onOrganizeAll
+		onOrganizeAll,
+		onSaveAll,
+		hasEdits,
+		editCount,
+		savingEdits
 	}: Props = $props();
 
 	$effect(() => {
@@ -126,6 +134,18 @@
 			</Button>
 		</div>
 		<div class="h-8 w-px bg-border"></div>
+		{#if hasEdits}
+			<Button onclick={onSaveAll} disabled={savingEdits || organizing} title="Save pending edits to the database">
+				{#snippet children()}
+					{#if savingEdits}
+						<LoaderCircle class="h-4 w-4 mr-2 animate-spin" />
+					{:else}
+						<Save class="h-4 w-4 mr-2" />
+					{/if}
+					{savingEdits ? 'Saving...' : `Save changes${editCount > 1 ? ` (${editCount})` : ''}`}
+				{/snippet}
+			</Button>
+		{/if}
 		<Button variant="outline" onclick={onClose} disabled={organizing}>
 			{#snippet children()}
 				<X class="h-4 w-4 mr-2" />

--- a/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
@@ -73,6 +73,7 @@ export function createReviewMutations(deps: ReviewMutationsDeps) {
 	function invalidateJobQueries() {
 		void queryClient.invalidateQueries({ queryKey: ['batch-job', deps.getJobId()] });
 		void queryClient.invalidateQueries({ queryKey: ['batch-job-slim', deps.getJobId()] });
+		void queryClient.invalidateQueries({ queryKey: ['actresses'] });
 	}
 
 	const posterFromUrlMutation = createMutation(() => ({

--- a/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
@@ -197,6 +197,7 @@ export function createReviewMutations(deps: ReviewMutationsDeps) {
 			deps.clearPosterPreviewOverrides();
 			deps.clearEditStorage();
 			invalidateJobQueries();
+			deps.toastSuccess('Changes saved to database');
 		},
 		onError: (err: Error) => {
 			deps.toastError(`Failed to save edits: ${err.message}`);

--- a/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
@@ -1537,6 +1537,8 @@ export function createReviewState(pageStore: Page) {
 		useScreenshotAsPoster,
 		useScreenshotAsCover,
 		saveAllEdits,
+		get isSavingEdits() { return mutations.saveEditsMutation.isPending; },
+		get editedMovieCount() { return editedMovies.size; },
 		get selectedMovieIds() {
 			return selectedMovieIds;
 		},


### PR DESCRIPTION
## Summary

Editing an existing actress's name on the **Review & Edit Metadata** page was not saved to the NFO file or reflected on the Actresses page (reported as broken "in all versions").

## Root cause

The review-edit path (`updateBatchMovie` → `jobEditorImpl.UpdateMovie`) reused the shared `MovieUpserter` to persist. The upserter's actress merge is **fill-missing-only** (`mergeActressData`: `if new.FirstName != "" && existing.FirstName == ""`) — intentional for scrape/aggregation (don't let scraped data clobber curated DB records, locked by tests since `c3ebcac3`). But reusing it for an explicit edit meant the rename was discarded:

- **Actresses page (DB):** `existing.FirstName != ""` → merge skipped → `actresses` table kept the old name.
- **NFO (in-memory):** `ensureActressesExistTx` does `actresses[i] = existing`, mutating `movie.Actresses` in place to the stale DB records *before* the in-memory clone → `buildActors(movie.Actresses)` emitted the old names.

## Fix (Shape B)

Inject an `ActressRepositoryInterface` into the edit layer and, **before** `movieRepo.Upsert`, rename each edited actress with `ID > 0` by primary key (`actressRepo.Update`). This reuses the exact global-rename-by-ID operation the Actresses page (`PUT /actresses/:id`) already uses.

- The scrape / shared-upserter path is **untouched** (`actressRepo == nil` → no rename), so fill-missing and its tests are preserved.
- Renaming **before** Upsert makes the upserter's name-based lookup find the renamed record, so the in-memory clone (NFO generation) carries the edited names.

## Changes

- `BatchJobDeps` / `jobEditorImpl`: new `ActressRepo` field.
- `JobStore`: `actressRepo` field + `WithActressRepo` option (avoids changing `NewJobStore`'s positional signature and its ~10 test callers).
- Wired in `buildAdapters`, the `createJob` fallback, `setDepsFromConfig`, and `wireJobDeps` (reconstruction).
- Production: `bootstrap.go` + testkit helper pass `WithActressRepo(repos.ActressRepo)`.
- `jobEditorImpl.UpdateMovie`: rename-by-ID before upsert.
- Regression tests (`actress_edit_test.go`):
  1. Edited existing actress (ID>0) persists to DB **and** in-memory (NFO path).
  2. Scrape/shared path (no actressRepo) preserves the curated name (fill-missing intact).
  3. New actress (ID==0) is left to the upserter, not force-renamed.

## Verification

- `go test -race -short ./internal/worker/` ✓
- `go vet ./...` ✓ · `golangci-lint run` ✓ (0 issues)
- worker / database / api / aggregator / nfo short suites ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review pages now offer bulk-saving of pending metadata edits with a “Save changes” button, showing edit count and save/loading feedback.
  * Actress edits participate in the same bulk-save flow, and a success message is shown after saving.

* **Bug Fixes**
  * Actress name edits are now reliably persisted during batch job updates (applied before related movie updates).
  * If saving actress edits fails, the job halts before continuing with the movie update.

* **Other**
  * After saves and actress mutations, relevant cached review/actress data is refreshed more completely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->