### PR TITLE
refactor(api/contracts): introduce DTOs for MovieView nested collections

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3379,6 +3379,79 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_javinizer_javinizer-go_internal_api_contracts.ActressTranslationView": {
+            "type": "object",
+            "properties": {
+                "actress_id": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "japanese_name": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "source_name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_javinizer_javinizer-go_internal_api_contracts.ActressView": {
+            "type": "object",
+            "properties": {
+                "aliases": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "dmm_id": {
+                    "type": "integer"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "japanese_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "thumb_url": {
+                    "type": "string"
+                },
+                "translations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ActressTranslationView"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_javinizer_javinizer-go_internal_api_contracts.AuthCredentialsRequest": {
             "type": "object",
             "required": [
@@ -3912,6 +3985,49 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_javinizer_javinizer-go_internal_api_contracts.GenreTranslationView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "genre_id": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source_name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_javinizer_javinizer-go_internal_api_contracts.GenreView": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "translations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.GenreTranslationView"
+                    }
+                }
+            }
+        },
         "github_com_javinizer_javinizer-go_internal_api_contracts.HealthResponse": {
             "type": "object",
             "properties": {
@@ -4067,14 +4183,61 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_javinizer_javinizer-go_internal_api_contracts.MovieTranslationView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "director": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "maker": {
+                    "type": "string"
+                },
+                "movie_id": {
+                    "type": "string"
+                },
+                "original_title": {
+                    "type": "string"
+                },
+                "series": {
+                    "type": "string"
+                },
+                "settings_hash": {
+                    "type": "string"
+                },
+                "source_name": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_javinizer_javinizer-go_internal_api_contracts.MovieView": {
             "type": "object",
             "properties": {
                 "actresses": {
-                    "description": "Relationships",
+                    "description": "Relationships (contract DTOs — see collection_views.go; persistence\nmodels.* types never cross the API boundary)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.Actress"
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ActressView"
                     }
                 },
                 "code": {
@@ -4107,7 +4270,7 @@ const docTemplate = `{
                 "genres": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.Genre"
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.GenreView"
                     }
                 },
                 "id": {
@@ -4196,7 +4359,7 @@ const docTemplate = `{
                 "translations": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.MovieTranslation"
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.MovieTranslationView"
                     }
                 },
                 "updated_at": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3377,6 +3377,79 @@
                 }
             }
         },
+        "github_com_javinizer_javinizer-go_internal_api_contracts.ActressTranslationView": {
+            "type": "object",
+            "properties": {
+                "actress_id": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "japanese_name": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "source_name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_javinizer_javinizer-go_internal_api_contracts.ActressView": {
+            "type": "object",
+            "properties": {
+                "aliases": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "dmm_id": {
+                    "type": "integer"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "japanese_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "thumb_url": {
+                    "type": "string"
+                },
+                "translations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ActressTranslationView"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_javinizer_javinizer-go_internal_api_contracts.AuthCredentialsRequest": {
             "type": "object",
             "required": [
@@ -3910,6 +3983,49 @@
                 }
             }
         },
+        "github_com_javinizer_javinizer-go_internal_api_contracts.GenreTranslationView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "genre_id": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source_name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_javinizer_javinizer-go_internal_api_contracts.GenreView": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "translations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.GenreTranslationView"
+                    }
+                }
+            }
+        },
         "github_com_javinizer_javinizer-go_internal_api_contracts.HealthResponse": {
             "type": "object",
             "properties": {
@@ -4065,14 +4181,61 @@
                 }
             }
         },
+        "github_com_javinizer_javinizer-go_internal_api_contracts.MovieTranslationView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "director": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "maker": {
+                    "type": "string"
+                },
+                "movie_id": {
+                    "type": "string"
+                },
+                "original_title": {
+                    "type": "string"
+                },
+                "series": {
+                    "type": "string"
+                },
+                "settings_hash": {
+                    "type": "string"
+                },
+                "source_name": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_javinizer_javinizer-go_internal_api_contracts.MovieView": {
             "type": "object",
             "properties": {
                 "actresses": {
-                    "description": "Relationships",
+                    "description": "Relationships (contract DTOs — see collection_views.go; persistence\nmodels.* types never cross the API boundary)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.Actress"
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ActressView"
                     }
                 },
                 "code": {
@@ -4105,7 +4268,7 @@
                 "genres": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.Genre"
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.GenreView"
                     }
                 },
                 "id": {
@@ -4194,7 +4357,7 @@
                 "translations": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.MovieTranslation"
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.MovieTranslationView"
                     }
                 },
                 "updated_at": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -76,6 +76,54 @@ definitions:
         example: 27
         type: integer
     type: object
+  github_com_javinizer_javinizer-go_internal_api_contracts.ActressTranslationView:
+    properties:
+      actress_id:
+        type: integer
+      created_at:
+        type: string
+      display_name:
+        type: string
+      first_name:
+        type: string
+      id:
+        type: integer
+      japanese_name:
+        type: string
+      language:
+        type: string
+      last_name:
+        type: string
+      source_name:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  github_com_javinizer_javinizer-go_internal_api_contracts.ActressView:
+    properties:
+      aliases:
+        type: string
+      created_at:
+        type: string
+      dmm_id:
+        type: integer
+      first_name:
+        type: string
+      id:
+        type: integer
+      japanese_name:
+        type: string
+      last_name:
+        type: string
+      thumb_url:
+        type: string
+      translations:
+        items:
+          $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ActressTranslationView'
+        type: array
+      updated_at:
+        type: string
+    type: object
   github_com_javinizer_javinizer-go_internal_api_contracts.AuthCredentialsRequest:
     properties:
       password:
@@ -461,6 +509,34 @@ definitions:
         example: 1024000000
         type: integer
     type: object
