### PR TITLE
feat(install): add self-upgrade, Homebrew/Scoop taps, and installers for v1.0.0

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -772,3 +772,113 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-homebrew-tap:
+    name: Update Homebrew tap
+    needs: [prepare-release, create-release]
+    # Only update the tap for stable releases. Prereleases (v1.0.0-rc.*) never
+    # reach the tap, so `brew upgrade` never hands a user a release candidate.
+    # Also skip nightlies/snapshots (create_release == 'false').
+    if: needs.prepare-release.outputs.create_release == 'true' && needs.prepare-release.outputs.prerelease != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout javinizer-go (formula template + render script)
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Download release bundle (checksums.txt)
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: release-bundle-${{ needs.prepare-release.outputs.version }}
+          path: ./release
+
+      - name: Render formula
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          ./scripts/homebrew/render-formula.sh "$VERSION" ./release/checksums.txt scripts/homebrew/javinizer.rb.tmpl > out/javinizer.rb
+          echo "=== rendered Formula/javinizer.rb ==="
+          cat out/javinizer.rb
+
+      - name: Checkout tap repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: javinizer/homebrew-tap
+          path: tap
+          ssh-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+
+      - name: Commit formula to tap
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p tap/Formula
+          cp out/javinizer.rb tap/Formula/javinizer.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/javinizer.rb
+          if git diff --cached --quiet; then
+            echo "No formula changes to commit."
+          else
+            git commit -m "brew: javinizer ${VERSION}"
+            git push
+          fi
+
+  update-scoop-bucket:
+    name: Update Scoop bucket
+    needs: [prepare-release, create-release]
+    # Only update the bucket for stable releases. Prereleases (v1.0.0-rc.*) never
+    # reach the bucket, so `scoop update` never hands a user a release candidate.
+    # Also skip nightlies/snapshots (create_release == 'false').
+    if: needs.prepare-release.outputs.create_release == 'true' && needs.prepare-release.outputs.prerelease != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout javinizer-go (manifest template + render script)
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Download release bundle (checksums.txt)
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: release-bundle-${{ needs.prepare-release.outputs.version }}
+          path: ./release
+
+      - name: Render manifest
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          ./scripts/scoop/render-manifest.sh "$VERSION" ./release/checksums.txt scripts/scoop/javinizer.json.tmpl > out/javinizer.json
+          echo "=== rendered bucket/javinizer.json ==="
+          cat out/javinizer.json
+
+      - name: Checkout bucket repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: javinizer/scoop-javinizer
+          path: bucket-repo
+          ssh-key: ${{ secrets.SCOOP_BUCKET_DEPLOY_KEY }}
+
+      - name: Commit manifest to bucket
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p bucket-repo/bucket
+          cp out/javinizer.json bucket-repo/bucket/javinizer.json
+          cd bucket-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add bucket/javinizer.json
+          if git diff --cached --quiet; then
+            echo "No manifest changes to commit."
+          else
+            git commit -m "scoop: javinizer ${VERSION}"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Open **http://localhost:8080**, create your admin login on first startup, and st
 
 - Replace `/path/to/your/media` with your JAV library path.
 - On Unraid, use `--user 99:100`.
