### PR TITLE
fix(api/auth): fail-closed on nil auth manager

### DIFF
--- a/cmd/javinizer/commands/api/command_test.go
+++ b/cmd/javinizer/commands/api/command_test.go
@@ -14,6 +14,7 @@ import (
 	api "github.com/javinizer/javinizer-go/cmd/javinizer/commands/api"
 	"github.com/javinizer/javinizer-go/internal/api/core"
 	apiserver "github.com/javinizer/javinizer-go/internal/api/server"
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
 	"github.com/javinizer/javinizer-go/internal/commandutil"
 	"github.com/javinizer/javinizer-go/internal/config"
 	"github.com/javinizer/javinizer-go/internal/database"
@@ -142,6 +143,7 @@ func createTestAPIServer(t *testing.T) *core.APIRuntime {
 		JobStore: jobStore,
 	}
 	deps.CoreDeps.SetConfig(cfg)
+	deps.Auth = testkit.NoOpAuth{}
 
 	rt := core.NewAPIRuntime(deps)
 	return rt

--- a/internal/api/auth/auth_disabler_invariant_test.go
+++ b/internal/api/auth/auth_disabler_invariant_test.go
@@ -1,0 +1,30 @@
+package auth
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+)
+
+// TestAuthManager_DoesNotSatisfyAuthDisabler is the security invariant that
+// keeps the fail-closed path safe in production: the production *AuthManager
+// must NOT implement authDisabler. If a future contributor adds IsDisabled()
+// to *AuthManager, the middleware would silently bypass authentication for
+// every request, re-introducing the exact bug this change fixes. This test
+// fails loudly if that happens.
+func TestAuthManager_DoesNotSatisfyAuthDisabler(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	manager, err := NewAuthManager(configFile, time.Hour)
+	require.NoError(t, err)
+
+	_, ok := any(manager).(authDisabler)
+	assert.False(t, ok, "*AuthManager must not satisfy authDisabler; doing so would silently bypass authentication in production")
+
+	_, ok = any(testkit.NoOpAuth{}).(authDisabler)
+	assert.True(t, ok, "testkit.NoOpAuth must satisfy authDisabler so the test pass-through works")
+}

--- a/internal/api/auth/http_miss2_test.go
+++ b/internal/api/auth/http_miss2_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/api/testkit"
 )
 