+  github_com_javinizer_javinizer-go_internal_api_contracts.GenreTranslationView:
+    properties:
+      created_at:
+        type: string
+      genre_id:
+        type: integer
+      id:
+        type: integer
+      language:
+        type: string
+      name:
+        type: string
+      source_name:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  github_com_javinizer_javinizer-go_internal_api_contracts.GenreView:
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      translations:
+        items:
+          $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.GenreTranslationView'
+        type: array
+    type: object
   github_com_javinizer_javinizer-go_internal_api_contracts.HealthResponse:
     properties:
       build_date:
@@ -568,12 +644,45 @@ definitions:
         description: Field-level data source tracking
         type: object
     type: object
+  github_com_javinizer_javinizer-go_internal_api_contracts.MovieTranslationView:
+    properties:
+      created_at:
+        type: string
+      description:
+        type: string
+      director:
+        type: string
+      id:
+        type: integer
+      label:
+        type: string
+      language:
+        type: string
+      maker:
+        type: string
+      movie_id:
+        type: string
+      original_title:
+        type: string
+      series:
+        type: string
+      settings_hash:
+        type: string
+      source_name:
+        type: string
+      title:
+        type: string
+      updated_at:
+        type: string
+    type: object
   github_com_javinizer_javinizer-go_internal_api_contracts.MovieView:
     properties:
       actresses:
-        description: Relationships
+        description: |-
+          Relationships (contract DTOs — see collection_views.go; persistence
+          models.* types never cross the API boundary)
         items:
-          $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_models.Actress'
+          $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ActressView'
         type: array
       code:
         description: Canonical JAV code (e.g., "IPX-535"). Renamed from content_id.
@@ -597,7 +706,7 @@ definitions:
         type: string
       genres:
         items:
-          $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_models.Genre'
+          $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.GenreView'
         type: array
       id:
         description: Secondary identifier — often equals Code but can differ.
@@ -661,7 +770,7 @@ definitions:
         type: string
       translations:
         items:
-          $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_models.MovieTranslation'
+          $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.MovieTranslationView'
         type: array
       updated_at:
         type: string

