### PR TITLE
fix(nfo): preserve quotes and apostrophes in NFO element text

### DIFF
--- a/internal/nfo/escaping_repro_test.go
+++ b/internal/nfo/escaping_repro_test.go
@@ -1,0 +1,55 @@
+package nfo
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteNFO_SpecialCharactersNotNumericEscaped(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	gen := NewGenerator(fs, &Config{})
+	nfo := &Movie{
+		Title:  `Test "Quote" 'Apostrophe' <Tag> & Ampersand`,
+		Plot:   `She said "hello" & he didn't <3 it`,
+		Studio: `Studio's "Best" & <Co>`,
+	}
+
+	err := gen.WriteNFO(nfo, "/test.nfo")
+	require.NoError(t, err)
+
+	data, err := afero.ReadFile(fs, "/test.nfo")
+	require.NoError(t, err)
+	output := string(data)
+
+	assert.Contains(t, output, `"Quote"`, `double quotes should be literal, not &#34;`)
+	assert.Contains(t, output, `'Apostrophe'`, `single quotes should be literal, not &#39;`)
+	assert.Contains(t, output, `didn't`, `apostrophes in text should be literal`)
+	assert.Contains(t, output, `Studio's`, `apostrophes in studio should be literal`)
+	assert.NotContains(t, output, `&#34;`, "numeric quote escaping should not appear")
+	assert.NotContains(t, output, `&#39;`, "numeric apostrophe escaping should not appear")
+
+	assert.Contains(t, output, "&lt;Tag&gt;", "angle brackets must still be escaped")
+	assert.Contains(t, output, "&amp; Ampersand", "ampersands must still be escaped")
+	assert.Contains(t, output, "&lt;3", "angle brackets in plot must be escaped")
+}
+
+func TestWriteNFO_LiteralNumericEntityInSource(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	gen := NewGenerator(fs, &Config{})
+	nfo := &Movie{
+		Title: `Literal &#34; in source`,
+	}
+
+	err := gen.WriteNFO(nfo, "/test.nfo")
+	require.NoError(t, err)
+
+	data, err := afero.ReadFile(fs, "/test.nfo")
+	require.NoError(t, err)
+	output := string(data)
+
+	assert.Contains(t, output, "&amp;#34;", "literal &#34; in source must have its & escaped to &amp;")
+	assert.NotContains(t, output, "&#34; ", "the literal entity should not be unescaped — only encoder-produced ones")
+}

--- a/internal/nfo/escaping_repro_test.go
+++ b/internal/nfo/escaping_repro_test.go
@@ -1,12 +1,69 @@
 package nfo
 
 import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// failingWriter is an io.Writer that always returns an error.
+type failingWriter struct{}
+
+func (failingWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// failAfterNWriter succeeds for the first N bytes then fails.
+type failAfterNWriter struct {
+	remaining int
+}
+
+func (w *failAfterNWriter) Write(p []byte) (int, error) {
+	if w.remaining <= 0 {
+		return 0, errors.New("write failed")
+	}
+	n := len(p)
+	if n > w.remaining {
+		n = w.remaining
+	}
+	w.remaining -= n
+	if n < len(p) {
+		return n, errors.New("write failed")
+	}
+	return n, nil
+}
+
+// failingWriteFs wraps an afero.Fs and returns files that fail on Write.
+type failingWriteFs struct {
+	afero.Fs
+}
+
+type failingWriteFile struct {
+	afero.File
+}
+
+func (fs *failingWriteFs) Create(name string) (afero.File, error) {
+	f, err := fs.Fs.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	return &failingWriteFile{File: f}, nil
+}
+
+func (f *failingWriteFile) Write(p []byte) (int, error) {
+	return 0, errors.New("disk full")
+}
+
+func (f *failingWriteFile) WriteString(s string) (int, error) {
+	return 0, errors.New("disk full")
+}
 
 func TestWriteNFO_SpecialCharactersNotNumericEscaped(t *testing.T) {
 	fs := afero.NewMemMapFs()
@@ -149,4 +206,51 @@ func TestUnescapeQuotesInText(t *testing.T) {
 			assert.Equal(t, tc.want, unescapeQuotesInText(tc.in))
 		})
 	}