-- Prefer a [binary](#prebuilt-binaries) or [build from source](#build-from-source) for a native install.
+- Prefer [Homebrew](#homebrew-macos--linux), a [one-shot installer](#one-shot-install-linux--macos--windows), a [binary](#prebuilt-binaries-manual-download), or [build from source](#build-from-source) for a native install.
 
 > **First time?** Skim [Features](#features) to see what it does, then jump to [Usage](#usage) or the [Web UI](#web-ui) section.
 
@@ -88,7 +88,55 @@ The compose file includes **javinizer** (API + web UI) and an optional **flareso
 
 **Tag policy:** `latest` tracks the most recent release; pin a tag (e.g. `v1.0.0-rc1`) for reproducible deployments.
 
-### Prebuilt Binaries
+### Homebrew (macOS / Linux)
+
+Once a stable `v1.0.0` is published, install via the Homebrew tap (recommended for macOS):
+
+```bash
+brew tap javinizer/homebrew-tap https://github.com/javinizer/homebrew-tap
+brew install javinizer
+
+brew upgrade javinizer   # update to the latest stable release later
+```
+
+The formula installs a prebuilt binary (CGO/SQLite is statically linked into each release asset, so Homebrew does not build from source or pull a SQLite dependency). The tap is updated automatically on each **stable** release; prereleases never reach it, so `brew upgrade` never hands you a release candidate.
+
+### Scoop (Windows)
+
+Once a stable `v1.0.0` is published, install via the Scoop bucket (recommended for Windows):
+
+```powershell
+scoop bucket add javinizer https://github.com/javinizer/scoop-javinizer
+scoop install javinizer
+
+scoop update javinizer   # update to the latest stable release later
+```
+
+The manifest installs the prebuilt `javinizer-windows-amd64.exe` and shims it as `javinizer`. The bucket is updated automatically on each **stable** release; prereleases never reach it, so `scoop update` never hands you a release candidate. This is the recommended Windows install path until release binaries are Authenticode-signed (see [issue #72](https://github.com/javinizer/javinizer-go/issues/72) — Scoop downloads via a trusted process and verifies the hash from the manifest, sidestepping the manual Mark-of-the-Web / Smart App Control friction of a raw browser download).
+
+### One-shot install (Linux / macOS / Windows)
+
+The installers download the latest **stable** release, verify its SHA256 against `checksums.txt`, and put `javinizer` on your `PATH`. Prereleases are opt-in: pass `--pre-release` (Linux/macOS) or `-PreRelease` (Windows) to install the newest release including prereleases.
+
+**Linux / macOS:**
+
+```bash
+curl -sSL https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.sh | bash
+# install the latest pre-release instead:
+curl -sSL https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.sh | bash -s -- --pre-release
+```
+
+**Windows** (PowerShell) — installs to `%LOCALAPPDATA%\javinizer\bin` (no admin required):
+
+```powershell
+irm https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.ps1 | iex
+# install the latest pre-release instead:
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.ps1))) -PreRelease
+```
+
+The Windows installer also runs `Unblock-File` on the downloaded binary, which strips the Mark-of-the-Web tag that can otherwise trigger an "Access is denied" error under Smart App Control (see [issue #72](https://github.com/javinizer/javinizer-go/issues/72)).
+
+### Prebuilt Binaries (manual download)
 
 Download from [GitHub Releases](https://github.com/javinizer/javinizer-go/releases) — available for `linux-amd64`, `linux-arm64`, `darwin-amd64`, `darwin-arm64`, `darwin-universal`, and `windows-amd64`. Binaries include the CLI, TUI, API server, and embedded web UI.
 
@@ -104,7 +152,7 @@ sudo mv javinizer /usr/local/bin/
 javinizer version
 ```
 
-> **One-shot install (from v1.0.0 stable):** once a non-prerelease `v1.0.0` is published, `releases/latest` resolves and you can fetch the latest binary directly — no version in the URL:
+> **One-shot download (from v1.0.0 stable):** once a non-prerelease `v1.0.0` is published, `releases/latest` resolves and you can fetch the latest binary directly — no version in the URL:
 > ```bash
 > curl -L -o javinizer https://github.com/javinizer/javinizer-go/releases/latest/download/javinizer-linux-amd64
 > ```
@@ -122,6 +170,8 @@ Rename-Item javinizer-windows-amd64.exe javinizer.exe
 .\javinizer.exe version
 ```
 
+> **Windows 11 + Smart App Control:** Windows release binaries are not yet Authenticode-signed (see the [Code signing policy](./CODE_SIGNING_POLICY.md) — SignPath Foundation signing is pending). If Smart App Control is in enforcement mode it may block the unsigned binary with an "Access is denied" error. The one-shot `install.ps1` above runs `Unblock-File` automatically; for a manual download, unblock it by right-clicking the `.exe` → Properties → check **Unblock** → OK (equivalently `Unblock-File .\javinizer.exe`), or build from source (below — locally-built binaries carry no Mark-of-the-Web and are not gated by SAC).
+
 To run `javinizer` from anywhere, add its folder to your `PATH` (System Properties → Environment Variables → Path → New), or copy `javinizer.exe` into a folder that's already on your `PATH`.
 
 ```powershell
@@ -131,6 +181,23 @@ To run `javinizer` from anywhere, add its folder to your `PATH` (System Properti
 ```
 
 > Windows builds are CLI/TUI/API + embedded web UI, same as the other platforms. CGO/SQLite is statically linked, so no separate runtime is required.
+
+### Self-upgrade
+
+Once installed from a binary or `install.sh`, update in place without re-downloading by hand:
+
+```bash
+javinizer upgrade           # download + verify + replace the running binary
+javinizer upgrade --check   # just report whether an update is available
+javinizer upgrade --force   # reinstall even if already at the latest version
+javinizer upgrade --prerelease  # upgrade to the newest release, including prereleases
+```
+
+The new binary is verified against the release `checksums.txt` before the swap. If javinizer was installed via **Homebrew** or **Scoop**, `upgrade` detects that and tells you to use `brew upgrade javinizer` / `scoop update javinizer` instead, so it never clobbers a package-manager install.
+
+By default `upgrade` targets the latest **stable** release. Add `--prerelease` to jump to a newer release candidate (e.g. `v1.1.0-rc1`) when you want to track prereleases.
+
+> Note: `javinizer upgrade` updates the **program**; `javinizer update` refreshes **metadata** for your existing files. They are different commands.
 
 ### Build from Source
 

--- a/cmd/javinizer/commands/upgrade/command.go
+++ b/cmd/javinizer/commands/upgrade/command.go
@@ -1,0 +1,77 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/javinizer/javinizer-go/internal/update"
+	"github.com/javinizer/javinizer-go/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// runUpgrade is the upgrade implementation. It is a package-level variable so
+// tests can swap it for a stub, covering the command's RunE branches without
+// touching the network. Production calls the real update.Upgrade.
+var runUpgrade = update.Upgrade
+
+// SetRunUpgrade swaps the upgrade implementation and returns the previous one,
+// so callers can restore it with `defer restore := SetRunUpgrade(stub); defer SetRunUpgrade(restore)`.
+// Intended for tests; production code should not call it.
+func SetRunUpgrade(fn func(context.Context, update.UpgradeOptions) (*update.UpgradeResult, error)) func(context.Context, update.UpgradeOptions) (*update.UpgradeResult, error) {
+	prev := runUpgrade
+	runUpgrade = fn
+	return prev
+}
+
+// NewCommand creates the upgrade subcommand that self-updates the javinizer
+// binary to the latest GitHub release.
+func NewCommand() *cobra.Command {
+	var check bool
+	var force bool
+	var prerelease bool
+
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade the javinizer binary to the latest release",
+		Long: `Download and install the latest javinizer release from GitHub, replacing the
+running binary in place. The asset for the current OS/arch is verified against
+the release checksums before the swap.
+
+By default only the latest stable release is considered. Use --prerelease to
+upgrade to the newest release even if it is a prerelease (e.g. v1.1.0-rc1).
+
+If javinizer was installed via Homebrew or Scoop, this command detects that and
+tells you to use the package manager instead, since self-replacing would break
+its bookkeeping.
+
+Note: 'javinizer upgrade' updates the program itself; 'javinizer update' updates
+metadata for your existing files. They are different commands.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			result, err := runUpgrade(ctx, update.UpgradeOptions{
+				CurrentVersion: version.Short(),
+				CheckOnly:      check,
+				Force:          force,
+				PreRelease:     prerelease,
+				Out:            cmd.OutOrStdout(),
+			})
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Upgrade failed: %v\n", err)
+				if result != nil && result.Handoff {
+					return nil
+				}
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&check, "check", "c", false, "check for an update without installing")
+	cmd.Flags().BoolVar(&force, "force", false, "reinstall even if already at the latest version")
+	cmd.Flags().BoolVar(&prerelease, "prerelease", false, "consider prereleases (e.g. v1.1.0-rc1) when finding the latest release")
+	return cmd
+}

--- a/cmd/javinizer/commands/upgrade/command.go
+++ b/cmd/javinizer/commands/upgrade/command.go
@@ -48,11 +48,7 @@ Note: 'javinizer upgrade' updates the program itself; 'javinizer update' updates
 metadata for your existing files. They are different commands.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			if ctx == nil {
-				ctx = context.Background()
-			}
-			result, err := runUpgrade(ctx, update.UpgradeOptions{
+			result, err := runUpgrade(cmd.Context(), update.UpgradeOptions{
 				CurrentVersion: version.Short(),
 				CheckOnly:      check,
 				Force:          force,

--- a/cmd/javinizer/commands/upgrade/command_test.go
+++ b/cmd/javinizer/commands/upgrade/command_test.go
@@ -1,0 +1,95 @@
+package upgrade_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	upgradecmd "github.com/javinizer/javinizer-go/cmd/javinizer/commands/upgrade"
+	"github.com/javinizer/javinizer-go/internal/update"
+	"github.com/javinizer/javinizer-go/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubUpgrade replaces upgradecmd.runUpgrade for deterministic command tests.
+type stubUpgrade struct {
+	result *update.UpgradeResult
+	err    error
+	called bool
+}
+
+func (s *stubUpgrade) run(ctx context.Context, opts update.UpgradeOptions) (*update.UpgradeResult, error) {
+	s.called = true
+	return s.result, s.err
+}
+
+func TestUpgradeCommand_Flags(t *testing.T) {
+	cmd := upgradecmd.NewCommand()
+	assert.Equal(t, "upgrade", cmd.Use)
+	assert.NotNil(t, cmd.Flags().Lookup("check"))
+	assert.NotNil(t, cmd.Flags().Lookup("force"))
+}
+
+func TestUpgradeCommand_Success(t *testing.T) {
+	stub := &stubUpgrade{result: &update.UpgradeResult{Upgraded: true, LatestVersion: "v1.0.0"}}
+	restore := upgradecmd.SetRunUpgrade(stub.run)
+	defer upgradecmd.SetRunUpgrade(restore)
+
+	var out bytes.Buffer
+	cmd := upgradecmd.NewCommand()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+	assert.True(t, stub.called)
+}
+
+func TestUpgradeCommand_ErrorPrintsToStderrAndReturnsErr(t *testing.T) {
+	stub := &stubUpgrade{result: &update.UpgradeResult{}, err: errors.New("network down")}
+	restore := upgradecmd.SetRunUpgrade(stub.run)
+	defer upgradecmd.SetRunUpgrade(restore)
+
+	var stderr bytes.Buffer
+	cmd := upgradecmd.NewCommand()
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, stderr.String(), "Upgrade failed: network down")
+}
+
+func TestUpgradeCommand_HandoffIsNotAnError(t *testing.T) {
+	// A package-manager handoff returns no error from RunE even though the
+	// upgrade did not happen — the user was told to run brew/scoop instead.
+	stub := &stubUpgrade{result: &update.UpgradeResult{Handoff: true}, err: errors.New("would clobber brew")}
+	restore := upgradecmd.SetRunUpgrade(stub.run)
+	defer upgradecmd.SetRunUpgrade(restore)
+
+	var stderr bytes.Buffer
+	cmd := upgradecmd.NewCommand()
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.NoError(t, err, "handoff should not surface as a CLI error")
+	assert.Contains(t, stderr.String(), "Upgrade failed")
+}
+
+func TestUpgradeCommand_PassesCurrentVersion(t *testing.T) {
+	orig := version.Version
+	defer func() { version.Version = orig }()
+	version.Version = "v1.2.3"
+
+	var captured update.UpgradeOptions
+	restore := upgradecmd.SetRunUpgrade(func(ctx context.Context, opts update.UpgradeOptions) (*update.UpgradeResult, error) {
+		captured = opts
+		return &update.UpgradeResult{UpToDate: true}, nil
+	})
+	defer upgradecmd.SetRunUpgrade(restore)
+
+	cmd := upgradecmd.NewCommand()
+	cmd.SetArgs([]string{"--check"})
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "v1.2.3", captured.CurrentVersion)
+	assert.True(t, captured.CheckOnly)
+}

--- a/cmd/javinizer/commands/version/command.go
+++ b/cmd/javinizer/commands/version/command.go
@@ -43,17 +43,17 @@ var runVersionCheck = func(ctx context.Context, configFile string) (*checkOutcom
 	} else {
 		service = update.NewService(ucfg)
 	}
-	state, err := service.ForceCheck(ctx)
+	state, _ := service.ForceCheck(ctx)
 
 	if state != nil && state.Source == update.UpdateSourceDisabled {
 		return &checkOutcome{disabled: true}, nil
 	}
 
-	if err != nil || state == nil || state.Version == "" || state.Source == update.UpdateSourceError {
+	// ForceCheck translates every failure into the state's Source/Error fields
+	// (it never returns a non-nil Go error), so branch on the state, not err.
+	if state == nil || state.Version == "" || state.Source == update.UpdateSourceError {
 		var errorMsg string
-		if err != nil {
-			errorMsg = err.Error()
-		} else if state != nil && state.Error != "" {
+		if state != nil && state.Error != "" {
 			errorMsg = state.Error
 		} else {
 			errorMsg = "Unknown error occurred while checking for updates"

--- a/cmd/javinizer/commands/version/command.go
+++ b/cmd/javinizer/commands/version/command.go
@@ -11,6 +11,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// updateChecker, when non-nil, is injected into the update service so tests
+// can drive the --check error branches deterministically without network or a
+// shared on-disk cache. Production leaves it nil (NewService is used).
+var updateChecker update.Checker
+
+// updateStatePath, when non-empty, overrides the on-disk cache location for the
+// update service. Tests set it to a temp dir so no stale cached state masks a
+// checker failure. Production leaves it empty (the real data dir is used).
+var updateStatePath string
+
 // runVersionCheck performs a sync update check and translates the service's
 // internal state into the simple outcome the command's output branches need.
 // It is a package-level variable so tests can swap it for a stub, covering the
@@ -22,11 +32,17 @@ var runVersionCheck = func(ctx context.Context, configFile string) (*checkOutcom
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	service := update.NewService(update.UpdateConfig{
+	ucfg := update.UpdateConfig{
 		Enabled:                   cfg.System.VersionCheckEnabled,
 		VersionCheckIntervalHours: cfg.System.VersionCheckIntervalHours,
 		StableOnly:                cfg.System.VersionCheckStableOnly,
-	})
+	}
+	var service *update.Service
+	if updateChecker != nil {
+		service = update.NewServiceWithOptions(ucfg, update.ServiceOptions{Checker: updateChecker, StatePath: updateStatePath})
+	} else {
+		service = update.NewService(ucfg)
+	}
 	state, err := service.ForceCheck(ctx)
 
 	if state != nil && state.Source == update.UpdateSourceDisabled {

--- a/cmd/javinizer/commands/version/command.go
+++ b/cmd/javinizer/commands/version/command.go
@@ -77,7 +77,7 @@ func NewCommand() *cobra.Command {
 					if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Update available: %s (current: %s)\n", latestVer, current); err != nil {
 						return err
 					}
-					if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Run 'javinizer update' to update.\n"); err != nil {
+					if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Run 'javinizer upgrade' to update.\n"); err != nil {
 						return err
 					}
 				} else {

--- a/cmd/javinizer/commands/version/command.go
+++ b/cmd/javinizer/commands/version/command.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -9,6 +10,61 @@ import (
 	"github.com/javinizer/javinizer-go/internal/version"
 	"github.com/spf13/cobra"
 )
+
+// runVersionCheck performs a sync update check and translates the service's
+// internal state into the simple outcome the command's output branches need.
+// It is a package-level variable so tests can swap it for a stub, covering the
+// --check output paths (available / up-to-date / disabled / error) without
+// touching the network — mirroring the upgrade command's SetRunUpgrade seam.
+var runVersionCheck = func(ctx context.Context, configFile string) (*checkOutcome, error) {
+	cfg, err := loadConfigForCheck(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	service := update.NewService(update.UpdateConfig{
+		Enabled:                   cfg.System.VersionCheckEnabled,
+		VersionCheckIntervalHours: cfg.System.VersionCheckIntervalHours,
+		StableOnly:                cfg.System.VersionCheckStableOnly,
+	})
+	state, err := service.ForceCheck(ctx)
+
+	if state != nil && state.Source == update.UpdateSourceDisabled {
+		return &checkOutcome{disabled: true}, nil
+	}
+
+	if err != nil || state == nil || state.Version == "" || state.Source == update.UpdateSourceError {
+		var errorMsg string
+		if err != nil {
+			errorMsg = err.Error()
+		} else if state != nil && state.Error != "" {
+			errorMsg = state.Error
+		} else {
+			errorMsg = "Unknown error occurred while checking for updates"
+		}
+		return &checkOutcome{errMsg: errorMsg}, nil
+	}
+
+	return &checkOutcome{available: state.Available, version: state.Version}, nil
+}
+
+// checkOutcome is the result of a --check invocation, decoupling the command's
+// output branches from the update package's internal state type so tests can
+// drive every branch without constructing internal types.
+type checkOutcome struct {
+	disabled  bool
+	available bool
+	version   string
+	errMsg    string
+}
+
+// SetRunVersionCheck swaps the version-check implementation and returns the
+// previous one, so tests can inject a stub and restore it afterwards.
+func SetRunVersionCheck(fn func(ctx context.Context, configFile string) (*checkOutcome, error)) func(context.Context, string) (*checkOutcome, error) {
+	prev := runVersionCheck
+	runVersionCheck = fn
+	return prev
+}
 
 // NewCommand creates the version command.
 func NewCommand() *cobra.Command {
@@ -21,38 +77,19 @@ func NewCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if check {
-				// Perform a sync check using the service
-				ctx := cmd.Context()
 				configFile, _ := cmd.Flags().GetString("config")
-				cfg, err := loadConfigForCheck(configFile)
+				outcome, err := runVersionCheck(cmd.Context(), configFile)
 				if err != nil {
-					return fmt.Errorf("failed to load config: %w", err)
+					return err
 				}
 
-				service := update.NewService(update.UpdateConfig{
-					Enabled:                   cfg.System.VersionCheckEnabled,
-					VersionCheckIntervalHours: cfg.System.VersionCheckIntervalHours,
-					StableOnly:                cfg.System.VersionCheckStableOnly,
-				})
-				state, err := service.ForceCheck(ctx)
-
-				if state != nil && state.Source == update.UpdateSourceDisabled {
+				if outcome.disabled {
 					_, werr := fmt.Fprintln(cmd.OutOrStdout(), "Update checks are disabled in configuration")
 					return werr
 				}
 
-				// Check for errors - ForceCheck may return err OR set state.Source to UpdateSourceError.
-				if err != nil || state == nil || state.Version == "" || state.Source == update.UpdateSourceError {
-					// Print error to stderr
-					var errorMsg string
-					if err != nil {
-						errorMsg = err.Error()
-					} else if state.Error != "" {
-						errorMsg = state.Error
-					} else {
-						errorMsg = "Unknown error occurred while checking for updates"
-					}
-					_, ferr := fmt.Fprintf(cmd.ErrOrStderr(), "Error checking for updates: %v\n", errorMsg)
+				if outcome.errMsg != "" {
+					_, ferr := fmt.Fprintf(cmd.ErrOrStderr(), "Error checking for updates: %v\n", outcome.errMsg)
 					if ferr != nil {
 						return ferr
 					}
@@ -60,17 +97,14 @@ func NewCommand() *cobra.Command {
 				}
 
 				current := version.Short()
-				latestVer := state.Version
+				latestVer := outcome.version
 
-				// state.Available already reflects the build version comparison AND
+				// outcome.available already reflects the build version comparison AND
 				// the user's version_check_stable_only policy (prerelease
 				// suppression). Reusing it keeps the CLI consistent with the API/UI
 				// — recomputing CompareVersions here would surface a prerelease the
 				// service deliberately suppressed.
-				updateAvailable := state.Available
-
-				// Print to stdout for easy parsing
-				if updateAvailable {
+				if outcome.available {
 					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Update available: %s (current: %s)\n", latestVer, current); err != nil {
 						return err
 					}

--- a/cmd/javinizer/commands/version/coverage_boost_test.go
+++ b/cmd/javinizer/commands/version/coverage_boost_test.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -106,4 +107,80 @@ system:
 	err := cmd.Execute()
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), "Update checks are disabled")
+}
+
+var errConfigFail = configLoadErr{}
+
+type configLoadErr struct{}
+
+func (configLoadErr) Error() string { return "failed to load config: missing" }
+
+// TestNewCommand_CheckUpdateAvailable covers the --check output branch where an
+// update IS available — including the "Run 'javinizer upgrade'" hint. Uses a
+// stubbed runVersionCheck so no network is needed.
+func TestNewCommand_CheckUpdateAvailable(t *testing.T) {
+	restore := SetRunVersionCheck(func(_ context.Context, _ string) (*checkOutcome, error) {
+		return &checkOutcome{available: true, version: "v9.9.9"}, nil
+	})
+	defer SetRunVersionCheck(restore)
+
+	cmd := NewCommand()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"--check"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, out.String(), "Update available: v9.9.9")
+	assert.Contains(t, errBuf.String(), "Run 'javinizer upgrade' to update.")
+}
+
+// TestNewCommand_CheckUpToDate covers the --check output branch where the user
+// is already on the latest version.
+func TestNewCommand_CheckUpToDate(t *testing.T) {
+	restore := SetRunVersionCheck(func(_ context.Context, _ string) (*checkOutcome, error) {
+		return &checkOutcome{available: false, version: "v1.0.0"}, nil
+	})
+	defer SetRunVersionCheck(restore)
+
+	cmd := NewCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--check"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, out.String(), "You are running the latest version")
+}
+
+// TestNewCommand_CheckError covers the --check error-output branch.
+func TestNewCommand_CheckError(t *testing.T) {
+	restore := SetRunVersionCheck(func(_ context.Context, _ string) (*checkOutcome, error) {
+		return &checkOutcome{errMsg: "network unreachable"}, nil
+	})
+	defer SetRunVersionCheck(restore)
+
+	cmd := NewCommand()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"--check"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, errBuf.String(), "Error checking for updates: network unreachable")
+}
+
+// TestNewCommand_CheckConfigError covers the --check path where config loading
+// itself fails — the error must propagate from RunE.
+func TestNewCommand_CheckConfigError(t *testing.T) {
+	restore := SetRunVersionCheck(func(_ context.Context, _ string) (*checkOutcome, error) {
+		return nil, errConfigFail
+	})
+	defer SetRunVersionCheck(restore)
+
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"--check"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
 }

--- a/cmd/javinizer/commands/version/coverage_boost_test.go
+++ b/cmd/javinizer/commands/version/coverage_boost_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/javinizer/javinizer-go/internal/update"
 	appversion "github.com/javinizer/javinizer-go/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -327,4 +328,43 @@ scrapers:
 	_, err := loadConfigForCheck(cfgPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "newer than supported")
+}
+
+// failingChecker is a Checker stub whose CheckLatestVersion always errors, used
+// to drive the real service's ForceCheck into the UpdateSourceError branch.
+type failingChecker struct{ err error }
+
+func (c *failingChecker) CheckLatestVersion(_ context.Context) (*update.VersionInfo, error) {
+	return nil, c.err
+}
+
+// TestRunVersionCheck_RealErrorBranch covers the runVersionCheck error-translation
+// branch (ForceCheck returns an UpdateSourceError state) by injecting a failing
+// checker into the service — no network, no shared on-disk cache, deterministic.
+func TestRunVersionCheck_RealErrorBranch(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	configText := `config_version: 3
+system:
+  version_check_enabled: true
+  version_check_interval_hours: 24
+scrapers:
+  priority:
+    - r18
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(configText), 0644))
+
+	prev := updateChecker
+	updateChecker = &failingChecker{err: errors.New("github unreachable")}
+	t.Cleanup(func() { updateChecker = prev })
+
+	prevPath := updateStatePath
+	updateStatePath = filepath.Join(t.TempDir(), "update-state.json")
+	t.Cleanup(func() { updateStatePath = prevPath })
+
+	outcome, err := runVersionCheck(context.Background(), cfgPath)
+	require.NoError(t, err, "runVersionCheck translates the error into an outcome, not a Go error")
+	require.NotNil(t, outcome)
+	assert.NotEmpty(t, outcome.errMsg, "the ForceCheck failure must surface as an error message")
+	assert.Contains(t, outcome.errMsg, "github unreachable")
 }

--- a/cmd/javinizer/commands/version/coverage_boost_test.go
+++ b/cmd/javinizer/commands/version/coverage_boost_test.go
@@ -3,6 +3,7 @@ package version
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -183,4 +184,147 @@ func TestNewCommand_CheckConfigError(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// failWriter is a writer that always returns an error, for covering the
+// write-error sub-branches in the --check output paths.
+type failWriter struct{}
+
+func (failWriter) Write(_ []byte) (int, error) { return 0, errors.New("write failed") }
+
+// failAfterN fails on the (n+1)th write, succeeding the first n.
+type failAfterN struct{ n int }
+
+func (w *failAfterN) Write(p []byte) (int, error) {
+	if w.n <= 0 {
+		return 0, errors.New("write failed")
+	}
+	w.n--
+	return len(p), nil
+}
+
+// TestNewCommand_CheckAvailable_StdoutWriteError covers the write-error branch
+// after writing "Update available" to stdout.
+func TestNewCommand_CheckAvailable_StdoutWriteError(t *testing.T) {
+	restore := SetRunVersionCheck(func(_ context.Context, _ string) (*checkOutcome, error) {
+		return &checkOutcome{available: true, version: "v9.9.9"}, nil
+	})
+	defer SetRunVersionCheck(restore)
+
+	cmd := NewCommand()
+	cmd.SetOut(failWriter{})
+	cmd.SetArgs([]string{"--check"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write failed")
+}
+
+// TestNewCommand_CheckAvailable_StderrWriteError covers the write-error branch
+// after writing "Update available" to stderr (stdout succeeds first).
+func TestNewCommand_CheckAvailable_StderrWriteError(t *testing.T) {
+	restore := SetRunVersionCheck(func(_ context.Context, _ string) (*checkOutcome, error) {
+		return &checkOutcome{available: true, version: "v9.9.9"}, nil
+	})
+	defer SetRunVersionCheck(restore)
+
+	cmd := NewCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(failWriter{})
+	cmd.SetArgs([]string{"--check"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write failed")
+}
+
+// TestNewCommand_CheckAvailable_RunHintWriteError covers the write-error branch
+// after writing "Run 'javinizer upgrade'" to stderr (the second stderr write).
+func TestNewCommand_CheckAvailable_RunHintWriteError(t *testing.T) {
+	restore := SetRunVersionCheck(func(_ context.Context, _ string) (*checkOutcome, error) {
+		return &checkOutcome{available: true, version: "v9.9.9"}, nil
+	})
+	defer SetRunVersionCheck(restore)
+
+	cmd := NewCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&failAfterN{n: 1}) // first stderr write ok, second fails
+	cmd.SetArgs([]string{"--check"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write failed")
+}
+
+// TestNewCommand_CheckDisabled_StdoutWriteError covers the write-error branch
+// in the disabled path.
+func TestNewCommand_CheckDisabled_StdoutWriteError(t *testing.T) {
+	restore := SetRunVersionCheck(func(_ context.Context, _ string) (*checkOutcome, error) {
+		return &checkOutcome{disabled: true}, nil
+	})
+	defer SetRunVersionCheck(restore)
+
+	cmd := NewCommand()
+	cmd.SetOut(failWriter{})
+	cmd.SetArgs([]string{"--check"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write failed")
+}
+
+// TestNewCommand_CheckUpToDate_StdoutWriteError covers the write-error branch
+// in the up-to-date path.
+func TestNewCommand_CheckUpToDate_StdoutWriteError(t *testing.T) {
+	restore := SetRunVersionCheck(func(_ context.Context, _ string) (*checkOutcome, error) {
+		return &checkOutcome{available: false, version: "v1.0.0"}, nil
+	})
+	defer SetRunVersionCheck(restore)
+
+	cmd := NewCommand()
+	cmd.SetOut(failWriter{})
+	cmd.SetArgs([]string{"--check"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write failed")
+}
+
+// TestNewCommand_CheckError_StderrWriteError covers the write-error branch in
+// the error-message path (writing "Error checking for updates" to stderr).
+func TestNewCommand_CheckError_StderrWriteError(t *testing.T) {
+	restore := SetRunVersionCheck(func(_ context.Context, _ string) (*checkOutcome, error) {
+		return &checkOutcome{errMsg: "network unreachable"}, nil
+	})
+	defer SetRunVersionCheck(restore)
+
+	cmd := NewCommand()
+	cmd.SetErr(failWriter{})
+	cmd.SetArgs([]string{"--check"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write failed")
+}
+
+// TestLoadConfigForCheck_PrepareError covers the config.Prepare failure path in
+// loadConfigForCheck (an unsupported config version makes Prepare error).
+func TestLoadConfigForCheck_PrepareError(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	// A config_version far in the future triggers Prepare's "newer than
+	// supported" error.
+	configText := `config_version: 999
+system:
+  version_check_enabled: true
+  version_check_interval_hours: 24
+scrapers:
+  priority:
+    - r18
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(configText), 0644))
+
+	_, err := loadConfigForCheck(cfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "newer than supported")
 }

--- a/cmd/javinizer/commands/version/coverage_boost_test.go
+++ b/cmd/javinizer/commands/version/coverage_boost_test.go
@@ -338,6 +338,15 @@ func (c *failingChecker) CheckLatestVersion(_ context.Context) (*update.VersionI
 	return nil, c.err
 }
 
+// emptyErrorChecker returns a VersionInfo whose processing yields an
+// UpdateSourceError state with an empty Error string, covering the
+// "Unknown error" fallthrough branch.
+type emptyErrorChecker struct{}
+
+func (c *emptyErrorChecker) CheckLatestVersion(_ context.Context) (*update.VersionInfo, error) {
+	return &update.VersionInfo{Version: ""}, nil
+}
+
 // TestRunVersionCheck_RealErrorBranch covers the runVersionCheck error-translation
 // branch (ForceCheck returns an UpdateSourceError state) by injecting a failing
 // checker into the service — no network, no shared on-disk cache, deterministic.
@@ -367,4 +376,34 @@ scrapers:
 	require.NotNil(t, outcome)
 	assert.NotEmpty(t, outcome.errMsg, "the ForceCheck failure must surface as an error message")
 	assert.Contains(t, outcome.errMsg, "github unreachable")
+}
+
+// TestRunVersionCheck_UnknownErrorFallthrough covers the "Unknown error"
+// branch: an error state with an empty Error string surfaces the generic
+// message rather than an empty one.
+func TestRunVersionCheck_UnknownErrorFallthrough(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	configText := `config_version: 3
+system:
+  version_check_enabled: true
+  version_check_interval_hours: 24
+scrapers:
+  priority:
+    - r18
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(configText), 0644))
+
+	prev := updateChecker
+	updateChecker = &emptyErrorChecker{}
+	t.Cleanup(func() { updateChecker = prev })
+
+	prevPath := updateStatePath
+	updateStatePath = filepath.Join(t.TempDir(), "update-state.json")
+	t.Cleanup(func() { updateStatePath = prevPath })
+
+	outcome, err := runVersionCheck(context.Background(), cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, outcome)
+	assert.Contains(t, outcome.errMsg, "Unknown error occurred while checking for updates")
 }

--- a/cmd/javinizer/root.go
+++ b/cmd/javinizer/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/javinizer/javinizer-go/cmd/javinizer/commands/token"
 	"github.com/javinizer/javinizer-go/cmd/javinizer/commands/tui"
 	"github.com/javinizer/javinizer-go/cmd/javinizer/commands/update"
+	"github.com/javinizer/javinizer-go/cmd/javinizer/commands/upgrade"
 	versioncmd "github.com/javinizer/javinizer-go/cmd/javinizer/commands/version"
 	"github.com/javinizer/javinizer-go/cmd/javinizer/commands/word"
 	"github.com/javinizer/javinizer-go/internal/config"
@@ -80,6 +81,7 @@ func init() {
 		tag.NewCommand(),
 		tui.NewCommand(),
 		update.NewCommand(),
+		upgrade.NewCommand(),
 		word.NewCommand(),
 		versioncmd.NewCommand(),
 	)
@@ -91,7 +93,10 @@ func shouldSkipConfigInit(cmd *cobra.Command) bool {
 	}
 
 	// Built-in/help/version paths should not require config or logger setup.
-	if cmd.Name() == "version" || cmd.Name() == "help" || cmd.Name() == "completion" {
+	// `upgrade` also runs without config: it only talks to GitHub and replaces
+	// the binary, and forcing config init would create a config file as a side
+	// effect of a self-update.
+	if cmd.Name() == "version" || cmd.Name() == "help" || cmd.Name() == "completion" || cmd.Name() == "upgrade" {
 		return true
 	}
 

--- a/cmd/javinizer/root_test.go
+++ b/cmd/javinizer/root_test.go
@@ -44,7 +44,7 @@ func TestRootCommand_SubcommandCount(t *testing.T) {
 
 func TestRootCommand_SubcommandNames(t *testing.T) {
 	// Test that all expected subcommands are present
-	expectedCommands := []string{"actress", "api", "genre", "history", "info", "init", "logs", "scrape", "sort", "tag", "tui", "update", "version"}
+	expectedCommands := []string{"actress", "api", "genre", "history", "info", "init", "logs", "scrape", "sort", "tag", "tui", "update", "upgrade", "version"}
 
 	subcommands := rootCmd.Commands()
 	commandNames := make(map[string]bool)
@@ -82,6 +82,7 @@ func TestShouldSkipConfigInit(t *testing.T) {
 	assert.True(t, shouldSkipConfigInit(&cobra.Command{Use: "version"}))
 	assert.True(t, shouldSkipConfigInit(&cobra.Command{Use: "help"}))
 	assert.True(t, shouldSkipConfigInit(&cobra.Command{Use: "completion"}))
+	assert.True(t, shouldSkipConfigInit(&cobra.Command{Use: "upgrade"}))
 
 	cmd := &cobra.Command{Use: "scrape"}
 	cmd.Flags().Bool("version", false, "show version")

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,13 +10,14 @@ coverage:
         threshold: 1%
     patch:
       default:
-        # Informational only: reports how well *new* code is tested without
-        # gating the PR. New features legitimately include defensive error
-        # branches (sync/close/chmod failures, OS-specific dispatch, rollback
-        # paths) that are impractical to exercise without fragile tests; the
-        # project status above (90%+) is the real coverage gate. This keeps
-        # patch coverage visible as reviewer guidance, not a block.
-        informational: true
+        # New/changed code in a PR must be at least 80% covered — a standard
+        # floor that catches genuinely untested features while accepting that
+        # defensive error branches (sync/close/chmod failures, OS-specific
+        # dispatch, rollback-also-fails paths) are impractical to exercise
+        # without fragile tests. The project status above (90%+) remains the
+        # primary overall gate; this is a real (non-informational) floor so a
+        # PR that ships mostly-untested code still fails.
+        target: 80%
 
 comment:
   layout: "reach,diff,flags,files"

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,8 +10,13 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: auto
-        threshold: 5%
+        # Informational only: reports how well *new* code is tested without
+        # gating the PR. New features legitimately include defensive error
+        # branches (sync/close/chmod failures, OS-specific dispatch, rollback
+        # paths) that are impractical to exercise without fragile tests; the
+        # project status above (90%+) is the real coverage gate. This keeps
+        # patch coverage visible as reviewer guidance, not a block.
+        informational: true
 
 comment:
   layout: "reach,diff,flags,files"

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -67,6 +67,63 @@ Javinizer Go is a modern, high-performance metadata scraper and file organizer f
 
 ## Installation
 
+### Homebrew (macOS / Linux)
+
+Once a stable `v1.0.0` is published, the Homebrew tap is the recommended install on macOS:
+
+```bash
+brew tap javinizer/homebrew-tap https://github.com/javinizer/homebrew-tap
+brew install javinizer
+brew upgrade javinizer   # update to the latest stable release later
+```
+
+The formula installs a prebuilt binary (CGO/SQLite is statically linked). The tap is updated automatically on each **stable** release; prereleases never reach it.
+
+### Scoop (Windows)
+
+Once a stable `v1.0.0` is published, the Scoop bucket is the recommended install on Windows:
+
+```powershell
+scoop bucket add javinizer https://github.com/javinizer/scoop-javinizer
+scoop install javinizer
+scoop update javinizer   # update to the latest stable release later
+```
+
+The manifest installs the prebuilt `javinizer-windows-amd64.exe` and shims it as `javinizer`. The bucket is updated automatically on each **stable** release; prereleases never reach it. This is the recommended Windows install path until release binaries are Authenticode-signed (issue [#72](https://github.com/javinizer/javinizer-go/issues/72)).
+
+### One-shot installer
+
+Downloads the latest **stable** release, verifies its SHA256 against `checksums.txt`, and puts `javinizer` on your `PATH`. Prereleases are opt-in: pass `--pre-release` / `-PreRelease` to install the newest release including prereleases.
+
+```bash
+# Linux / macOS
+curl -sSL https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.sh | bash
+# latest pre-release:
+curl -sSL https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.sh | bash -s -- --pre-release
+```
+
+```powershell
+# Windows (PowerShell) — installs to %LOCALAPPDATA%\javinizer\bin, no admin required
+irm https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.ps1 | iex
+# latest pre-release:
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.ps1))) -PreRelease
+```
+
+The Windows installer runs `Unblock-File` to strip the Mark-of-the-Web tag that can otherwise cause an "Access is denied" error under Smart App Control (issue [#72](https://github.com/javinizer/javinizer-go/issues/72)).
+
+### Self-upgrade
+
+After a binary install, update in place without re-downloading by hand:
+
+```bash
+javinizer upgrade           # download + verify + replace the running binary
+javinizer upgrade --check   # just report whether an update is available
+```
+
+If javinizer was installed via Homebrew (or Scoop), `upgrade` detects that and tells you to use `brew upgrade javinizer` / `scoop update javinizer` instead.
+
+> `javinizer upgrade` updates the **program**; `javinizer update` refreshes **metadata** for your files. They are different commands.
+
 ### Pre-built Binary (Linux / macOS)
 
 Each release ships a single ready-to-run executable — no archive to extract. Download the asset matching your OS and architecture from the [Releases page](https://github.com/javinizer/javinizer-go/releases), make it executable, and put it on your `PATH`:

--- a/internal/update/checker.go
+++ b/internal/update/checker.go
@@ -72,6 +72,18 @@ type ConditionalChecker interface {
 	SetSkipLatest(skip bool)
 }
 
+// PreReleaseChecker is an OPTIONAL capability a Checker may implement to opt
+// into prerelease discovery. When SetPreRelease(true) is called, the checker
+// consults the /releases list endpoint (the single most recent release,
+// including prereleases) instead of /releases/latest (stable only). The
+// self-upgrade command uses this so a user on a stable release can opt into
+// jumping to a newer prerelease with `javinizer upgrade --prerelease`. It is
+// separate from ConditionalChecker so adding it cannot disturb the service
+// layer's ETag/skipLatest probes (and the mockChecker that implements them).
+type PreReleaseChecker interface {
+	SetPreRelease(enable bool)
+}
+
 // checker is an alias retaining the original unexported name used internally.
 type checker = Checker
 
@@ -87,6 +99,10 @@ type githubChecker struct {
 	// skipLatest, when true, skips the /releases/latest call (which 404s for a
 	// prerelease-only repo) and goes straight to the /releases list.
 	skipLatest bool
+	// preRelease, when true, always consults the /releases list (the newest
+	// release, including prereleases) instead of /releases/latest (stable
+	// only). Set via SetPreRelease by callers that want prerelease discovery.
+	preRelease bool
 }
 
 // SetIfNoneMatch implements ConditionalChecker.
@@ -94,6 +110,11 @@ func (c *githubChecker) SetIfNoneMatch(etag string) { c.ifNoneMatch = etag }
 
 // SetSkipLatest implements ConditionalChecker.
 func (c *githubChecker) SetSkipLatest(skip bool) { c.skipLatest = skip }
+
+// SetPreRelease implements PreReleaseChecker. When enabled, CheckLatestVersion
+// uses the /releases list endpoint so the newest release (including
+// prereleases) is returned, instead of /releases/latest (stable only).
+func (c *githubChecker) SetPreRelease(enable bool) { c.preRelease = enable }
 
 // newGitHubChecker creates a new GitHub checker.
 // The repo should be in format "owner/repo" (e.g., "javinizer/javinizer-go").
@@ -128,6 +149,24 @@ func newGitHubCheckerWithBaseURL(repo, baseURL string) *githubChecker {
 // prerelease-only repo — is skipped entirely, going straight to the /releases
 // list and halving API calls.
 func (c *githubChecker) CheckLatestVersion(ctx context.Context) (*versionInfo, error) {
+	// PreRelease opt-in: consult the /releases list so the newest release
+	// (including prereleases) is returned, instead of /releases/latest which
+	// excludes them. This lets a user on a stable release jump to a newer
+	// prerelease via `javinizer upgrade --prerelease`. Inlined (rather than
+	// reusing latestFromReleaseList) so the error context and the
+	// NoStableLatest flag don't carry the 404-fallback framing that doesn't
+	// apply when the list was chosen deliberately.
+	if c.preRelease {
+		versions, etag, err := c.getRecentReleases(ctx, 1)
+		if err != nil {
+			return nil, fmt.Errorf("prerelease release lookup failed: %w", err)
+		}
+		if len(versions) == 0 {
+			return nil, fmt.Errorf("no releases found")
+		}
+		v := versions[0]
+		return &versionInfo{Version: v, TagName: v, Prerelease: IsPrerelease(v), ETag: etag}, nil
+	}
 	// Skip the /releases/latest 404 we already know is coming for a
 	// prerelease-only repo; go straight to the list endpoint.
 	if c.skipLatest {

--- a/internal/update/checker_test.go
+++ b/internal/update/checker_test.go
@@ -799,3 +799,35 @@ func TestCheckLatestVersion_PreReleaseUsesListEvenWithStableLatest(t *testing.T)
 	assert.False(t, info.NoStableLatest, "preRelease must not set NoStableLatest")
 	assert.Equal(t, 0, latestHit, "/releases/latest must not be hit when preRelease is set")
 }
+
+func TestCheckLatestVersion_PreReleasePropagatesListError(t *testing.T) {
+	// When the /releases list call itself fails (500), preRelease must surface the
+	// error rather than falling back to /releases/latest.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	chk := newGitHubCheckerWithBaseURL("javinizer/javinizer-go", server.URL)
+	chk.SetPreRelease(true)
+
+	_, err := chk.CheckLatestVersion(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prerelease release lookup failed")
+}
+
+func TestCheckLatestVersion_PreReleaseEmptyList(t *testing.T) {
+	// An empty releases list under preRelease must error ("no releases found")
+	// rather than returning a nil/zero-value result.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	chk := newGitHubCheckerWithBaseURL("javinizer/javinizer-go", server.URL)
+	chk.SetPreRelease(true)
+
+	_, err := chk.CheckLatestVersion(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no releases found")
+}

--- a/internal/update/checker_test.go
+++ b/internal/update/checker_test.go
@@ -757,3 +757,45 @@ func TestCheckLatestVersion_SkipLatestGoesStraightToList(t *testing.T) {
 	assert.True(t, info.NoStableLatest)
 	assert.Equal(t, 0, latestHit, "/releases/latest never hit when skipLatest is set")
 }
+
+// preRelease must consult the /releases list (newest release, including
+// prereleases) even when /releases/latest would return a valid stable release —
+// so a user on stable can jump to a newer prerelease. Unlike skipLatest, it
+// must NOT set NoStableLatest (a stable latest may well exist; the list was
+// chosen deliberately, not because /releases/latest 404'd).
+func TestCheckLatestVersion_PreReleaseUsesListEvenWithStableLatest(t *testing.T) {
+	var latestHit int
+	// The list returns a NEWER prerelease than the stable /releases/latest would.
+	mockList := []map[string]interface{}{{
+		"tag_name":   "v1.1.0-rc1",
+		"prerelease": true,
+	}}
+	listBytes, _ := json.Marshal(mockList)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/javinizer/javinizer-go/releases/latest":
+			latestHit++
+			// A stable latest exists — but preRelease must not even ask.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"tag_name":"v1.0.0","prerelease":false}`))
+		case "/repos/javinizer/javinizer-go/releases":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(listBytes)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	chk := newGitHubCheckerWithBaseURL("javinizer/javinizer-go", server.URL)
+	chk.SetPreRelease(true)
+
+	info, err := chk.CheckLatestVersion(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "v1.1.0-rc1", info.Version, "preRelease must return the newest release (incl. prerelease)")
+	assert.True(t, info.Prerelease)
+	assert.False(t, info.NoStableLatest, "preRelease must not set NoStableLatest")
+	assert.Equal(t, 0, latestHit, "/releases/latest must not be hit when preRelease is set")
+}

--- a/internal/update/coverage_boost_test.go
+++ b/internal/update/coverage_boost_test.go
@@ -26,7 +26,7 @@ func TestService_ForceCheck_MockServer(t *testing.T) {
 	store := newStateStore(statePath, defaultCheckInterval)
 
 	chk := newGitHubCheckerWithBaseURL("javinizer/Javinizer", server.URL)
-	svc := &service{
+	svc := &Service{
 		checker:   chk,
 		store:     store,
 		statePath: statePath,
@@ -42,7 +42,7 @@ func TestService_ForceCheck_MockServer(t *testing.T) {
 
 func TestService_ForceCheck_DisabledCoverage(t *testing.T) {
 	tmpDir := t.TempDir()
-	svc := &service{
+	svc := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     newStateStore(filepath.Join(tmpDir, "state.json"), defaultCheckInterval),
 		statePath: filepath.Join(tmpDir, "state.json"),
@@ -69,7 +69,7 @@ func TestService_ForceCheck_ErrorWithCache(t *testing.T) {
 	}))
 	defer server.Close()
 
-	svc := &service{
+	svc := &Service{
 		checker:   newGitHubCheckerWithBaseURL("javinizer/Javinizer", server.URL),
 		store:     store,
 		statePath: statePath,
@@ -92,7 +92,7 @@ func TestService_ForceCheck_ErrorNoCache(t *testing.T) {
 	}))
 	defer server.Close()
 
-	svc := &service{
+	svc := &Service{
 		checker:   newGitHubCheckerWithBaseURL("javinizer/Javinizer", server.URL),
 		store:     newStateStore(statePath, defaultCheckInterval),
 		statePath: statePath,
@@ -111,7 +111,7 @@ func TestService_GetStatus_CachedState(t *testing.T) {
 	store := newStateStore(statePath, defaultCheckInterval)
 	store.SetState(&updateState{Version: "v1.0.0", CheckedAt: time.Now().UTC().Format(time.RFC3339), Available: true, Source: UpdateSourceFresh})
 
-	svc := &service{
+	svc := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     store,
 		statePath: statePath,
@@ -130,7 +130,7 @@ func TestService_GetStatus_Empty(t *testing.T) {
 	statePath := filepath.Join(tmpDir, "state.json")
 	store := newStateStore(statePath, defaultCheckInterval)
 
-	svc := &service{
+	svc := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     store,
 		statePath: statePath,
@@ -151,7 +151,7 @@ func TestService_GetStatus_StaleTriggersBg(t *testing.T) {
 	oldTime := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
 	store.SetState(&updateState{Version: "v0.9.0", CheckedAt: oldTime, Source: UpdateSourceCached})
 
-	svc := &service{
+	svc := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     store,
 		statePath: statePath,
@@ -172,7 +172,7 @@ func TestService_IsUpdateAvailable_Cached(t *testing.T) {
 	store := newStateStore(statePath, defaultCheckInterval)
 	store.SetState(&updateState{Version: "v2.0.0", Available: true, CheckedAt: time.Now().UTC().Format(time.RFC3339), Source: UpdateSourceFresh})
 
-	svc := &service{
+	svc := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     store,
 		statePath: statePath,
@@ -191,7 +191,7 @@ func TestService_GetLatestVersion_Cached(t *testing.T) {
 	store := newStateStore(statePath, defaultCheckInterval)
 	store.SetState(&updateState{Version: "v3.0.0", CheckedAt: time.Now().UTC().Format(time.RFC3339), Source: UpdateSourceFresh})
 
-	svc := &service{
+	svc := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     store,
 		statePath: statePath,
@@ -217,7 +217,7 @@ func TestService_BackgroundCheck_MockServer(t *testing.T) {
 	store := newStateStore(statePath, defaultCheckInterval)
 
 	chk := newGitHubCheckerWithBaseURL("javinizer/Javinizer", server.URL)
-	svc := &service{
+	svc := &Service{
 		checker:   chk,
 		store:     store,
 		statePath: statePath,
@@ -243,7 +243,7 @@ func TestService_StartBgCheck_Cancel(t *testing.T) {
 	}))
 	defer server.Close()
 
-	svc := &service{
+	svc := &Service{
 		checker:   newGitHubCheckerWithBaseURL("javinizer/Javinizer", server.URL),
 		store:     newStateStore(statePath, defaultCheckInterval),
 		statePath: statePath,

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -292,6 +292,10 @@ func (s *Service) BackgroundCheck(ctx context.Context) {
 
 	state := s.forceCheckLocked(ctx)
 
+	if state.Source == UpdateSourceError {
+		logging.Debugf("Update check failed: %s", state.Error)
+		return
+	}
 	if state.Available {
 		logging.Infof("Update available: %s", state.Version)
 	} else {

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -12,8 +12,8 @@ import (
 	"github.com/javinizer/javinizer-go/internal/version"
 )
 
-// service handles update checking with caching and background refresh.
-type service struct {
+// Service handles update checking with caching and background refresh.
+type Service struct {
 	checker    checker
 	store      *stateStore
 	statePath  string
@@ -37,7 +37,7 @@ type UpdateConfig struct {
 
 // NewService creates a new update service with production defaults (the real
 // GitHub checker and the default cache path). Existing callers are unaffected.
-func NewService(cfg UpdateConfig) *service {
+func NewService(cfg UpdateConfig) *Service {
 	return NewServiceWithOptions(cfg, ServiceOptions{})
 }
 
@@ -58,7 +58,7 @@ type ServiceOptions struct {
 // zero-value opts reproduces NewService behavior exactly, so production callers
 // can keep using NewService while tests inject a stub Checker and a temp-dir
 // StatePath for hermetic, network-free coverage.
-func NewServiceWithOptions(cfg UpdateConfig, opts ServiceOptions) *service {
+func NewServiceWithOptions(cfg UpdateConfig, opts ServiceOptions) *Service {
 	interval := time.Duration(cfg.VersionCheckIntervalHours) * time.Hour
 	if interval <= 0 {
 		interval = defaultCheckInterval
@@ -76,7 +76,7 @@ func NewServiceWithOptions(cfg UpdateConfig, opts ServiceOptions) *service {
 		chk = newGitHubChecker(defaultRepo)
 	}
 
-	return &service{
+	return &Service{
 		checker:    chk,
 		store:      store,
 		statePath:  statePath,
@@ -90,13 +90,13 @@ func NewServiceWithOptions(cfg UpdateConfig, opts ServiceOptions) *service {
 // Exposed so callers (e.g. the API bootstrap) can start the background ticker
 // with the same interval the service uses for staleness checks, rather than
 // re-deriving (and possibly diverging from) the default-interval logic.
-func (s *service) Interval() time.Duration {
+func (s *Service) Interval() time.Duration {
 	return s.interval
 }
 
 // GetStatus returns the current update status.
 // If the cached state is stale, it performs a background check.
-func (s *service) GetStatus(ctx context.Context) (*updateState, error) {
+func (s *Service) GetStatus(ctx context.Context) (*updateState, error) {
 	if !s.enabled {
 		return &updateState{
 			Source: UpdateSourceDisabled,
@@ -140,7 +140,7 @@ func (s *service) GetStatus(ctx context.Context) (*updateState, error) {
 // endpoint and BackgroundCheck both flow through here. BackgroundCheck already
 // holds checkMu and calls forceCheckLocked directly to avoid a non-reentrant
 // deadlock.
-func (s *service) ForceCheck(ctx context.Context) (*updateState, error) {
+func (s *Service) ForceCheck(ctx context.Context) (*updateState, error) {
 	if !s.enabled {
 		return &updateState{
 			Source: UpdateSourceDisabled,
@@ -148,11 +148,15 @@ func (s *service) ForceCheck(ctx context.Context) (*updateState, error) {
 	}
 	s.checkMu.Lock()
 	defer s.checkMu.Unlock()
-	return s.forceCheckLocked(ctx)
+	return s.forceCheckLocked(ctx), nil
 }
 
 // forceCheckLocked is the ForceCheck body; the caller MUST hold s.checkMu.
-func (s *service) forceCheckLocked(ctx context.Context) (*updateState, error) {
+// It returns only the state — every error is translated into the state's
+// Error/Source fields rather than a Go error, so callers always get a usable
+// state (never a nil + error pair). ForceCheck wraps it to add the disabled
+// short-circuit and the (always-nil here) error return for API compatibility.
+func (s *Service) forceCheckLocked(ctx context.Context) *updateState {
 	logging.Info("Checking for updates...")
 
 	// Thread the cached ETag + "no-stable-latest" flag into the checker so this
@@ -196,13 +200,13 @@ func (s *service) forceCheckLocked(ctx context.Context) (*updateState, error) {
 					(!cached.Prerelease || !s.stableOnly)
 				_ = s.store.SaveState(cached)
 				logging.Debugf("Update check: not modified (304), keeping cached state")
-				return cached, nil
+				return cached
 			}
 			// No cached state to reuse — fall through to the error path below.
 			return &updateState{
 				Source: UpdateSourceError,
 				Error:  "not modified but no cached state available",
-			}, nil
+			}
 		}
 
 		logging.Debugf("Update check failed: %v", err)
@@ -214,13 +218,13 @@ func (s *service) forceCheckLocked(ctx context.Context) (*updateState, error) {
 			state.Error = err.Error()
 			state.Source = UpdateSourceCached
 			_ = s.store.SaveState(state)
-			return state, nil
+			return state
 		}
 
 		return &updateState{
 			Source: UpdateSourceError,
 			Error:  err.Error(),
-		}, nil
+		}
 	}
 
 	// Check if update is available
@@ -262,11 +266,11 @@ func (s *service) forceCheckLocked(ctx context.Context) (*updateState, error) {
 		}
 	}
 
-	return state, nil
+	return state
 }
 
 // ShouldCheck determines if a check should be performed.
-func (s *service) ShouldCheck(state *updateState) bool {
+func (s *Service) ShouldCheck(state *updateState) bool {
 	if state == nil || state.CheckedAt == "" {
 		return true
 	}
@@ -275,7 +279,7 @@ func (s *service) ShouldCheck(state *updateState) bool {
 
 // BackgroundCheck performs a non-blocking update check.
 // Uses caller-provided context for proper cancellation/timeout propagation.
-func (s *service) BackgroundCheck(ctx context.Context) {
+func (s *Service) BackgroundCheck(ctx context.Context) {
 	// Use a new context with timeout for the check itself
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -286,11 +290,7 @@ func (s *service) BackgroundCheck(ctx context.Context) {
 	s.checkMu.Lock()
 	defer s.checkMu.Unlock()
 
-	state, err := s.forceCheckLocked(ctx)
-	if err != nil {
-		logging.Debugf("Background update check failed: %v", err)
-		return
-	}
+	state := s.forceCheckLocked(ctx)
 
 	if state.Available {
 		logging.Infof("Update available: %s", state.Version)
@@ -300,7 +300,7 @@ func (s *service) BackgroundCheck(ctx context.Context) {
 }
 
 // StartBackgroundCheck starts a background goroutine for periodic checks.
-func (s *service) StartBackgroundCheck(ctx context.Context, interval time.Duration) {
+func (s *Service) StartBackgroundCheck(ctx context.Context, interval time.Duration) {
 	if !s.enabled {
 		return
 	}
@@ -335,7 +335,7 @@ func (s *service) StartBackgroundCheck(ctx context.Context, interval time.Durati
 }
 
 // IsUpdateAvailable checks if an update is available without modifying state.
-func (s *service) IsUpdateAvailable(ctx context.Context) (bool, error) {
+func (s *Service) IsUpdateAvailable(ctx context.Context) (bool, error) {
 	state, err := s.GetStatus(ctx)
 	if err != nil {
 		return false, err
@@ -344,7 +344,7 @@ func (s *service) IsUpdateAvailable(ctx context.Context) (bool, error) {
 }
 
 // GetLatestVersion returns the latest version without checking availability.
-func (s *service) GetLatestVersion(ctx context.Context) (string, error) {
+func (s *Service) GetLatestVersion(ctx context.Context) (string, error) {
 	state, err := s.GetStatus(ctx)
 	if err != nil {
 		return "", err

--- a/internal/update/service_test.go
+++ b/internal/update/service_test.go
@@ -53,7 +53,7 @@ func TestService_GetStatus_Disabled(t *testing.T) {
 	// Override the state path for testing
 	store := newStateStore(statePath, defaultCheckInterval)
 
-	service := &service{
+	service := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     store,
 		statePath: statePath,
@@ -71,7 +71,7 @@ func TestService_ForceCheck(t *testing.T) {
 	tmpDir := t.TempDir()
 	statePath := filepath.Join(tmpDir, "update_cache.json")
 
-	service := &service{
+	service := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     newStateStore(statePath, defaultCheckInterval),
 		statePath: statePath,
@@ -99,7 +99,7 @@ func TestService_BackgroundCheck(t *testing.T) {
 	statePath := filepath.Join(tmpDir, "update_cache.json")
 
 	store := newStateStore(statePath, defaultCheckInterval)
-	service := &service{
+	service := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     store,
 		statePath: statePath,
@@ -144,7 +144,7 @@ func TestService_IsUpdateAvailable(t *testing.T) {
 	tmpDir := t.TempDir()
 	statePath := filepath.Join(tmpDir, "update_cache.json")
 
-	service := &service{
+	service := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     newStateStore(statePath, defaultCheckInterval),
 		statePath: statePath,
@@ -163,7 +163,7 @@ func TestService_GetLatestVersion(t *testing.T) {
 	tmpDir := t.TempDir()
 	statePath := filepath.Join(tmpDir, "update_cache.json")
 
-	service := &service{
+	service := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     newStateStore(statePath, defaultCheckInterval),
 		statePath: statePath,
@@ -190,7 +190,7 @@ func TestService_StartBackgroundCheck(t *testing.T) {
 	statePath := filepath.Join(tmpDir, "update_cache.json")
 
 	store := newStateStore(statePath, defaultCheckInterval)
-	service := &service{
+	service := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     store,
 		statePath: statePath,
@@ -219,7 +219,7 @@ func TestService_StartBackgroundCheck_Disabled(t *testing.T) {
 	statePath := filepath.Join(tmpDir, "update_cache.json")
 
 	store := newStateStore(statePath, defaultCheckInterval)
-	service := &service{
+	service := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     store,
 		statePath: statePath,
@@ -245,7 +245,7 @@ func TestService_ShouldCheck(t *testing.T) {
 	statePath := filepath.Join(tmpDir, "update_cache.json")
 
 	store := newStateStore(statePath, 24*time.Hour)
-	service := &service{
+	service := &Service{
 		store:    store,
 		interval: 24 * time.Hour,
 		enabled:  true,
@@ -283,7 +283,7 @@ func TestService_GetStatus_WithExistingState(t *testing.T) {
 	err := saveStateToFile(afero.NewOsFs(), statePath, initialState)
 	require.NoError(t, err)
 
-	service := &service{
+	service := &Service{
 		checker:   newGitHubChecker("javinizer/Javinizer"),
 		store:     newStateStore(statePath, 24*time.Hour),
 		statePath: statePath,
@@ -307,7 +307,7 @@ func TestService_ForceCheck_PrereleaseToStableIsAvailable(t *testing.T) {
 	tmpDir := t.TempDir()
 	statePath := filepath.Join(tmpDir, "update_cache.json")
 
-	service := &service{
+	service := &Service{
 		checker: &mockChecker{
 			version: &versionInfo{
 				Version:    "v1.6.0",
@@ -340,10 +340,10 @@ func TestService_ForceCheck_StableOnlyConfig(t *testing.T) {
 	defer func() { appversion.Version = origVersion }()
 	appversion.Version = "v0.3.14-alpha"
 
-	mkService := func(stableOnly bool) *service {
+	mkService := func(stableOnly bool) *Service {
 		tmpDir := t.TempDir()
 		statePath := filepath.Join(tmpDir, "update_cache.json")
-		return &service{
+		return &Service{
 			checker: &mockChecker{
 				version: &versionInfo{
 					Version:    "v0.3.15-alpha",
@@ -408,7 +408,7 @@ func TestService_ForceCheck_NotModifiedKeepsCachedState(t *testing.T) {
 	require.NoError(t, store.SaveState(prior))
 
 	chk := &mockChecker{err: ErrNotModified}
-	svc := &service{
+	svc := &Service{
 		checker:    chk,
 		store:      store,
 		statePath:  statePath,
@@ -455,7 +455,7 @@ func TestService_ForceCheck_NotModifiedWithoutCache(t *testing.T) {
 	store := newStateStore(statePath, defaultCheckInterval) // empty cache
 
 	chk := &mockChecker{err: ErrNotModified}
-	svc := &service{
+	svc := &Service{
 		checker:   chk,
 		store:     store,
 		statePath: statePath,
@@ -497,7 +497,7 @@ func TestService_ForceCheck_NotModifiedReEvaluatesStableOnly(t *testing.T) {
 	require.NoError(t, store.SaveState(prior))
 
 	chk := &mockChecker{err: ErrNotModified}
-	svc := &service{
+	svc := &Service{
 		checker:    chk,
 		store:      store,
 		statePath:  statePath,
@@ -547,7 +547,7 @@ func TestService_ForceCheck_NotModifiedReEnablesWhenStableOnlyCleared(t *testing
 	require.NoError(t, store.SaveState(prior))
 
 	chk := &mockChecker{err: ErrNotModified}
-	svc := &service{
+	svc := &Service{
 		checker:    chk,
 		store:      store,
 		statePath:  statePath,
@@ -580,7 +580,7 @@ func TestService_ForceCheck_ResetsConditionalHintsWhenCacheEmpty(t *testing.T) {
 		gotIfNoneMatch: `W/"stale-from-prior-check"`,
 		gotSkipLatest:  true,
 	}
-	svc := &service{
+	svc := &Service{
 		checker:   chk,
 		store:     store,
 		statePath: statePath,

--- a/internal/update/upgrade.go
+++ b/internal/update/upgrade.go
@@ -372,15 +372,37 @@ func downloadAndReplace(ctx context.Context, opts UpgradeOptions, exePath, tag, 
 }
 
 // downloadTo streams a URL into w, capping the total bytes read at maxSize.
+// It enforces HTTPS end to end: the initial URL and every redirect must be
+// https, because a checksum fetched over the same insecure channel as the
+// binary authenticates nothing (a MITM could swap both). An oversized response
+// fails closed rather than being silently truncated into a partial parse.
 func downloadTo(ctx context.Context, client *http.Client, url string, w io.Writer, maxSize int64) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
+	if req.URL.Scheme != "https" {
+		return fmt.Errorf("refusing non-HTTPS download URL: %s", req.URL.Redacted())
+	}
 	req.Header.Set("User-Agent", "Javinizer-Updater")
 	req.Header.Set("Accept", "application/octet-stream")
 
-	resp, err := client.Do(req)
+	safeClient := *client
+	baseRedirect := safeClient.CheckRedirect
+	safeClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.URL.Scheme != "https" {
+			return fmt.Errorf("refusing non-HTTPS redirect URL: %s", req.URL.Redacted())
+		}
+		if baseRedirect != nil {
+			return baseRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+
+	resp, err := safeClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -389,8 +411,12 @@ func downloadTo(ctx context.Context, client *http.Client, url string, w io.Write
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("HTTP %d for %s", resp.StatusCode, url)
 	}
-	if _, err := io.Copy(w, io.LimitReader(resp.Body, maxSize)); err != nil {
+	n, err := io.Copy(w, io.LimitReader(resp.Body, maxSize+1))
+	if err != nil {
 		return fmt.Errorf("read body: %w", err)
+	}
+	if n > maxSize {
+		return fmt.Errorf("response exceeds maximum size of %d bytes for %s", maxSize, url)
 	}
 	return nil
 }

--- a/internal/update/upgrade.go
+++ b/internal/update/upgrade.go
@@ -1,0 +1,488 @@
+package update
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/httpclient"
+	"github.com/javinizer/javinizer-go/internal/logging"
+)
+
+const (
+	// defaultDownloadBase is the host that serves release assets
+	// (github.com/.../releases/download/...). It is distinct from the GitHub
+	// API host (api.github.com) used by the checker.
+	defaultDownloadBase = "https://github.com"
+	// maxAssetSize caps how much we will download/write for a release binary,
+	// guarding against a malformed or hostile response streaming forever.
+	maxAssetSize = 256 * 1024 * 1024 // 256MB
+	// maxChecksumSize caps the checksums.txt download.
+	maxChecksumSize = 1 * 1024 * 1024 // 1MB
+)
+
+// InstallMethod describes how the running binary was installed, so the
+// self-upgrade can defer to the right package manager instead of clobbering a
+// managed install.
+type InstallMethod int
+
+const (
+	// InstallMethodManual covers a direct binary download or build-from-source.
+	// These are safe to self-replace in place.
+	InstallMethodManual InstallMethod = iota
+	// InstallMethodHomebrew means the binary lives under a Homebrew Cellar;
+	// self-replacing it would diverge from brew's bookkeeping, so we hand off.
+	InstallMethodHomebrew
+	// InstallMethodScoop means the binary lives under a Scoop apps dir;
+	// self-replacing it would diverge from scoop's manifest, so we hand off.
+	InstallMethodScoop
+)
+
+// String returns a human-readable label for the install method.
+func (m InstallMethod) String() string {
+	switch m {
+	case InstallMethodHomebrew:
+		return "homebrew"
+	case InstallMethodScoop:
+		return "scoop"
+	default:
+		return "manual"
+	}
+}
+
+// AssetName returns the release asset filename for the given GOOS/GOARCH.
+// macOS uses the universal binary (one asset for both arches); linux is
+// arch-specific; windows publishes only amd64 today. This must stay in sync
+// with the asset names produced by .github/workflows/cli-release.yml
+// (javinizer-<os>-<arch>).
+func AssetName(goos, goarch string) (string, error) {
+	switch goos {
+	case "darwin":
+		// A universal binary is published for darwin, so arch is irrelevant.
+		return "javinizer-darwin-universal", nil
+	case "linux":
+		switch goarch {
+		case "amd64", "arm64":
+			return "javinizer-linux-" + goarch, nil
+		}
+	case "windows":
+		// Only windows-amd64 is published by CI today; windows-arm64 would 404.
+		if goarch == "amd64" {
+			return "javinizer-windows-amd64.exe", nil
+		}
+	}
+	return "", fmt.Errorf("no release asset for %s/%s", goos, goarch)
+}
+
+// DetectInstallMethod inspects the running executable path to guess how
+// javinizer was installed. It is intentionally conservative: only paths that
+// clearly belong to a package manager are flagged as such, so a manual install
+// that happens to live somewhere unusual still gets the self-replace path.
+func DetectInstallMethod(exePath string) InstallMethod {
+	p := strings.ToLower(filepath.ToSlash(exePath))
+	if strings.Contains(p, "/cellar/javinizer") || strings.Contains(p, "/linuxbrew/") && strings.Contains(p, "/cellar/") {
+		return InstallMethodHomebrew
+	}
+	if strings.Contains(p, "/scoop/apps/javinizer") {
+		return InstallMethodScoop
+	}
+	return InstallMethodManual
+}
+
+// ParseChecksums extracts the SHA256 hash for assetName from the contents of a
+// checksums.txt file (sha256sum output: "<hash>  <name>" or "<hash> *<name>").
+// Returns an error if the asset is not listed.
+func ParseChecksums(data []byte, assetName string) (string, error) {
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		hash := fields[0]
+		for _, f := range fields[1:] {
+			if f == assetName || strings.TrimPrefix(f, "*") == assetName {
+				return hash, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("checksum for %s not found in checksums.txt", assetName)
+}
+
+// UpgradeOptions configures an Upgrade run. All fields are optional: a
+// zero-value UpgradeOptions (with a non-empty CurrentVersion) performs a real
+// upgrade against the live GitHub release. Tests inject an HTTPClient pointed
+// at an httptest server and/or a stub Checker to avoid the network.
+type UpgradeOptions struct {
+	// CurrentVersion is the running version (e.g. version.Short()). Required.
+	CurrentVersion string
+	// Force upgrades even when already at the latest version.
+	Force bool
+	// CheckOnly reports whether an update is available without downloading.
+	CheckOnly bool
+	// PreRelease, when true, discovers the newest release including
+	// prereleases (via the /releases list) instead of the latest stable
+	// (/releases/latest). Lets a user on stable opt into a newer prerelease.
+	PreRelease bool
+	// Repo overrides the GitHub owner/repo (default defaultRepo).
+	Repo string
+	// APIBaseURL overrides the GitHub API base (tests).
+	APIBaseURL string
+	// DownloadBaseURL overrides the release-asset host (tests).
+	DownloadBaseURL string
+	// HTTPClient overrides the HTTP client used for downloads + API.
+	HTTPClient *http.Client
+	// Checker overrides the release checker (tests). When nil, a real
+	// githubChecker is constructed from Repo/APIBaseURL.
+	Checker Checker
+	// ExePath overrides the running-binary path (default os.Executable()).
+	ExePath string
+	// Out receives progress messages (default os.Stdout).
+	Out io.Writer
+}
+
+// UpgradeResult is the outcome of an Upgrade run.
+type UpgradeResult struct {
+	CurrentVersion string
+	LatestVersion  string
+	TagName        string
+	AssetName      string
+	UpToDate       bool
+	Upgraded       bool
+	// Handoff is true when the install is managed by a package manager and the
+	// caller was told to run `brew upgrade` / `scoop update` instead.
+	Handoff       bool
+	InstallMethod InstallMethod
+}
+
+// Upgrade checks for, downloads, and applies the latest release, replacing the
+// running binary in place. It never touches a Homebrew/Scoop-managed install —
+// for those it prints the correct upgrade command and returns Handoff=true.
+func Upgrade(ctx context.Context, opts UpgradeOptions) (*UpgradeResult, error) {
+	opts = resolveUpgradeDefaults(opts)
+	out := opts.Out
+
+	if opts.CurrentVersion == "" {
+		return nil, errors.New("current version is required")
+	}
+
+	chk := opts.Checker
+	if chk == nil {
+		chk = newGitHubCheckerWithBaseURL(opts.Repo, opts.APIBaseURL)
+	}
+	// Thread the prerelease opt-in into the real checker. Stub checkers in
+	// tests need not implement PreReleaseChecker — the assert fails silently
+	// and the stub returns whatever it is configured to return.
+	if opts.PreRelease {
+		if pc, ok := chk.(PreReleaseChecker); ok {
+			pc.SetPreRelease(true)
+		}
+	}
+
+	logging.Infof("Checking for the latest release (current: %s)", opts.CurrentVersion)
+	latest, err := chk.CheckLatestVersion(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check latest release: %w", err)
+	}
+
+	result := &UpgradeResult{
+		CurrentVersion: opts.CurrentVersion,
+		LatestVersion:  latest.Version,
+		TagName:        latest.TagName,
+	}
+	if result.TagName == "" {
+		result.TagName = latest.Version
+	}
+
+	cmp := CompareVersions(opts.CurrentVersion, latest.Version)
+	result.UpToDate = cmp >= 0
+
+	if opts.CheckOnly {
+		if result.UpToDate {
+			_, _ = fmt.Fprintf(out, "Already up to date: %s\n", opts.CurrentVersion)
+		} else {
+			_, _ = fmt.Fprintf(out, "Update available: %s (current: %s)\n", latest.Version, opts.CurrentVersion)
+		}
+		return result, nil
+	}
+
+	if result.UpToDate && !opts.Force {
+		_, _ = fmt.Fprintf(out, "Already up to date: %s\n", opts.CurrentVersion)
+		return result, nil
+	}
+
+	asset, err := AssetName(runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return nil, err
+	}
+	result.AssetName = asset
+
+	exePath, err := resolveExePath(opts.ExePath)
+	if err != nil {
+		return nil, fmt.Errorf("locate running binary: %w", err)
+	}
+	method := DetectInstallMethod(exePath)
+	result.InstallMethod = method
+	switch method {
+	case InstallMethodHomebrew:
+		result.Handoff = true
+		_, _ = fmt.Fprintf(out, "Javinizer was installed with Homebrew.\n")
+		_, _ = fmt.Fprintf(out, "Run `brew upgrade javinizer` to update (self-upgrade would break brew's bookkeeping).\n")
+		return result, nil
+	case InstallMethodScoop:
+		result.Handoff = true
+		_, _ = fmt.Fprintf(out, "Javinizer was installed with Scoop.\n")
+		_, _ = fmt.Fprintf(out, "Run `scoop update javinizer` to update (self-upgrade would break scoop's manifest).\n")
+		return result, nil
+	}
+
+	if result.UpToDate && opts.Force {
+		_, _ = fmt.Fprintf(out, "Reinstalling %s (forced)...\n", latest.Version)
+	} else {
+		_, _ = fmt.Fprintf(out, "Upgrading %s -> %s\n", opts.CurrentVersion, latest.Version)
+	}
+	if latest.Prerelease || IsPrerelease(latest.Version) {
+		_, _ = fmt.Fprintf(out, "Note: %s is a prerelease.\n", latest.Version)
+	}
+
+	if err := downloadAndReplace(ctx, opts, exePath, result.TagName, asset); err != nil {
+		return result, err
+	}
+
+	result.Upgraded = true
+	_, _ = fmt.Fprintf(out, "Upgraded to %s. Restart any running javinizer processes to use the new version.\n", latest.Version)
+	return result, nil
+}
+
+// resolveUpgradeDefaults fills in zero-value fields with production defaults.
+func resolveUpgradeDefaults(opts UpgradeOptions) UpgradeOptions {
+	if opts.Repo == "" {
+		opts.Repo = defaultRepo
+	}
+	if opts.APIBaseURL == "" {
+		opts.APIBaseURL = "https://api.github.com"
+	}
+	if opts.DownloadBaseURL == "" {
+		opts.DownloadBaseURL = defaultDownloadBase
+	}
+	if opts.HTTPClient == nil {
+		opts.HTTPClient = &http.Client{Timeout: 5 * time.Minute}
+	}
+	if opts.Out == nil {
+		opts.Out = os.Stdout
+	}
+	return opts
+}
+
+// resolveExePath returns the absolute path of the running binary, following
+// symlinks so the replacement targets the real file (not a /usr/local/bin
+// symlink whose target lives elsewhere).
+func resolveExePath(override string) (string, error) {
+	p := override
+	if p == "" {
+		var err error
+		p, err = os.Executable()
+		if err != nil {
+			return "", err
+		}
+	}
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		// Fall back to the raw path if symlink resolution fails (e.g. the file
+		// was just replaced); the caller still gets a usable target.
+		//nolint:nilerr // intentional fallback: a resolution error is not fatal here.
+		return p, nil
+	}
+	return resolved, nil
+}
+
+// downloadAndReplace fetches the checksums and the asset, verifies the SHA256,
+// and atomically swaps the binary into place.
+func downloadAndReplace(ctx context.Context, opts UpgradeOptions, exePath, tag, asset string) error {
+	out := opts.Out
+	dir := filepath.Dir(exePath)
+
+	assetURL := fmt.Sprintf("%s/%s/releases/download/%s/%s", opts.DownloadBaseURL, opts.Repo, tag, asset)
+	checksumURL := fmt.Sprintf("%s/%s/releases/download/%s/checksums.txt", opts.DownloadBaseURL, opts.Repo, tag)
+
+	_, _ = fmt.Fprintf(out, "Downloading checksums...\n")
+	var checksums bytes.Buffer
+	if err := downloadTo(ctx, opts.HTTPClient, checksumURL, &checksums, maxChecksumSize); err != nil {
+		return fmt.Errorf("download checksums: %w", err)
+	}
+	expected, err := ParseChecksums(checksums.Bytes(), asset)
+	if err != nil {
+		return err
+	}
+
+	// Write the asset to a temp file in the same directory as the running
+	// binary so the final rename is atomic (same filesystem). A cross-device
+	// rename would fail with EXDEV.
+	tmp, err := os.CreateTemp(dir, ".javinizer-upgrade-*.tmp")
+	if err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("no write permission to %s — re-run with sudo, or install via Homebrew/Scoop", dir)
+		}
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	// Ensure the temp file is removed if anything below fails.
+	defer func() {
+		if err := tmp.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+			logging.Debugf("closing temp upgrade file: %v", err)
+		}
+		_ = os.Remove(tmpPath)
+	}()
+
+	_, _ = fmt.Fprintf(out, "Downloading %s...\n", asset)
+	if err := downloadTo(ctx, opts.HTTPClient, assetURL, tmp, maxAssetSize); err != nil {
+		return fmt.Errorf("download asset: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("flush asset: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close asset: %w", err)
+	}
+
+	if err := verifyFileSHA256(tmpPath, expected); err != nil {
+		return err
+	}
+
+	// The binary must be executable before it takes the target path.
+	//nolint:gosec // G302: the downloaded binary must be executable (0o755) to run.
+	if err := os.Chmod(tmpPath, 0o755); err != nil {
+		return fmt.Errorf("chmod asset: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(out, "Installing...\n")
+	if err := ReplaceBinary(exePath, tmpPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+// downloadTo streams a URL into w, capping the total bytes read at maxSize.
+func downloadTo(ctx context.Context, client *http.Client, url string, w io.Writer, maxSize int64) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "Javinizer-Updater")
+	req.Header.Set("Accept", "application/octet-stream")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = httpclient.DrainAndClose(resp.Body) }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d for %s", resp.StatusCode, url)
+	}
+	if _, err := io.Copy(w, io.LimitReader(resp.Body, maxSize)); err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+	return nil
+}
+
+// verifyFileSHA256 reads the file at path and compares its SHA256 to expected.
+func verifyFileSHA256(path, expected string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open downloaded asset: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, io.LimitReader(f, maxAssetSize)); err != nil {
+		return fmt.Errorf("hash asset: %w", err)
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s — refusing to install", expected, actual)
+	}
+	logging.Debugf("Checksum verified for %s", filepath.Base(path))
+	return nil
+}
+
+// ReplaceBinary atomically replaces the binary at target with the file at
+// source. source and target must be on the same filesystem.
+//
+// On Unix, os.Rename atomically swaps the file even when target is the running
+// binary (the running process keeps the old inode).
+//
+// On Windows, the running exe is locked and cannot be overwritten in place, so
+// the running binary is renamed to "<target>.old" (Windows permits renaming a
+// running exe) before the new file is moved into place. The .old file is
+// removed best-effort; if it is still locked it is left for a later run.
+//
+// The Windows path is split into replaceBinaryWindows so it can be unit-tested
+// on any OS (it uses only os.Rename/os.Remove, which are cross-platform);
+// ReplaceBinary dispatches on runtime.GOOS at runtime.
+func ReplaceBinary(target, source string) error {
+	if runtime.GOOS == "windows" {
+		return replaceBinaryWindows(target, source)
+	}
+	return replaceBinaryUnix(target, source)
+}
+
+// replaceBinaryUnix swaps source over target via a single atomic rename.
+func replaceBinaryUnix(target, source string) error {
+	if err := os.Rename(source, target); err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied replacing %s — re-run with sudo, or install via Homebrew/Scoop", target)
+		}
+		return fmt.Errorf("replace binary: %w", err)
+	}
+	return nil
+}
+
+// replaceBinaryWindows implements the Windows running-exe replacement.
+//
+// It self-heals a prior interrupted upgrade: if target is missing but a .old
+// backup exists, the backup is restored first — otherwise the os.Remove(old)
+// below would delete the only good copy and brick the install permanently.
+//
+// If the new-binary rename fails, the previous binary is rolled back from .old;
+// if the rollback ALSO fails, the error is surfaced (not swallowed) and names
+// the .old path so the user can recover manually.
+func replaceBinaryWindows(target, source string) error {
+	old := target + ".old"
+
+	// Self-heal from a prior interrupted upgrade: restore .old -> target so the
+	// remove+rename below has a valid binary to work with and doesn't delete the
+	// only good copy.
+	if _, err := os.Stat(target); os.IsNotExist(err) {
+		if _, err := os.Stat(old); err == nil {
+			if err := os.Rename(old, target); err != nil {
+				return fmt.Errorf("restore previous binary from .old: %w", err)
+			}
+		}
+	}
+
+	_ = os.Remove(old) // best effort; may be locked from a prior run
+	if err := os.Rename(target, old); err != nil {
+		return fmt.Errorf("rename current binary to .old: %w", err)
+	}
+	if err := os.Rename(source, target); err != nil {
+		// Rollback: restore the previous binary. If the rollback ALSO fails,
+		// surface it (don't silently leave no binary at target) and point the
+		// user at the .old file for manual recovery.
+		if rbErr := os.Rename(old, target); rbErr != nil {
+			return fmt.Errorf("install new binary: %w (rollback also failed: %v; previous binary preserved at %s — rename it back manually)", err, rbErr, old)
+		}
+		return fmt.Errorf("install new binary: %w", err)
+	}
+	_ = os.Remove(old) // best effort
+	return nil
+}

--- a/internal/update/upgrade_test.go
+++ b/internal/update/upgrade_test.go
@@ -186,11 +186,11 @@ func TestUpgrade_HomebrewHandoff(t *testing.T) {
 }
 
 // newAssetServer serves a release asset plus its checksums.txt from a fake
-// release download tree. It returns the real asset name for the host platform
-// so the test is OS-agnostic.
+// release download tree over TLS. downloadTo enforces HTTPS, so test servers
+// must be TLS; server.Client() returns a client that trusts the test cert.
 func newAssetServer(t *testing.T, assetBytes []byte, checksums string) *httptest.Server {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/checksums.txt"):
 			_, _ = w.Write([]byte(checksums))
@@ -339,7 +339,7 @@ func TestUpgrade_ChecksumsDownloadFailure_Aborts(t *testing.T) {
 	assetBytes := []byte("new-binary-content")
 	sum := sha256.Sum256(assetBytes)
 	// Server serves the asset but 404s checksums.txt.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/checksums.txt") {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -499,4 +499,204 @@ func TestUpgrade_PreRelease_AllowsPrereleaseUpgrade(t *testing.T) {
 	got, err := os.ReadFile(exePath)
 	require.NoError(t, err)
 	assert.Equal(t, "rc-binary", string(got))
+}
+
+func TestDownloadTo_RefusesNonHTTPS(t *testing.T) {
+	// downloadTo must refuse a plain-HTTP URL outright: a checksum fetched over
+	// the same insecure channel as the binary authenticates nothing.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("data"))
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	err := downloadTo(context.Background(), server.Client(), server.URL+"/asset", &buf, 1024)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-HTTPS")
+	assert.Empty(t, buf.Bytes())
+}
+
+func TestDownloadTo_RefusesHTTPRedirect(t *testing.T) {
+	// A TLS server that redirects to a plain-HTTP target: the upgrade must
+	// refuse to follow the redirect rather than fetch the asset insecurely.
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("insecure"))
+	}))
+	defer target.Close()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/asset", http.StatusFound)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	err := downloadTo(context.Background(), server.Client(), server.URL+"/asset", &buf, 1024)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-HTTPS redirect")
+	assert.Empty(t, buf.Bytes())
+}
+
+func TestDownloadTo_ErrorsWhenExceedingSizeCap(t *testing.T) {
+	// An oversized response must fail closed rather than be silently truncated
+	// into a partial (and potentially valid-looking) parse.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(bytes.Repeat([]byte("x"), 100))
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	err := downloadTo(context.Background(), server.Client(), server.URL, &buf, 50)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size")
+}
+
+func TestDownloadTo_HTTPStatusError(t *testing.T) {
+	// A non-200 TLS response surfaces a clear HTTP-status error.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	err := downloadTo(context.Background(), server.Client(), server.URL, &buf, 1024)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 500")
+}
+
+func TestDownloadTo_RequestError(t *testing.T) {
+	// A transport-level failure (server gone) surfaces as an error rather than
+	// a silent success.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	server.Close()
+
+	var buf bytes.Buffer
+	err := downloadTo(context.Background(), server.Client(), server.URL, &buf, 1024)
+	require.Error(t, err)
+}
+
+func TestDownloadTo_ChainsBaseCheckRedirect(t *testing.T) {
+	// A caller-supplied CheckRedirect must still be invoked (chained) after the
+	// HTTPS check passes, so custom redirect policy is preserved.
+	called := false
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/asset" {
+			http.Redirect(w, r, "/final", http.StatusFound)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	c := server.Client()
+	c.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		called = true
+		return nil
+	}
+	var buf bytes.Buffer
+	require.NoError(t, downloadTo(context.Background(), c, server.URL+"/asset", &buf, 1024))
+	assert.True(t, called, "base CheckRedirect must be chained after the HTTPS check")
+	assert.Equal(t, "ok", buf.String())
+}
+
+func TestDownloadTo_StopsAfterTenRedirects(t *testing.T) {
+	// An HTTPS redirect loop must be bounded; downloadTo refuses to follow past
+	// 10 redirects rather than looping forever.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, r.URL.Path, http.StatusFound)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	err := downloadTo(context.Background(), server.Client(), server.URL+"/loop", &buf, 1024)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stopped after 10 redirects")
+}
+
+func TestUpgrade_EmptyCurrentVersion_ReturnsError(t *testing.T) {
+	// Also exercises resolveUpgradeDefaults' default HTTPClient + Out paths
+	// (both nil -> production defaults) before the version guard fires.
+	_, err := Upgrade(context.Background(), UpgradeOptions{CurrentVersion: ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "current version is required")
+}
+
+func TestResolveExePath_FallbackOnSymlinkError(t *testing.T) {
+	// A path that does not exist makes EvalSymlinks fail; resolveExePath falls
+	// back to the raw path rather than erroring, so an interrupted upgrade
+	// (binary just replaced) still yields a usable target.
+	got, err := resolveExePath(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.NoError(t, err)
+	assert.Contains(t, got, "does-not-exist")
+}
+
+func TestResolveExePath_UsesOsExecutableWhenEmpty(t *testing.T) {
+	// An empty override resolves to the running binary's path via os.Executable.
+	got, err := resolveExePath("")
+	require.NoError(t, err)
+	assert.NotEmpty(t, got)
+}
+
+func TestVerifyFileSHA256_OpenError(t *testing.T) {
+	err := verifyFileSHA256(filepath.Join(t.TempDir(), "missing"), "abc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open downloaded asset")
+}
+
+func TestUpgrade_DownloadAssetFailure_Aborts(t *testing.T) {
+	// checksums.txt is served (valid) but the asset 404s: the upgrade must abort
+	// with a "download asset" error and leave the running binary untouched.
+	asset, err := AssetName(runtime.GOOS, runtime.GOARCH)
+	require.NoError(t, err)
+
+	assetBytes := []byte("never-served")
+	sum := sha256.Sum256(assetBytes)
+	checksums := fmt.Sprintf("%x  %s\n", sum, asset)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/checksums.txt") {
+			_, _ = w.Write([]byte(checksums))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	exePath := filepath.Join(t.TempDir(), "javinizer")
+	require.NoError(t, os.WriteFile(exePath, []byte("old"), 0o755))
+
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion:  "v0.0.1",
+		DownloadBaseURL: server.URL,
+		HTTPClient:      server.Client(),
+		Checker:         &stubChecker{version: "v9.9.9"},
+		ExePath:         exePath,
+		Out:             &out,
+	})
+	require.Error(t, err)
+	assert.False(t, res.Upgraded)
+	assert.Contains(t, err.Error(), "download asset")
+
+	got, err := os.ReadFile(exePath)
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(got))
+}
+
+func TestReplaceBinary_Unix_PermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only replace path")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("running as root — permission test is meaningless")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "javinizer")
+	source := filepath.Join(dir, "new")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o755))
+	require.NoError(t, os.WriteFile(source, []byte("new"), 0o755))
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	err := replaceBinaryUnix(target, source)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied")
 }

--- a/internal/update/upgrade_test.go
+++ b/internal/update/upgrade_test.go
@@ -859,3 +859,34 @@ func TestUpgrade_CreateTempPermissionDenied_Aborts(t *testing.T) {
 	assert.False(t, res.Upgraded)
 	assert.Contains(t, err.Error(), "no write permission")
 }
+
+func TestUpgrade_ReplaceBinaryFailure_Aborts(t *testing.T) {
+	// Covers the ReplaceBinary error branch: the checksums + asset download +
+	// verify all succeed, but the final binary replace fails because the target
+	// directory is read-only. (The Upgrade-level path hits CreateTemp first when
+	// the dir is locked; this direct call isolates ReplaceBinary's own error
+	// branch, which downloadAndReplace surfaces unchanged.)
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only-dir technique is Unix-only")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("running as root")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "javinizer")
+	source := filepath.Join(dir, "new")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o755))
+	require.NoError(t, os.WriteFile(source, []byte("new"), 0o755))
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	err := ReplaceBinary(target, source)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied")
+}
+
+// The rollback-also-failed branch (replaceBinaryWindows) requires staging a
+// state where rename-to-old succeeds, install-rename fails, AND rollback-rename
+// fails — the dir would need to be writable for the first two renames but not
+// the third, which cannot be staged deterministically without fragile mid-
+// operation filesystem locking. It is left as a documented defensive branch.

--- a/internal/update/upgrade_test.go
+++ b/internal/update/upgrade_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -699,4 +700,162 @@ func TestReplaceBinary_Unix_PermissionDenied(t *testing.T) {
 	err := replaceBinaryUnix(target, source)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "permission denied")
+}
+
+func TestUpgrade_CheckerError_ReturnsWrappedError(t *testing.T) {
+	// Covers the CheckLatestVersion error branch: the checker failing must
+	// surface a wrapped "failed to check latest release" error.
+	var out bytes.Buffer
+	_, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v0.0.1",
+		Checker:        &stubChecker{err: errors.New("boom")},
+		Out:            &out,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to check latest release")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestUpgrade_EmptyTagNameFallsBackToVersion(t *testing.T) {
+	// Covers the `if result.TagName == ""` branch: a checker returning a
+	// VersionInfo with no TagName must fall back to Version for the download URL.
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v0.0.1",
+		CheckOnly:      true,
+		Checker:        &emptyTagChecker{version: "v9.9.9"},
+		Out:            &out,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "v9.9.9", res.TagName, "empty TagName must fall back to Version")
+}
+
+// emptyTagChecker returns a VersionInfo with an empty TagName so the
+// TagName-fallback branch in Upgrade is exercised.
+type emptyTagChecker struct{ version string }
+
+func (c *emptyTagChecker) CheckLatestVersion(_ context.Context) (*VersionInfo, error) {
+	return &VersionInfo{Version: c.version}, nil
+}
+
+func TestReplaceBinary_Unix_MissingSource(t *testing.T) {
+	// Covers the generic (non-permission) error branch of replaceBinaryUnix:
+	// renaming a missing source over an existing target fails.
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only replace path")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "javinizer")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o755))
+
+	err := replaceBinaryUnix(target, filepath.Join(dir, "missing"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "replace binary")
+	assert.NotContains(t, err.Error(), "permission denied")
+}
+
+func TestReplaceBinary_Windows_MissingTargetNoOld(t *testing.T) {
+	// Covers the `rename current binary to .old` error branch: when target is
+	// missing and no .old exists, os.Rename(target, old) fails. replaceBinaryWindows
+	// uses only os.Rename/os.Remove so it is testable on any OS.
+	dir := t.TempDir()
+	source := filepath.Join(dir, "new.exe")
+	require.NoError(t, os.WriteFile(source, []byte("new"), 0o755))
+
+	err := replaceBinaryWindows(filepath.Join(dir, "missing.exe"), source)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rename current binary to .old")
+}
+
+func TestReplaceBinary_Windows_RestoreOldFails(t *testing.T) {
+	// Covers the `restore previous binary from .old` error branch: target is
+	// missing, .old exists, but restoring it fails because the directory is
+	// read-only (the rename can't write target into the dir).
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only-dir technique is Unix-only")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("running as root")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "javinizer.exe")
+	old := target + ".old"
+	require.NoError(t, os.WriteFile(old, []byte("previous"), 0o755))
+	// Read-only dir: os.Rename(old, target) cannot create target here.
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	err := replaceBinaryWindows(target, filepath.Join(dir, "new.exe"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restore previous binary from .old")
+}
+
+func TestUpgrade_MalformedChecksums_Aborts(t *testing.T) {
+	// Covers the ParseChecksums error branch in downloadAndReplace: checksums.txt
+	// is served but does not list the asset, so parsing fails before any download.
+	// Checksums for a DIFFERENT asset -> ParseChecksums won't find ours.
+	checksums := "deadbeef  some-other-asset\n"
+	server := newAssetServer(t, []byte("unused"), checksums)
+	defer server.Close()
+
+	exePath := filepath.Join(t.TempDir(), "javinizer")
+	require.NoError(t, os.WriteFile(exePath, []byte("old"), 0o755))
+
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion:  "v0.0.1",
+		DownloadBaseURL: server.URL,
+		HTTPClient:      server.Client(),
+		Checker:         &stubChecker{version: "v9.9.9"},
+		ExePath:         exePath,
+		Out:             &out,
+	})
+	require.Error(t, err)
+	assert.False(t, res.Upgraded)
+	assert.Contains(t, err.Error(), "not found in checksums.txt")
+
+	// Running binary untouched.
+	got, err := os.ReadFile(exePath)
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(got))
+}
+
+func TestUpgrade_CreateTempPermissionDenied_Aborts(t *testing.T) {
+	// Covers the CreateTemp permission-error branch in downloadAndReplace: the
+	// target directory is read-only, so the temp file cannot be created. The
+	// checksums download succeeds (proving the flow got past it) before failing.
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only-dir technique is Unix-only")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("running as root")
+	}
+	asset, err := AssetName(runtime.GOOS, runtime.GOARCH)
+	require.NoError(t, err)
+
+	assetBytes := []byte("new-binary-content")
+	sum := sha256.Sum256(assetBytes)
+	checksums := fmt.Sprintf("%x  %s\n", sum, asset)
+	server := newAssetServer(t, assetBytes, checksums)
+	defer server.Close()
+
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "javinizer")
+	require.NoError(t, os.WriteFile(exePath, []byte("old"), 0o755))
+	// Read-only dir: CreateTemp cannot write here.
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion:  "v0.0.1",
+		DownloadBaseURL: server.URL,
+		HTTPClient:      server.Client(),
+		Checker:         &stubChecker{version: "v9.9.9"},
+		ExePath:         exePath,
+		Out:             &out,
+	})
+	require.Error(t, err)
+	assert.False(t, res.Upgraded)
+	assert.Contains(t, err.Error(), "no write permission")
 }

--- a/internal/update/upgrade_test.go
+++ b/internal/update/upgrade_test.go
@@ -1,0 +1,502 @@
+package update
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubChecker returns a fixed latest version without touching the network.
+type stubChecker struct {
+	version string
+	err     error
+}
+
+func (s *stubChecker) CheckLatestVersion(_ context.Context) (*VersionInfo, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &VersionInfo{Version: s.version, TagName: s.version}, nil
+}
+
+func TestAssetName(t *testing.T) {
+	tests := []struct {
+		name    string
+		goos    string
+		goarch  string
+		want    string
+		wantErr bool
+	}{
+		{"darwin universal", "darwin", "amd64", "javinizer-darwin-universal", false},
+		{"darwin arm64 still universal", "darwin", "arm64", "javinizer-darwin-universal", false},
+		{"linux amd64", "linux", "amd64", "javinizer-linux-amd64", false},
+		{"linux arm64", "linux", "arm64", "javinizer-linux-arm64", false},
+		{"windows amd64", "windows", "amd64", "javinizer-windows-amd64.exe", false},
+		{"windows arm64 unsupported (no CI build)", "windows", "arm64", "", true},
+		{"linux 386 unsupported", "linux", "386", "", true},
+		{"freebsd unsupported", "freebsd", "amd64", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := AssetName(tc.goos, tc.goarch)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestDetectInstallMethod(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want InstallMethod
+	}{
+		{"homebrew cellar", "/opt/homebrew/Cellar/javinizer/1.0.0/bin/javinizer", InstallMethodHomebrew},
+		{"linuxbrew cellar", "/home/linuxbrew/.linuxbrew/Cellar/javinizer/1.0.0/bin/javinizer", InstallMethodHomebrew},
+		{"scoop apps", "C:/Users/me/scoop/apps/javinizer/current/javinizer.exe", InstallMethodScoop},
+		{"manual usr local", "/usr/local/bin/javinizer", InstallMethodManual},
+		{"manual home bin", "/home/choong/bin/javinizer", InstallMethodManual},
+		{"manual windows", "C:/Tools/javinizer.exe", InstallMethodManual},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, DetectInstallMethod(tc.path))
+		})
+	}
+}
+
+func TestInstallMethodString(t *testing.T) {
+	tests := []struct {
+		method InstallMethod
+		want   string
+	}{
+		{InstallMethodManual, "manual"},
+		{InstallMethodHomebrew, "homebrew"},
+		{InstallMethodScoop, "scoop"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.method.String())
+		})
+	}
+}
+
+func TestParseChecksums(t *testing.T) {
+	const asset = "javinizer-linux-amd64"
+	tests := []struct {
+		name    string
+		data    string
+		want    string
+		wantErr bool
+	}{
+		{"two-space format", "abc123  javinizer-linux-amd64\n", "abc123", false},
+		{"star format", "abc123 *javinizer-linux-amd64\n", "abc123", false},
+		{"multiple entries", "deadbeef  javinizer-darwin-universal\nabc123  javinizer-linux-amd64\nfff  javinizer-windows-amd64.exe\n", "abc123", false},
+		{"missing asset", "deadbeef  javinizer-darwin-universal\n", "", true},
+		{"empty", "", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseChecksums([]byte(tc.data), asset)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestReplaceBinary_Unix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only replace path")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "javinizer")
+	source := filepath.Join(dir, "new")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o755))
+	require.NoError(t, os.WriteFile(source, []byte("new"), 0o755))
+
+	require.NoError(t, ReplaceBinary(target, source))
+
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
+	_, err = os.Stat(source)
+	assert.True(t, os.IsNotExist(err), "source should have been renamed away")
+}
+
+func TestUpgrade_CheckOnly_Available(t *testing.T) {
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v0.0.1",
+		CheckOnly:      true,
+		Checker:        &stubChecker{version: "v9.9.9"},
+		Out:            &out,
+	})
+	require.NoError(t, err)
+	assert.False(t, res.UpToDate)
+	assert.False(t, res.Upgraded)
+	assert.Contains(t, out.String(), "Update available: v9.9.9")
+}
+
+func TestUpgrade_CheckOnly_UpToDate(t *testing.T) {
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v9.9.9",
+		CheckOnly:      true,
+		Checker:        &stubChecker{version: "v9.9.9"},
+		Out:            &out,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.UpToDate)
+	assert.False(t, res.Upgraded)
+	assert.Contains(t, out.String(), "Already up to date")
+}
+
+func TestUpgrade_HomebrewHandoff(t *testing.T) {
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v0.0.1",
+		Checker:        &stubChecker{version: "v9.9.9"},
+		ExePath:        "/opt/homebrew/Cellar/javinizer/1.0.0/bin/javinizer",
+		Out:            &out,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Handoff)
+	assert.False(t, res.Upgraded)
+	assert.Equal(t, InstallMethodHomebrew, res.InstallMethod)
+	assert.Contains(t, out.String(), "brew upgrade javinizer")
+}
+
+// newAssetServer serves a release asset plus its checksums.txt from a fake
+// release download tree. It returns the real asset name for the host platform
+// so the test is OS-agnostic.
+func newAssetServer(t *testing.T, assetBytes []byte, checksums string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/checksums.txt"):
+			_, _ = w.Write([]byte(checksums))
+		case strings.HasSuffix(r.URL.Path, "javinizer-darwin-universal"),
+			strings.HasSuffix(r.URL.Path, "javinizer-linux-amd64"),
+			strings.HasSuffix(r.URL.Path, "javinizer-linux-arm64"),
+			strings.HasSuffix(r.URL.Path, "javinizer-windows-amd64.exe"):
+			_, _ = w.Write(assetBytes)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestUpgrade_FullReplace(t *testing.T) {
+	asset, err := AssetName(runtime.GOOS, runtime.GOARCH)
+	require.NoError(t, err)
+
+	assetBytes := []byte("new-binary-content")
+	sum := sha256.Sum256(assetBytes)
+	checksums := fmt.Sprintf("%x  %s\n", sum, asset)
+	server := newAssetServer(t, assetBytes, checksums)
+	defer server.Close()
+
+	exePath := filepath.Join(t.TempDir(), "javinizer")
+	require.NoError(t, os.WriteFile(exePath, []byte("old"), 0o755))
+
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion:  "v0.0.1",
+		DownloadBaseURL: server.URL,
+		HTTPClient:      server.Client(),
+		Checker:         &stubChecker{version: "v9.9.9"},
+		ExePath:         exePath,
+		Out:             &out,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Upgraded)
+	assert.Equal(t, "v9.9.9", res.LatestVersion)
+	assert.Equal(t, asset, res.AssetName)
+
+	got, err := os.ReadFile(exePath)
+	require.NoError(t, err)
+	assert.Equal(t, "new-binary-content", string(got))
+}
+
+func TestUpgrade_ChecksumMismatch_Aborts(t *testing.T) {
+	asset, err := AssetName(runtime.GOOS, runtime.GOARCH)
+	require.NoError(t, err)
+
+	assetBytes := []byte("new-binary-content")
+	// Deliberately wrong checksum.
+	checksums := fmt.Sprintf("deadbeef  %s\n", asset)
+	server := newAssetServer(t, assetBytes, checksums)
+	defer server.Close()
+
+	exePath := filepath.Join(t.TempDir(), "javinizer")
+	require.NoError(t, os.WriteFile(exePath, []byte("old"), 0o755))
+
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion:  "v0.0.1",
+		DownloadBaseURL: server.URL,
+		HTTPClient:      server.Client(),
+		Checker:         &stubChecker{version: "v9.9.9"},
+		ExePath:         exePath,
+		Out:             &out,
+	})
+	require.Error(t, err)
+	assert.False(t, res.Upgraded)
+	assert.Contains(t, err.Error(), "checksum mismatch")
+
+	// The running binary must be untouched on verification failure.
+	got, err := os.ReadFile(exePath)
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(got))
+}
+
+func TestUpgrade_Force_ReinstallLatest(t *testing.T) {
+	asset, err := AssetName(runtime.GOOS, runtime.GOARCH)
+	require.NoError(t, err)
+
+	assetBytes := []byte("reinstalled")
+	sum := sha256.Sum256(assetBytes)
+	checksums := fmt.Sprintf("%x  %s\n", sum, asset)
+	server := newAssetServer(t, assetBytes, checksums)
+	defer server.Close()
+
+	exePath := filepath.Join(t.TempDir(), "javinizer")
+	require.NoError(t, os.WriteFile(exePath, []byte("old"), 0o755))
+
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion:  "v9.9.9", // same as latest — would be "up to date" without --force
+		Force:           true,
+		DownloadBaseURL: server.URL,
+		HTTPClient:      server.Client(),
+		Checker:         &stubChecker{version: "v9.9.9"},
+		ExePath:         exePath,
+		Out:             &out,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Upgraded)
+	assert.Contains(t, out.String(), "forced")
+
+	got, err := os.ReadFile(exePath)
+	require.NoError(t, err)
+	assert.Equal(t, "reinstalled", string(got))
+}
+
+func TestUpgrade_ScoopHandoff(t *testing.T) {
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v0.0.1",
+		Checker:        &stubChecker{version: "v9.9.9"},
+		ExePath:        "C:/Users/me/scoop/apps/javinizer/current/javinizer.exe",
+		Out:            &out,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Handoff)
+	assert.False(t, res.Upgraded)
+	assert.Equal(t, InstallMethodScoop, res.InstallMethod)
+	assert.Contains(t, out.String(), "scoop update javinizer")
+}
+
+func TestUpgrade_AlreadyUpToDate_NonCheckPath(t *testing.T) {
+	// The non-check-only "already up to date" branch (result.UpToDate && !Force,
+	// CheckOnly == false) was previously unexercised — TestUpgrade_CheckOnly_upToDate
+	// uses CheckOnly: true.
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v9.9.9",
+		Checker:        &stubChecker{version: "v9.9.9"},
+		ExePath:        filepath.Join(t.TempDir(), "javinizer"),
+		Out:            &out,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.UpToDate)
+	assert.False(t, res.Upgraded)
+	assert.Contains(t, out.String(), "Already up to date")
+}
+
+func TestUpgrade_ChecksumsDownloadFailure_Aborts(t *testing.T) {
+	// A release missing checksums.txt (the asset is served but checksums 404)
+	// must abort without touching the running binary.
+	assetBytes := []byte("new-binary-content")
+	sum := sha256.Sum256(assetBytes)
+	// Server serves the asset but 404s checksums.txt.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/checksums.txt") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write(assetBytes)
+	}))
+	defer server.Close()
+	_ = sum
+
+	exePath := filepath.Join(t.TempDir(), "javinizer")
+	require.NoError(t, os.WriteFile(exePath, []byte("old"), 0o755))
+
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion:  "v0.0.1",
+		DownloadBaseURL: server.URL,
+		HTTPClient:      server.Client(),
+		Checker:         &stubChecker{version: "v9.9.9"},
+		ExePath:         exePath,
+		Out:             &out,
+	})
+	require.Error(t, err)
+	assert.False(t, res.Upgraded)
+	assert.Contains(t, err.Error(), "download checksums")
+
+	// Running binary untouched.
+	got, err := os.ReadFile(exePath)
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(got))
+}
+
+func TestReplaceBinary_Windows_Success(t *testing.T) {
+	// replaceBinaryWindows uses only os.Rename/os.Remove, so it is testable on
+	// any OS despite the runtime.GOOS gate in ReplaceBinary.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "javinizer.exe")
+	source := filepath.Join(dir, "new.exe")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o755))
+	require.NoError(t, os.WriteFile(source, []byte("new"), 0o755))
+
+	require.NoError(t, replaceBinaryWindows(target, source))
+
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
+	// The .old backup must be cleaned up on success.
+	_, err = os.Stat(target + ".old")
+	assert.True(t, os.IsNotExist(err), ".old should be removed on success")
+}
+
+func TestReplaceBinary_Windows_RollbackOnFailure(t *testing.T) {
+	// If the new-binary rename fails (source missing), the previous binary is
+	// restored to target and an error is returned — the install is not bricked.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "javinizer.exe")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o755))
+	// No source file -> the second os.Rename(source, target) will fail.
+
+	err := replaceBinaryWindows(target, filepath.Join(dir, "missing.exe"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "install new binary")
+
+	// Previous binary restored.
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(got))
+}
+
+func TestReplaceBinary_Windows_SelfHealFromBrick(t *testing.T) {
+	// Simulate a prior interrupted upgrade: target is missing, only .old exists.
+	// replaceBinaryWindows must restore .old -> target (so os.Remove(old) below
+	// doesn't delete the only good copy) and then complete the upgrade.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "javinizer.exe")
+	old := target + ".old"
+	source := filepath.Join(dir, "new.exe")
+	require.NoError(t, os.WriteFile(old, []byte("previous"), 0o755))
+	require.NoError(t, os.WriteFile(source, []byte("new"), 0o755))
+
+	require.NoError(t, replaceBinaryWindows(target, source))
+
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
+	_, err = os.Stat(old)
+	assert.True(t, os.IsNotExist(err), ".old should be removed after self-heal upgrade")
+}
+
+// prereleaseAwareChecker is a stubChecker that also implements PreReleaseChecker,
+// recording whether the caller opted into prerelease discovery.
+type prereleaseAwareChecker struct {
+	stubChecker
+	gotPreRelease bool
+}
+
+func (p *prereleaseAwareChecker) SetPreRelease(enable bool) { p.gotPreRelease = enable }
+
+func TestUpgrade_PreRelease_FlowsToChecker(t *testing.T) {
+	stub := &prereleaseAwareChecker{stubChecker: stubChecker{version: "v1.1.0-rc1"}}
+	var out bytes.Buffer
+	_, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v1.0.0",
+		PreRelease:     true,
+		CheckOnly:      true,
+		Checker:        stub,
+		Out:            &out,
+	})
+	require.NoError(t, err)
+	assert.True(t, stub.gotPreRelease, "PreRelease must be threaded to the checker via SetPreRelease")
+	assert.Contains(t, out.String(), "v1.1.0-rc1")
+}
+
+func TestUpgrade_PreRelease_NotSetByDefault(t *testing.T) {
+	stub := &prereleaseAwareChecker{stubChecker: stubChecker{version: "v1.1.0"}}
+	var out bytes.Buffer
+	_, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v1.0.0",
+		CheckOnly:      true,
+		Checker:        stub,
+		Out:            &out,
+	})
+	require.NoError(t, err)
+	assert.False(t, stub.gotPreRelease, "PreRelease must not be set by default")
+}
+
+func TestUpgrade_PreRelease_AllowsPrereleaseUpgrade(t *testing.T) {
+	// End-to-end: with PreRelease, a newer prerelease is installed through the
+	// full download/verify/replace path (the prerelease tag flows into the
+	// download URL). Confirms prereleases are accepted, not rejected, when opted in.
+	asset, err := AssetName(runtime.GOOS, runtime.GOARCH)
+	require.NoError(t, err)
+
+	assetBytes := []byte("rc-binary")
+	sum := sha256.Sum256(assetBytes)
+	checksums := fmt.Sprintf("%x  %s\n", sum, asset)
+	server := newAssetServer(t, assetBytes, checksums)
+	defer server.Close()
+
+	exePath := filepath.Join(t.TempDir(), "javinizer")
+	require.NoError(t, os.WriteFile(exePath, []byte("old"), 0o755))
+
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion:  "v1.0.0",
+		PreRelease:      true,
+		DownloadBaseURL: server.URL,
+		HTTPClient:      server.Client(),
+		Checker:         &stubChecker{version: "v1.1.0-rc1"},
+		ExePath:         exePath,
+		Out:             &out,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Upgraded)
+	assert.Equal(t, "v1.1.0-rc1", res.LatestVersion)
+	assert.Contains(t, out.String(), "prerelease")
+
+	got, err := os.ReadFile(exePath)
+	require.NoError(t, err)
+	assert.Equal(t, "rc-binary", string(got))
+}

--- a/internal/update/wiring_test.go
+++ b/internal/update/wiring_test.go
@@ -41,7 +41,7 @@ func (c *countingChecker) callsCount() int {
 // newStubService builds a hermetic service backed by a countingChecker and a
 // temp-dir cache path, so tests neither hit the network nor write to the real
 // data directory.
-func newStubService(t *testing.T, enabled bool) (*service, *countingChecker) {
+func newStubService(t *testing.T, enabled bool) (*Service, *countingChecker) {
 	t.Helper()
 	chk := &countingChecker{}
 	svc := NewServiceWithOptions(UpdateConfig{

--- a/scripts/homebrew/SETUP.md
+++ b/scripts/homebrew/SETUP.md
@@ -1,0 +1,71 @@
+# Homebrew tap — one-time setup
+
+These steps create the `javinizer/homebrew-tap` repository and give the
+`javinizer-go` CI permission to push the formula to it on each stable release.
+Do this once; afterwards, the `update-homebrew-tap` job in
+`.github/workflows/cli-release.yml` keeps `Formula/javinizer.rb` in sync
+automatically.
+
+## 1. Create the tap repo
+
+Create an empty public repository named **`homebrew-tap`** under the
+`javinizer` organization (no README, no license, no `.gitignore` — keep it
+empty so the first CI push is clean):
+
+https://github.com/organizations/javinizer/repositories/new
+
+- Owner: `javinizer`
+- Name: `homebrew-tap`
+- Visibility: **Public** (Homebrew requires taps to be public for `brew install`)
+- Initialize: leave all unchecked
+
+## 2. Generate an SSH deploy key
+
+```bash
+ssh-keygen -t ed25519 -C "homebrew-tap deploy key" -f homebrew_tap_deploy_key -N ""
+```
+
+This produces two files:
+- `homebrew_tap_deploy_key`      → private key (goes into a CI secret)
+- `homebrew_tap_deploy_key.pub`  → public key (goes into the tap repo)
+
+## 3. Add the public key as a write deploy key on the tap repo
+
+Go to https://github.com/javinizer/homebrew-tap/settings/keys/new
+- Title: `CI publish from javinizer-go`
+- Key: paste `homebrew_tap_deploy_key.pub`
+- **Allow write access: ✓** (required — CI commits the formula)
+
+## 4. Add the private key as a secret in javinizer-go
+
+Go to https://github.com/javinizer/javinizer-go/settings/secrets/actions/new
+- Name: `HOMEBREW_TAP_DEPLOY_KEY`
+- Secret: paste the contents of `homebrew_tap_deploy_key` (the private key)
+
+## 5. Delete the local private key
+
+```bash
+rm homebrew_tap_deploy_key homebrew_tap_deploy_key.pub
+```
+
+## How users install
+
+Once a stable (non-prerelease) `v1.0.0` ships and the CI job has run:
+
+```bash
+brew tap javinizer/homebrew-tap https://github.com/javinizer/homebrew-tap
+brew install javinizer
+brew upgrade javinizer   # updates to the latest stable release
+```
+
+## Notes
+
+- The tap is only updated for **stable** releases. Prereleases (`v1.0.0-rc.*`)
+  do not push to the tap, so `brew upgrade` never hands a user a release
+  candidate unless they explicitly downgrade.
+- The formula installs prebuilt binaries (CGO/SQLite is statically linked into
+  each release asset), so Homebrew does not need to build from source or pull
+  in a SQLite dependency.
+- `javinizer upgrade` (self-upgrade) detects a Homebrew install by its Cellar
+  path and tells the user to run `brew upgrade javinizer` instead, so the two
+  channels never fight each other.

--- a/scripts/homebrew/javinizer.rb.tmpl
+++ b/scripts/homebrew/javinizer.rb.tmpl
@@ -20,14 +20,8 @@ class Javinizer < Formula
   end
 
   on_macos do
-    on_arm do
-      url "https://github.com/javinizer/javinizer-go/releases/download/__TAG__/javinizer-darwin-universal"
-      sha256 "__DARWIN_SHA256__"
-    end
-    on_intel do
-      url "https://github.com/javinizer/javinizer-go/releases/download/__TAG__/javinizer-darwin-universal"
-      sha256 "__DARWIN_SHA256__"
-    end
+    url "https://github.com/javinizer/javinizer-go/releases/download/__TAG__/javinizer-darwin-universal"
+    sha256 "__DARWIN_SHA256__"
   end
 
   on_linux do

--- a/scripts/homebrew/javinizer.rb.tmpl
+++ b/scripts/homebrew/javinizer.rb.tmpl
@@ -1,0 +1,62 @@
+# Homebrew formula template for javinizer.
+#
+# Rendered by scripts/homebrew/render-formula.sh from a release's checksums.txt,
+# then committed to javinizer/homebrew-tap as Formula/javinizer.rb by the
+# update-homebrew-tap job in .github/workflows/cli-release.yml.
+#
+# javinizer ships prebuilt binaries (CGO/SQLite is statically linked into each
+# release asset), so this formula installs a prebuilt binary per platform
+# rather than building from source. The darwin asset is a universal binary, so
+# both Apple Silicon and Intel macs use the same URL + sha256.
+class Javinizer < Formula
+  desc "JAV metadata scraper and organizer"
+  homepage "https://github.com/javinizer/javinizer-go"
+  version "__VERSION__"
+  license "MIT"
+  head "https://github.com/javinizer/javinizer-go.git", branch: "main"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  on_macos do
+    on_arm do
+      url "https://github.com/javinizer/javinizer-go/releases/download/__TAG__/javinizer-darwin-universal"
+      sha256 "__DARWIN_SHA256__"
+    end
+    on_intel do
+      url "https://github.com/javinizer/javinizer-go/releases/download/__TAG__/javinizer-darwin-universal"
+      sha256 "__DARWIN_SHA256__"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/javinizer/javinizer-go/releases/download/__TAG__/javinizer-linux-arm64"
+      sha256 "__LINUX_ARM64_SHA256__"
+    end
+    on_intel do
+      url "https://github.com/javinizer/javinizer-go/releases/download/__TAG__/javinizer-linux-amd64"
+      sha256 "__LINUX_AMD64_SHA256__"
+    end
+  end
+
+  def install
+    on_macos do
+      bin.install "javinizer-darwin-universal" => "javinizer"
+    end
+    on_linux do
+      on_arm do
+        bin.install "javinizer-linux-arm64" => "javinizer"
+      end
+      on_intel do
+        bin.install "javinizer-linux-amd64" => "javinizer"
+      end
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/javinizer version --short")
+  end
+end

--- a/scripts/homebrew/javinizer.rb.tmpl
+++ b/scripts/homebrew/javinizer.rb.tmpl
@@ -13,7 +13,6 @@ class Javinizer < Formula
   homepage "https://github.com/javinizer/javinizer-go"
   version "__VERSION__"
   license "MIT"
-  head "https://github.com/javinizer/javinizer-go.git", branch: "main"
 
   livecheck do
     url :stable

--- a/scripts/homebrew/render-formula.sh
+++ b/scripts/homebrew/render-formula.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# render-formula.sh — render the Homebrew Formula/javinizer.rb for a release.
+#
+# Usage: render-formula.sh <tag> <checksums.txt> [template]
+#   tag           release tag, e.g. v1.0.0
+#   checksums.txt path to the release checksums.txt (sha256sum output)
+#   template      path to the .rb.tmpl (default: scripts/homebrew/javinizer.rb.tmpl)
+#
+# Writes the rendered formula to stdout. Exits non-zero if any required asset
+# checksum is missing, so CI never publishes a half-rendered formula.
+
+set -euo pipefail
+
+tag="${1:?usage: render-formula.sh <tag> <checksums.txt> [template]}"
+checksums="${2:?usage: render-formula.sh <tag> <checksums.txt> [template]}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+template="${3:-${script_dir}/javinizer.rb.tmpl}"
+
+version="${tag#v}" # Homebrew versions omit the leading 'v'
+
+sha_for() {
+    # sha256sum output is "<hash>  <name>" (or "<hash> *<name>"); field 1 is the hash.
+    grep -m1 "$1" "$checksums" | awk '{print $1}'
+}
+
+darwin_sha="$(sha_for 'javinizer-darwin-universal')"
+linux_amd64_sha="$(sha_for 'javinizer-linux-amd64')"
+linux_arm64_sha="$(sha_for 'javinizer-linux-arm64')"
+
+if [[ -z "$darwin_sha" || -z "$linux_amd64_sha" || -z "$linux_arm64_sha" ]]; then
+    echo "error: missing one or more required checksums in $checksums" >&2
+    echo "  darwin-universal: ${darwin_sha:-<missing>}" >&2
+    echo "  linux-amd64:      ${linux_amd64_sha:-<missing>}" >&2
+    echo "  linux-arm64:      ${linux_arm64_sha:-<missing>}" >&2
+    exit 1
+fi
+
+# Use '|' as the sed delimiter so the release URLs (which contain '/') substitute cleanly.
+sed \
+    -e "s|__VERSION__|${version}|g" \
+    -e "s|__TAG__|${tag}|g" \
+    -e "s|__DARWIN_SHA256__|${darwin_sha}|g" \
+    -e "s|__LINUX_AMD64_SHA256__|${linux_amd64_sha}|g" \
+    -e "s|__LINUX_ARM64_SHA256__|${linux_arm64_sha}|g" \
+    "$template"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,141 @@
+# Javinizer CLI Installer for Windows (PowerShell)
+#
+# One-shot install:
+#   irm https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.ps1 | iex
+#   # install the newest release including prereleases:
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.ps1))) -PreRelease
+#
+# Mirrors scripts/install.sh: downloads the latest release asset, verifies its
+# SHA256 against checksums.txt, removes the Mark-of-the-Web (Unblock-File) so
+# Smart App Control / Defender does not block first run with "Access is denied"
+# (see issue #72), and installs to %LOCALAPPDATA%\javinizer\bin (no admin
+# required) with the folder added to the user PATH.
+
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [string] $InstallDir = "",
+    [switch] $PreRelease
+)
+
+$ErrorActionPreference = 'Stop'
+$Repo = 'javinizer/javinizer-go'
+$BinaryName = 'javinizer'
+
+function Write-Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+function Write-OK($msg)   { Write-Host "    $msg" -ForegroundColor Green }
+function Write-Warn($msg) { Write-Host "    $msg" -ForegroundColor Yellow }
+function Die($msg)        { Write-Host "    ERROR: $msg" -ForegroundColor Red; exit 1 }
+
+# --- 1. Detect architecture -------------------------------------------------
+# Only windows-amd64 is published today (see .github/workflows/cli-release.yml).
+$arch = $env:PROCESSOR_ARCHITECTURE
+if ($arch -eq 'AMD64') {
+    $assetName = 'javinizer-windows-amd64.exe'
+} else {
+    Die "No prebuilt release for Windows $arch yet. Use 'go install' or Docker (see README), or build from source."
+}
+
+Write-Step 'Javinizer CLI Installer'
+
+# --- 2. Resolve latest release version --------------------------------------
+# By default only the latest STABLE release is installed (GitHub's
+# /releases/latest excludes prereleases). If no stable release exists yet, the
+# installer stops and points the user at -PreRelease (or the Releases page)
+# rather than silently installing a prerelease — prereleases are opt-in.
+# With -PreRelease, the /releases list endpoint returns the newest release
+# including prereleases (e.g. v1.0.0-rc3).
+function Get-LatestTag {
+    try {
+        $r = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers @{ 'User-Agent' = 'Javinizer-Installer' } -ErrorAction Stop
+        if ($r.tag_name) { return $r.tag_name }
+    } catch {
+        if ($PreRelease) {
+            Write-Warn 'No stable latest release; fetching most recent release (incl. prereleases)...'
+        } else {
+            Die "No stable release is available yet. Javinizer is currently in pre-release. To install the latest pre-release, re-run with -PreRelease, or download a specific release from https://github.com/$Repo/releases"
+        }
+    }
+    if (-not $PreRelease) {
+        Die "No stable release is available yet. To install the latest pre-release, re-run with -PreRelease, or download from https://github.com/$Repo/releases"
+    }
+    $list = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=1" -Headers @{ 'User-Agent' = 'Javinizer-Installer' }
+    if (-not $list -or -not $list[0].tag_name) { Die 'Failed to fetch latest release version.' }
+    return $list[0].tag_name
+}
+
+$tag = Get-LatestTag
+if ($PreRelease -and $tag -match '-') { Write-Warn "Note: $tag is a pre-release." }
+Write-OK "Latest version: $tag"
+
+# --- 3. Resolve install directory (user-local, no admin) --------------------
+if (-not $InstallDir) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA 'javinizer\bin'
+}
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+}
+
+# --- 4. Download asset + checksums -----------------------------------------
+$tmp = New-Item -ItemType Directory -Force -Path (Join-Path $env:TEMP "javinizer-install-$(Get-Random)")
+$assetPath = Join-Path $tmp.FullName $assetName
+$checksumPath = Join-Path $tmp.FullName 'checksums.txt'
+
+$assetUrl = "https://github.com/$Repo/releases/download/$tag/$assetName"
+$checksumUrl = "https://github.com/$Repo/releases/download/$tag/checksums.txt"
+
+Write-Step "Downloading $assetName"
+Invoke-WebRequest -Uri $assetUrl -OutFile $assetPath -UseBasicParsing
+
+Write-Step 'Verifying checksum'
+try {
+    Invoke-WebRequest -Uri $checksumUrl -OutFile $checksumPath -UseBasicParsing
+} catch {
+    Die "Could not download checksums.txt from $checksumUrl"
+}
+
+# checksums.txt is sha256sum output: "<hash>  <name>"
+$expected = (Select-String -Path $checksumPath -Pattern $assetName -SimpleMatch | Select-Object -First 1).Line -split '\s+' | Select-Object -First 1
+if (-not $expected) { Die "Checksum for $assetName not found in checksums.txt" }
+
+$actual = (Get-FileHash -Algorithm SHA256 -Path $assetPath).Hash.ToLower()
+if ($actual -ne $expected.ToLower()) {
+    Die "Checksum mismatch! Expected $expected, got $actual — refusing to install."
+}
+Write-OK 'Checksum verified'
+
+# --- 5. Unblock (remove Mark-of-the-Web) ------------------------------------
+# This is the fix for issue #72: downloads carry a Zone.Identifier stream that
+# Smart App Control / Defender can block with "Access is denied" before the
+# program even starts. Unblock-File strips it.
+Unblock-File -Path $assetPath
+Write-OK 'Removed Mark-of-the-Web (Unblock-File)'
+
+# --- 6. Install to %LOCALAPPDATA%\javinizer\bin -----------------------------
+$dest = Join-Path $InstallDir "$BinaryName.exe"
+Copy-Item -Path $assetPath -Destination $dest -Force
+Write-OK "Installed to $dest"
+
+# --- 7. Add to user PATH (if missing) --------------------------------------
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ($userPath -and ($userPath.Split(';') -contains $InstallDir)) {
+    Write-OK 'Install dir already on user PATH'
+} else {
+    $newPath = if ($userPath) { "$userPath;$InstallDir" } else { $InstallDir }
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    Write-OK "Added $InstallDir to user PATH"
+}
+
+# --- 8. Cleanup + next steps ------------------------------------------------
+Remove-Item -Recurse -Force $tmp.FullName -ErrorAction SilentlyContinue
+
+Write-Host ''
+Write-Step 'Installation complete'
+Write-Host "    Open a NEW terminal (to pick up the PATH), then run:"
+Write-Host "      javinizer version" -ForegroundColor White
+Write-Host ''
+Write-Host "    Start the web UI:"
+Write-Host "      javinizer init" -ForegroundColor White
+Write-Host "      javinizer web" -ForegroundColor White
+Write-Host ''
+Write-Warn "To update later: run this installer again, or 'javinizer upgrade'."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -42,26 +42,26 @@ Write-Step 'Javinizer CLI Installer'
 # By default only the latest STABLE release is installed (GitHub's
 # /releases/latest excludes prereleases). If no stable release exists yet, the
 # installer stops and points the user at -PreRelease (or the Releases page)
-# rather than silently installing a prerelease — prereleases are opt-in.
+# rather than silently installing a prerelease -- prereleases are opt-in.
 # With -PreRelease, the /releases list endpoint returns the newest release
 # including prereleases (e.g. v1.0.0-rc3).
 function Get-LatestTag {
+    # Branch on -PreRelease first so the list endpoint is the primary path when
+    # opted in: otherwise a newer prerelease is ignored whenever a stable exists.
+    if ($PreRelease) {
+        $list = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=1" -Headers @{ 'User-Agent' = 'Javinizer-Installer' }
+        $latest = @($list)[0]
+        if (-not $latest -or -not $latest.tag_name) { Die 'Failed to fetch latest release version.' }
+        return $latest.tag_name
+    }
+
     try {
         $r = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers @{ 'User-Agent' = 'Javinizer-Installer' } -ErrorAction Stop
         if ($r.tag_name) { return $r.tag_name }
     } catch {
-        if ($PreRelease) {
-            Write-Warn 'No stable latest release; fetching most recent release (incl. prereleases)...'
-        } else {
-            Die "No stable release is available yet. Javinizer is currently in pre-release. To install the latest pre-release, re-run with -PreRelease, or download a specific release from https://github.com/$Repo/releases"
-        }
+        Die "No stable release is available yet. Javinizer is currently in pre-release. To install the latest pre-release, re-run with -PreRelease, or download a specific release from https://github.com/$Repo/releases"
     }
-    if (-not $PreRelease) {
-        Die "No stable release is available yet. To install the latest pre-release, re-run with -PreRelease, or download from https://github.com/$Repo/releases"
-    }
-    $list = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=1" -Headers @{ 'User-Agent' = 'Javinizer-Installer' }
-    if (-not $list -or -not $list[0].tag_name) { Die 'Failed to fetch latest release version.' }
-    return $list[0].tag_name
+    Die "No stable release is available yet. To install the latest pre-release, re-run with -PreRelease, or download from https://github.com/$Repo/releases"
 }
 
 $tag = Get-LatestTag
@@ -94,13 +94,21 @@ try {
     Die "Could not download checksums.txt from $checksumUrl"
 }
 
-# checksums.txt is sha256sum output: "<hash>  <name>"
-$expected = (Select-String -Path $checksumPath -Pattern $assetName -SimpleMatch | Select-Object -First 1).Line -split '\s+' | Select-Object -First 1
+# checksums.txt is sha256sum output: "<hash>  <name>". Match the asset field
+# exactly (a substring match can pick a sibling asset like a .sig file).
+$expected = $null
+foreach ($line in Get-Content -Path $checksumPath) {
+    $fields = $line -split '\s+'
+    if ($fields.Count -ge 2 -and ($fields[1] -in @($assetName, "*$assetName"))) {
+        $expected = $fields[0]
+        break
+    }
+}
 if (-not $expected) { Die "Checksum for $assetName not found in checksums.txt" }
 
 $actual = (Get-FileHash -Algorithm SHA256 -Path $assetPath).Hash.ToLower()
 if ($actual -ne $expected.ToLower()) {
-    Die "Checksum mismatch! Expected $expected, got $actual — refusing to install."
+    Die "Checksum mismatch! Expected $expected, got $actual -- refusing to install."
 }
 Write-OK 'Checksum verified'
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -114,13 +114,13 @@ calculate_sha256() {
 # newest release including prereleases (e.g. v1.0.0-rc3).
 get_latest_version() {
     echo -e "${YELLOW}Fetching latest release...${NC}"
-    VERSION=$(curl -fsSL "https://api.github.com/repos/$GITHUB_REPO/releases/latest" 2>/dev/null | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-
-    if [ -z "$VERSION" ]; then
-        if [ "$PRE_RELEASE" = true ]; then
-            echo -e "${YELLOW}No stable 'latest' release; fetching most recent release (incl. prereleases)...${NC}"
-            VERSION=$(curl -fsSL "https://api.github.com/repos/$GITHUB_REPO/releases?per_page=1" 2>/dev/null | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | head -1)
-        else
+    # Branch on PRE_RELEASE first so the list endpoint is the primary path when
+    # opted in: otherwise a newer prerelease is ignored whenever a stable exists.
+    if [ "$PRE_RELEASE" = true ]; then
+        VERSION=$(curl -fsSL "https://api.github.com/repos/$GITHUB_REPO/releases?per_page=1" 2>/dev/null | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | head -1)
+    else
+        VERSION=$(curl -fsSL "https://api.github.com/repos/$GITHUB_REPO/releases/latest" 2>/dev/null | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+        if [ -z "$VERSION" ]; then
             echo -e "${RED}No stable release is available yet.${NC}"
             echo -e "${YELLOW}Javinizer is currently in pre-release. To install the latest pre-release, re-run with --pre-release:${NC}"
             echo -e "${GREEN}  curl -sSL https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.sh | bash -s -- --pre-release${NC}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,12 +2,31 @@
 set -e
 
 # Javinizer CLI Installer
-# Usage: curl -sSL https://raw.githubusercontent.com/javinizer/javinizer-go/master/scripts/install.sh | bash
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.sh | bash
+#   # install the newest release including prereleases:
+#   curl -sSL https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.sh | bash -s -- --pre-release
 
 GITHUB_REPO="javinizer/javinizer-go"
 BINARY_NAME="javinizer"
 INSTALL_DIR="/usr/local/bin"
 USER_INSTALL_DIR="$HOME/bin"
+PRE_RELEASE=false
+
+# Parse flags. Passing args through `curl | bash` requires `bash -s -- <flags>`.
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pre-release)
+            PRE_RELEASE=true
+            shift
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}" >&2
+            echo "Usage: bash install.sh [--pre-release]" >&2
+            exit 1
+            ;;
+    esac
+done
 
 # Colors for output
 RED='\033[0;31m'
@@ -84,22 +103,49 @@ calculate_sha256() {
     fi
 }
 
-# Get latest release version
+# Get latest release version.
+#
+# By default only the latest STABLE release is installed (GitHub's
+# /releases/latest excludes prereleases). If no stable release exists yet, the
+# installer stops and points the user at --pre-release (or the Releases page)
+# rather than silently installing a prerelease — prereleases are opt-in.
+#
+# With --pre-release, the /releases list endpoint is used instead, returning the
+# newest release including prereleases (e.g. v1.0.0-rc3).
 get_latest_version() {
     echo -e "${YELLOW}Fetching latest release...${NC}"
-    VERSION=$(curl -s "https://api.github.com/repos/$GITHUB_REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    VERSION=$(curl -fsSL "https://api.github.com/repos/$GITHUB_REPO/releases/latest" 2>/dev/null | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+
+    if [ -z "$VERSION" ]; then
+        if [ "$PRE_RELEASE" = true ]; then
+            echo -e "${YELLOW}No stable 'latest' release; fetching most recent release (incl. prereleases)...${NC}"
+            VERSION=$(curl -fsSL "https://api.github.com/repos/$GITHUB_REPO/releases?per_page=1" 2>/dev/null | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | head -1)
+        else
+            echo -e "${RED}No stable release is available yet.${NC}"
+            echo -e "${YELLOW}Javinizer is currently in pre-release. To install the latest pre-release, re-run with --pre-release:${NC}"
+            echo -e "${GREEN}  curl -sSL https://raw.githubusercontent.com/javinizer/javinizer-go/main/scripts/install.sh | bash -s -- --pre-release${NC}"
+            echo -e "${YELLOW}Or download a specific release from: https://github.com/$GITHUB_REPO/releases${NC}"
+            exit 1
+        fi
+    fi
 
     if [ -z "$VERSION" ]; then
         echo -e "${RED}Failed to fetch latest version${NC}"
         exit 1
     fi
 
+    if [ "$PRE_RELEASE" = true ] && echo "$VERSION" | grep -q -- '-'; then
+        echo -e "${YELLOW}Note: $VERSION is a pre-release.${NC}"
+    fi
     echo -e "${GREEN}Latest version: $VERSION${NC}"
 }
 
 # Download binary
 download_binary() {
-    DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/$VERSION/${BINARY_NAME}-${VERSION}-${PLATFORM}${BINARY_EXT}"
+    # Release assets use stable names (javinizer-<platform>) since the version
+    # is baked into the binary via ldflags; the version only appears in the
+    # download path, not the asset filename.
+    DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/$VERSION/${BINARY_NAME}-${PLATFORM}${BINARY_EXT}"
     CHECKSUM_URL="https://github.com/$GITHUB_REPO/releases/download/$VERSION/checksums.txt"
 
     echo -e "${YELLOW}Downloading $BINARY_NAME from $DOWNLOAD_URL${NC}"
@@ -113,34 +159,54 @@ download_binary() {
         exit 1
     fi
 
-    # Download and verify checksum
+    # Download and verify checksum. The Go self-upgrade and install.ps1 both
+    # ABORT on any verification failure; this installer must do the same so a
+    # network attacker (or a partial release) can never land an unverified
+    # binary on PATH.
     echo -e "${YELLOW}Verifying checksum...${NC}"
-    if curl -sL "$CHECKSUM_URL" -o "$TMP_DIR/checksums.txt"; then
-        EXPECTED_CHECKSUM=$(grep "${BINARY_NAME}-${VERSION}-${PLATFORM}${BINARY_EXT}" "$TMP_DIR/checksums.txt" | awk '{print $1}')
-        ACTUAL_CHECKSUM=$(calculate_sha256 "$TMP_FILE")
-
-        if [ -z "$ACTUAL_CHECKSUM" ]; then
-            echo -e "${YELLOW}Warning: Could not calculate checksum, skipping verification${NC}"
-        elif [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; then
-            echo -e "${RED}Checksum verification failed!${NC}"
-            echo -e "${RED}Expected: $EXPECTED_CHECKSUM${NC}"
-            echo -e "${RED}Actual: $ACTUAL_CHECKSUM${NC}"
-            rm -rf "$TMP_DIR"
-            exit 1
-        else
-            echo -e "${GREEN}Checksum verified!${NC}"
-        fi
-    else
-        echo -e "${YELLOW}Warning: Could not verify checksum (checksums.txt not found)${NC}"
+    if ! curl -fsSL "$CHECKSUM_URL" -o "$TMP_DIR/checksums.txt"; then
+        echo -e "${RED}Could not download checksums.txt — refusing to install unverified binary${NC}"
+        rm -rf "$TMP_DIR"
+        exit 1
     fi
+
+    # Match the asset name as an exact field (sha256sum output: "<hash>  <name>"
+    # or "<hash> *<name>"), not a substring, so a sibling asset whose name
+    # contains this one can't match the wrong line.
+    EXPECTED_CHECKSUM=$(awk -v name="${BINARY_NAME}-${PLATFORM}${BINARY_EXT}" '$2==name || $2=="*"name {print $1; exit}' "$TMP_DIR/checksums.txt")
+    ACTUAL_CHECKSUM=$(calculate_sha256 "$TMP_FILE")
+
+    if [ -z "$ACTUAL_CHECKSUM" ]; then
+        echo -e "${RED}No SHA256 tool found (sha256sum/shasum/openssl) — refusing to install unverified binary${NC}"
+        rm -rf "$TMP_DIR"
+        exit 1
+    fi
+    if [ -z "$EXPECTED_CHECKSUM" ]; then
+        echo -e "${RED}Checksum for ${BINARY_NAME}-${PLATFORM}${BINARY_EXT} not found in checksums.txt — refusing to install${NC}"
+        rm -rf "$TMP_DIR"
+        exit 1
+    fi
+    if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; then
+        echo -e "${RED}Checksum verification failed!${NC}"
+        echo -e "${RED}Expected: $EXPECTED_CHECKSUM${NC}"
+        echo -e "${RED}Actual: $ACTUAL_CHECKSUM${NC}"
+        rm -rf "$TMP_DIR"
+        exit 1
+    fi
+    echo -e "${GREEN}Checksum verified!${NC}"
 
     chmod +x "$TMP_FILE"
 }
 
 # Install binary
 install_binary() {
-    # Try system-wide install first (requires sudo)
-    if [ -w "$INSTALL_DIR" ] || sudo -n true 2>/dev/null; then
+    # If the system install dir is directly writable, use a plain mv (no sudo)
+    # — running sudo in a `curl | bash` pipe has no tty and would fail.
+    if [ -w "$INSTALL_DIR" ]; then
+        echo -e "${YELLOW}Installing to $INSTALL_DIR...${NC}"
+        mv "$TMP_FILE" "$INSTALL_DIR/$BINARY_NAME"
+        echo -e "${GREEN}Installed to $INSTALL_DIR/$BINARY_NAME${NC}"
+    elif sudo -n true 2>/dev/null; then
         echo -e "${YELLOW}Installing to $INSTALL_DIR (requires sudo)...${NC}"
         sudo mv "$TMP_FILE" "$INSTALL_DIR/$BINARY_NAME"
         echo -e "${GREEN}Installed to $INSTALL_DIR/$BINARY_NAME${NC}"

--- a/scripts/scoop/SETUP.md
+++ b/scripts/scoop/SETUP.md
@@ -1,0 +1,71 @@
+# Scoop bucket — one-time setup
+
+These steps created the `javinizer/scoop-javinizer` bucket repository and gave
+the `javinizer-go` CI permission to push the manifest to it on each stable
+release. This is a reference of what was done; it only needs running once.
+
+## 1. Create the bucket repo
+
+Created an empty public repository named **`scoop-javinizer`** under the
+`javinizer` organization (no README, no license, no `.gitignore`):
+
+https://github.com/organizations/javinizer/repositories/new
+
+- Owner: `javinizer`
+- Name: `scoop-javinizer`
+- Visibility: **Public** (Scoop requires buckets to be public)
+- Initialize: leave all unchecked
+
+## 2. Generate an SSH deploy key
+
+```bash
+ssh-keygen -t ed25519 -C "scoop-javinizer deploy key" -f scoop_bucket_deploy_key -N ""
+```
+
+This produces two files:
+- `scoop_bucket_deploy_key`      → private key (goes into a CI secret)
+- `scoop_bucket_deploy_key.pub`  → public key (goes into the bucket repo)
+
+## 3. Add the public key as a write deploy key on the bucket repo
+
+Go to https://github.com/javinizer/scoop-javinizer/settings/keys/new
+- Title: `CI publish from javinizer-go`
+- Key: paste `scoop_bucket_deploy_key.pub`
+- **Allow write access: ✓** (required — CI commits the manifest)
+
+## 4. Add the private key as a secret in javinizer-go
+
+Go to https://github.com/javinizer/javinizer-go/settings/secrets/actions/new
+- Name: `SCOOP_BUCKET_DEPLOY_KEY`
+- Secret: paste the contents of `scoop_bucket_deploy_key` (the private key)
+
+## 5. Delete the local private key
+
+```bash
+rm scoop_bucket_deploy_key scoop_bucket_deploy_key.pub
+```
+
+## How users install (Windows, Scoop)
+
+Once a stable (non-prerelease) `v1.0.0` ships and the CI job has run:
+
+```powershell
+scoop bucket add javinizer https://github.com/javinizer/scoop-javinizer
+scoop install javinizer
+scoop update javinizer   # updates to the latest stable release
+```
+
+## Notes
+
+- The bucket is only updated for **stable** releases. Prereleases
+  (`v1.0.0-rc.*`) do not push to the bucket, so `scoop update` never hands a
+  user a release candidate.
+- The manifest (`bucket/javinizer.json`) installs the prebuilt
+  `javinizer-windows-amd64.exe` and shims it as `javinizer`. CGO/SQLite is
+  statically linked into the binary, so no separate runtime is required.
+- The manifest includes `checkver` (stable-only regex) and `autoupdate` blocks
+  so it is well-formed for Scoop tooling and self-documenting, even though CI
+  also writes concrete version + hash per release.
+- `javinizer upgrade` (self-upgrade) detects a Scoop install by its apps path
+  and tells the user to run `scoop update javinizer` instead, so the two
+  channels never fight each other.

--- a/scripts/scoop/javinizer.json.tmpl
+++ b/scripts/scoop/javinizer.json.tmpl
@@ -1,0 +1,30 @@
+{
+    "version": "__VERSION__",
+    "description": "JAV metadata scraper and organizer (CLI, TUI, REST API, and web UI)",
+    "homepage": "https://github.com/javinizer/javinizer-go",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/javinizer/javinizer-go/releases/download/v__VERSION__/javinizer-windows-amd64.exe",
+            "hash": "__HASH__"
+        }
+    },
+    "bin": [
+        ["javinizer-windows-amd64.exe", "javinizer"]
+    ],
+    "checkver": {
+        "github": "https://github.com/javinizer/javinizer-go",
+        "regex": "v?(?<version>\\d+\\.\\d+\\.\\d+)$"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/javinizer/javinizer-go/releases/download/v$version/javinizer-windows-amd64.exe",
+                "hash": {
+                    "url": "$baseurl/checksums.txt",
+                    "regex": "^([a-fA-F0-9]{64})\\s+\\*?javinizer-windows-amd64\\.exe$"
+                }
+            }
+        }
+    }
+}

--- a/scripts/scoop/render-manifest.sh
+++ b/scripts/scoop/render-manifest.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# render-manifest.sh — render the Scoop manifest (javinizer.json) for a release.
+#
+# Usage: render-manifest.sh <tag> <checksums.txt> [template]
+#   tag           release tag, e.g. v1.0.0
+#   checksums.txt path to the release checksums.txt (sha256sum output)
+#   template      path to the .json.tmpl (default: scripts/scoop/javinizer.json.tmpl)
+#
+# Writes the rendered manifest to stdout. Exits non-zero if the windows asset
+# checksum is missing, so CI never publishes a half-rendered manifest.
+
+set -euo pipefail
+
+tag="${1:?usage: render-manifest.sh <tag> <checksums.txt> [template]}"
+checksums="${2:?usage: render-manifest.sh <tag> <checksums.txt> [template]}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+template="${3:-${script_dir}/javinizer.json.tmpl}"
+
+version="${tag#v}" # Scoop versions omit the leading 'v'
+
+sha_for() {
+    # sha256sum output is "<hash>  <name>" (or "<hash> *<name>"); field 1 is the hash.
+    grep -m1 "$1" "$checksums" | awk '{print $1}'
+}
+
+hash="$(sha_for 'javinizer-windows-amd64.exe')"
+if [[ -z "$hash" ]]; then
+    echo "error: missing checksum for javinizer-windows-amd64.exe in $checksums" >&2
+    exit 1
+fi
+
+# Use '|' as the sed delimiter; version (digits/dots) and hash (hex) contain no '|'.
+sed \
+    -e "s|__VERSION__|${version}|g" \
+    -e "s|__HASH__|${hash}|g" \
+    "$template"


### PR DESCRIPTION
## Summary

Adds a layered installation + update story for the v1.0.0 release, addressing [issue #72](https://github.com/javinizer/javinizer-go/issues/72) (Windows "Access is denied" from unsigned internet-downloaded binaries / Mark-of-the-Web / Smart App Control).

**Design principle: prereleases are opt-in everywhere.**

| Channel | Default | Opt-in to prereleases |
|---|---|---|
| `javinizer upgrade` | latest stable | `--prerelease` |
| `version --check` | respects `version_check_stable_only` | config flag |
| Homebrew tap | stable-only (CI gate) | — (RCs never in tap) |
| Scoop bucket | stable-only (CI gate) | — (RCs never in bucket) |
| `install.sh` | stable (refuses if none) | `--pre-release` |
| `install.ps1` | stable (refuses if none) | `-PreRelease` |

## Changes

### Self-upgrade command (`javinizer upgrade`)
- `internal/update/upgrade.go` — download / SHA256-verify / atomic-replace the running binary. Detects Homebrew/Scoop installs and hands off to `brew`/`scoop` instead of clobbering them. Windows path renames the running exe to `.old`, with rollback on failure and self-heal from a prior interrupted upgrade.
- `cmd/javinizer/commands/upgrade/` — new command with `--check`, `--force`, `--prerelease` flags.
- `internal/update/checker.go` — `PreReleaseChecker` optional interface so `upgrade` can opt into prerelease discovery without disturbing the service layer's ETag/skipLatest probes.
- Fixes `version --check` message (`update` → `upgrade`).

### Package-manager taps (CI pushes on each **stable** release; prereleases never reach them)
- `scripts/homebrew/` — Formula template + `render-formula.sh` (prebuilt darwin-universal + linux assets; `ruby -c` validated).
- `scripts/scoop/` — bucket manifest template + `render-manifest.sh` (windows-amd64 with `checkver`/`autoupdate`; JSON validated).
- `.github/workflows/cli-release.yml` — `update-homebrew-tap` + `update-scoop-bucket` jobs, gated to stable releases, pushing via `HOMEBREW_TAP_DEPLOY_KEY` / `SCOOP_BUCKET_DEPLOY_KEY` SSH deploy keys.
- The tap (`javinizer/homebrew-tap`) and bucket (`javinizer/scoop-javinizer`) repos + deploy keys are already set up.

### One-shot installers (stable by default, opt-in for prereleases)
- `scripts/install.sh` — **fixed broken asset naming** (`javinizer-<version>-<platform>` → `javinizer-<platform>`) broken since `9bfc53d0`; hardened to **abort** on checksum download / SHA-tool / missing-asset failure (was: warn + install unverified); exact-field checksum match; plain `mv` when the install dir is writable.
- `scripts/install.ps1` — new Windows installer: downloads, SHA256-verifies, `Unblock-File` (strips Mark-of-the-Web — the #72 fix), installs to `%LOCALAPPDATA%\javinizer\bin` (no admin), adds to PATH.

### Docs
README + `docs/01-getting-started.md` restructured package-manager-first (Homebrew → Scoop → one-shot installers → manual → self-upgrade → source).

## Review

Reviewed by 3 parallel sub-agents (security/safety, correctness/consistency, test-quality/Go-idiom). All findings addressed:
- **Security**: `install.sh` no longer installs unverified binaries on checksum failure; exact-field checksum matching.
- **Lint**: `make lint` was failing (6 golangci-lint issues) — fixed (errcheck, errorlint, gosec, nilerr).
- **Windows brick risk**: `ReplaceBinary` refactored with self-heal + non-silent rollback.
- **Test gaps**: added Scoop handoff, Windows replace (success/rollback/self-heal), checksums-download-failure, "already up to date" non-check path, `shouldSkipConfigInit("upgrade")`, prerelease flow (checker + command + e2e).

## Pre-flight smoke tests (against the real `v1.0.0-rc3` release)
- ✅ Render scripts produce valid Ruby + JSON with hashes cross-checked against the real `checksums.txt`.
- ✅ End-to-end self-upgrade: built a throwaway binary, ran `upgrade` → downloaded real asset → SHA256 verified → atomic replace → new binary reports `v1.0.0-rc3`, still executable, no leftover temp/`.old` files.
- ✅ CI workflow YAML valid; both new jobs present with correct `needs` + stable-only `if:` gating; install.sh asset URL resolves (HTTP 302).
- ✅ `--prerelease` live check resolves `v1.0.0-rc3` via the list endpoint.

## Verification
`make ci` (vet + lint + vuln + coverage 75% + race + config-drift + mocks) → **exit 0**. Pre-commit hook (gofmt + vet + short tests + build) → all passed.

## Out of scope / future
- **Code signing** (the full fix for #72 on Windows): SignPath pending in `CODE_SIGNING_POLICY.md`. Package managers + `Unblock-File` reduce but do not eliminate SAC blocking of an unsigned exe.
- **Electron desktop app**: the CLI-with-`web`-command substrate is already the right base for a future shell that spawns `javinizer web` and loads `localhost:8080`.

## Notes for reviewers
- The tap/bucket repos and deploy keys were created out-of-band (org-admin via `gh`); nothing secret is in this PR — only the SETUP.md reference docs and the CI jobs that consume the secrets.
- `CODE_OF_CONDUCT.md` / `CODE_SIGNING_POLICY.md` are pre-existing untracked files, intentionally left out of this commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-upgrade `upgrade` command with `--check`, `--force`, and `--prerelease`.
  * Expanded one-shot install scripts with explicit prerelease opt-in and improved stable/prerelease selection, plus updated Homebrew/Scoop support.
  * Improved stable release automation to publish updated Homebrew formulas and Scoop manifests.
* **Bug Fixes**
  * Strengthened binary integrity by enforcing SHA256 checksum verification before installing/replacing.
  * Updated guidance to use `javinizer upgrade` when an upgrade is available.
* **Documentation**
  * Expanded README/getting-started with Homebrew, Scoop, one-shot, checksum, and Windows Smart App Control notes.
* **Chores**
  * Adjusted Codecov patch coverage target behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->