--- a/internal/api/contracts/collection_views.go
+++ b/internal/api/contracts/collection_views.go
@@ -1,0 +1,407 @@
+package contracts
+
+import (
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+// Collection view DTOs decouple MovieView's nested relationships from the
+// persistence-layer models.* types. Per ADR-0007 ("one representation per
+// layer, not one representation total"), schema/tag changes in
+// internal/models must not leak into the public API contract.
+//
+// The JSON tags below are the API contract and intentionally mirror the
+// current models json tags so the wire format is preserved — the
+// decoupling is structural, not a rename. DTOs carry no gorm/persistence
+// tags.
+
+// ActressView is the API-layer projection of models.Actress.
+type ActressView struct {
+	ID           uint                     `json:"id"`
+	DMMID        int                      `json:"dmm_id"`
+	FirstName    string                   `json:"first_name"`
+	LastName     string                   `json:"last_name"`
+	JapaneseName string                   `json:"japanese_name"`
+	ThumbURL     string                   `json:"thumb_url"`
+	Aliases      string                   `json:"aliases"`
+	Translations []ActressTranslationView `json:"translations,omitempty"`
+	CreatedAt    time.Time                `json:"created_at"`
+	UpdatedAt    time.Time                `json:"updated_at"`
+}
+
+// GenreView is the API-layer projection of models.Genre.
+type GenreView struct {
+	ID           uint                   `json:"id"`
+	Name         string                 `json:"name"`
+	Translations []GenreTranslationView `json:"translations,omitempty"`
+}
+
+// MovieTranslationView is the API-layer projection of models.MovieTranslation.
+type MovieTranslationView struct {
+	ID            uint      `json:"id"`
+	MovieID       string    `json:"movie_id"`
+	Language      string    `json:"language"`
+	Title         string    `json:"title"`
+	OriginalTitle string    `json:"original_title"`
+	Description   string    `json:"description"`
+	Director      string    `json:"director"`
+	Maker         string    `json:"maker"`
+	Label         string    `json:"label"`
+	Series        string    `json:"series"`
+	SourceName    string    `json:"source_name"`
+	SettingsHash  string    `json:"settings_hash"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// ActressTranslationView is the API-layer projection of models.ActressTranslation.
+type ActressTranslationView struct {
+	ID           uint      `json:"id"`
+	ActressID    uint      `json:"actress_id"`
+	Language     string    `json:"language"`
+	FirstName    string    `json:"first_name"`
+	LastName     string    `json:"last_name"`
+	JapaneseName string    `json:"japanese_name"`
+	DisplayName  string    `json:"display_name"`
+	SourceName   string    `json:"source_name"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// GenreTranslationView is the API-layer projection of models.GenreTranslation.
+type GenreTranslationView struct {
+	ID         uint      `json:"id"`
+	GenreID    uint      `json:"genre_id"`
+	Language   string    `json:"language"`
+	Name       string    `json:"name"`
+	SourceName string    `json:"source_name"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// ActressViewFromModel maps a persistence-layer Actress to an API-layer
+// ActressView. Returns nil for nil input. Nested translations are copied
+// into fresh slices so the view does not alias the model.
+func ActressViewFromModel(a *models.Actress) *ActressView {
+	if a == nil {
+		return nil
+	}
+	return &ActressView{
+		ID:           a.ID,
+		DMMID:        a.DMMID,
+		FirstName:    a.FirstName,
+		LastName:     a.LastName,
+		JapaneseName: a.JapaneseName,
+		ThumbURL:     a.ThumbURL,
+		Aliases:      a.Aliases,
+		Translations: ActressTranslationViewSliceFromModels(a.Translations),
+		CreatedAt:    a.CreatedAt,
+		UpdatedAt:    a.UpdatedAt,
+	}
+}
+
+// ActressViewToModel maps an API-layer ActressView back to a persistence-layer
+// Actress. Returns nil for nil input. Inverse of ActressViewFromModel.
+func ActressViewToModel(v *ActressView) *models.Actress {
+	if v == nil {
+		return nil
+	}
+	return &models.Actress{
+		ID:           v.ID,
+		DMMID:        v.DMMID,
+		FirstName:    v.FirstName,
+		LastName:     v.LastName,
+		JapaneseName: v.JapaneseName,
+		ThumbURL:     v.ThumbURL,
+		Aliases:      v.Aliases,
+		Translations: ActressTranslationViewSliceToModels(v.Translations),
+		CreatedAt:    v.CreatedAt,
+		UpdatedAt:    v.UpdatedAt,
+	}
+}
+
+// GenreViewFromModel maps a persistence-layer Genre to an API-layer GenreView.
+// Returns nil for nil input.
+func GenreViewFromModel(g *models.Genre) *GenreView {
+	if g == nil {
+		return nil
+	}
+	return &GenreView{
+		ID:           g.ID,
+		Name:         g.Name,
+		Translations: GenreTranslationViewSliceFromModels(g.Translations),
+	}
+}
+
+// GenreViewToModel maps an API-layer GenreView back to a persistence-layer
+// Genre. Returns nil for nil input. Inverse of GenreViewFromModel.
+func GenreViewToModel(v *GenreView) *models.Genre {
+	if v == nil {
+		return nil
+	}
+	return &models.Genre{
+		ID:           v.ID,
+		Name:         v.Name,
+		Translations: GenreTranslationViewSliceToModels(v.Translations),
+	}
+}
+
+// MovieTranslationViewFromModel maps a persistence-layer MovieTranslation to
+// an API-layer MovieTranslationView. Returns nil for nil input.
+func MovieTranslationViewFromModel(t *models.MovieTranslation) *MovieTranslationView {
+	if t == nil {
+		return nil
+	}
+	return &MovieTranslationView{
+		ID:            t.ID,
+		MovieID:       t.MovieID,
+		Language:      t.Language,
+		Title:         t.Title,
+		OriginalTitle: t.OriginalTitle,
+		Description:   t.Description,
+		Director:      t.Director,
+		Maker:         t.Maker,
+		Label:         t.Label,
+		Series:        t.Series,
+		SourceName:    t.SourceName,
+		SettingsHash:  t.SettingsHash,
+		CreatedAt:     t.CreatedAt,
+		UpdatedAt:     t.UpdatedAt,
+	}
+}
+
+// MovieTranslationViewToModel maps an API-layer MovieTranslationView back to a
+// persistence-layer MovieTranslation. Returns nil for nil input. Inverse of
+// MovieTranslationViewFromModel.
+func MovieTranslationViewToModel(v *MovieTranslationView) *models.MovieTranslation {
+	if v == nil {
+		return nil
+	}
+	return &models.MovieTranslation{
+		ID:            v.ID,
+		MovieID:       v.MovieID,
+		Language:      v.Language,
+		Title:         v.Title,
+		OriginalTitle: v.OriginalTitle,
+		Description:   v.Description,
+		Director:      v.Director,
+		Maker:         v.Maker,
+		Label:         v.Label,
+		Series:        v.Series,
+		SourceName:    v.SourceName,
+		SettingsHash:  v.SettingsHash,
+		CreatedAt:     v.CreatedAt,
+		UpdatedAt:     v.UpdatedAt,
+	}
+}
+
+// ActressTranslationViewFromModel maps a persistence-layer ActressTranslation
+// to an API-layer ActressTranslationView. Returns nil for nil input.
+func ActressTranslationViewFromModel(t *models.ActressTranslation) *ActressTranslationView {
+	if t == nil {
+		return nil
+	}
+	return &ActressTranslationView{
+		ID:           t.ID,
+		ActressID:    t.ActressID,
+		Language:     t.Language,
+		FirstName:    t.FirstName,
+		LastName:     t.LastName,
+		JapaneseName: t.JapaneseName,
+		DisplayName:  t.DisplayName,
+		SourceName:   t.SourceName,
+		CreatedAt:    t.CreatedAt,
+		UpdatedAt:    t.UpdatedAt,
+	}
+}
+
+// ActressTranslationViewToModel maps an API-layer ActressTranslationView back
+// to a persistence-layer ActressTranslation. Returns nil for nil input.
+func ActressTranslationViewToModel(v *ActressTranslationView) *models.ActressTranslation {
+	if v == nil {
+		return nil
+	}
+	return &models.ActressTranslation{
+		ID:           v.ID,
+		ActressID:    v.ActressID,
+		Language:     v.Language,
+		FirstName:    v.FirstName,
+		LastName:     v.LastName,
+		JapaneseName: v.JapaneseName,
+		DisplayName:  v.DisplayName,
+		SourceName:   v.SourceName,
+		CreatedAt:    v.CreatedAt,
+		UpdatedAt:    v.UpdatedAt,
+	}
+}
+
+// GenreTranslationViewFromModel maps a persistence-layer GenreTranslation to
+// an API-layer GenreTranslationView. Returns nil for nil input.
+func GenreTranslationViewFromModel(t *models.GenreTranslation) *GenreTranslationView {
+	if t == nil {
+		return nil
+	}
+	return &GenreTranslationView{
+		ID:         t.ID,
+		GenreID:    t.GenreID,
+		Language:   t.Language,
+		Name:       t.Name,
+		SourceName: t.SourceName,
+		CreatedAt:  t.CreatedAt,
+		UpdatedAt:  t.UpdatedAt,
+	}
+}
+
+// GenreTranslationViewToModel maps an API-layer GenreTranslationView back to a
+// persistence-layer GenreTranslation. Returns nil for nil input.
+func GenreTranslationViewToModel(v *GenreTranslationView) *models.GenreTranslation {
+	if v == nil {
+		return nil
+	}
+	return &models.GenreTranslation{
+		ID:         v.ID,
+		GenreID:    v.GenreID,
+		Language:   v.Language,
+		Name:       v.Name,
+		SourceName: v.SourceName,
+		CreatedAt:  v.CreatedAt,
+		UpdatedAt:  v.UpdatedAt,
+	}
+}
+
+// ActressViewSliceFromModels maps a slice of Actresses to ActressViews.
+// A nil input yields a nil result so the JSON shape (null vs []) is preserved.
+func ActressViewSliceFromModels(ms []models.Actress) []ActressView {
+	if ms == nil {
+		return nil
+	}
+	vs := make([]ActressView, len(ms))
+	for i := range ms {
+		vs[i] = *ActressViewFromModel(&ms[i])
+	}
+	return vs
+}
+
+// ActressViewSliceToModels maps a slice of ActressViews to Actresses.
+// A nil input yields a nil result so the JSON shape (null vs []) is preserved.
+func ActressViewSliceToModels(vs []ActressView) []models.Actress {
+	if vs == nil {
+		return nil
+	}
+	ms := make([]models.Actress, len(vs))
+	for i := range vs {
+		ms[i] = *ActressViewToModel(&vs[i])
+	}
+	return ms
+}
+
+// GenreViewSliceFromModels maps a slice of Genres to GenreViews.
+// A nil input yields a nil result so the JSON shape (null vs []) is preserved.
+func GenreViewSliceFromModels(ms []models.Genre) []GenreView {
+	if ms == nil {
+		return nil
+	}
+	vs := make([]GenreView, len(ms))
+	for i := range ms {
+		vs[i] = *GenreViewFromModel(&ms[i])
+	}
+	return vs
+}
+
+// GenreViewSliceToModels maps a slice of GenreViews to Genres.
+// A nil input yields a nil result so the JSON shape (null vs []) is preserved.
+func GenreViewSliceToModels(vs []GenreView) []models.Genre {
+	if vs == nil {
+		return nil
+	}
+	ms := make([]models.Genre, len(vs))
+	for i := range vs {
+		ms[i] = *GenreViewToModel(&vs[i])
+	}
+	return ms
+}
+
+// MovieTranslationViewSliceFromModels maps a slice of MovieTranslations to
+// MovieTranslationViews. A nil input yields a nil result so the JSON shape
+// (null vs []) is preserved.
+func MovieTranslationViewSliceFromModels(ms []models.MovieTranslation) []MovieTranslationView {
+	if ms == nil {
+		return nil
+	}
+	vs := make([]MovieTranslationView, len(ms))
+	for i := range ms {
+		vs[i] = *MovieTranslationViewFromModel(&ms[i])
+	}
+	return vs
+}
+
+// MovieTranslationViewSliceToModels maps a slice of MovieTranslationViews to
+// MovieTranslations. A nil input yields a nil result so the JSON shape
+// (null vs []) is preserved.
+func MovieTranslationViewSliceToModels(vs []MovieTranslationView) []models.MovieTranslation {
+	if vs == nil {
+		return nil
+	}
+	ms := make([]models.MovieTranslation, len(vs))
+	for i := range vs {
+		ms[i] = *MovieTranslationViewToModel(&vs[i])
+	}
+	return ms
+}
+
+// ActressTranslationViewSliceFromModels maps a slice of ActressTranslations to
+// ActressTranslationViews. A nil input yields a nil result so the JSON shape
+// (null vs []) is preserved.
+func ActressTranslationViewSliceFromModels(ms []models.ActressTranslation) []ActressTranslationView {
+	if ms == nil {
+		return nil
+	}
+	vs := make([]ActressTranslationView, len(ms))
+	for i := range ms {
+		vs[i] = *ActressTranslationViewFromModel(&ms[i])
+	}
+	return vs
+}
+
+// ActressTranslationViewSliceToModels maps a slice of ActressTranslationViews
+// to ActressTranslations. A nil input yields a nil result so the JSON shape
+// (null vs []) is preserved.
+func ActressTranslationViewSliceToModels(vs []ActressTranslationView) []models.ActressTranslation {
+	if vs == nil {
+		return nil
+	}
+	ms := make([]models.ActressTranslation, len(vs))
+	for i := range vs {
+		ms[i] = *ActressTranslationViewToModel(&vs[i])
+	}
+	return ms
+}
+
+// GenreTranslationViewSliceFromModels maps a slice of GenreTranslations to
+// GenreTranslationViews. A nil input yields a nil result so the JSON shape
+// (null vs []) is preserved.
+func GenreTranslationViewSliceFromModels(ms []models.GenreTranslation) []GenreTranslationView {
+	if ms == nil {
+		return nil
+	}
+	vs := make([]GenreTranslationView, len(ms))
+	for i := range ms {
+		vs[i] = *GenreTranslationViewFromModel(&ms[i])
+	}
+	return vs
+}
+
+// GenreTranslationViewSliceToModels maps a slice of GenreTranslationViews to
+// GenreTranslations. A nil input yields a nil result so the JSON shape
+// (null vs []) is preserved.
+func GenreTranslationViewSliceToModels(vs []GenreTranslationView) []models.GenreTranslation {
+	if vs == nil {
+		return nil
+	}
+	ms := make([]models.GenreTranslation, len(vs))
+	for i := range vs {
+		ms[i] = *GenreTranslationViewToModel(&vs[i])
+	}
+	return ms
+}

--- a/internal/api/contracts/collection_views.go
+++ b/internal/api/contracts/collection_views.go
@@ -270,138 +270,97 @@ func GenreTranslationViewToModel(v *GenreTranslationView) *models.GenreTranslati
 	}
 }
 
-// ActressViewSliceFromModels maps a slice of Actresses to ActressViews.
-// A nil input yields a nil result so the JSON shape (null vs []) is preserved.
-func ActressViewSliceFromModels(ms []models.Actress) []ActressView {
+// sliceFromModels maps a slice of persistence models to contract views via
+// conv. A nil input yields a nil result so the JSON shape (null vs []) is
+// preserved. It is the shared implementation behind every *SliceFromModels
+// helper, keeping nil-handling and value-semantics identical across DTOs.
+func sliceFromModels[M any, V any](ms []M, conv func(*M) *V) []V {
 	if ms == nil {
 		return nil
 	}
-	vs := make([]ActressView, len(ms))
+	vs := make([]V, len(ms))
 	for i := range ms {
-		vs[i] = *ActressViewFromModel(&ms[i])
+		vs[i] = *conv(&ms[i])
 	}
 	return vs
+}
+
+// sliceToModels is the inverse of sliceFromModels, mapping contract views back
+// to persistence models. A nil input yields a nil result so the JSON shape
+// (null vs []) is preserved.
+func sliceToModels[V any, M any](vs []V, conv func(*V) *M) []M {
+	if vs == nil {
+		return nil
+	}
+	ms := make([]M, len(vs))
+	for i := range vs {
+		ms[i] = *conv(&vs[i])
+	}
+	return ms
+}
+
+// ActressViewSliceFromModels maps a slice of Actresses to ActressViews.
+// A nil input yields a nil result so the JSON shape (null vs []) is preserved.
+func ActressViewSliceFromModels(ms []models.Actress) []ActressView {
+	return sliceFromModels(ms, ActressViewFromModel)
 }
 
 // ActressViewSliceToModels maps a slice of ActressViews to Actresses.
 // A nil input yields a nil result so the JSON shape (null vs []) is preserved.
 func ActressViewSliceToModels(vs []ActressView) []models.Actress {
-	if vs == nil {
-		return nil
-	}
-	ms := make([]models.Actress, len(vs))
-	for i := range vs {
-		ms[i] = *ActressViewToModel(&vs[i])
-	}
-	return ms
+	return sliceToModels(vs, ActressViewToModel)
 }
 
 // GenreViewSliceFromModels maps a slice of Genres to GenreViews.
 // A nil input yields a nil result so the JSON shape (null vs []) is preserved.
 func GenreViewSliceFromModels(ms []models.Genre) []GenreView {
-	if ms == nil {
-		return nil
-	}
-	vs := make([]GenreView, len(ms))
-	for i := range ms {
-		vs[i] = *GenreViewFromModel(&ms[i])
-	}
-	return vs
+	return sliceFromModels(ms, GenreViewFromModel)
 }
 
 // GenreViewSliceToModels maps a slice of GenreViews to Genres.
 // A nil input yields a nil result so the JSON shape (null vs []) is preserved.
 func GenreViewSliceToModels(vs []GenreView) []models.Genre {
-	if vs == nil {
-		return nil
-	}
-	ms := make([]models.Genre, len(vs))
-	for i := range vs {
-		ms[i] = *GenreViewToModel(&vs[i])
-	}
-	return ms
+	return sliceToModels(vs, GenreViewToModel)
 }
 
 // MovieTranslationViewSliceFromModels maps a slice of MovieTranslations to
 // MovieTranslationViews. A nil input yields a nil result so the JSON shape
 // (null vs []) is preserved.
 func MovieTranslationViewSliceFromModels(ms []models.MovieTranslation) []MovieTranslationView {
-	if ms == nil {
-		return nil
-	}
-	vs := make([]MovieTranslationView, len(ms))
-	for i := range ms {
-		vs[i] = *MovieTranslationViewFromModel(&ms[i])
-	}
-	return vs
+	return sliceFromModels(ms, MovieTranslationViewFromModel)
 }
 
 // MovieTranslationViewSliceToModels maps a slice of MovieTranslationViews to
 // MovieTranslations. A nil input yields a nil result so the JSON shape
 // (null vs []) is preserved.
 func MovieTranslationViewSliceToModels(vs []MovieTranslationView) []models.MovieTranslation {
-	if vs == nil {
-		return nil
-	}
-	ms := make([]models.MovieTranslation, len(vs))
-	for i := range vs {
-		ms[i] = *MovieTranslationViewToModel(&vs[i])
-	}
-	return ms
+	return sliceToModels(vs, MovieTranslationViewToModel)
 }
 
 // ActressTranslationViewSliceFromModels maps a slice of ActressTranslations to
 // ActressTranslationViews. A nil input yields a nil result so the JSON shape
 // (null vs []) is preserved.
 func ActressTranslationViewSliceFromModels(ms []models.ActressTranslation) []ActressTranslationView {
-	if ms == nil {
-		return nil
-	}
-	vs := make([]ActressTranslationView, len(ms))
-	for i := range ms {
-		vs[i] = *ActressTranslationViewFromModel(&ms[i])
-	}
-	return vs
+	return sliceFromModels(ms, ActressTranslationViewFromModel)
 }
 
 // ActressTranslationViewSliceToModels maps a slice of ActressTranslationViews
 // to ActressTranslations. A nil input yields a nil result so the JSON shape
 // (null vs []) is preserved.
 func ActressTranslationViewSliceToModels(vs []ActressTranslationView) []models.ActressTranslation {
-	if vs == nil {
-		return nil
-	}
-	ms := make([]models.ActressTranslation, len(vs))
-	for i := range vs {
-		ms[i] = *ActressTranslationViewToModel(&vs[i])
-	}
-	return ms
+	return sliceToModels(vs, ActressTranslationViewToModel)
 }
 
 // GenreTranslationViewSliceFromModels maps a slice of GenreTranslations to
 // GenreTranslationViews. A nil input yields a nil result so the JSON shape
 // (null vs []) is preserved.
 func GenreTranslationViewSliceFromModels(ms []models.GenreTranslation) []GenreTranslationView {
-	if ms == nil {
-		return nil
-	}
-	vs := make([]GenreTranslationView, len(ms))
-	for i := range ms {
-		vs[i] = *GenreTranslationViewFromModel(&ms[i])
-	}
-	return vs
+	return sliceFromModels(ms, GenreTranslationViewFromModel)
 }
 
 // GenreTranslationViewSliceToModels maps a slice of GenreTranslationViews to
 // GenreTranslations. A nil input yields a nil result so the JSON shape
 // (null vs []) is preserved.
 func GenreTranslationViewSliceToModels(vs []GenreTranslationView) []models.GenreTranslation {
-	if vs == nil {
-		return nil
-	}
-	ms := make([]models.GenreTranslation, len(vs))
-	for i := range vs {
-		ms[i] = *GenreTranslationViewToModel(&vs[i])
-	}
-	return ms
+	return sliceToModels(vs, GenreTranslationViewToModel)
 }

--- a/internal/api/contracts/collection_views_test.go
+++ b/internal/api/contracts/collection_views_test.go
@@ -1,0 +1,270 @@
+package contracts
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newFixedTime() time.Time {
+	return time.Date(2024, 3, 15, 9, 30, 0, 0, time.UTC)
+}
+
+func sampleActress() models.Actress {
+	return models.Actress{
+		ID:           7,
+		DMMID:        9012,
+		FirstName:    "Yui",
+		LastName:     "Hatano",
+		JapaneseName: "波多野結衣",
+		ThumbURL:     "https://example.com/yui.jpg",
+		Aliases:      "Yui Hatano|Hatano Yui",
+		Translations: []models.ActressTranslation{
+			{
+				ID:           100,
+				ActressID:    7,
+				Language:     "ja",
+				FirstName:    "結衣",
+				LastName:     "波多野",
+				JapaneseName: "波多野結衣",
+				DisplayName:  "波多野結衣",
+				SourceName:   "dmm",
+				CreatedAt:    newFixedTime(),
+				UpdatedAt:    newFixedTime(),
+			},
+		},
+		CreatedAt: newFixedTime(),
+		UpdatedAt: newFixedTime(),
+	}
+}
+
+func sampleGenre() models.Genre {
+	return models.Genre{
+		ID:   42,
+		Name: "Featured Actress",
+		Translations: []models.GenreTranslation{
+			{
+				ID:         5,
+				GenreID:    42,
+				Language:   "ja",
+				Name:       "魅力女優",
+				SourceName: "r18dev",
+				CreatedAt:  newFixedTime(),
+				UpdatedAt:  newFixedTime(),
+			},
+		},
+	}
+}
+
+func sampleMovieTranslation() models.MovieTranslation {
+	return models.MovieTranslation{
+		ID:            55,
+		MovieID:       "IPX-535",
+		Language:      "ja",
+		Title:         "美人女教師",
+		OriginalTitle: "美人女教師",
+		Description:   "あらすじ",
+		Director:      "山田",
+		Maker:         "IPX",
+		Label:         "IPX Zeta",
+		Series:        "Lady Teacher",
+		SourceName:    "dmm",
+		SettingsHash:  "abc12345",
+		CreatedAt:     newFixedTime(),
+		UpdatedAt:     newFixedTime(),
+	}
+}
+
+func TestActressView_RoundTrip(t *testing.T) {
+	orig := sampleActress()
+	back := ActressViewToModel(ActressViewFromModel(&orig))
+	require.NotNil(t, back)
+	assert.Equal(t, orig, *back)
+}
+
+func TestGenreView_RoundTrip(t *testing.T) {
+	orig := sampleGenre()
+	back := GenreViewToModel(GenreViewFromModel(&orig))
+	require.NotNil(t, back)
+	assert.Equal(t, orig, *back)
+}
+
+func TestMovieTranslationView_RoundTrip(t *testing.T) {
+	orig := sampleMovieTranslation()
+	back := MovieTranslationViewToModel(MovieTranslationViewFromModel(&orig))
+	require.NotNil(t, back)
+	assert.Equal(t, orig, *back)
+}
+
+// JSON parity guards the API contract: the DTO must serialize identically to
+// the persistence model it replaces, so the refactor is wire-format-neutral.
+func TestActressView_JSONParity(t *testing.T) {
+	orig := sampleActress()
+	view := ActressViewFromModel(&orig)
+
+	modelJSON, err := json.Marshal(orig)
+	require.NoError(t, err)
+	viewJSON, err := json.Marshal(view)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(modelJSON), string(viewJSON))
+}
+
+func TestGenreView_JSONParity(t *testing.T) {
+	orig := sampleGenre()
+	view := GenreViewFromModel(&orig)
+
+	modelJSON, err := json.Marshal(orig)
+	require.NoError(t, err)
+	viewJSON, err := json.Marshal(view)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(modelJSON), string(viewJSON))
+}
+
+func TestMovieTranslationView_JSONParity(t *testing.T) {
+	orig := sampleMovieTranslation()
+	view := MovieTranslationViewFromModel(&orig)
+
+	modelJSON, err := json.Marshal(orig)
+	require.NoError(t, err)
+	viewJSON, err := json.Marshal(view)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(modelJSON), string(viewJSON))
+}
+
+func TestCollectionViews_NilElementMappers(t *testing.T) {
+	assert.Nil(t, ActressViewFromModel(nil))
+	assert.Nil(t, ActressViewToModel(nil))
+	assert.Nil(t, GenreViewFromModel(nil))
+	assert.Nil(t, GenreViewToModel(nil))
+	assert.Nil(t, MovieTranslationViewFromModel(nil))
+	assert.Nil(t, MovieTranslationViewToModel(nil))
+	assert.Nil(t, ActressTranslationViewFromModel(nil))
+	assert.Nil(t, ActressTranslationViewToModel(nil))
+	assert.Nil(t, GenreTranslationViewFromModel(nil))
+	assert.Nil(t, GenreTranslationViewToModel(nil))
+}
+
+// nil slices must stay nil (→ JSON null), not become [] (→ JSON []).
+func TestCollectionViews_NilSlicesPreserveNull(t *testing.T) {
+	assert.Nil(t, ActressViewSliceFromModels(nil))
+	assert.Nil(t, ActressViewSliceToModels(nil))
+	assert.Nil(t, GenreViewSliceFromModels(nil))
+	assert.Nil(t, GenreViewSliceToModels(nil))
+	assert.Nil(t, MovieTranslationViewSliceFromModels(nil))
+	assert.Nil(t, MovieTranslationViewSliceToModels(nil))
+	assert.Nil(t, ActressTranslationViewSliceFromModels(nil))
+	assert.Nil(t, ActressTranslationViewSliceToModels(nil))
+	assert.Nil(t, GenreTranslationViewSliceFromModels(nil))
+	assert.Nil(t, GenreTranslationViewSliceToModels(nil))
+
+	// End-to-end: a nil collection on the model surfaces as JSON null on the view.
+	m := &models.Movie{ContentID: "IPX-1"}
+	view := MovieViewFromModel(m)
+	raw, err := json.Marshal(view)
+	require.NoError(t, err)
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &fields))
+	assert.JSONEq(t, `null`, string(fields["actresses"]))
+	assert.JSONEq(t, `null`, string(fields["genres"]))
+	assert.JSONEq(t, `null`, string(fields["translations"]))
+}
+
+func TestCollectionViews_EmptySlicesPreserveArray(t *testing.T) {
+	// Non-nil empty slices must stay non-nil (→ JSON []), not become null.
+	a := ActressViewSliceFromModels([]models.Actress{})
+	require.NotNil(t, a)
+	assert.Empty(t, a)
+	raw, err := json.Marshal(struct {
+		A []ActressView `json:"actresses"`
+	}{A: a})
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"actresses":[]`)
+}
+
+// MovieView round-trip ensures the wired-up MovieView mappers preserve the
+// relationship collections end to end.
+func TestMovieView_CollectionRoundTrip(t *testing.T) {
+	m := &models.Movie{
+		ContentID: "IPX-535",
+		Actresses: []models.Actress{sampleActress()},
+		Genres:    []models.Genre{sampleGenre(), {ID: 8, Name: "Solowork"}},
+		Translations: []models.MovieTranslation{
+			sampleMovieTranslation(),
+			{ID: 56, MovieID: "IPX-535", Language: "en", Title: "Beautiful Woman"},
+		},
+	}
+
+	view := MovieViewFromModel(m)
+	require.NotNil(t, view)
+	require.Len(t, view.Actresses, 1)
+	require.Len(t, view.Genres, 2)
+	require.Len(t, view.Translations, 2)
+
+	back := MovieViewToModel(view)
+	require.NotNil(t, back)
+	assert.Equal(t, m.Actresses, back.Actresses)
+	assert.Equal(t, m.Genres, back.Genres)
+	assert.Equal(t, m.Translations, back.Translations)
+}
+
+// Mutating the view's collections must not bleed back into the model — the
+// projection owns its own slices.
+func TestMovieView_CollectionIsolation(t *testing.T) {
+	m := &models.Movie{
+		ContentID: "IPX-535",
+		Actresses: []models.Actress{sampleActress()},
+	}
+	view := MovieViewFromModel(m)
+	view.Actresses[0].FirstName = "MUTATED"
+	view.Actresses[0].Translations[0].DisplayName = "MUTATED"
+
+	assert.NotEqual(t, "MUTATED", m.Actresses[0].FirstName)
+	assert.NotEqual(t, "MUTATED", m.Actresses[0].Translations[0].DisplayName)
+}
+
+// Non-nil empty collections on the model must serialize as JSON [] through
+// MovieView, not null or omitted — mirroring the nil→null guard above for
+// the empty-slice case, across all three collections end-to-end.
+func TestMovieView_EmptySlicesPreserveArray(t *testing.T) {
+	m := &models.Movie{
+		ContentID:    "IPX-1",
+		Actresses:    []models.Actress{},
+		Genres:       []models.Genre{},
+		Translations: []models.MovieTranslation{},
+	}
+	view := MovieViewFromModel(m)
+	require.NotNil(t, view)
+	raw, err := json.Marshal(view)
+	require.NoError(t, err)
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &fields))
+	assert.JSONEq(t, `[]`, string(fields["actresses"]))
+	assert.JSONEq(t, `[]`, string(fields["genres"]))
+	assert.JSONEq(t, `[]`, string(fields["translations"]))
+}
+
+// Extends collection-isolation coverage to Genres (including nested
+// GenreTranslation) and Translations, proving the view's slices don't alias
+// the model's for all three relationship collections.
+func TestMovieView_CollectionIsolation_AllCollections(t *testing.T) {
+	m := &models.Movie{
+		ContentID:    "IPX-535",
+		Actresses:    []models.Actress{sampleActress()},
+		Genres:       []models.Genre{sampleGenre()},
+		Translations: []models.MovieTranslation{sampleMovieTranslation()},
+	}
+	view := MovieViewFromModel(m)
+	require.NotNil(t, view)
+
+	view.Genres[0].Name = "MUTATED"
+	view.Genres[0].Translations[0].Name = "MUTATED"
+	view.Translations[0].Title = "MUTATED"
+
+	assert.NotEqual(t, "MUTATED", m.Genres[0].Name)
+	assert.NotEqual(t, "MUTATED", m.Genres[0].Translations[0].Name)
+	assert.NotEqual(t, "MUTATED", m.Translations[0].Title)
+}