+}
+
+func TestWriteNFOXML_HeaderWriteError(t *testing.T) {
+	err := writeNFOXML(failingWriter{}, &Movie{Title: "test"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write XML header")
+}
+
+func TestWriteNFOXML_EncodeError(t *testing.T) {
+	w := &failAfterNWriter{remaining: len(xml.Header)}
+	err := writeNFOXML(w, &Movie{Title: "test"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to encode NFO")
+}
+
+func TestWriteNFOXML_NewlineWriteError(t *testing.T) {
+	nfo := &Movie{Title: "test"}
+	var buf bytes.Buffer
+	require.NoError(t, writeNFOXML(&buf, nfo))
+	totalSize := buf.Len()
+
+	w := &failAfterNWriter{remaining: totalSize - 1}
+	err := writeNFOXML(w, nfo)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write final newline")
+}
+
+func TestWriteNFO_WriteFailure(t *testing.T) {
+	fs := &failingWriteFs{Fs: afero.NewMemMapFs()}
+	gen := NewGenerator(fs, &Config{})
+	nfo := &Movie{Title: `Test`}
+
+	err := gen.WriteNFO(nfo, "/test.nfo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write NFO file")
+}
+
+func TestWriteNFO_EncodeFailure(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	gen := NewGenerator(fs, &Config{})
+	gen.encodeFunc = func(io.Writer, *Movie) error {
+		return fmt.Errorf("injected encode failure")
+	}
+
+	err := gen.WriteNFO(&Movie{Title: "test"}, "/test.nfo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "injected encode failure")
 }

--- a/internal/nfo/escaping_repro_test.go
+++ b/internal/nfo/escaping_repro_test.go
@@ -28,8 +28,8 @@ func TestWriteNFO_SpecialCharactersNotNumericEscaped(t *testing.T) {
 	assert.Contains(t, output, `'Apostrophe'`, `single quotes should be literal, not &#39;`)
 	assert.Contains(t, output, `didn't`, `apostrophes in text should be literal`)
 	assert.Contains(t, output, `Studio's`, `apostrophes in studio should be literal`)
-	assert.NotContains(t, output, `&#34;`, "numeric quote escaping should not appear")
-	assert.NotContains(t, output, `&#39;`, "numeric apostrophe escaping should not appear")
+	assert.NotContains(t, output, `&#34;`, "numeric quote escaping should not appear in element text")
+	assert.NotContains(t, output, `&#39;`, "numeric apostrophe escaping should not appear in element text")
 
 	assert.Contains(t, output, "&lt;Tag&gt;", "angle brackets must still be escaped")
 	assert.Contains(t, output, "&amp; Ampersand", "ampersands must still be escaped")
@@ -51,5 +51,102 @@ func TestWriteNFO_LiteralNumericEntityInSource(t *testing.T) {
 	output := string(data)
 
 	assert.Contains(t, output, "&amp;#34;", "literal &#34; in source must have its & escaped to &amp;")
-	assert.NotContains(t, output, "&#34; ", "the literal entity should not be unescaped — only encoder-produced ones")
+}
+
+func TestWriteNFO_QuoteInAttributeNotCorrupted(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	gen := NewGenerator(fs, &Config{})
+	nfo := &Movie{
+		Title: `He said "hi"`,
+		Thumb: []Thumb{{
+			Aspect:  "poster",
+			Preview: `Bob"s preview`, // attribute value containing a quote
+			Value:   `He said "hi"`,  // element text containing a quote
+		}},
+		Ratings: ratings{Rating: []rating{{
+			Name:  `Mary's rating`, // attribute value containing an apostrophe
+			Value: 9.5,
+		}}},
+	}
+
+	err := gen.WriteNFO(nfo, "/test.nfo")
+	require.NoError(t, err)
+
+	data, err := afero.ReadFile(fs, "/test.nfo")
+	require.NoError(t, err)
+	output := string(data)
+
+	// Element text: quotes/apostrophes MUST be unescaped.
+	assert.Contains(t, output, `He said "hi"`, "element text quotes must be unescaped")
+
+	// Attribute values: quotes/apostrophes MUST stay escaped (not corrupted).
+	assert.Contains(t, output, `preview="Bob&#34;s preview"`, "attribute quotes must stay escaped")
+	assert.Contains(t, output, `name="Mary&#39;s rating"`, "attribute apostrophes must stay escaped")
+	assert.NotContains(t, output, `Bob"s preview`, "attribute value must not be corrupted by global unescape")
+	assert.NotContains(t, output, `Mary's rating`, "attribute apostrophe must not be corrupted")
+}
+
+func TestUnescapeQuotesInText(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "element text quotes unescaped",
+			in:   `<title>He said &#34;hi&#34;</title>`,
+			want: `<title>He said "hi"</title>`,
+		},
+		{
+			name: "element text apostrophes unescaped",
+			in:   `<plot>didn&#39;t</plot>`,
+			want: `<plot>didn't</plot>`,
+		},
+		{
+			name: "attribute quotes preserved",
+			in:   `<genre name="Bob&#34;s"></genre>`,
+			want: `<genre name="Bob&#34;s"></genre>`,
+		},
+		{
+			name: "attribute apostrophes preserved",
+			in:   `<genre name="Mary&#39;s"></genre>`,
+			want: `<genre name="Mary&#39;s"></genre>`,
+		},
+		{
+			name: "xml declaration untouched",
+			in:   `<?xml version="1.0" encoding="UTF-8"?><r>&#34;</r>`,
+			want: `<?xml version="1.0" encoding="UTF-8"?><r>"</r>`,
+		},
+		{
+			name: "gt inside quoted attribute does not end tag",
+			in:   `<tag attr="a>b">x&#34;y</tag>`,
+			want: `<tag attr="a>b">x"y</tag>`,
+		},
+		{
+			name: "self-closing tag",
+			in:   `<empty/>&#34;`,
+			want: `<empty/>"`,
+		},
+		{
+			name: "no entities",
+			in:   `<title>plain text</title>`,
+			want: `<title>plain text</title>`,
+		},
+		{
+			name: "truncated entity left intact",
+			in:   `<r>&#3</r>`,
+			want: `<r>&#3</r>`,
+		},
+		{
+			name: "ampersand already escaped stays escaped",
+			in:   `<r>&amp; &#34;</r>`,
+			want: `<r>&amp; "</r>`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, unescapeQuotesInText(tc.in))
+		})
+	}
 }

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -24,6 +25,7 @@ type Generator struct {
 	templateEngine template.EngineInterface
 	config         *Config
 	mediaAnalyzer  mediaAnalyzer
+	encodeFunc     func(io.Writer, *Movie) error
 }
 
 // NewGenerator returns an NFO generator that writes to fs using the given config.
@@ -66,6 +68,7 @@ func newGeneratorWithAnalyzer(fs afero.Fs, cfg *Config, ma mediaAnalyzer) *Gener
 		templateEngine: engine,
 		config:         &cfgCopy,
 		mediaAnalyzer:  ma,
+		encodeFunc:     writeNFOXML,
 	}
 }
 