-// --- requireTokenOrSession: nil deps calls c.Next() ---
+// --- requireTokenOrSession: nil deps fails closed (503) ---
 
 func TestRequireTokenOrSession_Miss2_NilDeps(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -31,7 +31,8 @@ func TestRequireTokenOrSession_Miss2_NilDeps(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.True(t, called)
+	assert.False(t, called, "handler must not run when auth is unavailable")
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
 // --- requireTokenOrSession: Bearer token without jv_ prefix ---
@@ -206,7 +207,7 @@ func TestRequireTokenOrSession_Miss2_SessionAuthNotInitialized(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-// --- authMiddleware: nil deps with Bearer token should call c.Next() ---
+// --- requireTokenOrSession: nil deps with Bearer token still fails closed (503) ---
 
 func TestRequireTokenOrSession_Miss2_NilDepsWithBearer(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -219,7 +220,8 @@ func TestRequireTokenOrSession_Miss2_NilDepsWithBearer(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.True(t, called)
+	assert.False(t, called, "handler must not run when auth is unavailable")
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
 // --- setupAuth: remote setup with valid bootstrap secret ---

--- a/internal/api/auth/http_miss4_test.go
+++ b/internal/api/auth/http_miss4_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/api/testkit"
 )
 
-// --- requireTokenOrSession: nil deps passes through ---
+// --- requireTokenOrSession: nil deps fails closed (503) ---
 
 func TestMiss4_RequireTokenOrSession_NilDeps(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -29,27 +30,79 @@ func TestMiss4_RequireTokenOrSession_NilDeps(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.True(t, called)
+	assert.False(t, called, "handler must not run when auth is unavailable")
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
-// --- requireTokenOrSession: nil auth passes through ---
+// --- requireTokenOrSession: nil auth fails closed (503) ---
 
 func TestMiss4_RequireTokenOrSession_NilAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cfg := config.DefaultConfig(nil, nil)
 	configFile := filepath.Join(t.TempDir(), "config.yaml")
 	deps := createTestDeps(t, cfg, configFile)
+	// GetTestRuntime auto-wires NoOpAuth for test convenience; nil it out
+	// afterward to simulate a wiring bug and assert the fail-closed path.
+	rt := testkit.GetTestRuntime(deps)
 	deps.Auth = nil
 
 	called := false
 	router := gin.New()
-	router.GET("/test", requireTokenOrSession(testkit.GetTestRuntime(deps)), func(c *gin.Context) { called = true })
+	router.GET("/test", requireTokenOrSession(rt), func(c *gin.Context) { called = true })
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.True(t, called)
+	assert.False(t, called, "handler must not run when auth is unavailable")
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// --- requireAuthenticated: nil auth fails closed (503) ---
+
+func TestMiss4_RequireAuthenticated_NilAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := config.DefaultConfig(nil, nil)
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	deps := createTestDeps(t, cfg, configFile)
+	rt := testkit.GetTestRuntime(deps)
+	deps.Auth = nil
+
+	called := false
+	router := gin.New()
+	router.GET("/test", requireAuthenticated(rt), func(c *gin.Context) { called = true })
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.False(t, called, "handler must not run when auth is unavailable")
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// --- requireAuthenticated: NoOpAuth satisfies authDisabler, so the middleware short-circuits to c.Next() before the credentials check ---
+
+func TestMiss4_RequireAuthenticated_NoOpAuthPassesThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := config.DefaultConfig(nil, nil)
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	deps := createTestDeps(t, cfg, configFile)
+	deps.Auth = testkit.NoOpAuth{}
+	rt := testkit.GetTestRuntime(deps)
+
+	called := false
+	router := gin.New()
+	router.GET("/test", requireAuthenticated(rt), func(c *gin.Context) {
+		called = true
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.True(t, called, "handler should be called when NoOpAuth bypasses auth")
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 // --- requireTokenOrSession: session with ErrAuthNotInitialized returns 503 ---
@@ -117,19 +170,15 @@ func TestMiss4_SetupAuth_AlreadyInitialized(t *testing.T) {
 	router := gin.New()
 	router.POST("/api/v1/auth/setup", setupAuth(testkit.GetTestRuntime(deps)))
 
-	body := `{"username":"newuser","password":"newpass123"}`
-	req := httptest.NewRequest("POST", "/api/v1/auth/setup", nil)
+	body := strings.NewReader(`{"username":"newuser","password":"newpass123"}`)
+	req := httptest.NewRequest("POST", "/api/v1/auth/setup", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.RemoteAddr = "127.0.0.1:12345"
-	_ = body
 
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	// Already initialized → 409 (after auth check passes since we're from localhost)
-	// But we didn't send a body, so it might be 400
-	// The key coverage is: IsInitialized() returns true → 409 path
-	// Actually without body we get 400 first. Let's send body properly.
+	assert.Equal(t, http.StatusConflict, w.Code)
 }
 
 // --- setupAuth: with bootstrap secret, wrong secret ---
@@ -174,14 +223,14 @@ func TestMiss4_LoginAuth_AuthNotInitialized(t *testing.T) {
 	router := gin.New()
 	router.POST("/api/v1/auth/login", loginAuth(testkit.GetTestRuntime(deps)))
 
-	req := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+	body := strings.NewReader(`{"username":"admin","password":"password123"}`)
+	req := httptest.NewRequest("POST", "/api/v1/auth/login", body)
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	// Empty body → 400 before we even check auth
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
 // --- loginAuth: invalid credentials returns 401 ---
@@ -199,13 +248,14 @@ func TestMiss4_LoginAuth_InvalidCredentials(t *testing.T) {
 	router := gin.New()
 	router.POST("/api/v1/auth/login", loginAuth(testkit.GetTestRuntime(deps)))
 
-	req := httptest.NewRequest("POST", "/api/v1/auth/login", nil)
+	body := strings.NewReader(`{"username":"admin","password":"wrongpassword"}`)
+	req := httptest.NewRequest("POST", "/api/v1/auth/login", body)
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 // --- parseCIDRList tests ---

--- a/internal/api/auth/http_miss_test.go
+++ b/internal/api/auth/http_miss_test.go
@@ -41,8 +41,10 @@ func TestLoginAuth_Miss_NilDeps(t *testing.T) {
 func TestLoginAuth_Miss_NilAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	deps := &core.APIDeps{}
+	rt := testkit.GetTestRuntime(deps)
+	deps.Auth = nil
 	router := gin.New()
-	router.POST("/login", loginAuth(testkit.GetTestRuntime(deps)))
+	router.POST("/login", loginAuth(rt))
 
 	body := []byte(`{"username":"admin","password":"password123"}`)
 	req := httptest.NewRequest("POST", "/login", bytes.NewReader(body))
@@ -183,8 +185,10 @@ func TestGetAuthStatus_Miss_NilDeps(t *testing.T) {
 func TestGetAuthStatus_Miss_NilAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	deps := &core.APIDeps{}
+	rt := testkit.GetTestRuntime(deps)
+	deps.Auth = nil
 	router := gin.New()
-	router.GET("/status", getAuthStatus(testkit.GetTestRuntime(deps)))
+	router.GET("/status", getAuthStatus(rt))
 
 	req := httptest.NewRequest("GET", "/status", nil)
 	w := httptest.NewRecorder()
@@ -305,8 +309,10 @@ func TestSetupAuth_Miss_NilDeps(t *testing.T) {
 func TestSetupAuth_Miss_NilAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	deps := &core.APIDeps{}
+	rt := testkit.GetTestRuntime(deps)
+	deps.Auth = nil
 	router := gin.New()
-	router.POST("/setup", setupAuth(testkit.GetTestRuntime(deps)))
+	router.POST("/setup", setupAuth(rt))
 
 	body := []byte(`{"username":"admin","password":"password123"}`)
 	req := httptest.NewRequest("POST", "/setup", bytes.NewReader(body))
@@ -360,8 +366,10 @@ func TestLogoutAuth_Miss_NilDeps(t *testing.T) {
 func TestLogoutAuth_Miss_NilAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	deps := &core.APIDeps{}
+	rt := testkit.GetTestRuntime(deps)
+	deps.Auth = nil
 	router := gin.New()
-	router.POST("/logout", logoutAuth(testkit.GetTestRuntime(deps)))
+	router.POST("/logout", logoutAuth(rt))
 
 	req := httptest.NewRequest("POST", "/logout", nil)
 	w := httptest.NewRecorder()
@@ -370,21 +378,25 @@ func TestLogoutAuth_Miss_NilAuth(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-// --- requireTokenOrSession: nil Auth with session cookie should call c.Next() ---
+// --- requireTokenOrSession: nil auth with cookie still fails closed (503) ---
 
 func TestRequireTokenOrSession_Miss_NilAuthWithCookie(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	deps := &core.APIDeps{}
+	rt := testkit.GetTestRuntime(deps)
+	deps.Auth = nil
 	called := false
 	router := gin.New()
-	router.GET("/test", requireTokenOrSession(testkit.GetTestRuntime(deps)), func(c *gin.Context) { called = true })
+	router.GET("/test", requireTokenOrSession(rt), func(c *gin.Context) { called = true })
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "some-session"})
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.True(t, called)
+	// A cookie must not bypass fail-closed: nil auth still returns 503.
+	assert.False(t, called, "handler must not run when auth is unavailable")
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
 // --- requireTokenOrSession: initialized but non-NotFound session error ---

--- a/internal/api/auth/http_test.go
+++ b/internal/api/auth/http_test.go
@@ -1057,7 +1057,8 @@ func TestRequireAuthenticated_NilDeps(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 	testRouter.ServeHTTP(w, req)
-	assert.True(t, called)
+	assert.False(t, called, "handler must not run when auth is unavailable")
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
 func TestRequireTokenOrSession_ExportedWrapper(t *testing.T) {
@@ -1068,7 +1069,8 @@ func TestRequireTokenOrSession_ExportedWrapper(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 	testRouter.ServeHTTP(w, req)
-	assert.True(t, called)
+	assert.False(t, called, "handler must not run when auth is unavailable")
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
 func TestRequireTokenOrSession_EmptyBearerValue(t *testing.T) {

--- a/internal/api/auth/middleware.go
+++ b/internal/api/auth/middleware.go
@@ -29,6 +29,27 @@ func authBypassed(auth commandutil.AuthProvider) bool {
 	return ok && d.IsDisabled()
 }
 
+func resolveAuth(c *gin.Context, rt *core.APIRuntime) (deps *core.APIDeps, handled bool) {
+	if rt == nil {
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable, contracts.ErrorResponse{
+			Error: "authentication is unavailable",
+		})
+		return nil, true
+	}
+	deps = rt.Deps()
+	if deps == nil || deps.Auth == nil {
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable, contracts.ErrorResponse{
+			Error: "authentication is unavailable",
+		})
+		return nil, true
+	}
+	if authBypassed(deps.Auth) {
+		c.Next()
+		return deps, true
+	}
+	return deps, false
+}
+
 func securityConfig(rt *core.APIRuntime) *core.SecurityNarrowConfig {
 	if rt == nil {
 		return nil
@@ -39,22 +60,8 @@ func securityConfig(rt *core.APIRuntime) *core.SecurityNarrowConfig {
 //nolint:unused // used by same-package tests
 func requireAuthenticated(rt *core.APIRuntime) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if rt == nil {
-			c.AbortWithStatusJSON(http.StatusServiceUnavailable, contracts.ErrorResponse{
-				Error: "authentication is unavailable",
-			})
-			return
-		}
-		deps := rt.Deps()
-		if deps == nil || deps.Auth == nil {
-			c.AbortWithStatusJSON(http.StatusServiceUnavailable, contracts.ErrorResponse{
-				Error: "authentication is unavailable",
-			})
-			return
-		}
-
-		if authBypassed(deps.Auth) {
-			c.Next()
+		deps, handled := resolveAuth(c, rt)
+		if handled {
 			return
 		}
 
@@ -95,22 +102,8 @@ func requireAuthenticated(rt *core.APIRuntime) gin.HandlerFunc {
 
 func requireTokenOrSession(rt *core.APIRuntime) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if rt == nil {
-			c.AbortWithStatusJSON(http.StatusServiceUnavailable, contracts.ErrorResponse{
-				Error: "authentication is unavailable",
-			})
-			return
-		}
-		deps := rt.Deps()
-		if deps == nil || deps.Auth == nil {
-			c.AbortWithStatusJSON(http.StatusServiceUnavailable, contracts.ErrorResponse{
-				Error: "authentication is unavailable",
-			})
-			return
-		}
-
-		if authBypassed(deps.Auth) {
-			c.Next()
+		deps, handled := resolveAuth(c, rt)
+		if handled {
 			return
 		}
 

--- a/internal/api/auth/middleware.go
+++ b/internal/api/auth/middleware.go
@@ -9,10 +9,25 @@ import (
 	contracts "github.com/javinizer/javinizer-go/internal/api/contracts"
 	"github.com/javinizer/javinizer-go/internal/api/core"
 	"github.com/javinizer/javinizer-go/internal/api/token"
+	"github.com/javinizer/javinizer-go/internal/commandutil"
 	"github.com/javinizer/javinizer-go/internal/logging"
 )
 
 const sessionCookieName = "javinizer_session"
+
+// authDisabler is an optional capability of AuthProvider implementations that
+// explicitly bypasses authentication. Only the test-only testkit.NoOpAuth
+// implements it; the production *AuthManager does not, so this path is
+// unreachable in production. This keeps the test pass-through out of the
+// production AuthProvider contract and free of any config-level bypass flag.
+type authDisabler interface {
+	IsDisabled() bool
+}
+
+func authBypassed(auth commandutil.AuthProvider) bool {
+	d, ok := auth.(authDisabler)
+	return ok && d.IsDisabled()
+}
 
 func securityConfig(rt *core.APIRuntime) *core.SecurityNarrowConfig {
 	if rt == nil {
@@ -25,11 +40,20 @@ func securityConfig(rt *core.APIRuntime) *core.SecurityNarrowConfig {
 func requireAuthenticated(rt *core.APIRuntime) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if rt == nil {
-			c.Next()
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, contracts.ErrorResponse{
+				Error: "authentication is unavailable",
+			})
 			return
 		}
 		deps := rt.Deps()
 		if deps == nil || deps.Auth == nil {
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, contracts.ErrorResponse{
+				Error: "authentication is unavailable",
+			})
+			return
+		}
+
+		if authBypassed(deps.Auth) {
 			c.Next()
 			return
 		}
@@ -72,11 +96,20 @@ func requireAuthenticated(rt *core.APIRuntime) gin.HandlerFunc {
 func requireTokenOrSession(rt *core.APIRuntime) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if rt == nil {
-			c.Next()
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, contracts.ErrorResponse{
+				Error: "authentication is unavailable",
+			})
 			return
 		}
 		deps := rt.Deps()
 		if deps == nil || deps.Auth == nil {
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, contracts.ErrorResponse{
+				Error: "authentication is unavailable",
+			})
+			return
+		}
+
+		if authBypassed(deps.Auth) {
 			c.Next()
 			return
 		}

--- a/internal/api/testkit/helpers.go
+++ b/internal/api/testkit/helpers.go
@@ -104,6 +104,47 @@ func NewMockActressRepo() *database.ActressRepository {
 	return database.NewActressRepository(db)
 }
 
+// NoOpAuth is a test-only commandutil.AuthProvider that bypasses authentication.
+// The auth middleware type-asserts to an IsDisabled() capability; only NoOpAuth
+// satisfies it, so the production *AuthManager always enforces real auth and this
+// path is unreachable in production. Test setup helpers auto-wire NoOpAuth via
+// GetTestRuntime so integration tests reach protected handlers without
+// per-test credentials. Tests that assert the fail-closed path set
+// deps.Auth = nil after retrieving the runtime.
+type NoOpAuth struct{}
+
+// SessionTTL returns a fixed one-hour TTL. Unused on the pass-through path.
+func (NoOpAuth) SessionTTL() time.Duration { return time.Hour }
+
+// IsInitialized always reports true. Unused on the pass-through path.
+func (NoOpAuth) IsInitialized() bool { return true }
+
+// AuthenticateSession always succeeds with a placeholder username.
+func (NoOpAuth) AuthenticateSession(string) (string, error) { return "test", nil }
+
+// Setup is a no-op that always succeeds.
+func (NoOpAuth) Setup(string, string) error { return nil }
+
+// Login always succeeds and returns a placeholder session ID.
+func (NoOpAuth) Login(string, string, bool) (string, error) { return "test-session", nil }
+
+// Logout is a no-op.
+func (NoOpAuth) Logout(string) {}
+
+// ValidateToken always succeeds and returns a placeholder token ID.
+func (NoOpAuth) ValidateToken(context.Context, string) (string, error) { return "test-token", nil }
+
+// UpdateTokenLastUsed is a no-op that always succeeds.
+func (NoOpAuth) UpdateTokenLastUsed(context.Context, string) error { return nil }
+
+// GetEnv always returns the empty string.
+func (NoOpAuth) GetEnv(string) string { return "" }
+
+// IsDisabled reports that authentication is bypassed. Only NoOpAuth implements
+// this; the production *AuthManager does not, so the middleware's type assertion
+// never matches in production.
+func (NoOpAuth) IsDisabled() bool { return true }
+
 // CreateTestDeps creates minimal *core.APIDeps for testing.
 // Per DEEP-2: the APIRuntime is stored internally and can be retrieved
 // via GetTestRuntime(deps). This avoids requiring all test callers to
@@ -181,6 +222,13 @@ var runtimeMap sync.Map
 // and returned. This prevents nil-pointer dereferences in test helpers
 // that construct *APIDeps directly and then call runtime methods.
 func GetTestRuntime(deps *core.APIDeps) *core.APIRuntime {
+	// Tests that don't care about auth get a pass-through NoOpAuth so the
+	// fail-closed middleware (nil deps.Auth → 503) doesn't block them. Tests
+	// that need real auth set deps.Auth before calling this; tests that need
+	// to assert the fail-closed path set deps.Auth = nil AFTER this call.
+	if deps != nil && deps.Auth == nil {
+		deps.Auth = NoOpAuth{}
+	}
 	val, ok := runtimeMap.Load(deps)
 	if ok {
 		return val.(*core.APIRuntime)

--- a/internal/api/testkit/helpers_test.go
+++ b/internal/api/testkit/helpers_test.go
@@ -3,6 +3,7 @@ package testkit
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/javinizer/javinizer-go/internal/api/core"
 	"github.com/javinizer/javinizer-go/internal/config"
@@ -87,4 +88,32 @@ func TestCleanupServerHub(t *testing.T) {
 func TestCleanupServerHub_NilDeps(t *testing.T) {
 	// Should not panic
 	CleanupServerHub(t, (*core.APIRuntime)(nil))
+}
+
+func TestNoOpAuth_InterfaceMethods(t *testing.T) {
+	auth := NoOpAuth{}
+
+	assert.Equal(t, time.Hour, auth.SessionTTL())
+	assert.True(t, auth.IsInitialized())
+
+	username, err := auth.AuthenticateSession("any-session")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, username)
+
+	assert.NoError(t, auth.Setup("user", "pass"))
+
+	sessionID, err := auth.Login("user", "pass", false)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sessionID)
+
+	auth.Logout("any-session")
+
+	ctx := context.Background()
+	tokenID, err := auth.ValidateToken(ctx, "any-hash")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, tokenID)
+
+	assert.NoError(t, auth.UpdateTokenLastUsed(ctx, "any-id"))
+	assert.Empty(t, auth.GetEnv("ANY_KEY"))
+	assert.True(t, auth.IsDisabled())
 }


### PR DESCRIPTION
## Summary

The auth middleware failed **open** (`c.Next()`) when `deps.Auth` was nil, so a wiring bug would silently bypass authentication for every request. Both `requireAuthenticated` and `requireTokenOrSession` now return `503` on nil `rt`/`deps`/`deps.Auth`, matching the `session.go` precedent established in PR #35.

Test pass-through is preserved via a test-only `testkit.NoOpAuth` that satisfies an unexported `authDisabler` capability; the production `*AuthManager` does not implement it, so the bypass is unreachable in production. A regression test (`TestAuthManager_DoesNotSatisfyAuthDisabler`) guards against a future contributor adding `IsDisabled()` to `*AuthManager`.

This implements **Option A** from the issue (mandatory auth / fail-closed) with the test convenience of Option B, but without adding any config-level bypass flag.

## Changes

- **`internal/api/auth/middleware.go`** — both middleware factories now fail-closed (503) on nil `rt`/`deps`/`deps.Auth`; extracted `authBypassed` helper for the `authDisabler` capability check.
- **`internal/api/testkit/helpers.go`** — added `NoOpAuth` (test-only `AuthProvider` + `IsDisabled()`); `GetTestRuntime` auto-wires it when `deps.Auth` is nil, so integration tests reach protected handlers without per-test credentials.
- **`internal/api/auth/auth_disabler_invariant_test.go`** (new) — security-invariant test asserting `*AuthManager` does **not** satisfy `authDisabler` and `NoOpAuth` does.
- **Test updates** — flipped the nil-auth pass-through assertions to expect 503 + handler-not-called; added `requireAuthenticated` nil-auth + NoOpAuth pass-through coverage; wired `NoOpAuth` into the one test helper (`createTestAPIServer`) that bypasses `GetTestRuntime`; fixed three pre-existing broken tests in `http_miss4_test.go` (mismatched names/assertions, missing bodies).

## Why not Option B (explicit `AuthDisabled` config flag)

An explicit `auth_disabled: true` flag would itself be a silent-bypass footgun — a misconfiguration would replicate the exact risk this issue exists to eliminate. The test-only `NoOpAuth` achieves the same test convenience with no config surface and no production reachability.

## Security

- The `authDisabler` interface is unexported and satisfied **only** by `testkit.NoOpAuth` (verified: no production type implements `IsDisabled()`).
- `testkit` is imported only by `*_test.go` files — no production binary pulls in `NoOpAuth`.
- Production wiring (`cmd/javinizer/commands/api/command.go` → `BootstrapAPI`) always constructs and sets `deps.Auth`; a nil `deps.Auth` can only arise from a wiring bug, which now fails loud (503) instead of silently authenticating.

## Validation

- `go test -short ./...` — all packages pass
- `go test -race` on `internal/api/auth`, `testkit`, `server`, `cmd/javinizer/commands/api` — clean
- `go vet ./...`, `go build ./...` — clean
- `golangci-lint run` — 0 issues
- Coverage: `internal/api/auth` = 91.6% (≥ 75% threshold)
- Pre-commit hook passed (gofmt, vet, tests, build, swagger)

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now returns a clear “service unavailable” response when required authentication dependencies are missing, instead of failing or behaving inconsistently.
  * Requests still pass through when authentication is explicitly disabled by the auth provider (including in supported test setups).
* **Tests**
  * Added a default no-op authentication path for test environments when authentication isn’t configured, simplifying local and CI API testing without extra setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->