--- a/internal/api/contracts/movie_view.go
+++ b/internal/api/contracts/movie_view.go
@@ -56,10 +56,11 @@ type MovieView struct {
 	OriginalFileName string   `json:"original_filename"`
 	Screenshots      []string `json:"screenshot_urls"`
 
-	// Relationships
-	Actresses    []models.Actress          `json:"actresses"`
-	Genres       []models.Genre            `json:"genres"`
-	Translations []models.MovieTranslation `json:"translations"`
+	// Relationships (contract DTOs — see collection_views.go; persistence
+	// models.* types never cross the API boundary)
+	Actresses    []ActressView          `json:"actresses"`
+	Genres       []GenreView            `json:"genres"`
+	Translations []MovieTranslationView `json:"translations"`
 
 	// Source provenance
 	SourceName string `json:"source_name"` // Primary source
@@ -72,9 +73,10 @@ type MovieView struct {
 
 // MovieViewFromModel maps a persistence-layer Movie to an API-layer MovieView.
 // The single rename (content_id → code) is the only wire-format change.
-// PosterState fields are lifted to top-level MovieView fields.
-// Slice fields are shared (not deep-copied) — callers must treat the
-// MovieView as read-only or copy slices before mutation.
+// PosterState fields are lifted to top-level MovieView fields. Relationship
+// collections (Actresses/Genres/Translations) are projected through contract
+// DTOs and copied into fresh slices, so the view does not alias the model.
+// Screenshots remains a shared string slice — treat it as read-only.
 func MovieViewFromModel(m *models.Movie) *MovieView {
 	if m == nil {
 		return nil
@@ -107,9 +109,9 @@ func MovieViewFromModel(m *models.Movie) *MovieView {
 		TrailerURL:               m.TrailerURL,
 		OriginalFileName:         m.OriginalFileName,
 		Screenshots:              m.Screenshots,
-		Actresses:                m.Actresses,
-		Genres:                   m.Genres,
-		Translations:             m.Translations,
+		Actresses:                ActressViewSliceFromModels(m.Actresses),
+		Genres:                   GenreViewSliceFromModels(m.Genres),
+		Translations:             MovieTranslationViewSliceFromModels(m.Translations),
 		SourceName:               m.SourceName,
 		SourceURL:                m.SourceURL,
 		CreatedAt:                m.CreatedAt,
@@ -145,9 +147,9 @@ func MovieViewToModel(v *MovieView) *models.Movie {
 		TrailerURL:       v.TrailerURL,
 		OriginalFileName: v.OriginalFileName,
 		Screenshots:      v.Screenshots,
-		Actresses:        v.Actresses,
-		Genres:           v.Genres,
-		Translations:     v.Translations,
+		Actresses:        ActressViewSliceToModels(v.Actresses),
+		Genres:           GenreViewSliceToModels(v.Genres),
+		Translations:     MovieTranslationViewSliceToModels(v.Translations),
 		SourceName:       v.SourceName,
 		SourceURL:        v.SourceURL,
 		CreatedAt:        v.CreatedAt,


### PR DESCRIPTION
## Summary

Decouples `MovieView`'s nested collections (`Actresses`, `Genres`, `Translations`) from persistence-layer `models.*` types by introducing contract DTOs + bidirectional mappers. The projection layer introduced in PR #35 was only a partial boundary — the nested collections still passed through `models.*` types, so schema/tag changes in `internal/models` could leak into the public API contract. This closes that gap.

Closes #45

## Changes

- **`internal/api/contracts/collection_views.go`** (new) — 5 contract DTOs + `FromModel`/`ToModel` element + slice mappers:
  - `ActressView`, `GenreView`, `MovieTranslationView` (the 3 nested collections)
  - `ActressTranslationView`, `GenreTranslationView` (nested within Actress/Genre, to fully close the boundary)
  - All nil-safe (nil slice → JSON `null`, non-nil empty → `[]`)
- **`internal/api/contracts/movie_view.go`** — `MovieView.Actresses/Genres/Translations` now use the DTOs; `MovieViewFromModel`/`MovieViewToModel` route through the slice mappers; collections are copied into fresh slices (no aliasing)
- **`internal/api/contracts/collection_views_test.go`** (new) — 13 tests: round-trip equality, JSON-parity (DTO serializes identically to the model it replaces), nil-slice → `null` end-to-end through `MovieView`, empty-slice → `[]` end-to-end, collection isolation (non-aliasing for all 3 collections incl. nested translations)
- **`docs/swagger/{docs.go,swagger.json,swagger.yaml}`** — regenerated; `MovieView` collections now `$ref` the contract DTOs (exactly 3 `$ref` swaps + 5 new DTO definitions)

## Wire format

**Unchanged.** JSON tags on the new DTOs mirror the `models.*` tags exactly. Verified by JSON-parity tests (`assert.JSONEq` between model and DTO marshals) for all 3 collections including nested translations. Zero user-facing impact, as the issue framed it.

## Scope notes

- `actress_types.go` (merge preview/response) still embeds `models.Actress` directly — intentionally left untouched; the issue is scoped to `MovieView` nested collections. Separate follow-up.
- `MovieViewSliceFromModels` nil-preservation is a pre-existing inconsistency (not introduced here) — candidate for a separate follow-up.

## Validation

- `go build ./...` — clean
- `go vet ./internal/api/...` — clean
- `go test -short ./...` — all pass
- `go test -race -short ./internal/api/{contracts,server}/...` — pass
- `golangci-lint run` — 0 issues
- `make swagger` — deterministic (consecutive runs byte-identical); `make check-swagger` up to date
- Pre-commit hooks (fmt, lint, vet, tests, build, swagger) — all passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced movie-related API responses to use dedicated “view” formats for related items and translations, making returned structures more consistent.
* **Bug Fixes**
  * Improved conversion of relationship data between API and storage representations, helping preserve the correct handling of empty versus missing related values in movie responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->