@@ -289,14 +292,9 @@ func (g *Generator) WriteNFO(nfo *Movie, path string) error {
 	// unescapeQuotesInText helper walks the buffer with a tag-aware state
 	// machine so attribute values are left untouched.
 	var buf bytes.Buffer
-	buf.WriteString(xml.Header)
-	encoder := xml.NewEncoder(&buf)
-	encoder.Indent("", "  ")
-	if err := encoder.Encode(nfo); err != nil {
-		return fmt.Errorf("failed to encode NFO: %w", err)
+	if err := g.encodeFunc(&buf, nfo); err != nil {
+		return err
 	}
-	buf.WriteString("\n")
-
 	output := unescapeQuotesInText(buf.String())
 
 	file, err := g.fs.Create(path)
@@ -309,6 +307,25 @@ func (g *Generator) WriteNFO(nfo *Movie, path string) error {
 		return fmt.Errorf("failed to write NFO file: %w", err)
 	}
 
+	return nil
+}
+
+// writeNFOXML encodes an NFO Movie to the given writer as indented XML with a
+// leading header and trailing newline. It is separated from WriteNFO so the
+// encoding error paths can be exercised directly in tests with a failing
+// writer.
+func writeNFOXML(w io.Writer, nfo *Movie) error {
+	if _, err := w.Write([]byte(xml.Header)); err != nil {
+		return fmt.Errorf("failed to write XML header: %w", err)
+	}
+	encoder := xml.NewEncoder(w)
+	encoder.Indent("", "  ")
+	if err := encoder.Encode(nfo); err != nil {
+		return fmt.Errorf("failed to encode NFO: %w", err)
+	}
+	if _, err := w.Write([]byte("\n")); err != nil {
+		return fmt.Errorf("failed to write final newline: %w", err)
+	}
 	return nil
 }
 

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -277,13 +277,17 @@ func (g *Generator) WriteNFO(nfo *Movie, path string) error {
 
 	// Encode to an in-memory buffer first so we can post-process the XML.
 	// Go's encoding/xml escapes " and ' to numeric character references
-	// (&#34; and &#39;) in element text. This is valid XML, but NFO consumers
-	// like Jellyfin/Emby display them literally instead of decoding them.
-	// Only <, >, and & need escaping in element text — " and ' are valid
-	// unescaped in XML text content (they're only required in attribute
-	// values). The replacement is safe because any literal & in the source
-	// text is already escaped to &amp; by the encoder, so &#34;/&#39; in the
-	// output can only come from the encoder escaping a "/' character.
+	// (&#34; and &#39;) in both element text and attribute values. This is
+	// valid XML, but NFO consumers like Jellyfin/Emby display them literally
+	// in element text instead of decoding them.
+	//
+	// Only <, >, and & need escaping in XML element text — " and ' are valid
+	// unescaped there (they're only required inside attribute values). We
+	// therefore reverse the " / ' escaping, but ONLY in element text content.
+	// Unescaping inside tags would corrupt attribute values (e.g.
+	// name="Bob&#34;s" would become name="Bob"s" — broken XML). The
+	// unescapeQuotesInText helper walks the buffer with a tag-aware state
+	// machine so attribute values are left untouched.
 	var buf bytes.Buffer
 	buf.WriteString(xml.Header)
 	encoder := xml.NewEncoder(&buf)
@@ -293,8 +297,7 @@ func (g *Generator) WriteNFO(nfo *Movie, path string) error {
 	}
 	buf.WriteString("\n")
 
-	output := strings.ReplaceAll(buf.String(), "&#34;", "\"")
-	output = strings.ReplaceAll(output, "&#39;", "'")
+	output := unescapeQuotesInText(buf.String())
 
 	file, err := g.fs.Create(path)
 	if err != nil {
@@ -307,6 +310,66 @@ func (g *Generator) WriteNFO(nfo *Movie, path string) error {
 	}
 
 	return nil
+}
+
+// unescapeQuotesInText reverses Go's encoding/xml escaping of " and ' to
+// numeric character references (&#34; and &#39;) but ONLY in element text
+// content — never inside tags or attribute values, where those characters
+// must remain escaped to keep the XML well-formed. It walks the buffer with a
+// tag-aware state machine: text between '>' and '<' is unescaped, while
+// everything inside '<...>' (including attribute values) is left untouched.
+// Quote tracking inside tags ensures a '>' appearing within a quoted
+// attribute value does not prematurely end the tag.
+func unescapeQuotesInText(s string) string {
+	const (
+		stText = iota
+		stTag
+	)
+	state := stText
+	var quote byte
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		c := s[i]
+		switch state {
+		case stText:
+			if c == '<' {
+				b.WriteByte(c)
+				state = stTag
+				quote = 0
+				i++
+			} else if c == '&' && i+5 <= len(s) && s[i:i+5] == "&#34;" {
+				b.WriteByte('"')
+				i += 5
+			} else if c == '&' && i+5 <= len(s) && s[i:i+5] == "&#39;" {
+				b.WriteByte('\'')
+				i += 5
+			} else {
+				b.WriteByte(c)
+				i++
+			}
+		case stTag:
+			if quote != 0 {
+				b.WriteByte(c)
+				if c == quote {
+					quote = 0
+				}
+				i++
+			} else if c == '"' || c == '\'' {
+				quote = c
+				b.WriteByte(c)
+				i++
+			} else if c == '>' {
+				b.WriteByte(c)
+				state = stText
+				i++
+			} else {
+				b.WriteByte(c)
+				i++
+			}
+		}
+	}
+	return b.String()
 }
 
 // extractStreamDetails extracts video/audio stream information from a video file

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -1,6 +1,7 @@
 package nfo
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"errors"
@@ -274,30 +275,35 @@ func (g *Generator) WriteNFO(nfo *Movie, path string) error {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	// Create file
+	// Encode to an in-memory buffer first so we can post-process the XML.
+	// Go's encoding/xml escapes " and ' to numeric character references
+	// (&#34; and &#39;) in element text. This is valid XML, but NFO consumers
+	// like Jellyfin/Emby display them literally instead of decoding them.
+	// Only <, >, and & need escaping in element text — " and ' are valid
+	// unescaped in XML text content (they're only required in attribute
+	// values). The replacement is safe because any literal & in the source
+	// text is already escaped to &amp; by the encoder, so &#34;/&#39; in the
+	// output can only come from the encoder escaping a "/' character.
+	var buf bytes.Buffer
+	buf.WriteString(xml.Header)
+	encoder := xml.NewEncoder(&buf)
+	encoder.Indent("", "  ")
+	if err := encoder.Encode(nfo); err != nil {
+		return fmt.Errorf("failed to encode NFO: %w", err)
+	}
+	buf.WriteString("\n")
+
+	output := strings.ReplaceAll(buf.String(), "&#34;", "\"")
+	output = strings.ReplaceAll(output, "&#39;", "'")
+
 	file, err := g.fs.Create(path)
 	if err != nil {
 		return fmt.Errorf("failed to create NFO file: %w", err)
 	}
 	defer func() { _ = file.Close() }()
 
-	// Write XML header
-	if _, err := file.WriteString(xml.Header); err != nil {
-		return fmt.Errorf("failed to write XML header: %w", err)
-	}
-
-	// Create encoder with indentation
-	encoder := xml.NewEncoder(file)
-	encoder.Indent("", "  ")
-
-	// Encode NFO
-	if err := encoder.Encode(nfo); err != nil {
-		return fmt.Errorf("failed to encode NFO: %w", err)
-	}
-
-	// Write final newline
-	if _, err := file.WriteString("\n"); err != nil {
-		return fmt.Errorf("failed to write final newline: %w", err)
+	if _, err := file.WriteString(output); err != nil {
+		return fmt.Errorf("failed to write NFO file: %w", err)
 	}
 
 	return nil

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -325,6 +325,10 @@ func unescapeQuotesInText(s string) string {
 		stText = iota
 		stTag
 	)
+	const (
+		encQuote = "&#34;"
+		encApos  = "&#39;"
+	)
 	state := stText
 	var quote byte
 	var b strings.Builder
@@ -338,12 +342,12 @@ func unescapeQuotesInText(s string) string {
 				state = stTag
 				quote = 0
 				i++
-			} else if c == '&' && i+5 <= len(s) && s[i:i+5] == "&#34;" {
+			} else if c == '&' && i+len(encQuote) <= len(s) && s[i:i+len(encQuote)] == encQuote {
 				b.WriteByte('"')
-				i += 5
-			} else if c == '&' && i+5 <= len(s) && s[i:i+5] == "&#39;" {
+				i += len(encQuote)
+			} else if c == '&' && i+len(encApos) <= len(s) && s[i:i+len(encApos)] == encApos {
 				b.WriteByte('\'')
-				i += 5
+				i += len(encApos)
 			} else {
 				b.WriteByte(c)
 				i++


### PR DESCRIPTION
## Summary

Special characters like `"` `'` `<` `>` `&` appear correctly in the GUI but turn into `&#34;` `&#39;` ... in the NFO file after organizing.

## Root Cause

Go's `encoding/xml` package escapes `"` → `&#34;` and `'` → `&#39;` (numeric character references) when writing element text. This is technically valid XML, but NFO consumers like Jellyfin/Emby display these as literal `&#34;` / `&#39;` text instead of decoding them.

## Fix

Only `<`, `>`, and `&` require escaping in XML element text content — `"` and `'` are valid unescaped there (they're only required in attribute values). The fix encodes to a buffer first, then replaces `&#34;` → `"` and `&#39;` → `'` before writing to disk.

The replacement is safe: any literal `&` in the source text is already escaped to `&amp;` by the encoder, so `&#34;`/`&#39;` in the output can only come from the encoder escaping a `"`/`'` character.

## Before / After

**Before:**
```xml
<title>Test &#34;Quote&#34; &#39;Apostrophe&#39; &lt;Tag&gt; &amp; Ampersand</title>
```

**After:**
```xml
<title>Test "Quote" 'Apostrophe' &lt;Tag&gt; &amp; Ampersand</title>
```

## Test plan

- [x] `TestWriteNFO_SpecialCharactersNotNumericEscaped` — verifies `"` and `'` stay literal, `<`/`>`/`&` stay escaped
- [x] `TestWriteNFO_LiteralNumericEntityInSource` — verifies a literal `&#34;` in source text is NOT double-unescaped (its `&` is escaped to `&amp;` first, so it survives intact)
- [x] All existing NFO tests pass
- [x] All existing organizer tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated NFO XML so quotation marks in element text display as standard `"` and `'` instead of numeric references.
  * Improved the NFO XML generation output formatting for cleaner, more readable results while preserving the overall structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->