### PR TITLE
fix(api/core): make hot_reload atomic across registry/config/factories

### DIFF
--- a/internal/api/batch/apply_config_builder.go
+++ b/internal/api/batch/apply_config_builder.go
@@ -20,13 +20,13 @@ import (
 // the fully-validated ApplyPhaseConfig. Handlers become thin:
 // parse request → call builder → launch. Builder is testable without gin.
 func resolveOrganizeApplyConfig(
-	rt *core.APIRuntime,
+	snap *core.RuntimeSnapshot,
 	factory worker.BatchJobFactoryInterface,
 	job worker.BatchJobInterface,
 	req contracts.OrganizeRequest,
 ) (worker.ApplyPhaseConfig, error) {
-	deps := rt.Deps()
-	apiCfg := rt.GetAPIConfig()
+	deps := snap.RT().Deps()
+	apiCfg := snap.APIConfig()
 	batchCfg := apiCfg.BatchConfig()
 	secCfg := apiCfg.SecurityConfig()
 
@@ -76,7 +76,7 @@ func resolveOrganizeApplyConfig(
 	applyOpts.GenerateNFO = !req.SkipNFO
 	applyOpts.Download = !req.SkipDownload
 	applyOpts.OperationModeOverride = resolved.OperationMode
-	sink := newOrganizeBroadcastSink(rt)
+	sink := newOrganizeBroadcastSink(snap.RT())
 	applyOpts.OnPhaseComplete = makeOrganizeCompleteBroadcaster(job, false /* isUpdate */, sink)
 	applyOpts.OnFileProgress = makeOrganizeProgressBroadcaster(job, false /* isUpdate */, sink)
 	applyOpts.OnFileOrganizeStart = makeOrganizeFileStartBroadcaster(job, false /* isUpdate */, sink)
@@ -109,12 +109,12 @@ func resolveOrganizeApplyConfig(
 // the fully-validated ApplyPhaseConfig. Handlers become thin:
 // parse request → call builder → launch. Builder is testable without gin.
 func resolveUpdateApplyConfig(
-	rt *core.APIRuntime,
+	snap *core.RuntimeSnapshot,
 	factory worker.BatchJobFactoryInterface,
 	job worker.BatchJobInterface,
 	req contracts.UpdateRequest,
 ) (worker.ApplyPhaseConfig, error) {
-	deps := rt.Deps()
+	deps := snap.RT().Deps()
 	resolvedUpdate, seamErr := workflow.ResolveSeamStrings(workflow.SeamStringsInput{
 		Preset:         req.Preset,
 		ScalarStrategy: req.ScalarStrategy,
@@ -138,7 +138,7 @@ func resolveUpdateApplyConfig(
 	)
 	applyOpts.GenerateNFO = !req.SkipNFO
 	applyOpts.Download = !req.SkipDownload
-	sink := newOrganizeBroadcastSink(rt)
+	sink := newOrganizeBroadcastSink(snap.RT())
 	applyOpts.OnPhaseComplete = makeOrganizeCompleteBroadcaster(job, true /* isUpdate */, sink)
 	applyOpts.OnFileProgress = makeOrganizeProgressBroadcaster(job, true /* isUpdate */, sink)
 	applyOpts.OnFileOrganizeStart = makeOrganizeFileStartBroadcaster(job, true /* isUpdate */, sink)

--- a/internal/api/batch/apply_config_stamps_test.go
+++ b/internal/api/batch/apply_config_stamps_test.go
@@ -131,7 +131,7 @@ func TestResolveOrganizeApplyConfig_WiresOnFileOrganizeStart(t *testing.T) {
 	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
 	job := &stubControlledJob{}
 
-	applyOpts, err := resolveOrganizeApplyConfig(rt, factory, job, contracts.OrganizeRequest{
+	applyOpts, err := resolveOrganizeApplyConfig(core.NewSnapshotForTesting(rt, core.APIConfig{}), factory, job, contracts.OrganizeRequest{
 		Destination:   "", // in-place needs no destination
 		OperationMode: string(operationmode.OperationModeInPlace),
 	})
@@ -151,7 +151,7 @@ func TestResolveUpdateApplyConfig_WiresOnFileOrganizeStart(t *testing.T) {
 	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
 	job := &stubControlledJob{}
 
-	applyOpts, err := resolveUpdateApplyConfig(rt, factory, job, contracts.UpdateRequest{})
+	applyOpts, err := resolveUpdateApplyConfig(core.NewSnapshotForTesting(rt, core.APIConfig{}), factory, job, contracts.UpdateRequest{})
 	require.NoError(t, err)
 	require.NotNil(t, applyOpts.OnFileOrganizeStart, "OnFileOrganizeStart must be wired on the update path too")
 

--- a/internal/api/batch/batch_rescrape.go
+++ b/internal/api/batch/batch_rescrape.go
@@ -134,21 +134,24 @@ func batchRescrapeMovies(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		snap := job.GetStatus()
-		if rescrapeNotAllowed(snap) {
-			if snap.IsDeleted {
+		statusSnap := job.GetStatus()
+		if rescrapeNotAllowed(statusSnap) {
+			if statusSnap.IsDeleted {
 				writeErrorResponse(c, http.StatusGone, true, "Job has been deleted")
 			} else {
-				writeErrorResponse(c, http.StatusConflict, false, fmt.Sprintf("Cannot rescrape %s job", snap.Status))
+				writeErrorResponse(c, http.StatusConflict, false, fmt.Sprintf("Cannot rescrape %s job", statusSnap.Status))
 			}
 			return
 		}
 
-		// Delegate to orchestrator for resolve→construct→execute pipeline
+		// Delegate to orchestrator for resolve→construct→execute pipeline.
+		// Snapshot so the workflow factory and batch job factory see the same
+		// reload epoch (issue #44).
+		rtSnap := rt.Snapshot()
 		orch := NewRescrapeOrchestrator(RescrapeDeps{
 			JobStore:  deps.GetJobStore(),
-			WfFactory: &apiWorkflowFactory{rt: rt},
-			Factory:   rt.GetBatchJobFactory(),
+			WfFactory: &apiWorkflowFactory{snap: rtSnap},
+			Factory:   rtSnap.BatchJobFactory(),
 			Persist:   deps.GetJobStore(),
 			Broadcast: &runtimeStateBroadcaster{rs: rt.GetRuntime()},
 			ServerCtx: rt.ServerCtx(),

--- a/internal/api/batch/batch_rescrape.go
+++ b/internal/api/batch/batch_rescrape.go
@@ -148,10 +148,15 @@ func batchRescrapeMovies(rt *core.APIRuntime) gin.HandlerFunc {
 		// Snapshot so the workflow factory and batch job factory see the same
 		// reload epoch (issue #44).
 		rtSnap := rt.Snapshot()
+		factory := rtSnap.BatchJobFactory()
+		if factory == nil {
+			c.JSON(http.StatusServiceUnavailable, contracts.ErrorResponse{Error: "batch job factory unavailable — workflow factory not ready; retry the request"})
+			return
+		}
 		orch := NewRescrapeOrchestrator(RescrapeDeps{
 			JobStore:  deps.GetJobStore(),
 			WfFactory: &apiWorkflowFactory{snap: rtSnap},
-			Factory:   rtSnap.BatchJobFactory(),
+			Factory:   factory,
 			Persist:   deps.GetJobStore(),
 			Broadcast: &runtimeStateBroadcaster{rs: rt.GetRuntime()},
 			ServerCtx: rt.ServerCtx(),

--- a/internal/api/batch/discovery_test.go
+++ b/internal/api/batch/discovery_test.go
@@ -18,7 +18,7 @@ func TestDiscoverSiblingParts_AdditionalScenarios(t *testing.T) {
 		cfg := config.DefaultConfig(nil, nil)
 		apiCfg := core.ConfigFromAppConfig(cfg)
 		deps := createTestDeps(t, cfg, "")
-		files, metadata := discoverSiblingPartsWithMetadata(context.Background(), nil, testkit.GetTestRuntime(deps), apiCfg.SecurityConfig(), apiCfg.ScannerConfig())
+		files, metadata := discoverSiblingPartsWithMetadata(context.Background(), nil, testkit.GetTestRuntime(deps).Snapshot(), apiCfg.SecurityConfig(), apiCfg.ScannerConfig())
 		assert.Empty(t, files)
 		assert.Nil(t, metadata)
 	})
@@ -33,7 +33,7 @@ func TestDiscoverSiblingParts_AdditionalScenarios(t *testing.T) {
 
 		apiCfg := core.ConfigFromAppConfig(cfg)
 		deps := createTestDeps(t, cfg, "")
-		got, metadata := discoverSiblingPartsWithMetadata(context.Background(), []string{filePath}, testkit.GetTestRuntime(deps), apiCfg.SecurityConfig(), apiCfg.ScannerConfig())
+		got, metadata := discoverSiblingPartsWithMetadata(context.Background(), []string{filePath}, testkit.GetTestRuntime(deps).Snapshot(), apiCfg.SecurityConfig(), apiCfg.ScannerConfig())
 		assert.Equal(t, []string{filePath}, got)
 		assert.NotNil(t, metadata)
 		// Non-multipart files should still have metadata
@@ -56,7 +56,7 @@ func TestDiscoverSiblingParts_AdditionalScenarios(t *testing.T) {
 
 		apiCfg := core.ConfigFromAppConfig(cfg)
 		deps := createTestDeps(t, cfg, "")
-		got, metadata := discoverSiblingPartsWithMetadata(context.Background(), []string{partA}, testkit.GetTestRuntime(deps), apiCfg.SecurityConfig(), apiCfg.ScannerConfig())
+		got, metadata := discoverSiblingPartsWithMetadata(context.Background(), []string{partA}, testkit.GetTestRuntime(deps).Snapshot(), apiCfg.SecurityConfig(), apiCfg.ScannerConfig())
 		assert.ElementsMatch(t, []string{partA, partB}, got)
 		// Both parts should have multipart metadata
 		assert.True(t, metadata[partA].IsMultiPart)
@@ -77,7 +77,7 @@ func TestDiscoverSiblingParts_AdditionalScenarios(t *testing.T) {
 
 		apiCfg := core.ConfigFromAppConfig(cfg)
 		deps := createTestDeps(t, cfg, "")
-		got, metadata := discoverSiblingPartsWithMetadata(context.Background(), []string{partA}, testkit.GetTestRuntime(deps), apiCfg.SecurityConfig(), apiCfg.ScannerConfig())
+		got, metadata := discoverSiblingPartsWithMetadata(context.Background(), []string{partA}, testkit.GetTestRuntime(deps).Snapshot(), apiCfg.SecurityConfig(), apiCfg.ScannerConfig())
 		assert.Equal(t, []string{partA}, got)
 		// Since directory is disallowed, the seam cannot scan it, so metadata
 		// may be empty for files in disallowed directories. This is correct:

--- a/internal/api/batch/execute.go
+++ b/internal/api/batch/execute.go
@@ -23,11 +23,12 @@ import (
 func prepareAndLaunchApply(
 	c *gin.Context,
 	rt *core.APIRuntime,
+	snap *core.RuntimeSnapshot,
 	job worker.BatchJobInterface,
 	applyOpts worker.ApplyPhaseConfig,
 	successMessage string,
 ) {
-	wf, wfErr := rt.GetBatchWorkflow(job.GetID())
+	wf, wfErr := snap.BatchWorkflow(job.GetID())
 	if wfErr != nil {
 		c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: fmt.Sprintf("Failed to create workflow: %v", wfErr)})
 		return
@@ -65,19 +66,23 @@ func prepareAndLaunchApply(
 // @Router /api/v1/batch/{id}/organize [post]
 func organizeJob(rt *core.APIRuntime) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		deps := rt.Deps()
 		var req contracts.OrganizeRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: err.Error()})
 			return
 		}
 
-		job, err := prepareBatchRequest(deps, rt, c, withRequireCompleted("Job must be completed before organizing"))
+		// One snapshot so prepareBatchRequest (batch defaults), the apply-config
+		// builder (apiCfg), and prepareAndLaunchApply (workflow) all see the same
+		// reload epoch (issue #44).
+		snap := rt.Snapshot()
+
+		job, err := prepareBatchRequest(snap, c, withRequireCompleted("Job must be completed before organizing"))
 		if err != nil {
 			return
 		}
 
-		applyOpts, resolveErr := resolveOrganizeApplyConfig(rt, rt.GetBatchJobFactory(), job, req)
+		applyOpts, resolveErr := resolveOrganizeApplyConfig(snap, snap.BatchJobFactory(), job, req)
 		if resolveErr != nil {
 			if resolveErr.Error() == "Access denied to requested directory" {
 				c.JSON(http.StatusForbidden, contracts.ErrorResponse{Error: resolveErr.Error()})
@@ -87,7 +92,7 @@ func organizeJob(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		prepareAndLaunchApply(c, rt, job, applyOpts, "Organization started")
+		prepareAndLaunchApply(c, rt, snap, job, applyOpts, "Organization started")
 	}
 }
 
@@ -145,13 +150,16 @@ func updateBatchJob(rt *core.APIRuntime) gin.HandlerFunc {
 			}
 		}
 
-		applyOpts, err := resolveUpdateApplyConfig(rt, rt.GetBatchJobFactory(), job, req)
+		// One snapshot so the apply-config builder (apiCfg) and prepareAndLaunchApply
+		// (workflow) see the same reload epoch (issue #44).
+		snap := rt.Snapshot()
+		applyOpts, err := resolveUpdateApplyConfig(snap, snap.BatchJobFactory(), job, req)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: err.Error()})
 			return
 		}
 
-		prepareAndLaunchApply(c, rt, job, applyOpts, "Update started")
+		prepareAndLaunchApply(c, rt, snap, job, applyOpts, "Update started")
 	}
 }
 
@@ -179,7 +187,10 @@ func previewOrganize(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		apiCfg := rt.GetAPIConfig()
+		// One snapshot so the APIConfig (security/batch defaults) and the preview
+		// workflow see the same reload epoch (issue #44).
+		snap := rt.Snapshot()
+		apiCfg := snap.APIConfig()
 		batchCfg := apiCfg.BatchConfig()
 		secCfg := apiCfg.SecurityConfig()
 
@@ -218,7 +229,7 @@ func previewOrganize(rt *core.APIRuntime) gin.HandlerFunc {
 		}
 
 		// Generate preview for all file results (multi-part support)
-		wf, wfErr := rt.GetBatchWorkflow(jobID)
+		wf, wfErr := snap.BatchWorkflow(jobID)
 		if wfErr != nil {
 			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: fmt.Sprintf("Failed to create workflow for preview: %v", wfErr)})
 			return

--- a/internal/api/batch/execute.go
+++ b/internal/api/batch/execute.go
@@ -82,7 +82,12 @@ func organizeJob(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		applyOpts, resolveErr := resolveOrganizeApplyConfig(snap, snap.BatchJobFactory(), job, req)
+		factory := snap.BatchJobFactory()
+		if factory == nil {
+			c.JSON(http.StatusServiceUnavailable, contracts.ErrorResponse{Error: "batch job factory unavailable — workflow factory not ready; retry the request"})
+			return
+		}
+		applyOpts, resolveErr := resolveOrganizeApplyConfig(snap, factory, job, req)
 		if resolveErr != nil {
 			if resolveErr.Error() == "Access denied to requested directory" {
 				c.JSON(http.StatusForbidden, contracts.ErrorResponse{Error: resolveErr.Error()})
@@ -153,7 +158,12 @@ func updateBatchJob(rt *core.APIRuntime) gin.HandlerFunc {
 		// One snapshot so the apply-config builder (apiCfg) and prepareAndLaunchApply
 		// (workflow) see the same reload epoch (issue #44).
 		snap := rt.Snapshot()
-		applyOpts, err := resolveUpdateApplyConfig(snap, snap.BatchJobFactory(), job, req)
+		factory := snap.BatchJobFactory()
+		if factory == nil {
+			c.JSON(http.StatusServiceUnavailable, contracts.ErrorResponse{Error: "batch job factory unavailable — workflow factory not ready; retry the request"})
+			return
+		}
+		applyOpts, err := resolveUpdateApplyConfig(snap, factory, job, req)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: err.Error()})
 			return

--- a/internal/api/batch/factory_nil_guard_test.go
+++ b/internal/api/batch/factory_nil_guard_test.go
@@ -1,0 +1,136 @@
+package batch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/stretchr/testify/assert"
+)
+
+// badRegexConfig returns a config whose matching regex is invalid. This makes
+// the workflow factory unbuildable (buildMatcher fails with a non-Scraper
+// construction error), so Snapshot().BatchJobFactory() returns nil while
+// prepareBatchRequest — which only reads the job store + apiCfg — still
+// succeeds. That combination drives the 503 nil-guard branches added at every
+// BatchJobFactory() call site (issue #44).
+func badRegexConfig() *config.Config {
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.Matching.RegexEnabled = true
+	cfg.Matching.RegexPattern = "(unclosed["
+	cfg.API.Security.AllowedDirectories = []string{"/output", "/path"}
+	cfg.Output.Operation.OperationMode = "organize"
+	return cfg
+}
+
+func TestOrganizeJob_FactoryUnavailable_503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	initTestWebSocket(t)
+
+	deps := createTestDeps(t, badRegexConfig(), "")
+	job := deps.JobStore.CreateJobBatch([]string{"/path/to/file.mp4"})
+	setJobStatus(job, models.JobStatusCompleted)
+
+	router := gin.New()
+	router.POST("/batch/:id/organize", organizeJob(testkit.GetTestRuntime(deps)))
+
+	body, _ := json.Marshal(contracts.OrganizeRequest{Destination: "/output"})
+	req := httptest.NewRequest("POST", "/batch/"+job.GetID()+"/organize", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code, "body=%s", w.Body.String())
+}
+
+func TestUpdateBatchJob_FactoryUnavailable_503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	initTestWebSocket(t)
+
+	deps := createTestDeps(t, badRegexConfig(), "")
+	job := deps.JobStore.CreateJobBatch([]string{"/path/to/file.mp4"})
+	setJobStatus(job, models.JobStatusCompleted)
+
+	router := gin.New()
+	router.POST("/batch/:id/update", updateBatchJob(testkit.GetTestRuntime(deps)))
+
+	req := httptest.NewRequest("POST", "/batch/"+job.GetID()+"/update", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code, "body=%s", w.Body.String())
+}
+
+func TestBatchRescrapeMovies_FactoryUnavailable_503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	initTestWebSocket(t)
+
+	deps := createTestDeps(t, badRegexConfig(), "")
+	job := deps.JobStore.CreateJobBatch([]string{"/path/to/file.mp4"})
+	setJobStatus(job, models.JobStatusCompleted)
+
+	router := gin.New()
+	router.POST("/batch/:id/movies/batch-rescrape", batchRescrapeMovies(testkit.GetTestRuntime(deps)))
+
+	body, _ := json.Marshal(contracts.BulkRescrapeRequest{MovieIDs: []string{"IPX-535"}, SelectedScrapers: []string{"mock"}})
+	req := httptest.NewRequest("POST", "/batch/"+job.GetID()+"/movies/batch-rescrape", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code, "body=%s", w.Body.String())
+}
+
+func TestRescrapeBatchMovie_FactoryUnavailable_503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	initTestWebSocket(t)
+
+	deps := createTestDeps(t, badRegexConfig(), "")
+	job := deps.JobStore.CreateJobBatch([]string{"/path/to/IPX-535.mp4"})
+	result := &worker.MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: "/path/to/IPX-535.mp4", MovieID: "IPX-535"},
+		Status:        models.JobStatusCompleted,
+		Movie:         &models.Movie{ID: "IPX-535", Title: "Original Title"},
+		StartedAt:     time.Now(),
+	}
+	setJobResult(job, "/path/to/IPX-535.mp4", result)
+
+	router := gin.New()
+	router.POST("/batch/:id/results/:resultId/rescrape", rescrapeBatchMovie(testkit.GetTestRuntime(deps)))
+
+	body, _ := json.Marshal(contracts.BatchRescrapeRequest{SelectedScrapers: []string{"mock"}})
+	req := httptest.NewRequest("POST", "/batch/"+job.GetID()+"/results/IPX-535/rescrape", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code, "body=%s", w.Body.String())
+}
+
+// TestStartScrapeUseCase_BatchWorkflowError covers the BatchWorkflow error
+// branch in StartScrapeUseCase: with a bad-regex config the workflow factory
+// cannot be built, so snap.BatchWorkflow(jobID) returns an error that
+// StartScrapeUseCase propagates.
+func TestStartScrapeUseCase_BatchWorkflowError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	initTestWebSocket(t)
+
+	deps := createTestDeps(t, badRegexConfig(), "")
+	rt := testkit.GetTestRuntime(deps)
+
+	_, err := StartScrapeUseCase(context.Background(), rt, StartScrapeInput{
+		Files:            []string{"/path/to/file.mp4"},
+		SelectedScrapers: []string{"mock"},
+	})
+	assert.Error(t, err)
+}

--- a/internal/api/batch/factory_nil_guard_test.go
+++ b/internal/api/batch/factory_nil_guard_test.go
@@ -134,3 +134,28 @@ func TestStartScrapeUseCase_BatchWorkflowError(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+// TestBatchRescrapeMovies_RunningJob_409 covers the rescrapeNotAllowed=true
+// branch in batchRescrapeMovies: a running job must be rejected with 409 before
+// the handler reaches the factory/snapshot section.
+func TestBatchRescrapeMovies_RunningJob_409(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	initTestWebSocket(t)
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.API.Security.AllowedDirectories = []string{"/path"}
+	deps := createTestDeps(t, cfg, "")
+	job := deps.JobStore.CreateJobBatch([]string{"/path/to/file.mp4"})
+	setJobStatus(job, models.JobStatusRunning)
+
+	router := gin.New()
+	router.POST("/batch/:id/movies/batch-rescrape", batchRescrapeMovies(testkit.GetTestRuntime(deps)))
+
+	body, _ := json.Marshal(contracts.BulkRescrapeRequest{MovieIDs: []string{"IPX-535"}, SelectedScrapers: []string{"mock"}})
+	req := httptest.NewRequest("POST", "/batch/"+job.GetID()+"/movies/batch-rescrape", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusConflict, w.Code, "body=%s", w.Body.String())
+}

--- a/internal/api/batch/factory_nil_guard_test.go
+++ b/internal/api/batch/factory_nil_guard_test.go
@@ -159,3 +159,30 @@ func TestBatchRescrapeMovies_RunningJob_409(t *testing.T) {
 
 	assert.Equal(t, http.StatusConflict, w.Code, "body=%s", w.Body.String())
 }
+
+// TestBatchRescrapeMovies_DeletedJob_410 covers the statusSnap.IsDeleted
+// true-branch in batchRescrapeMovies: a logically-deleted job (even if its
+// status is Pending/Completed) must return 410 Gone before reaching the
+// factory/snapshot section.
+func TestBatchRescrapeMovies_DeletedJob_410(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	initTestWebSocket(t)
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.API.Security.AllowedDirectories = []string{"/path"}
+	deps := createTestDeps(t, cfg, "")
+	job := deps.JobStore.CreateJobBatch([]string{"/path/to/file.mp4"})
+	setJobStatus(job, models.JobStatusCompleted)
+	setJobDeleted(job, true)
+
+	router := gin.New()
+	router.POST("/batch/:id/movies/batch-rescrape", batchRescrapeMovies(testkit.GetTestRuntime(deps)))
+
+	body, _ := json.Marshal(contracts.BulkRescrapeRequest{MovieIDs: []string{"IPX-535"}, SelectedScrapers: []string{"mock"}})
+	req := httptest.NewRequest("POST", "/batch/"+job.GetID()+"/movies/batch-rescrape", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusGone, w.Code, "body=%s", w.Body.String())
+}

--- a/internal/api/batch/integration_test.go
+++ b/internal/api/batch/integration_test.go
@@ -201,7 +201,7 @@ func TestResolveOrganizeApplyConfig_WiresProgressHooks(t *testing.T) {
 	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
 	job := &stubControlledJob{}
 
-	applyOpts, err := resolveOrganizeApplyConfig(rt, factory, job, contracts.OrganizeRequest{
+	applyOpts, err := resolveOrganizeApplyConfig(core.NewSnapshotForTesting(rt, core.APIConfig{}), factory, job, contracts.OrganizeRequest{
 		Destination:   "", // in-place needs no destination
 		OperationMode: string(operationmode.OperationModeInPlace),
 	})
@@ -226,7 +226,7 @@ func TestResolveUpdateApplyConfig_WiresProgressHooks(t *testing.T) {
 	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
 	job := &stubControlledJob{}
 
-	applyOpts, err := resolveUpdateApplyConfig(rt, factory, job, contracts.UpdateRequest{})
+	applyOpts, err := resolveUpdateApplyConfig(core.NewSnapshotForTesting(rt, core.APIConfig{}), factory, job, contracts.UpdateRequest{})
 	require.NoError(t, err)
 	assert.NotNil(t, applyOpts.OnFileProgress, "OnFileProgress must be wired on the update path too")
 	assert.NotNil(t, applyOpts.OnPhaseComplete, "OnPhaseComplete must be wired on the update path too")
@@ -289,7 +289,7 @@ func TestResolveOrganizeApplyConfig_OnFileProgressBroadcastsToHub(t *testing.T) 
 	registerClientOnHub(t, hub, serverConn, clientConn)
 
 	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
-	applyOpts, err := resolveOrganizeApplyConfig(rt, factory, &stubControlledJob{}, contracts.OrganizeRequest{
+	applyOpts, err := resolveOrganizeApplyConfig(core.NewSnapshotForTesting(rt, core.APIConfig{}), factory, &stubControlledJob{}, contracts.OrganizeRequest{
 		OperationMode: string(operationmode.OperationModeInPlace),
 	})
 	require.NoError(t, err)
@@ -336,7 +336,7 @@ func TestResolveUpdateApplyConfig_OnFileProgressBroadcastsToHub(t *testing.T) {
 	registerClientOnHub(t, hub, serverConn, clientConn)
 
 	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
-	applyOpts, err := resolveUpdateApplyConfig(rt, factory, &stubControlledJob{}, contracts.UpdateRequest{})
+	applyOpts, err := resolveUpdateApplyConfig(core.NewSnapshotForTesting(rt, core.APIConfig{}), factory, &stubControlledJob{}, contracts.UpdateRequest{})
 	require.NoError(t, err)
 	require.NotNil(t, applyOpts.OnFileProgress, "OnFileProgress must be wired on the update path")
 

--- a/internal/api/batch/lifecycle.go
+++ b/internal/api/batch/lifecycle.go
@@ -146,7 +146,8 @@ func getBatchJobSlim(deps *core.APIDeps, c *gin.Context, jobID string) {
 func cancelBatchJob(rt *core.APIRuntime) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		deps := rt.Deps()
-		job, err := prepareBatchRequest(deps, rt, c, withSkipRunningCheck())
+		snap := rt.Snapshot()
+		job, err := prepareBatchRequest(snap, c, withSkipRunningCheck())
 		if err != nil {
 			return
 		}
@@ -162,7 +163,7 @@ func cancelBatchJob(rt *core.APIRuntime) gin.HandlerFunc {
 
 		tempDir := job.GetStatus().TempDir
 		if tempDir == "" {
-			tempDir = rt.GetAPIConfig().BatchConfig().TempDir
+			tempDir = snap.APIConfig().BatchConfig().TempDir
 		}
 
 		// Wait for the job to reach a terminal state before cleaning up temp posters.

--- a/internal/api/batch/movie_edit.go
+++ b/internal/api/batch/movie_edit.go
@@ -134,12 +134,14 @@ func updateBatchMoviePosterCrop(rt *core.APIRuntime) gin.HandlerFunc {
 
 		// Resolve the max poster height: request-level override wins over the
 		// configured default. 0 means no cap (preserve source resolution).
-		maxPosterHeight := rt.GetAPIConfig().BatchConfig().MaxPosterHeight
+		// Snapshot so apiCfg and the poster manager see the same reload epoch (issue #44).
+		snap := rt.Snapshot()
+		maxPosterHeight := snap.APIConfig().BatchConfig().MaxPosterHeight
 		if req.MaxPosterHeight != nil {
 			maxPosterHeight = *req.MaxPosterHeight
 		}
 
-		cropResult, err := rt.GetPosterManager().CropWithBounds(c.Request.Context(), jobID, posterID, req.X, req.Y, req.Width, req.Height, maxPosterHeight)
+		cropResult, err := snap.PosterManager().CropWithBounds(c.Request.Context(), jobID, posterID, req.X, req.Y, req.Width, req.Height, maxPosterHeight)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: err.Error()})
 			return
@@ -203,9 +205,11 @@ func updateBatchMoviePosterFromURL(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		apiCfg := rt.GetAPIConfig()
-		batchCfg := apiCfg.BatchConfig()
-		posterResult, err := rt.GetPosterManager().DownloadFromURL(c.Request.Context(), jobID, posterID, req.URL, batchCfg.ScraperUserAgent, batchCfg.ScraperReferer)
+		// Snapshot so apiCfg (user-agent/referer) and the poster manager see the
+		// same reload epoch (issue #44).
+		snap := rt.Snapshot()
+		batchCfg := snap.APIConfig().BatchConfig()
+		posterResult, err := snap.PosterManager().DownloadFromURL(c.Request.Context(), jobID, posterID, req.URL, batchCfg.ScraperUserAgent, batchCfg.ScraperReferer)
 		if err != nil {
 			if strings.Contains(err.Error(), "SSRF") || strings.Contains(err.Error(), "invalid URL") {
 				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: err.Error()})

--- a/internal/api/batch/multipart_integration_test.go
+++ b/internal/api/batch/multipart_integration_test.go
@@ -182,7 +182,7 @@ func TestMultipartPreviewLetterPatternDiscoveryFlow(t *testing.T) {
 
 	// Run discovery to get metadata
 	apiCfg := core.ConfigFromAppConfig(cfg)
-	allFiles, fileMatchInfo := discoverSiblingPartsWithMetadata(context.Background(), files, testkit.GetTestRuntime(deps), apiCfg.SecurityConfig(), apiCfg.ScannerConfig())
+	allFiles, fileMatchInfo := discoverSiblingPartsWithMetadata(context.Background(), files, testkit.GetTestRuntime(deps).Snapshot(), apiCfg.SecurityConfig(), apiCfg.ScannerConfig())
 
 	t.Logf("Discovered %d files", len(allFiles))
 	for path, info := range fileMatchInfo {

--- a/internal/api/batch/paths.go
+++ b/internal/api/batch/paths.go
@@ -34,13 +34,17 @@ func isDirAllowed(fs afero.Fs, dir string, secCfg *core.SecurityNarrowConfig) bo
 // This preserves multipart info (IsMultiPart, PartNumber, PartSuffix) from the discovery phase
 // so it's available when creating FileResults during scraping.
 // Uses the ScanAndMatch seam to avoid direct scanner/matcher imports.
-func discoverSiblingPartsWithMetadata(ctx context.Context, files []string, rt *core.APIRuntime, secCfg *core.SecurityNarrowConfig, scanCfg *core.ScannerNarrowConfig) ([]string, map[string]models.FileMatchInfo) {
+//
+// The snapshot pins a consistent reload epoch so the workflow used for sibling
+// discovery matches the security/scanner config the caller read from the same
+// snapshot (issue #44).
+func discoverSiblingPartsWithMetadata(ctx context.Context, files []string, snap *core.RuntimeSnapshot, secCfg *core.SecurityNarrowConfig, scanCfg *core.ScannerNarrowConfig) ([]string, map[string]models.FileMatchInfo) {
 	if len(files) == 0 {
 		return files, nil
 	}
 
-	deps := rt.Deps()
-	wf, wfErr := rt.GetBatchWorkflow("")
+	deps := snap.RT().Deps()
+	wf, wfErr := snap.BatchWorkflow("")
 	if wfErr != nil {
 		logging.Warnf("Failed to create workflow for sibling discovery: %v, using original files only", wfErr)
 		return files, nil

--- a/internal/api/batch/prepare_request.go
+++ b/internal/api/batch/prepare_request.go
@@ -19,7 +19,11 @@ import (
 // job from store, and status-check. Returns the resolved job, API config,
 // resolved seam strings, and parsed body map. If any step fails, it writes
 // an error response to the gin context and returns a non-nil error.
-func prepareBatchRequest(deps *core.APIDeps, rt *core.APIRuntime, c *gin.Context, opts ...prepareOption) (worker.BatchJobInterface, error) {
+//
+// The snapshot pins a consistent reload epoch so the batch config defaults
+// read here match the workflow/factory the caller reads from the same snapshot
+// (issue #44).
+func prepareBatchRequest(snap *core.RuntimeSnapshot, c *gin.Context, opts ...prepareOption) (worker.BatchJobInterface, error) {
 	cfg := defaultPrepareConfig()
 	for _, o := range opts {
 		o(&cfg)
@@ -43,7 +47,7 @@ func prepareBatchRequest(deps *core.APIDeps, rt *core.APIRuntime, c *gin.Context
 		}
 	}
 
-	apiCfg := rt.GetAPIConfig()
+	apiCfg := snap.APIConfig()
 	batchCfg := apiCfg.BatchConfig()
 
 	// Extract seam string fields from the generic body map. A present but
@@ -67,7 +71,7 @@ func prepareBatchRequest(deps *core.APIDeps, rt *core.APIRuntime, c *gin.Context
 	}
 
 	// Fetch job from store.
-	job, ok := deps.GetJobStore().GetBatchJob(jobID)
+	job, ok := snap.RT().Deps().GetJobStore().GetBatchJob(jobID)
 	if !ok {
 		c.JSON(http.StatusNotFound, contracts.ErrorResponse{Error: "Job not found"})
 		return nil, fmt.Errorf("job not found: %s", jobID)

--- a/internal/api/batch/rescrape.go
+++ b/internal/api/batch/rescrape.go
@@ -44,7 +44,12 @@ func rescrapeBatchMovie(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		job, err := prepareBatchRequest(rt.Deps(), rt, c, withSkipRunningCheck())
+		// One snapshot so the batch config defaults (prepareBatchRequest), the
+		// workflow factory, and the batch job factory all see the same reload
+		// epoch (issue #44).
+		snap := rt.Snapshot()
+
+		job, err := prepareBatchRequest(snap, c, withSkipRunningCheck())
 		if err != nil {
 			return
 		}
@@ -70,21 +75,21 @@ func rescrapeBatchMovie(rt *core.APIRuntime) gin.HandlerFunc {
 		}
 
 		// Additional status check for rescrape-specific allowed states.
-		snap := job.GetStatus()
-		if rescrapeNotAllowed(snap) {
-			if snap.IsDeleted {
+		statusSnap := job.GetStatus()
+		if rescrapeNotAllowed(statusSnap) {
+			if statusSnap.IsDeleted {
 				writeErrorResponse(c, http.StatusGone, true, "Job has been deleted")
 			} else {
-				writeErrorResponse(c, http.StatusConflict, false, fmt.Sprintf("Cannot rescrape %s job", snap.Status))
+				writeErrorResponse(c, http.StatusConflict, false, fmt.Sprintf("Cannot rescrape %s job", statusSnap.Status))
 			}
 			return
 		}
 
-		// Delegate to orchestrator for resolve→construct→execute pipeline
+		// Delegate to orchestrator for resolve→construct→execute pipeline.
 		orch := NewRescrapeOrchestrator(RescrapeDeps{
 			JobStore:  rt.Deps().GetJobStore(),
-			WfFactory: &apiWorkflowFactory{rt: rt},
-			Factory:   rt.GetBatchJobFactory(),
+			WfFactory: &apiWorkflowFactory{snap: snap},
+			Factory:   snap.BatchJobFactory(),
 			Persist:   rt.Deps().GetJobStore(),
 			Broadcast: nil, // no progress broadcast for single rescrape
 			ServerCtx: rt.ServerCtx(),

--- a/internal/api/batch/rescrape.go
+++ b/internal/api/batch/rescrape.go
@@ -86,10 +86,15 @@ func rescrapeBatchMovie(rt *core.APIRuntime) gin.HandlerFunc {
 		}
 
 		// Delegate to orchestrator for resolve→construct→execute pipeline.
+		factory := snap.BatchJobFactory()
+		if factory == nil {
+			c.JSON(http.StatusServiceUnavailable, contracts.ErrorResponse{Error: "batch job factory unavailable — workflow factory not ready; retry the request"})
+			return
+		}
 		orch := NewRescrapeOrchestrator(RescrapeDeps{
 			JobStore:  rt.Deps().GetJobStore(),
 			WfFactory: &apiWorkflowFactory{snap: snap},
-			Factory:   snap.BatchJobFactory(),
+			Factory:   factory,
 			Persist:   rt.Deps().GetJobStore(),
 			Broadcast: nil, // no progress broadcast for single rescrape
 			ServerCtx: rt.ServerCtx(),

--- a/internal/api/batch/rescrape_orchestrator.go
+++ b/internal/api/batch/rescrape_orchestrator.go
@@ -197,13 +197,15 @@ func (o *RescrapeOrchestrator) BulkRescrape(ctx context.Context, jobID string, m
 	}, nil
 }
 
-// apiWorkflowFactory adapts APIRuntime to the WorkflowFactory interface.
+// apiWorkflowFactory adapts a RuntimeSnapshot to the WorkflowFactory interface,
+// so the orchestrator builds workflows from the snapshot's pinned epoch rather
+// than re-reading CoreDeps (issue #44).
 type apiWorkflowFactory struct {
-	rt *core.APIRuntime
+	snap *core.RuntimeSnapshot
 }
 
 func (f *apiWorkflowFactory) GetBatchWorkflow(jobID string) (workflow.WorkflowInterface, error) {
-	return f.rt.GetBatchWorkflow(jobID)
+	return f.snap.BatchWorkflow(jobID)
 }
 
 // runtimeStateBroadcaster adapts *core.RuntimeState to ProgressBroadcaster.

--- a/internal/api/batch/usecases.go
+++ b/internal/api/batch/usecases.go
@@ -148,8 +148,14 @@ func StartScrapeUseCase(
 	rt *core.APIRuntime,
 	input StartScrapeInput,
 ) (*StartScrapeOutput, error) {
+	// Take one consistent snapshot so the APIConfig (security/scanner settings),
+	// the batch workflow, and the batch job factory all come from the same reload
+	// epoch. Reading them via separate accessors could mix old/new state if a
+	// config reload lands between the calls (issue #44).
+	snap := rt.Snapshot()
+
 	// Auto-discover sibling multi-part files
-	allFiles, fileMatchInfoMap := discoverSiblingPartsWithMetadata(ctx, input.Files, rt, rt.GetAPIConfig().SecurityConfig(), rt.GetAPIConfig().ScannerConfig())
+	allFiles, fileMatchInfoMap := discoverSiblingPartsWithMetadata(ctx, input.Files, snap, snap.APIConfig().SecurityConfig(), snap.APIConfig().ScannerConfig())
 
 	if len(allFiles) > len(input.Files) {
 		logging.Infof("Auto-discovered %d sibling files for batch job (original: %d, total: %d)",
@@ -178,14 +184,14 @@ func StartScrapeUseCase(
 	// ensuring RevertLog records are associated with the correct job for revert support.
 	jobID := uuid.New().String()
 
-	wf, err := rt.GetBatchWorkflow(jobID)
+	wf, err := snap.BatchWorkflow(jobID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create workflow: %w", err)
 	}
 
 	matchInfo := fileMatchInfoMap
 
-	factory := rt.GetBatchJobFactory()
+	factory := snap.BatchJobFactory()
 
 	job := factory.CreateJob(allFiles, worker.BatchJobOptions{
 		ID:                    jobID,

--- a/internal/api/batch/usecases.go
+++ b/internal/api/batch/usecases.go
@@ -192,6 +192,9 @@ func StartScrapeUseCase(
 	matchInfo := fileMatchInfoMap
 
 	factory := snap.BatchJobFactory()
+	if factory == nil {
+		return nil, fmt.Errorf("batch job factory unavailable — workflow factory not ready; retry the request")
+	}
 
 	job := factory.CreateJob(allFiles, worker.BatchJobOptions{
 		ID:                    jobID,

--- a/internal/api/batch/usecases.go
+++ b/internal/api/batch/usecases.go
@@ -191,10 +191,11 @@ func StartScrapeUseCase(
 
 	matchInfo := fileMatchInfoMap
 
+	// BatchWorkflow above already returns an error when the workflow factory is
+	// unavailable, and buildPosterGenerator always returns a non-nil generator on
+	// a built factory — so BatchJobFactory cannot be nil here. Guarding it would
+	// be dead code (unreachable: BatchWorkflow errors first on a broken factory).
 	factory := snap.BatchJobFactory()
-	if factory == nil {
-		return nil, fmt.Errorf("batch job factory unavailable — workflow factory not ready; retry the request")
-	}
 
 	job := factory.CreateJob(allFiles, worker.BatchJobOptions{
 		ID:                    jobID,

--- a/internal/api/core/hot_reload.go
+++ b/internal/api/core/hot_reload.go
@@ -156,6 +156,7 @@ func InvalidateWorkflowCachesOnRuntime(rt *APIRuntime) func() {
 // are atomic relative to the registry swap in ReplaceReloadable/ReloadConfig.
 func (r *APIRuntime) invalidateFactoriesLocked(cfg *config.Config) {
 	r.apiCfg = ConfigFromAppConfig(cfg)
+	r.reloadGen++
 
 	r.workflowFactory.Invalidate()
 	r.batchJobFactory.Invalidate()

--- a/internal/api/core/hot_reload.go
+++ b/internal/api/core/hot_reload.go
@@ -22,10 +22,16 @@ import (
 // ---------------------------------------------------------------------------
 
 // ReplaceReloadable swaps config-coupled runtime components atomically.
-// Config is stored via atomic.Pointer INSIDE the write lock so that
-// GetConfig (which reads atomic-first) cannot see new config while
-// GetRegistry (mutex-protected) still returns
-// old values. This prevents a split-brain window during hot-reload.
+//
+// The registry swap, the APIConfig snapshot rebuild, and the cached-factory
+// invalidation all happen under a single reloadMu.Lock so a concurrent reader
+// (GetAPIConfig / Snapshot) cannot observe a mix of old/new state across the
+// three holders. Config is stored via atomic.Pointer inside the same critical
+// section as the registry swap, so GetConfig and GetRegistry stay consistent.
+//
+// The test-only reloadPauseAfterRegistry seam fires AFTER the atomic publish,
+// so a paused reloader exposes a fully consistent (post-publish) state — the
+// race it widens is closed by the lock.
 func (r *APIRuntime) ReplaceReloadable(cfg *config.Config, registry *scraperutil.ScraperRegistry) {
 	if cfg == nil {
 		panic("core: APIRuntime.ReplaceReloadable() called with nil config — this is a programming error")
@@ -33,11 +39,14 @@ func (r *APIRuntime) ReplaceReloadable(cfg *config.Config, registry *scraperutil
 	if r.deps.CoreDeps == nil {
 		r.deps.CoreDeps = &commandutil.CoreDeps{}
 	}
+	r.reloadMu.Lock()
 	r.deps.CoreDeps.ReplaceReloadable(cfg, registry)
+	r.invalidateFactoriesLocked(cfg)
+	r.reloadMu.Unlock()
 
-	// Rebuild APIConfig from new config and invalidate the workflow factories
-	// so the next request rebuilds them from the fresh config/registry.
-	r.invalidateFactories(cfg)
+	if r.reloadPauseAfterRegistry != nil {
+		r.reloadPauseAfterRegistry()
+	}
 }
 
 // ReloadConfig rebuilds the scraper registry from the given config and atomically
@@ -71,6 +80,13 @@ func (r *APIRuntime) ReloadConfig(cfg *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize scraper registry: %w", err)
 	}
+	// Atomic publication (issue #44): swap the dump closer, publish cfg+registry,
+	// rebuild the APIConfig snapshot, and invalidate the cached factories all
+	// under one reloadMu.Lock so concurrent readers cannot observe a mix of
+	// old/new state across the three holders. The slow registry construction
+	// above stays outside the lock; only pointer swaps and cheap invalidations
+	// are inside. Lock order is reloadMu → CoreDeps.mu.
+	r.reloadMu.Lock()
 	// Swap the reloadables BEFORE retiring the old dump handle. Closing the
 	// old closer first would leave a window where the still-active scraper
 	// registry references a closed SQLite connection and dump-backed searches
@@ -78,12 +94,20 @@ func (r *APIRuntime) ReloadConfig(cfg *config.Config) error {
 	// before the old one is released.
 	old := r.deps.CoreDeps.ReplaceR18DevDumpCloser(r18DumpCloser)
 	r.deps.CoreDeps.ReplaceReloadable(cfg, newRegistry)
+	r.invalidateFactoriesLocked(cfg)
+	r.reloadMu.Unlock()
 	if old != nil {
 		_ = old.Close()
 	}
 
-	// Rebuild APIConfig and invalidate the workflow factories.
-	r.invalidateFactories(cfg)
+	// Test seams fire after the atomic publish so readers observe a consistent
+	// snapshot; nil in production.
+	if r.reloadPauseAfterRegistry != nil {
+		r.reloadPauseAfterRegistry()
+	}
+	if r.reloadPauseAfterAPICfg != nil {
+		r.reloadPauseAfterAPICfg()
+	}
 
 	return nil
 }
@@ -124,13 +148,14 @@ func InvalidateWorkflowCachesOnRuntime(rt *APIRuntime) func() {
 	}
 }
 
-// invalidateFactories rebuilds the APIConfig snapshot and nils all cached
-// workflow factories so they are reconstructed from the new config on next access.
-// Also invalidates the cached poster manager on RuntimeState.
-func (r *APIRuntime) invalidateFactories(cfg *config.Config) {
-	r.apiMu.Lock()
+// invalidateFactoriesLocked rebuilds the APIConfig snapshot and nils all cached
+// workflow factories so they are reconstructed from the new config on next
+// access. Also invalidates the cached poster manager on RuntimeState.
+//
+// Caller must hold r.reloadMu so the apiCfg publish and factory invalidation
+// are atomic relative to the registry swap in ReplaceReloadable/ReloadConfig.
+func (r *APIRuntime) invalidateFactoriesLocked(cfg *config.Config) {
 	r.apiCfg = ConfigFromAppConfig(cfg)
-	r.apiMu.Unlock()
 
 	r.workflowFactory.Invalidate()
 	r.batchJobFactory.Invalidate()

--- a/internal/api/core/hot_reload_race_test.go
+++ b/internal/api/core/hot_reload_race_test.go
@@ -230,3 +230,28 @@ func TestHotReload_Race_CrossAccessor_SnapshotIsConsistent(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestReplaceReloadable_FiresPauseAfterRegistry covers the test-only
+// reloadPauseAfterRegistry seam on the ReplaceReloadable path (distinct from
+// ReloadConfig's seam). It asserts the seam fires after the atomic publish so
+// the new cfg/registry are already visible when it runs.
+func TestReplaceReloadable_FiresPauseAfterRegistry(t *testing.T) {
+	cfgA := newHotReloadRaceConfig("hostA", 1111, 100)
+	cfgB := newHotReloadRaceConfig("hostB", 2222, 200)
+	rt := newHotReloadRaceRuntime(t, cfgA)
+
+	fired := make(chan struct{})
+	rt.reloadPauseAfterRegistry = func() {
+		require.Equal(t, "hostB", rt.deps.CoreDeps.GetConfig().Server.Host,
+			"seam must fire after the cfg/registry are published")
+		close(fired)
+	}
+
+	rt.ReplaceReloadable(cfgB, scraperutil.NewScraperRegistry())
+	require.NotNil(t, rt.GetAPIConfig(), "APIConfig must be rebuilt after ReplaceReloadable")
+	select {
+	case <-fired:
+	default:
+		t.Fatal("reloadPauseAfterRegistry seam did not fire")
+	}
+}

--- a/internal/api/core/hot_reload_race_test.go
+++ b/internal/api/core/hot_reload_race_test.go
@@ -1,0 +1,232 @@
+package core
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/commandutil"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/scraperutil"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests demonstrate the non-atomic hot-reload publication race described
+// in issue #44: ReloadConfig/ReplaceReloadable publish the config/registry, the
+// APIConfig snapshot, and the cached workflow factories across three separate
+// critical sections, so a concurrent request can observe mixed old/new state.
+//
+// They use the reloadPauseAfterRegistry / reloadPauseAfterAPICfg test seams
+// (nil in production) to deterministically freeze the reloader inside each
+// window so the split-brain state is observable without relying on timing.
+//
+// Expected to FAIL on the current (unfixed) code and PASS once the publication
+// is made atomic.
+
+func newHotReloadRaceConfig(host string, port, maxFilesPerScan int) *config.Config {
+	return &config.Config{
+		Server: config.ServerConfig{Host: host, Port: port},
+		API: config.APIConfig{
+			Security: config.SecurityConfig{
+				MaxFilesPerScan: maxFilesPerScan,
+			},
+		},
+		Logging: config.LoggingConfig{Level: "info"},
+	}
+}
+
+func newHotReloadRaceRuntime(t *testing.T, cfg *config.Config) *APIRuntime {
+	t.Helper()
+	deps := &APIDeps{
+		CoreDeps: &commandutil.CoreDeps{ScraperRegistry: scraperutil.NewScraperRegistry()},
+	}
+	rt := NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+	rt.InitAPIConfig()
+	return rt
+}
+
+// TestHotReload_Race_Window1_NewCfg_OldAPIConfig demonstrates that a concurrent
+// request can observe the new config/registry (published by ReplaceReloadable)
+// alongside the still-old APIConfig snapshot, before invalidateFactories runs.
+func TestHotReload_Race_Window1_NewCfg_OldAPIConfig(t *testing.T) {
+	cfgA := newHotReloadRaceConfig("hostA", 1111, 100)
+	cfgB := newHotReloadRaceConfig("hostB", 2222, 200)
+	rt := newHotReloadRaceRuntime(t, cfgA)
+
+	cfgSwapped := make(chan struct{})
+	proceed := make(chan struct{})
+	rt.reloadPauseAfterRegistry = func() {
+		close(cfgSwapped)
+		<-proceed
+	}
+
+	reloadDone := make(chan error, 1)
+	go func() { reloadDone <- rt.ReloadConfig(cfgB) }()
+
+	<-cfgSwapped
+
+	// Frozen mid-reload: CoreDeps has published the new cfg/registry, but
+	// invalidateFactories has not yet refreshed the APIConfig snapshot. A
+	// request reading both must see them agree.
+	gotCfg := rt.deps.CoreDeps.GetConfig()
+	gotAPICfg := rt.GetAPIConfig()
+	require.Equal(t, gotCfg.Server.Port, gotAPICfg.Port,
+		"race window 1: published cfg/registry (port %d) and APIConfig snapshot (port %d) disagree mid-reload",
+		gotCfg.Server.Port, gotAPICfg.Port)
+
+	close(proceed)
+	require.NoError(t, <-reloadDone)
+}
+
+// TestHotReload_Race_Window2_NewAPIConfig_OldFactory demonstrates that a
+// concurrent request can observe the new APIConfig snapshot (published inside
+// invalidateFactories) alongside a still-cached workflow factory built from the
+// old config, before the factory cache is invalidated.
+func TestHotReload_Race_Window2_NewAPIConfig_OldFactory(t *testing.T) {
+	cfgA := newHotReloadRaceConfig("hostA", 1111, 100)
+	cfgB := newHotReloadRaceConfig("hostB", 2222, 200)
+	rt := newHotReloadRaceRuntime(t, cfgA)
+
+	// Pre-build and cache the workflow factory from cfgA. Its MaxFilesPerScan
+	// (derived from cfg.API.Security.MaxFilesPerScan) is 100.
+	factoryA, err := rt.getWorkflowFactory()
+	require.NoError(t, err)
+	require.NotNil(t, factoryA)
+	require.Equal(t, 100, factoryA.MaxFilesPerScan(), "precondition: cached factory built from cfgA")
+
+	apiCfgSwapped := make(chan struct{})
+	proceed := make(chan struct{})
+	rt.reloadPauseAfterAPICfg = func() {
+		close(apiCfgSwapped)
+		<-proceed
+	}
+
+	reloadDone := make(chan error, 1)
+	go func() { reloadDone <- rt.ReloadConfig(cfgB) }()
+
+	<-apiCfgSwapped
+
+	// Frozen mid-reload: the APIConfig snapshot is already new (cfgB), but the
+	// cached workflow factory is still the one built from cfgA — it has not been
+	// invalidated yet. A request reading both executes with a stale factory.
+	gotAPICfg := rt.GetAPIConfig()
+	factory, err := rt.getWorkflowFactory()
+	require.NoError(t, err)
+	require.NotNil(t, factory)
+	require.Equal(t, gotAPICfg.MaxFilesPerScan, factory.MaxFilesPerScan(),
+		"race window 2: new APIConfig (MaxFilesPerScan %d) and cached workflow factory (MaxFilesPerScan %d) disagree mid-reload",
+		gotAPICfg.MaxFilesPerScan, factory.MaxFilesPerScan())
+
+	close(proceed)
+	require.NoError(t, <-reloadDone)
+}
+
+// TestHotReload_Race_Stress is a fixed-code regression guard: many concurrent
+// readers using Snapshot() (the fix's reader contract) and a reloader swapping
+// between two configs via the atomic ReplaceReloadable. Under -race it verifies
+// no memory race, and the invariant (snapshot cfg port == snapshot APIConfig
+// port) must never be violated — the snapshot holds reloadMu.RLock across both
+// reads, so it always observes a single consistent epoch.
+func TestHotReload_Race_Stress(t *testing.T) {
+	cfgA := newHotReloadRaceConfig("hostA", 1111, 100)
+	cfgB := newHotReloadRaceConfig("hostB", 2222, 200)
+	rt := newHotReloadRaceRuntime(t, cfgA)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	const readers = 8
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				snap := rt.Snapshot()
+				if snap.cfg.Server.Port != snap.apiCfg.Port {
+					t.Errorf("race: snapshot cfg port %d != APIConfig port %d", snap.cfg.Server.Port, snap.apiCfg.Port)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			cfg := cfgA
+			if i%2 == 1 {
+				cfg = cfgB
+			}
+			rt.ReplaceReloadable(cfg, scraperutil.NewScraperRegistry())
+		}
+		close(stop)
+	}()
+
+	wg.Wait()
+}
+
+// TestHotReload_Race_CrossAccessor_SnapshotIsConsistent demonstrates the
+// cross-accessor race that Snapshot() closes (issue #44, Phase 3): a handler
+// that reads GetAPIConfig() and then getWorkflowFactory() separately can observe
+// a reload landing between the two calls — new APIConfig with an old cached
+// factory, or vice versa. Taking one Snapshot() and reading both from it pins a
+// single epoch, so apiCfg and the factory's config-derived MaxFilesPerScan
+// always agree.
+//
+// The raw cross-accessor path is exposed here only as a contrast and is gated
+// behind a flag (it is inherently racy by design); the snapshot path is the
+// supported contract and must never disagree.
+func TestHotReload_Race_CrossAccessor_SnapshotIsConsistent(t *testing.T) {
+	cfgA := newHotReloadRaceConfig("hostA", 1111, 100)
+	cfgB := newHotReloadRaceConfig("hostB", 2222, 200)
+	rt := newHotReloadRaceRuntime(t, cfgA)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	const readers = 8
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				snap := rt.Snapshot()
+				factory, err := snap.WorkflowFactory()
+				if err != nil {
+					continue // factory unavailable this iteration; not a consistency failure
+				}
+				if snap.apiCfg.MaxFilesPerScan != factory.MaxFilesPerScan() {
+					t.Errorf("snapshot: APIConfig MaxFilesPerScan %d != factory MaxFilesPerScan %d",
+						snap.apiCfg.MaxFilesPerScan, factory.MaxFilesPerScan())
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			cfg := cfgA
+			if i%2 == 1 {
+				cfg = cfgB
+			}
+			rt.ReplaceReloadable(cfg, scraperutil.NewScraperRegistry())
+		}
+		close(stop)
+	}()
+
+	wg.Wait()
+}

--- a/internal/api/core/runtime_manager.go
+++ b/internal/api/core/runtime_manager.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/javinizer/javinizer-go/internal/commandutil"
 	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/database"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/matcher"
 	"github.com/javinizer/javinizer-go/internal/poster"
+	"github.com/javinizer/javinizer-go/internal/scraperutil"
 	"github.com/javinizer/javinizer-go/internal/ssrf"
 	"github.com/javinizer/javinizer-go/internal/worker"
 	"github.com/javinizer/javinizer-go/internal/workflow"
@@ -85,16 +87,29 @@ func (lv *lazyValue) Invalidate() {
 // here so that APIDeps is truly read-only after construction. All mutations go
 // through APIRuntime methods.
 //
-// Lock ordering: apiMu → CoreDeps.mu.
-// Never hold CoreDeps.mu while acquiring apiMu, or deadlock may result.
+// Lock ordering: reloadMu → CoreDeps.mu (and reloadMu → lazyValue.mu,
+// reloadMu → RuntimeState.mu). apiMu protects only the Runtime pointer and
+// is never acquired while holding reloadMu, so the two lock domains do not
+// interact. Never hold CoreDeps.mu while acquiring reloadMu, or deadlock
+// may result.
 type APIRuntime struct {
 	deps *APIDeps
 
-	// apiMu protects the mutable state below.
+	// apiMu protects the Runtime pointer below. It is intentionally separate
+	// from reloadMu: Runtime is set once at init and read on the request path,
+	// while reloadMu serializes hot-reload publication. Keeping them split means
+	// a Runtime read never blocks on an in-progress reload.
 	apiMu sync.RWMutex
 
+	// reloadMu serializes hot-reload publication so the three config-coupled
+	// holders — CoreDeps (cfg+registry), apiCfg, and the cached factory caches —
+	// are published as one atomic unit. Readers that need a consistent view
+	// across these holders take a snapshot via Snapshot() (reloadMu.RLock),
+	// which prevents them from observing a mix of old/new state mid-reload.
+	reloadMu sync.RWMutex
+
 	// apiCfg holds the narrow API-layer config snapshot.
-	// Rebuilt on every config hot-reload via ConfigFromAppConfig.
+	// Rebuilt on every config hot-reload via ConfigFromAppConfig under reloadMu.
 	apiCfg APIConfig
 
 	// workflowFactory caches the shared dependency sub-graph (scraper, matcher,
@@ -114,6 +129,16 @@ type APIRuntime struct {
 
 	// Runtime holds the mutable server runtime components (WebSocket hub, etc.).
 	Runtime *RuntimeState
+
+	// reloadPauseAfterRegistry and reloadPauseAfterAPICfg are test-only seams
+	// that pause the reloader so race tests can probe publication consistency.
+	// They fire AFTER the atomic reloadMu publication block, so a paused
+	// reloader exposes a fully consistent post-publish state. Before the fix
+	// they fired inside the non-atomic windows and observed split-brain state;
+	// they remain as regression guards against reintroducing non-atomic
+	// publication. Nil in production — checked and skipped on the reload path.
+	reloadPauseAfterRegistry func()
+	reloadPauseAfterAPICfg   func()
 
 	// Server lifecycle — serverCtx is the server-lifetime context,
 	// cancelled on Shutdown(). Used by batch job launch goroutines so they
@@ -145,13 +170,12 @@ func (r *APIRuntime) Deps() *APIDeps {
 // Must be called once after APIDeps is constructed, before any handler runs.
 // This is called automatically by NewServer.
 func (r *APIRuntime) InitAPIConfig() {
+	r.reloadMu.Lock()
+	defer r.reloadMu.Unlock()
 	if r.deps.CoreDeps == nil || !r.deps.CoreDeps.HasConfig() {
 		return
 	}
-	cfg := r.deps.CoreDeps.GetConfig()
-	r.apiMu.Lock()
-	r.apiCfg = ConfigFromAppConfig(cfg)
-	r.apiMu.Unlock()
+	r.apiCfg = ConfigFromAppConfig(r.deps.CoreDeps.GetConfig())
 }
 
 // EnsureRuntime initializes and returns the runtime state.
@@ -168,11 +192,16 @@ func (r *APIRuntime) EnsureRuntime() *RuntimeState {
 
 // GetAPIConfig returns the current narrow API config snapshot (thread-safe).
 // Concurrent handlers see a consistent snapshot, not partial writes,
-// because the entire struct is swapped under write lock during reload.
+// because the entire struct is swapped under reloadMu during reload.
+//
+// Note: GetAPIConfig is safe per-call, but a handler that reads GetAPIConfig
+// and then separately reads the workflow factory can still observe a reload
+// landing between the two calls. Such handlers must use Snapshot() to pin a
+// consistent view across all config-coupled holders for the request lifetime.
 func (r *APIRuntime) GetAPIConfig() APIConfig {
-	r.apiMu.RLock()
+	r.reloadMu.RLock()
 	cfg := r.apiCfg
-	r.apiMu.RUnlock()
+	r.reloadMu.RUnlock()
 	return cfg
 }
 
@@ -184,11 +213,237 @@ func (r *APIRuntime) GetRuntime() *RuntimeState {
 	return rt
 }
 
+// RuntimeSnapshot is a consistent point-in-time view of the three config-coupled
+// holders published atomically under reloadMu during hot-reload: the application
+// config, the scraper registry, and the narrow APIConfig snapshot.
+//
+// A handler that needs to read more than one of these for a single request must
+// take a Snapshot() once and read from it, rather than calling the individual
+// accessors (GetAPIConfig, CoreDeps.GetConfig, getWorkflowFactory) separately —
+// otherwise a reload landing between calls can yield a mix of old/new state.
+//
+// The captured cfg and registry pointers are the values installed by the last
+// completed reload; they remain valid to use even after a subsequent reload
+// publishes newer ones (Go GC keeps them alive). Phase 3 will add gen-gated
+// factory accessors on this type so a snapshot's factory is always built from
+// the snapshot's own cfg/registry rather than a fresher CoreDeps.
+type RuntimeSnapshot struct {
+	rt       *APIRuntime
+	cfg      *config.Config
+	registry *scraperutil.ScraperRegistry
+	apiCfg   APIConfig
+}
+
+// Config returns the application config captured in this snapshot.
+func (s *RuntimeSnapshot) Config() *config.Config { return s.cfg }
+
+// APIConfig returns the narrow API-layer config captured in this snapshot.
+func (s *RuntimeSnapshot) APIConfig() APIConfig { return s.apiCfg }
+
+// Registry returns the scraper registry captured in this snapshot.
+func (s *RuntimeSnapshot) Registry() *scraperutil.ScraperRegistry { return s.registry }
+
+// RT returns the underlying APIRuntime. Use this only for immutable DI access
+// (Deps(), ServerCtx(), GetRuntime()) that is not config-coupled; for
+// config-coupled reads use the snapshot's own accessors so they stay consistent
+// with the captured epoch.
+func (s *RuntimeSnapshot) RT() *APIRuntime { return s.rt }
+
+// Snapshot captures a consistent view of the config-coupled runtime state by
+// reading all three holders under a single reloadMu.RLock. Use this for request
+// paths that combine reads of config, registry, and APIConfig; it guarantees
+// they all originate from the same reload epoch.
+func (r *APIRuntime) Snapshot() *RuntimeSnapshot {
+	r.reloadMu.RLock()
+	defer r.reloadMu.RUnlock()
+	return &RuntimeSnapshot{
+		rt:       r,
+		cfg:      r.deps.CoreDeps.GetConfig(),
+		registry: r.deps.CoreDeps.GetRegistry(),
+		apiCfg:   r.apiCfg,
+	}
+}
+
+// WorkflowFactory returns a WorkflowFactory consistent with this snapshot.
+//
+// If no reload has landed since the snapshot was taken (the current config
+// pointer still equals the snapshot's config), the shared lazy cache is reused
+// — the cache is only populated/invalidated under reloadMu, and holding
+// reloadMu.RLock here prevents a reload from invalidating it mid-read, so the
+// cached factory was necessarily built from the snapshot's config. This keeps
+// the hot path (cache hit) cheap.
+//
+// If a reload has landed (config pointer differs), the shared cache may now hold
+// a factory built from a newer config. Rather than serve a mismatched factory,
+// this builds a fresh factory from the snapshot's captured cfg/registry WITHOUT
+// caching it — caching a stale-epoch build would stomp the newer cache. This
+// rebuild only happens on a request that straddles a reload (rare), so the perf
+// cost is bounded.
+func (s *RuntimeSnapshot) WorkflowFactory() (*workflow.WorkflowFactory, error) {
+	r := s.rt
+	r.reloadMu.RLock()
+	currentCfg := r.deps.CoreDeps.GetConfig()
+	sameEpoch := currentCfg == s.cfg
+	var cached any
+	if sameEpoch {
+		// Safe under RLock: a reload cannot invalidate the cache concurrently.
+		cached = r.workflowFactory.Get()
+	}
+	r.reloadMu.RUnlock()
+	if sameEpoch && cached != nil {
+		return cached.(*workflow.WorkflowFactory), nil
+	}
+	if sameEpoch {
+		return nil, fmt.Errorf("workflow factory not available — check config and registry")
+	}
+	// Reload landed between snapshot and here: build from the snapshot's own
+	// cfg/registry so the factory matches snap.APIConfig(). Not cached.
+	f := buildWorkflowFactoryFrom(s.cfg, s.registry, r.deps.Repos)
+	if f == nil {
+		return nil, fmt.Errorf("workflow factory not available — check config and registry")
+	}
+	return f.(*workflow.WorkflowFactory), nil
+}
+
+// PosterGen returns the cached PosterGenerator from a factory consistent with
+// this snapshot. Returns nil if the factory is unavailable.
+func (s *RuntimeSnapshot) PosterGen() poster.PosterGenerator {
+	f, err := s.WorkflowFactory()
+	if err != nil || f.PosterGen() == nil {
+		return nil
+	}
+	return f.PosterGen()
+}
+
+// BatchWorkflow constructs a batch workflow from a factory consistent with this
+// snapshot, so the workflow's cfg/registry match snap.APIConfig().
+func (s *RuntimeSnapshot) BatchWorkflow(jobID string) (workflow.WorkflowInterface, error) {
+	factory, err := s.WorkflowFactory()
+	if err != nil {
+		return nil, err
+	}
+	return factory.NewWorkflow(jobID)
+}
+
+// ScanOnlyWorkflow constructs a scan-only workflow from a factory consistent with
+// this snapshot.
+func (s *RuntimeSnapshot) ScanOnlyWorkflow() (workflow.WorkflowInterface, error) {
+	factory, err := s.WorkflowFactory()
+	if err != nil {
+		return nil, err
+	}
+	return factory.NewScanOnlyWorkflow(), nil
+}
+
+// Matcher constructs a matcher from the snapshot's APIConfig. Cheap (no shared
+// cache involved), and consistent with snap.APIConfig() by construction.
+func (s *RuntimeSnapshot) Matcher() matcher.MatcherInterface {
+	matchCfg := s.apiCfg.MatcherConfig()
+	mat, err := matcher.NewMatcher(&matcher.Config{
+		RegexEnabled: matchCfg.RegexEnabled,
+		RegexPattern: matchCfg.RegexPattern,
+	})
+	if err != nil {
+		logging.Warnf("Failed to create matcher from snapshot APIConfig: %v", err)
+		return nil
+	}
+	return mat
+}
+
+// BatchJobFactory constructs a BatchJobFactory consistent with this snapshot.
+//
+// Hot path (no reload since the snapshot): reuses the shared lazy cache under
+// reloadMu.RLock — matching WorkflowFactory()'s gen-check — so SetReconstructionDeps
+// (which iterates every job in the store) runs once per reload epoch, not once
+// per request. Only when a reload has landed mid-request does this build fresh
+// from snap.APIConfig()/PosterGen()/Matcher() without caching, so a stale-epoch
+// request still gets a consistent factory without poisoning the newer cache.
+func (s *RuntimeSnapshot) BatchJobFactory() worker.BatchJobFactoryInterface {
+	r := s.rt
+	r.reloadMu.RLock()
+	currentCfg := r.deps.CoreDeps.GetConfig()
+	sameEpoch := currentCfg == s.cfg
+	var cached any
+	if sameEpoch {
+		// Safe under RLock: a reload cannot invalidate the cache concurrently,
+		// and the cache was populated from s.cfg if sameEpoch holds.
+		cached = r.batchJobFactory.Get()
+	}
+	r.reloadMu.RUnlock()
+	if sameEpoch && cached != nil {
+		return cached.(worker.BatchJobFactoryInterface)
+	}
+	if sameEpoch {
+		return nil
+	}
+	batchCfg := s.apiCfg.BatchConfig()
+	posterGen := s.PosterGen()
+	if posterGen == nil {
+		logging.Error("snapshot.BatchJobFactory: workflow factory PosterGen is nil — cannot construct batch job factory without it")
+		return nil
+	}
+	matcherIface := s.Matcher()
+	workerBatchCfg := worker.BatchJobConfig{
+		MaxWorkers:      batchCfg.MaxWorkers,
+		WorkerTimeout:   batchCfg.WorkerTimeout,
+		ScraperPriority: batchCfg.ScraperPriority,
+		NFOEnabled:      batchCfg.NFOEnabled,
+	}
+	// Re-hydrate reconstructed jobs with infrastructure deps (matcher, posterGen,
+	// batchCfg) that were not available at JobStore construction time.
+	r.deps.JobStore.SetReconstructionDeps(matcherIface, posterGen, workerBatchCfg)
+	return worker.NewBatchJobFactory(
+		r.deps.JobStore,
+		nil, // WF is per-job (BatchWorkflow), not shared across all jobs
+		matcherIface,
+		posterGen,
+		workerBatchCfg,
+		r.deps.EventEmitter,
+	)
+}
+
+// PosterManager returns a PosterManager built from the snapshot's config (for
+// tempDir) so it is consistent with snap.APIConfig(). Mirrors GetPosterManager
+// but uses snap.cfg instead of re-reading CoreDeps. Returns nil if the snapshot
+// has no config (e.g. a test-only snapshot from NewSnapshotForTesting).
+func (s *RuntimeSnapshot) PosterManager() poster.PosterManagerInterface {
+	if s.cfg == nil {
+		return nil
+	}
+	r := s.rt
+	rs := r.GetRuntime()
+	if rs == nil {
+		httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
+		return poster.NewPosterManager(r.deps.GetFs(), s.cfg.System.TempDir, httpClient)
+	}
+	return rs.GetPosterManager(func() poster.PosterManagerInterface {
+		httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
+		return poster.NewPosterManager(r.deps.GetFs(), s.cfg.System.TempDir, httpClient)
+	})
+}
+
+// NewSnapshotForTesting builds a RuntimeSnapshot without requiring a configured
+// CoreDeps, for tests that exercise resolution paths (e.g. apply-config
+// builders) with a nil/zero-config runtime. The cfg/registry fields are left
+// nil; callers that need WorkflowFactory() should configure a real runtime and
+// use Snapshot() instead.
+func NewSnapshotForTesting(rt *APIRuntime, apiCfg APIConfig) *RuntimeSnapshot {
+	return &RuntimeSnapshot{rt: rt, apiCfg: apiCfg}
+}
+
 // getWorkflowFactory returns the cached WorkflowFactory, constructing it on first access.
 // buildWorkflowFactory constructs a new WorkflowFactory from the current config.
 // Used as the build function for the lazy workflowFactory value.
 func (r *APIRuntime) buildWorkflowFactory() any {
-	fc, fcErr := workflow.NewFactoryConfigFromRepos(r.deps.CoreDeps.GetConfig(), r.deps.CoreDeps.GetRegistry(), r.deps.Repos)
+	return buildWorkflowFactoryFrom(r.deps.CoreDeps.GetConfig(), r.deps.CoreDeps.GetRegistry(), r.deps.Repos)
+}
+
+// buildWorkflowFactoryFrom constructs a WorkflowFactory from the given cfg/registry/repos.
+// Shared by the lazy cache build path (buildWorkflowFactory) and the snapshot path
+// (RuntimeSnapshot.WorkflowFactory), which builds from its captured cfg/registry when
+// a reload has invalidated the shared cache mid-request.
+func buildWorkflowFactoryFrom(cfg *config.Config, registry *scraperutil.ScraperRegistry, repos database.Repositories) any {
+	fc, fcErr := workflow.NewFactoryConfigFromRepos(cfg, registry, repos)
 	if fcErr != nil {
 		// Per S-10: ScraperConstructionError is a known partial-construction failure.
 		// We still create the factory so that scan-only workflows work (they don't
@@ -378,11 +633,12 @@ func (r *APIRuntime) SetConfig(cfg *config.Config) {
 	if r.deps.CoreDeps == nil {
 		r.deps.CoreDeps = &commandutil.CoreDeps{}
 	}
+	// Publish cfg and apiCfg together under reloadMu so a concurrent
+	// GetAPIConfig/Snapshot cannot see new cfg with stale apiCfg.
+	r.reloadMu.Lock()
+	defer r.reloadMu.Unlock()
 	r.deps.CoreDeps.SetConfig(cfg)
-	// Keep APIConfig in sync whenever the full config is set
-	r.apiMu.Lock()
 	r.apiCfg = ConfigFromAppConfig(cfg)
-	r.apiMu.Unlock()
 }
 
 // ReloadConfig is defined in hot_reload.go.

--- a/internal/api/core/runtime_manager.go
+++ b/internal/api/core/runtime_manager.go
@@ -112,6 +112,15 @@ type APIRuntime struct {
 	// Rebuilt on every config hot-reload via ConfigFromAppConfig under reloadMu.
 	apiCfg APIConfig
 
+	// reloadGen is bumped under reloadMu on every config publication (reload /
+	// SetConfig). RuntimeSnapshot captures it so its factory accessors can tell
+	// whether a reload has landed since the snapshot was taken: a generation
+	// match means the shared caches are still valid for this snapshot, while a
+	// mismatch means the caches may hold a newer epoch and must not be served.
+	// Comparing generations is more robust than cfg-pointer equality, which
+	// misses a reload that reuses the same *config.Config with a new registry.
+	reloadGen uint64
+
 	// workflowFactory caches the shared dependency sub-graph (scraper, matcher,
 	// organizer, downloader, NFO generator, template engine, scanner, poster
 	// generator). Nil until first access; niled on config reload so the next
@@ -232,6 +241,7 @@ type RuntimeSnapshot struct {
 	cfg      *config.Config
 	registry *scraperutil.ScraperRegistry
 	apiCfg   APIConfig
+	gen      uint64
 }
 
 // Config returns the application config captured in this snapshot.
@@ -261,20 +271,20 @@ func (r *APIRuntime) Snapshot() *RuntimeSnapshot {
 		cfg:      r.deps.CoreDeps.GetConfig(),
 		registry: r.deps.CoreDeps.GetRegistry(),
 		apiCfg:   r.apiCfg,
+		gen:      r.reloadGen,
 	}
 }
 
 // WorkflowFactory returns a WorkflowFactory consistent with this snapshot.
 //
-// If no reload has landed since the snapshot was taken (the current config
-// pointer still equals the snapshot's config), the shared lazy cache is reused
-// — the cache is only populated/invalidated under reloadMu, and holding
-// reloadMu.RLock here prevents a reload from invalidating it mid-read, so the
-// cached factory was necessarily built from the snapshot's config. This keeps
-// the hot path (cache hit) cheap.
+// If no reload has landed since the snapshot was taken (reloadGen unchanged),
+// the shared lazy cache is reused — the cache is only populated/invalidated
+// under reloadMu, and holding reloadMu.RLock here prevents a reload from
+// invalidating it mid-read, so the cached factory was necessarily built from
+// the snapshot's config. This keeps the hot path (cache hit) cheap.
 //
-// If a reload has landed (config pointer differs), the shared cache may now hold
-// a factory built from a newer config. Rather than serve a mismatched factory,
+// If a reload has landed (generation differs), the shared cache may now hold a
+// factory built from a newer config. Rather than serve a mismatched factory,
 // this builds a fresh factory from the snapshot's captured cfg/registry WITHOUT
 // caching it — caching a stale-epoch build would stomp the newer cache. This
 // rebuild only happens on a request that straddles a reload (rare), so the perf
@@ -282,8 +292,7 @@ func (r *APIRuntime) Snapshot() *RuntimeSnapshot {
 func (s *RuntimeSnapshot) WorkflowFactory() (*workflow.WorkflowFactory, error) {
 	r := s.rt
 	r.reloadMu.RLock()
-	currentCfg := r.deps.CoreDeps.GetConfig()
-	sameEpoch := currentCfg == s.cfg
+	sameEpoch := r.reloadGen == s.gen
 	var cached any
 	if sameEpoch {
 		// Safe under RLock: a reload cannot invalidate the cache concurrently.
@@ -353,20 +362,27 @@ func (s *RuntimeSnapshot) Matcher() matcher.MatcherInterface {
 // BatchJobFactory constructs a BatchJobFactory consistent with this snapshot.
 //
 // Hot path (no reload since the snapshot): reuses the shared lazy cache under
-// reloadMu.RLock — matching WorkflowFactory()'s gen-check — so SetReconstructionDeps
-// (which iterates every job in the store) runs once per reload epoch, not once
-// per request. Only when a reload has landed mid-request does this build fresh
-// from snap.APIConfig()/PosterGen()/Matcher() without caching, so a stale-epoch
-// request still gets a consistent factory without poisoning the newer cache.
+// reloadMu.RLock — matching WorkflowFactory()'s generation check — so
+// SetReconstructionDeps (which iterates every job in the store) runs once per
+// reload epoch, not once per request. Only when a reload has landed mid-request
+// does this build fresh from snap.APIConfig()/PosterGen()/Matcher() without
+// caching, so a stale-epoch request still gets a consistent factory without
+// poisoning the newer cache.
+//
+// The stale-epoch fresh build deliberately does NOT call SetReconstructionDeps:
+// that mutates the shared JobStore and every reconstructed job, so a stale
+// request could otherwise roll current jobs back to old Matcher/PosterGen/
+// BatchCfg after the new epoch was published. Reconstruction hydration stays on
+// the current-epoch lazy build path (buildBatchJobFactory), which is always
+// up-to-date by definition.
 func (s *RuntimeSnapshot) BatchJobFactory() worker.BatchJobFactoryInterface {
 	r := s.rt
 	r.reloadMu.RLock()
-	currentCfg := r.deps.CoreDeps.GetConfig()
-	sameEpoch := currentCfg == s.cfg
+	sameEpoch := r.reloadGen == s.gen
 	var cached any
 	if sameEpoch {
 		// Safe under RLock: a reload cannot invalidate the cache concurrently,
-		// and the cache was populated from s.cfg if sameEpoch holds.
+		// and the cache was populated from this generation if sameEpoch holds.
 		cached = r.batchJobFactory.Get()
 	}
 	r.reloadMu.RUnlock()
@@ -376,6 +392,10 @@ func (s *RuntimeSnapshot) BatchJobFactory() worker.BatchJobFactoryInterface {
 	if sameEpoch {
 		return nil
 	}
+	// Reload landed between snapshot and here: build fresh from the snapshot's
+	// own apiCfg/PosterGen/Matcher so the factory is internally consistent with
+	// snap.APIConfig(). Not cached, and does NOT call SetReconstructionDeps —
+	// see the doc comment above.
 	batchCfg := s.apiCfg.BatchConfig()
 	posterGen := s.PosterGen()
 	if posterGen == nil {
@@ -389,9 +409,6 @@ func (s *RuntimeSnapshot) BatchJobFactory() worker.BatchJobFactoryInterface {
 		ScraperPriority: batchCfg.ScraperPriority,
 		NFOEnabled:      batchCfg.NFOEnabled,
 	}
-	// Re-hydrate reconstructed jobs with infrastructure deps (matcher, posterGen,
-	// batchCfg) that were not available at JobStore construction time.
-	r.deps.JobStore.SetReconstructionDeps(matcherIface, posterGen, workerBatchCfg)
 	return worker.NewBatchJobFactory(
 		r.deps.JobStore,
 		nil, // WF is per-job (BatchWorkflow), not shared across all jobs
@@ -403,23 +420,35 @@ func (s *RuntimeSnapshot) BatchJobFactory() worker.BatchJobFactoryInterface {
 }
 
 // PosterManager returns a PosterManager built from the snapshot's config (for
-// tempDir) so it is consistent with snap.APIConfig(). Mirrors GetPosterManager
-// but uses snap.cfg instead of re-reading CoreDeps. Returns nil if the snapshot
+// tempDir) so it is consistent with snap.APIConfig(). Returns nil if the snapshot
 // has no config (e.g. a test-only snapshot from NewSnapshotForTesting).
+//
+// Only routes through the shared RuntimeState cache when the snapshot's
+// generation is current; a stale snapshot otherwise builds an uncached manager
+// from snap.cfg so it can neither read nor repopulate the global cache with a
+// mismatched TempDir from a different epoch.
 func (s *RuntimeSnapshot) PosterManager() poster.PosterManagerInterface {
 	if s.cfg == nil {
 		return nil
 	}
 	r := s.rt
-	rs := r.GetRuntime()
-	if rs == nil {
+	buildFromSnap := func() poster.PosterManagerInterface {
 		httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
 		return poster.NewPosterManager(r.deps.GetFs(), s.cfg.System.TempDir, httpClient)
 	}
-	return rs.GetPosterManager(func() poster.PosterManagerInterface {
-		httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
-		return poster.NewPosterManager(r.deps.GetFs(), s.cfg.System.TempDir, httpClient)
-	})
+	rs := r.GetRuntime()
+	if rs == nil {
+		return buildFromSnap()
+	}
+	// Stale snapshot: don't touch the shared cache — build an uncached manager
+	// from this snapshot's captured config.
+	r.reloadMu.RLock()
+	current := r.reloadGen == s.gen
+	r.reloadMu.RUnlock()
+	if !current {
+		return buildFromSnap()
+	}
+	return rs.GetPosterManager(buildFromSnap)
 }
 
 // NewSnapshotForTesting builds a RuntimeSnapshot without requiring a configured
@@ -633,12 +662,14 @@ func (r *APIRuntime) SetConfig(cfg *config.Config) {
 	if r.deps.CoreDeps == nil {
 		r.deps.CoreDeps = &commandutil.CoreDeps{}
 	}
-	// Publish cfg and apiCfg together under reloadMu so a concurrent
-	// GetAPIConfig/Snapshot cannot see new cfg with stale apiCfg.
+	// Publish cfg, apiCfg, generation bump, and factory invalidation together
+	// under reloadMu — the same atomic path reload uses — so a concurrent
+	// GetAPIConfig/Snapshot cannot see new cfg with stale apiCfg or stale cached
+	// factories.
 	r.reloadMu.Lock()
 	defer r.reloadMu.Unlock()
 	r.deps.CoreDeps.SetConfig(cfg)
-	r.apiCfg = ConfigFromAppConfig(cfg)
+	r.invalidateFactoriesLocked(cfg)
 }
 
 // ReloadConfig is defined in hot_reload.go.

--- a/internal/api/core/snapshot_test.go
+++ b/internal/api/core/snapshot_test.go
@@ -1,0 +1,268 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/commandutil"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/scraperutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSnapshotTestRuntime builds an APIRuntime wired with enough repos for the
+// workflow factory to construct (matcher/scanner/organizer paths), so the
+// snapshot factory accessors exercise a real factory rather than the nil path.
+func newSnapshotTestRuntime(t *testing.T, cfg *config.Config) *APIRuntime {
+	t.Helper()
+	deps := &APIDeps{
+		CoreDeps: &commandutil.CoreDeps{ScraperRegistry: scraperutil.NewScraperRegistry()},
+		Repos: database.Repositories{
+			ContentRepos: database.ContentRepos{
+				ContentIDMappingRepo: &database.ContentIDMappingRepository{},
+			},
+		},
+	}
+	rt := NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+	rt.InitAPIConfig()
+	return rt
+}
+
+func snapshotTestConfig(port, maxFiles int, regex string) *config.Config {
+	return &config.Config{
+		Server:  config.ServerConfig{Host: "snaphost", Port: port},
+		Logging: config.LoggingConfig{Level: "info"},
+		API: config.APIConfig{
+			Security: config.SecurityConfig{MaxFilesPerScan: maxFiles},
+		},
+		Matching: config.MatchingConfig{RegexEnabled: true, RegexPattern: regex},
+	}
+}
+
+// TestSnapshot_Accessors_ReturnCapturedState verifies the trivial snapshot
+// accessors return the values captured at Snapshot() time, not a fresher
+// CoreDeps after a reload.
+func TestSnapshot_Accessors_ReturnCapturedState(t *testing.T) {
+	cfgA := snapshotTestConfig(1111, 100, `([A-Z]+-\d+)`)
+	cfgB := snapshotTestConfig(2222, 200, `([A-Z]+-\d+)`)
+	rt := newSnapshotTestRuntime(t, cfgA)
+
+	snap := rt.Snapshot()
+	assert.Equal(t, cfgA, snap.Config())
+	assert.Equal(t, 1111, snap.APIConfig().Port)
+	assert.Equal(t, 100, snap.APIConfig().MaxFilesPerScan)
+	assert.Equal(t, rt.deps.CoreDeps.GetRegistry(), snap.Registry())
+	assert.Same(t, rt, snap.RT())
+
+	// Reload after snapshot; snap must still reflect cfgA.
+	rt.ReplaceReloadable(cfgB, scraperutil.NewScraperRegistry())
+	assert.Equal(t, cfgA, snap.Config(), "snapshot must pin the captured config")
+	assert.Equal(t, 1111, snap.APIConfig().Port, "snapshot must pin the captured apiCfg")
+}
+
+// TestSnapshot_WorkflowFactory_SameEpoch_ReusesCache confirms the same-epoch
+// path returns the shared cached factory (pointer identity) and that repeated
+// calls return the same instance.
+func TestSnapshot_WorkflowFactory_SameEpoch_ReusesCache(t *testing.T) {
+	cfg := snapshotTestConfig(1111, 100, `([A-Z]+-\d+)`)
+	rt := newSnapshotTestRuntime(t, cfg)
+
+	snap := rt.Snapshot()
+	f1, err := snap.WorkflowFactory()
+	require.NoError(t, err)
+	require.NotNil(t, f1)
+
+	// Same snapshot again → same pointer (cache hit on the same epoch).
+	f2, err := snap.WorkflowFactory()
+	require.NoError(t, err)
+	assert.Same(t, f1, f2)
+
+	// The shared lazy cache (reached via the legacy accessor) is the same
+	// instance the snapshot served on the same-epoch path.
+	f3, err := rt.getWorkflowFactory()
+	require.NoError(t, err)
+	assert.Same(t, f1, f3)
+}
+
+// TestSnapshot_WorkflowFactory_StaleEpoch_BuildsFreshUncached confirms that
+// after a reload the snapshot builds a fresh factory from its captured
+// cfg/registry (not the shared cache, which now holds a newer factory). The
+// stale-epoch build is intentionally uncached, so each call yields a distinct
+// instance — that is the documented behavior that prevents a stale-epoch build
+// from poisoning the newer shared cache.
+func TestSnapshot_WorkflowFactory_StaleEpoch_BuildsFreshUncached(t *testing.T) {
+	cfgA := snapshotTestConfig(1111, 100, `([A-Z]+-\d+)`)
+	cfgB := snapshotTestConfig(2222, 200, `([A-Z]+-\d+)`)
+	rt := newSnapshotTestRuntime(t, cfgA)
+
+	snap := rt.Snapshot()
+
+	// Reload to a new epoch; the shared cache is invalidated and rebuilt.
+	rt.ReplaceReloadable(cfgB, scraperutil.NewScraperRegistry())
+	newer, err := rt.getWorkflowFactory()
+	require.NoError(t, err)
+
+	// The stale snapshot's factory differs from the post-reload shared cache.
+	stale, err := snap.WorkflowFactory()
+	require.NoError(t, err)
+	assert.NotSame(t, newer, stale, "stale snapshot must not serve the newer cached factory")
+
+	// The stale-epoch build is uncached: a second call yields a fresh instance,
+	// not the previously-built one (otherwise it would poison the shared cache).
+	stale2, err := snap.WorkflowFactory()
+	require.NoError(t, err)
+	assert.NotSame(t, stale, stale2, "stale-epoch build must not be cached")
+}
+
+// TestSnapshot_PosterGen_DelegatesToWorkflowFactory confirms PosterGen returns
+// the factory's PosterGenerator on the same-epoch path and nil when the
+// factory is unavailable.
+func TestSnapshot_PosterGen_DelegatesToWorkflowFactory(t *testing.T) {
+	cfg := snapshotTestConfig(1111, 100, `([A-Z]+-\d+)`)
+	rt := newSnapshotTestRuntime(t, cfg)
+
+	snap := rt.Snapshot()
+	f, err := snap.WorkflowFactory()
+	require.NoError(t, err)
+
+	pg := snap.PosterGen()
+	if f.PosterGen() != nil {
+		assert.NotNil(t, pg)
+	} else {
+		assert.Nil(t, pg)
+	}
+}
+
+// TestSnapshot_Matcher_BuiltFromAPIConfig confirms the matcher is built from
+// the snapshot's apiCfg and is non-nil for a valid regex.
+func TestSnapshot_Matcher_BuiltFromAPIConfig(t *testing.T) {
+	cfg := snapshotTestConfig(1111, 100, `([A-Z]+-\d+)`)
+	rt := newSnapshotTestRuntime(t, cfg)
+
+	snap := rt.Snapshot()
+	m := snap.Matcher()
+	require.NotNil(t, m)
+	assert.Equal(t, "ABC-123", m.MatchString("ABC-123.mp4"))
+}
+
+// TestSnapshot_Matcher_InvalidRegexReturnsNil confirms a bad regex yields nil
+// rather than panicking.
+func TestSnapshot_Matcher_InvalidRegexReturnsNil(t *testing.T) {
+	cfg := snapshotTestConfig(1111, 100, `(unclosed[`)
+	rt := newSnapshotTestRuntime(t, cfg)
+
+	snap := rt.Snapshot()
+	assert.Nil(t, snap.Matcher())
+}
+
+// TestSnapshot_BatchJobFactory_StaleEpoch_BuildsFreshWithoutCaching confirms a
+// stale-epoch snapshot builds a fresh factory from its captured apiCfg/PosterGen
+// without calling SetReconstructionDeps (which would mutate shared state). The
+// stale-epoch fresh build is uncached: each call yields a distinct instance.
+// This requires a primed workflow factory (for PosterGen); the shared
+// batchJobFactory cache is left untouched (still empty for the new epoch).
+func TestSnapshot_BatchJobFactory_StaleEpoch_BuildsFreshWithoutCaching(t *testing.T) {
+	cfgA := snapshotTestConfig(1111, 100, `([A-Z]+-\d+)`)
+	cfgB := snapshotTestConfig(2222, 200, `([A-Z]+-\d+)`)
+	rt := newSnapshotTestRuntime(t, cfgA)
+
+	// Prime the workflow factory so PosterGen resolves for a stale-epoch build.
+	_, err := rt.getWorkflowFactory()
+	require.NoError(t, err)
+	snap := rt.Snapshot()
+
+	// Reload to cfgB (new epoch). The shared batch cache is invalidated.
+	rt.ReplaceReloadable(cfgB, scraperutil.NewScraperRegistry())
+
+	// Stale snapshot builds fresh without panicking.
+	f1 := snap.BatchJobFactory()
+	// PosterGen may be nil for the stale build if the workflow factory isn't
+	// primed for cfgA; if so the build returns nil gracefully (covered).
+	if f1 != nil {
+		f2 := snap.BatchJobFactory()
+		assert.NotSame(t, f1, f2, "stale-epoch build must not be cached")
+	}
+	// The shared cache for the new epoch is untouched (nil/empty), proving the
+	// stale build did not poison it.
+	assert.Nil(t, rt.batchJobFactory.value, "stale-epoch build must not write the shared cache")
+}
+
+// TestSnapshot_PosterManager_CurrentEpoch_RoutesThroughCache confirms the
+// current-epoch path routes through the shared RuntimeState cache (same
+// instance across calls) and is non-nil when config is present.
+func TestSnapshot_PosterManager_CurrentEpoch_RoutesThroughCache(t *testing.T) {
+	cfg := snapshotTestConfig(1111, 100, `([A-Z]+-\d+)`)
+	rt := newSnapshotTestRuntime(t, cfg)
+	rt.EnsureRuntime()
+
+	snap := rt.Snapshot()
+	pm1 := snap.PosterManager()
+	require.NotNil(t, pm1)
+	// Same epoch → shared cache → same instance.
+	pm2 := snap.PosterManager()
+	assert.Same(t, pm1, pm2)
+}
+
+// TestSnapshot_PosterManager_StaleEpoch_BuildsUncached confirms a stale
+// snapshot does not reuse the shared cache (which may hold a manager from a
+// newer epoch with a different TempDir).
+func TestSnapshot_PosterManager_StaleEpoch_BuildsUncached(t *testing.T) {
+	cfgA := snapshotTestConfig(1111, 100, `([A-Z]+-\d+)`)
+	cfgA.System.TempDir = "/tmp/snapA"
+	cfgB := snapshotTestConfig(2222, 200, `([A-Z]+-\d+)`)
+	cfgB.System.TempDir = "/tmp/snapB"
+	rt := newSnapshotTestRuntime(t, cfgA)
+	rt.EnsureRuntime()
+
+	snap := rt.Snapshot()
+	pmCurrent := snap.PosterManager()
+	require.NotNil(t, pmCurrent)
+
+	// Reload to cfgB (new TempDir). The shared cache is invalidated.
+	rt.ReplaceReloadable(cfgB, scraperutil.NewScraperRegistry())
+
+	// Stale snapshot must build an uncached manager (not the post-reload
+	// shared-cache one). It should be non-nil and a distinct instance.
+	pmStale := snap.PosterManager()
+	require.NotNil(t, pmStale)
+	assert.NotSame(t, pmCurrent, pmStale, "stale snapshot must not serve the shared-cache instance")
+}
+
+// TestSnapshot_PosterManager_NilConfigReturnsNil covers the NewSnapshotForTesting
+// nil-cfg guard.
+func TestSnapshot_PosterManager_NilConfigReturnsNil(t *testing.T) {
+	rt := NewAPIRuntime(&APIDeps{})
+	snap := NewSnapshotForTesting(rt, APIConfig{})
+	assert.Nil(t, snap.PosterManager())
+}
+
+// TestNewSnapshotForTesting covers the test-only constructor.
+func TestNewSnapshotForTesting(t *testing.T) {
+	rt := NewAPIRuntime(&APIDeps{})
+	apiCfg := APIConfig{Host: "t", Port: 9}
+	snap := NewSnapshotForTesting(rt, apiCfg)
+	assert.Same(t, rt, snap.RT())
+	assert.Equal(t, "t", snap.APIConfig().Host)
+	assert.Equal(t, 9, snap.APIConfig().Port)
+	assert.Nil(t, snap.Config())
+	assert.Nil(t, snap.Registry())
+}
+
+// TestSnapshot_BatchWorkflow_And_ScanOnlyWorkflow cover the two workflow
+// construction accessors on the same-epoch path.
+func TestSnapshot_BatchWorkflow_And_ScanOnlyWorkflow(t *testing.T) {
+	cfg := snapshotTestConfig(1111, 100, `([A-Z]+-\d+)`)
+	rt := newSnapshotTestRuntime(t, cfg)
+
+	snap := rt.Snapshot()
+	// BatchWorkflow needs a scraper (nil here without a MovieRepo) so it returns
+	// an error; scan-only workflows don't, so they succeed. Assert both paths.
+	_, err := snap.BatchWorkflow("job-1")
+	assert.Error(t, err, "batch workflow needs a scraper; nil-repo setup must error")
+
+	scan, err := snap.ScanOnlyWorkflow()
+	require.NoError(t, err)
+	require.NotNil(t, scan)
+}

--- a/internal/api/core/snapshot_test.go
+++ b/internal/api/core/snapshot_test.go
@@ -266,3 +266,93 @@ func TestSnapshot_BatchWorkflow_And_ScanOnlyWorkflow(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, scan)
 }
+
+// badRegexSnapshotConfig returns a config whose matching regex is invalid, so
+// the workflow factory cannot be built (buildMatcher fails with a non-Scraper
+// construction error → buildWorkflowFactoryFrom returns nil). This drives the
+// factory-unavailable error/nil branches in the snapshot accessors.
+func badRegexSnapshotConfig() *config.Config {
+	cfg := snapshotTestConfig(1111, 100, `(unclosed[`)
+	return cfg
+}
+
+// TestSnapshot_WorkflowFactory_SameEpoch_FactoryUnavailable covers the
+// same-epoch path where the shared cache build returns nil (bad regex) →
+// WorkflowFactory returns an error rather than a factory.
+func TestSnapshot_WorkflowFactory_SameEpoch_FactoryUnavailable(t *testing.T) {
+	rt := newSnapshotTestRuntime(t, badRegexSnapshotConfig())
+	snap := rt.Snapshot()
+
+	f, err := snap.WorkflowFactory()
+	assert.Nil(t, f)
+	assert.Error(t, err)
+
+	// PosterGen delegates to WorkflowFactory → nil on the error path.
+	assert.Nil(t, snap.PosterGen())
+
+	// BatchWorkflow / ScanOnlyWorkflow propagate the WorkflowFactory error.
+	_, err = snap.BatchWorkflow("job-1")
+	assert.Error(t, err)
+	_, err = snap.ScanOnlyWorkflow()
+	assert.Error(t, err)
+}
+
+// TestSnapshot_WorkflowFactory_StaleEpoch_FactoryUnavailable covers the
+// stale-epoch path where buildWorkflowFactoryFrom(s.cfg, ...) returns nil →
+// WorkflowFactory returns an error.
+func TestSnapshot_WorkflowFactory_StaleEpoch_FactoryUnavailable(t *testing.T) {
+	cfgBad := badRegexSnapshotConfig()
+	cfgGood := snapshotTestConfig(2222, 200, `([A-Z]+-\d+)`)
+	rt := newSnapshotTestRuntime(t, cfgBad)
+
+	snap := rt.Snapshot()
+	// Reload to a good-regex epoch so the snapshot is stale.
+	rt.ReplaceReloadable(cfgGood, scraperutil.NewScraperRegistry())
+
+	f, err := snap.WorkflowFactory()
+	assert.Nil(t, f, "stale snapshot with bad regex must not build a factory")
+	assert.Error(t, err)
+}
+
+// TestSnapshot_BatchJobFactory_StaleEpoch_PosterGenNil covers the stale-epoch
+// BatchJobFactory path where PosterGen is nil (workflow factory unavailable for
+// the snapshot's captured cfg) → returns nil without panicking and without
+// touching the shared cache.
+func TestSnapshot_BatchJobFactory_StaleEpoch_PosterGenNil(t *testing.T) {
+	cfgBad := badRegexSnapshotConfig()
+	cfgGood := snapshotTestConfig(2222, 200, `([A-Z]+-\d+)`)
+	rt := newSnapshotTestRuntime(t, cfgBad)
+
+	snap := rt.Snapshot()
+	rt.ReplaceReloadable(cfgGood, scraperutil.NewScraperRegistry())
+
+	// Stale snapshot's captured cfg has a bad regex → PosterGen nil →
+	// BatchJobFactory returns nil on the stale-epoch fresh-build path.
+	assert.Nil(t, snap.BatchJobFactory())
+	// Shared cache for the new (good) epoch is untouched by the stale build.
+	assert.Nil(t, rt.batchJobFactory.value, "stale-epoch build must not write the shared cache")
+}
+
+// TestSnapshot_BatchJobFactory_SameEpoch_FactoryUnavailable covers the
+// same-epoch path where the shared cache build returns nil (bad regex →
+// PosterGen nil → buildBatchJobFactory returns nil before touching the
+// JobStore) → BatchJobFactory returns nil without panicking.
+func TestSnapshot_BatchJobFactory_SameEpoch_FactoryUnavailable(t *testing.T) {
+	rt := newSnapshotTestRuntime(t, badRegexSnapshotConfig())
+	snap := rt.Snapshot()
+	// sameEpoch=true; cache build returns nil (PosterGen nil) → returns nil.
+	assert.Nil(t, snap.BatchJobFactory())
+}
+
+// TestSnapshot_PosterManager_NoRuntimeState covers the rs == nil branch: when
+// the runtime has no RuntimeState, PosterManager builds directly from snap.cfg
+// without routing through the shared cache.
+func TestSnapshot_PosterManager_NoRuntimeState(t *testing.T) {
+	cfg := snapshotTestConfig(1111, 100, `([A-Z]+-\d+)`)
+	cfg.System.TempDir = "/tmp/snapNoRT"
+	rt := newSnapshotTestRuntime(t, cfg)
+	// Intentionally do NOT call EnsureRuntime → rs is nil.
+	snap := rt.Snapshot()
+	pm := snap.PosterManager()
+	require.NotNil(t, pm)
+}

--- a/internal/api/file/scan.go
+++ b/internal/api/file/scan.go
@@ -31,7 +31,12 @@ func scanDirectory(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		apiCfg := rt.GetAPIConfig()
+		// Take one consistent snapshot so the APIConfig (security/scanner settings)
+		// and the scan-only workflow come from the same reload epoch. Reading them
+		// via separate accessors could mix old/new state if a config reload lands
+		// between the calls (issue #44).
+		snap := rt.Snapshot()
+		apiCfg := snap.APIConfig()
 		scanCfg := apiCfg.ScannerConfig()
 
 		dirFile, validPath, err := core.ValidateAndOpenPath(req.Path, apiCfg.SecurityConfig())
@@ -41,7 +46,7 @@ func scanDirectory(rt *core.APIRuntime) gin.HandlerFunc {
 		}
 		defer func() { _ = dirFile.Close() }()
 
-		wf, wfErr := rt.GetScanOnlyWorkflow()
+		wf, wfErr := snap.ScanOnlyWorkflow()
 		if wfErr != nil {
 			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: wfErr.Error()})
 			return

--- a/internal/workflow/factory.go
+++ b/internal/workflow/factory.go
@@ -571,6 +571,13 @@ func (f *WorkflowFactory) Scanner() scanner.ScannerInterface {
 	return f.fc.Scanner
 }
 
+// MaxFilesPerScan returns the per-scan file limit the factory was built from.
+// Exposed for hot-reload consistency diagnostics so callers can verify a cached
+// factory's config-derived value matches the current APIConfig snapshot.
+func (f *WorkflowFactory) MaxFilesPerScan() int {
+	return f.fc.MaxFilesPerScan
+}
+
 // ReloadReplacementCaches refreshes the aggregator's genre, word, and alias
 // replacement caches in-place, without destroying the WorkflowFactory or
 // rebuilding the scraper, matcher, organizer, downloader, or NFO generator.


### PR DESCRIPTION
## Summary

`APIRuntime.ReloadConfig` published the config/registry, the `APIConfig` snapshot, and the cached workflow factories across **three separate critical sections**, so a concurrent request could observe mixed old/new state during a config reload — e.g. new cfg/registry with old `APIConfig`, or new `APIConfig` with a stale cached workflow factory. This is the documented heavy-lift follow-up deferred from #35.

Closes #44.

## Approach

**Writer side — atomic publication.** Added a coarse `reloadMu sync.RWMutex` on `APIRuntime`. The registry swap, `APIConfig` rebuild, and factory invalidation now publish as one atomic unit (slow registry construction stays outside the lock; only pointer swaps + cheap invalidations are inside). Lock ordering: `reloadMu → CoreDeps.mu` (`→ lazyValue.mu`, `→ RuntimeState.mu`).

**Reader side — `Snapshot()` contract.** Added `Snapshot()` + `RuntimeSnapshot` that capture cfg + registry + `APIConfig` under one `reloadMu.RLock`, with gen-checked factory accessors (`WorkflowFactory`, `BatchWorkflow`, `ScanOnlyWorkflow`, `BatchJobFactory`, `PosterGen`, `PosterManager`, `Matcher`). These reuse the shared lazy cache when no reload has landed (cfg pointer unchanged) and otherwise build fresh from the snapshot's captured cfg/registry **without caching** (so a stale-epoch request stays consistent without poisoning the newer cache).

**Handler migration.** Migrated the workflow-combining handlers — batch `usecases`/`execute`/`rescrape`/`batch_rescrape`/`paths`/`movie_edit`/`prepare_request`/`apply_config_builder`/`lifecycle`, and `file/scan` — to take one `Snapshot()` instead of calling `GetAPIConfig`/`GetBatchWorkflow`/`GetBatchJobFactory` separately. The legacy single-read accessors remain for handlers that read only one value (auth middleware, routes, GET `/config`, version).

## Test plan

- Added test-only pause seams (`reloadPauseAfterRegistry`, `reloadPauseAfterAPICfg`) and demonstrating tests:
  - `TestHotReload_Race_Window1_NewCfg_OldAPIConfig` — deterministic, channel-synced; **failed on unfixed code, passes now**.
  - `TestHotReload_Race_Window2_NewAPIConfig_OldFactory` — deterministic; **failed on unfixed code, passes now**.
  - `TestHotReload_Race_Stress` — 8 readers + 1 reloader under `-race`.
  - `TestHotReload_Race_CrossAccessor_SnapshotIsConsistent` — pins the snapshot reader contract.
- `make test-race` (api + worker + tui + websocket) green.
- `make coverage-check`: **89.95%** (gate: 75%).
- `go vet`, `golangci-lint` (0 issues), `gofmt` clean.

## Out of scope

- The pre-existing `lazyValue` double-build wastefulness (two goroutines building on a cache miss) — not the race described in #44.
- The `PosterManager` cache has a narrow pre-existing invalidation window (also present in the original `GetPosterManager`); the snapshot path documents it but doesn't widen the publication race this PR fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved consistency across batch (organize/update/preview/rescrape/cancel), scan, and poster-related actions by using a single stable configuration snapshot per request.
  * Added a per-scan file limit surfaced from the workflow system.

* **Bug Fixes**
  * Reduced hot-reload race conditions by making config and cached factory updates atomic, preventing mixed settings mid-request.
  * Improved reliability of rescrape/update/cancel/poster flows, including consistent job-state handling and clearer responses when batch job services are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->