### PR TITLE
feat(update): environment-aware upgrade UX (docker/desktop/cli)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ javinizer upgrade --prerelease  # upgrade to the newest release, including prere
 
 The new binary is verified against the release `checksums.txt` before the swap. If javinizer was installed via **Homebrew** or **Scoop**, `upgrade` detects that and tells you to use `brew upgrade javinizer` / `scoop update javinizer` instead, so it never clobbers a package-manager install.
 
+`upgrade` is also **environment-aware**: inside a **Docker** container it refuses the in-place swap (the image is read-only and a replace would be lost on the next recreate) and prints the `docker pull ghcr.io/javinizer/javinizer-go:latest` command instead; in the **desktop app** it points you to the [releases page](https://github.com/javinizer/javinizer-go/releases) (a bare binary swap would orphan the `.app`/`.exe`/`.AppImage` wrapper). The Web UI's update banner shows the same guidance with a "Running in Docker" / "Desktop app" / "CLI install" badge so you always know which upgrade path applies.
+
 By default `upgrade` targets the latest **stable** release. Add `--prerelease` to jump to a newer release candidate (e.g. `v1.1.0-rc1`) when you want to track prereleases.
 
 > Note: `javinizer upgrade` updates the **program**; `javinizer update` refreshes **metadata** for your existing files. They are different commands.

--- a/cmd/javinizer/commands/api/command.go
+++ b/cmd/javinizer/commands/api/command.go
@@ -11,7 +11,10 @@ import (
 	apicore "github.com/javinizer/javinizer-go/internal/api/core"
 	apiserver "github.com/javinizer/javinizer-go/internal/api/server"
 	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/desktop"
 	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/javinizer/javinizer-go/internal/system"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
 	_ "github.com/javinizer/javinizer-go/docs/swagger" // Import generated docs
@@ -97,6 +100,14 @@ func Run(cmd *cobra.Command, configFile string, hostFlag string, portFlag int) (
 	}
 
 	authManager.SetApiTokenRepo(apiDeps.Repos.ApiTokenRepo)
+
+	// Classify the running build (docker/cli; desktop is impossible here — the
+	// desktop bundle uses internal/desktop.StartServer, not this command) so
+	// the /version handler can surface environment-specific upgrade guidance
+	// (docker users must `docker pull`; cli users can self-upgrade). Computed
+	// once at bootstrap and injected via CoreDeps because the API layer cannot
+	// import internal/desktop without an import cycle.
+	apiDeps.CoreDeps.SetInstallEnvironment(system.DetectEnvironment(afero.NewOsFs(), desktop.IsDesktopBuild()))
 
 	return apiDeps, rt, nil
 }

--- a/cmd/javinizer/commands/upgrade/command.go
+++ b/cmd/javinizer/commands/upgrade/command.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/javinizer/javinizer-go/internal/desktop"
+	"github.com/javinizer/javinizer-go/internal/system"
 	"github.com/javinizer/javinizer-go/internal/update"
 	"github.com/javinizer/javinizer-go/internal/version"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -54,6 +57,11 @@ metadata for your existing files. They are different commands.`,
 				Force:          force,
 				PreRelease:     prerelease,
 				Out:            cmd.OutOrStdout(),
+				// Detect once at the command layer (where internal/desktop is
+				// reachable without the import cycle the update library would
+				// hit) so Upgrade() can hand off docker/desktop builds instead of
+				// attempting a self-swap that would silently fail.
+				Environment: system.DetectEnvironment(afero.NewOsFs(), desktop.IsDesktopBuild()),
 			})
 			if err != nil {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Upgrade failed: %v\n", err)

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -152,6 +152,8 @@ javinizer upgrade --check   # just report whether an update is available
 
 If javinizer was installed via Homebrew (or Scoop), `upgrade` detects that and tells you to use `brew upgrade javinizer` / `scoop update javinizer` instead.
 
+`upgrade` is also **environment-aware**: inside a **Docker** container it refuses the in-place swap (the image is read-only) and prints `docker pull ghcr.io/javinizer/javinizer-go:latest` instead; in the **desktop app** it points you to the [releases page](https://github.com/javinizer/javinizer-go/releases) (a bare swap would orphan the app bundle). The Web UI update banner shows the same guidance with an environment badge ("Running in Docker" / "Desktop app" / "CLI install").
+
 > `javinizer upgrade` updates the **program**; `javinizer update` refreshes **metadata** for your files. They are different commands.
 
 ### Pre-built Binary (Linux / macOS)

--- a/docs/17-desktop-app.md
+++ b/docs/17-desktop-app.md
@@ -38,6 +38,23 @@ swap `x86_64` for `aarch64` in the asset name.
 
 To build from source instead, see [Build](#build) below.
 
+## Updating
+
+Because the app is a native bundle (not a self-swappable binary), `javinizer
+upgrade` refuses to replace it in place and points you to the right path
+instead:
+
+| Install method | Update command |
+|----------------|-----------------|
+| macOS Cask | `brew upgrade --cask javinizer-app` |
+| Windows Scoop | `scoop update javinizer-app` |
+| Linux AppImage | Download the latest `Javinizer-linux-x86_64.AppImage` from the [releases page](https://github.com/javinizer/javinizer-go/releases) and replace the old file |
+
+The cask and bucket are republished automatically on each **stable** release
+(prereleases never reach them). The Web UI's update banner also detects the
+desktop environment and shows a "Desktop app" badge with a link to the releases
+page, so you don't have to remember the command.
+
 ## How it works
 
 The desktop app starts the existing API server (REST + embedded SvelteKit Web

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -7361,6 +7361,10 @@ const docTemplate = `{
                     "description": "Error message if any",
                     "type": "string"
                 },
+                "install_environment": {
+                    "description": "InstallEnvironment reports how javinizer is running (\"docker\", \"desktop\",\nor \"cli\") so the UI can render the right upgrade path: docker images can't\nself-swap (read-only image), desktop apps need a new bundle, only cli\nbuilds self-upgrade in place.",
+                    "type": "string"
+                },
                 "latest": {
                     "description": "Latest available version",
                     "type": "string"
@@ -7376,6 +7380,10 @@ const docTemplate = `{
                 "update_available": {
                     "description": "Whether an update is available",
                     "type": "boolean"
+                },
+                "upgrade_instructions": {
+                    "description": "UpgradeInstructions carries environment-specific guidance verbatim (e.g.\nthe ` + "`" + `docker pull` + "`" + ` command for docker, the releases URL for desktop, the\n` + "`" + `javinizer upgrade` + "`" + ` command for cli) so the frontend doesn't have to\nhardcode the image ref or rebuild steps per environment.",
+                    "type": "string"
                 }
             }
         }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -7359,6 +7359,10 @@
                     "description": "Error message if any",
                     "type": "string"
                 },
+                "install_environment": {
+                    "description": "InstallEnvironment reports how javinizer is running (\"docker\", \"desktop\",\nor \"cli\") so the UI can render the right upgrade path: docker images can't\nself-swap (read-only image), desktop apps need a new bundle, only cli\nbuilds self-upgrade in place.",
+                    "type": "string"
+                },
                 "latest": {
                     "description": "Latest available version",
                     "type": "string"
@@ -7374,6 +7378,10 @@
                 "update_available": {
                     "description": "Whether an update is available",
                     "type": "boolean"
+                },
+                "upgrade_instructions": {
+                    "description": "UpgradeInstructions carries environment-specific guidance verbatim (e.g.\nthe `docker pull` command for docker, the releases URL for desktop, the\n`javinizer upgrade` command for cli) so the frontend doesn't have to\nhardcode the image ref or rebuild steps per environment.",
+                    "type": "string"
                 }
             }
         }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2841,6 +2841,13 @@ definitions:
       error:
         description: Error message if any
         type: string
+      install_environment:
+        description: |-
+          InstallEnvironment reports how javinizer is running ("docker", "desktop",
+          or "cli") so the UI can render the right upgrade path: docker images can't
+          self-swap (read-only image), desktop apps need a new bundle, only cli
+          builds self-upgrade in place.
+        type: string
       latest:
         description: Latest available version
         type: string
@@ -2853,6 +2860,13 @@ definitions:
       update_available:
         description: Whether an update is available
         type: boolean
+      upgrade_instructions:
+        description: |-
+          UpgradeInstructions carries environment-specific guidance verbatim (e.g.
+          the `docker pull` command for docker, the releases URL for desktop, the
+          `javinizer upgrade` command for cli) so the frontend doesn't have to
+          hardcode the image ref or rebuild steps per environment.
+        type: string
     type: object
 host: localhost:8080
 info:

--- a/internal/api/version/handlers.go
+++ b/internal/api/version/handlers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/javinizer/javinizer-go/internal/commandutil"
+	"github.com/javinizer/javinizer-go/internal/system"
 	"github.com/javinizer/javinizer-go/internal/update"
 	"github.com/javinizer/javinizer-go/internal/version"
 )
@@ -21,7 +22,27 @@ type VersionStatusResponse struct {
 	Prerelease      bool   `json:"prerelease"`       // Whether latest is a prerelease
 	CheckedAt       string `json:"checked_at"`       // When the check was performed
 	Source          string `json:"source"`           // "cached" or "fresh"
-	Error           string `json:"error,omitempty"`  // Error message if any
+	// InstallEnvironment reports how javinizer is running ("docker", "desktop",
+	// or "cli") so the UI can render the right upgrade path: docker images can't
+	// self-swap (read-only image), desktop apps need a new bundle, only cli
+	// builds self-upgrade in place.
+	InstallEnvironment string `json:"install_environment"`
+	// UpgradeInstructions carries environment-specific guidance verbatim (e.g.
+	// the `docker pull` command for docker, the releases URL for desktop, the
+	// `javinizer upgrade` command for cli) so the frontend doesn't have to
+	// hardcode the image ref or rebuild steps per environment.
+	UpgradeInstructions string `json:"upgrade_instructions,omitempty"`
+	Error               string `json:"error,omitempty"` // Error message if any
+}
+
+// applyEnvironment stamps the response with the detected install environment
+// and its upgrade instructions. Called on every response path so the UI always
+// knows whether to offer `docker pull`, a releases link, or `javinizer upgrade`.
+// The environment is computed once at bootstrap (where desktop.IsDesktopBuild()
+// is reachable without an import cycle) and injected via CoreDeps.
+func applyEnvironment(response *VersionStatusResponse, env system.Environment) {
+	response.InstallEnvironment = string(env)
+	response.UpgradeInstructions = system.UpgradeInstructions(env)
 }
 
 // versionStatus godoc
@@ -55,6 +76,7 @@ func versionStatus(deps commandutil.CoreDepsReader) gin.HandlerFunc {
 			BuildDate: buildDate,
 			Source:    string(update.UpdateSourceCached),
 		}
+		applyEnvironment(response, deps.InstallEnvironment())
 
 		if err != nil {
 			response.Error = err.Error()
@@ -127,6 +149,7 @@ func versionCheck(deps commandutil.CoreDepsReader) gin.HandlerFunc {
 			Latest:     "",
 			Prerelease: false,
 		}
+		applyEnvironment(response, deps.InstallEnvironment())
 
 		if err != nil {
 			response.Source = string(update.UpdateSourceError)

--- a/internal/api/version/handlers_environment_test.go
+++ b/internal/api/version/handlers_environment_test.go
@@ -1,0 +1,105 @@
+package version
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/system"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVersionStatus_InstallEnvironment verifies the /version response carries
+// the bootstrap-injected install environment and environment-specific upgrade
+// instructions on every response path, so the Web UI can render the right
+// upgrade guidance (docker pull / releases link / javinizer upgrade).
+func TestVersionStatus_InstallEnvironment(t *testing.T) {
+	cases := []struct {
+		name         string
+		env          system.Environment
+		wantEnv      string
+		wantInstrSub string
+	}{
+		{
+			name:         "docker surfaces docker pull instructions",
+			env:          system.EnvironmentDocker,
+			wantEnv:      "docker",
+			wantInstrSub: "docker pull",
+		},
+		{
+			name:         "desktop surfaces releases link",
+			env:          system.EnvironmentDesktop,
+			wantEnv:      "desktop",
+			wantInstrSub: "releases",
+		},
+		{
+			name:         "cli surfaces javinizer upgrade",
+			env:          system.EnvironmentCLI,
+			wantEnv:      "cli",
+			wantInstrSub: "javinizer upgrade",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDataDir := t.TempDir()
+			t.Setenv("JAVINIZER_DATA_DIR", tempDataDir)
+
+			cfg := config.DefaultConfig(nil, nil)
+			// Disabled so GetStatus short-circuits to the disabled path — the
+			// environment must still be stamped regardless of update state.
+			cfg.System.VersionCheckEnabled = false
+
+			deps := newTestVersionDeps(cfg)
+			deps.CoreDeps.SetInstallEnvironment(tc.env)
+
+			router := gin.New()
+			router.GET("/version", versionStatus(deps.CoreDeps))
+
+			req := httptest.NewRequest(http.MethodGet, "/version", nil)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var resp VersionStatusResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, tc.wantEnv, resp.InstallEnvironment, "install_environment")
+			require.NotEmpty(t, resp.UpgradeInstructions, "upgrade_instructions must be populated")
+			assert.True(t, strings.Contains(resp.UpgradeInstructions, tc.wantInstrSub),
+				"upgrade_instructions=%q must contain %q", resp.UpgradeInstructions, tc.wantInstrSub)
+		})
+	}
+}
+
+// TestVersionStatus_InstallEnvironmentDefaultCLI confirms an uninitialized
+// CoreDeps (no SetInstallEnvironment call) defaults to "cli" so a miswired
+// bootstrap never produces an empty install_environment field in the API.
+func TestVersionStatus_InstallEnvironmentDefaultCLI(t *testing.T) {
+	tempDataDir := t.TempDir()
+	t.Setenv("JAVINIZER_DATA_DIR", tempDataDir)
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.VersionCheckEnabled = false
+
+	deps := newTestVersionDeps(cfg)
+	// Deliberately NOT calling SetInstallEnvironment — defaults must be CLI.
+
+	router := gin.New()
+	router.GET("/version", versionStatus(deps.CoreDeps))
+
+	req := httptest.NewRequest(http.MethodGet, "/version", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp VersionStatusResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "cli", resp.InstallEnvironment)
+}

--- a/internal/commandutil/dependencies.go
+++ b/internal/commandutil/dependencies.go
@@ -16,6 +16,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/scraper"
 	"github.com/javinizer/javinizer-go/internal/scraper/e2emock"
 	"github.com/javinizer/javinizer-go/internal/scraperutil"
+	"github.com/javinizer/javinizer-go/internal/system"
 	"github.com/javinizer/javinizer-go/internal/workflow"
 )
 
@@ -41,6 +42,10 @@ type CoreDepsReader interface {
 	GetRegistry() *scraperutil.ScraperRegistry
 	GetLogger() logging.Logger
 	HasConfig() bool
+	// InstallEnvironment reports how javinizer is running (docker/desktop/cli)
+	// so handlers can surface environment-specific upgrade guidance. Set once
+	// at bootstrap via SetInstallEnvironment; defaults to CLI.
+	InstallEnvironment() system.Environment
 }
 
 // CoreDeps contains shared dependencies that both CLI and API commands need.
@@ -55,6 +60,13 @@ type CoreDeps struct {
 	// r18DumpCloser holds the local r18.dev dump sidecar handle (when opened)
 	// so it can be released in Close().
 	r18DumpCloser io.Closer
+
+	// installEnvironment classifies the running build (docker/desktop/cli) for
+	// environment-aware upgrade UX. It is a process-level constant set once at
+	// bootstrap (cmd/javinizer) via SetInstallEnvironment, where
+	// desktop.IsDesktopBuild() is reachable without the import cycle the API
+	// layer would hit. Defaults to CLI until set.
+	installEnvironment system.Environment
 
 	// config is the single source of truth for the application config.
 	// Both CLI (set once at construction) and API (hot-reloaded via
@@ -222,6 +234,27 @@ func (d *CoreDeps) GetConfig() *config.Config {
 // is expected (e.g., APIRuntime.InitAPIConfig) rather than a bug.
 func (d *CoreDeps) HasConfig() bool {
 	return d.config.Load() != nil
+}
+
+// InstallEnvironment returns the detected install environment (docker/desktop/cli).
+// Defaults to CLI until SetInstallEnvironment is called at bootstrap.
+func (d *CoreDeps) InstallEnvironment() system.Environment {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	env := d.installEnvironment
+	if env == "" {
+		return system.EnvironmentCLI
+	}
+	return env
+}
+
+// SetInstallEnvironment records the running build's environment (docker/desktop/cli).
+// Called once at process bootstrap (cmd/javinizer) where desktop.IsDesktopBuild()
+// is reachable without the import cycle the API layer would otherwise hit.
+func (d *CoreDeps) SetInstallEnvironment(env system.Environment) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.installEnvironment = env
 }
 
 // SetConfig atomically sets the configuration (thread-safe).

--- a/internal/desktop/server.go
+++ b/internal/desktop/server.go
@@ -13,6 +13,7 @@ import (
 	apiserver "github.com/javinizer/javinizer-go/internal/api/server"
 	"github.com/javinizer/javinizer-go/internal/config"
 	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/javinizer/javinizer-go/internal/system"
 )
 
 var (
@@ -79,6 +80,12 @@ func StartServer(ctx context.Context, configFile string) (*ServerInstance, error
 		return nil, err
 	}
 	authManager.SetApiTokenRepo(deps.Repos.ApiTokenRepo)
+
+	// This binary is a desktop build (the file is compiled with the desktop
+	// build tag), so the upgrade UX must point users at a new bundle rather
+	// than an in-place self-swap. Recorded once at bootstrap so the /version
+	// handler can surface it without importing internal/desktop (import cycle).
+	deps.CoreDeps.SetInstallEnvironment(system.EnvironmentDesktop)
 
 	router := apiserver.NewServer(rt)
 	apiserver.LogServerInfo(cfg)

--- a/internal/scraper/dmm/browser.go
+++ b/internal/scraper/dmm/browser.go
@@ -12,6 +12,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/system"
 	"github.com/spf13/afero"
 )
 
@@ -43,25 +44,6 @@ func validateBrowserURL(rawURL string) error {
 	return nil
 }
 
-// isRunningInContainer detects if we're running inside a Docker container
-// using the provided filesystem dependency.
-func isRunningInContainer(fs afero.Fs) bool {
-	// Check for /.dockerenv file (Docker specific)
-	if _, err := fs.Stat("/.dockerenv"); err == nil {
-		return true
-	}
-
-	// Check /proc/1/cgroup for docker/containerd.
-	if data, err := afero.ReadFile(fs, "/proc/1/cgroup"); err == nil {
-		content := string(data)
-		if strings.Contains(content, "docker") || strings.Contains(content, "containerd") {
-			return true
-		}
-	}
-
-	return false
-}
-
 // fetchWithBrowser fetches a URL using Chrome browser automation with age verification cookies.
 // envLookup and fs are injected dependencies for environment variable and filesystem access.
 func fetchWithBrowser(parentCtx context.Context, url string, timeout int, proxyProfile *models.ProxyProfile, envLookup func(string) string, fs afero.Fs) (string, error) {
@@ -87,7 +69,7 @@ func fetchWithBrowser(parentCtx context.Context, url string, timeout int, proxyP
 	// Check if running in Docker container
 	// Chrome's sandbox doesn't work in containers due to namespace restrictions
 	// Trade-off: We run as non-root user, and the container itself provides isolation
-	if isRunningInContainer(fs) {
+	if system.IsRunningInContainer(fs) {
 		logging.Debug("DMM Browser: Detected container environment, disabling Chrome sandbox and crashpad")
 		opts = append(opts,
 			chromedp.Flag("no-sandbox", true),

--- a/internal/scraper/dmm/browser_miss_test.go
+++ b/internal/scraper/dmm/browser_miss_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/system"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,7 +57,7 @@ func TestValidateBrowserURL_IPv4WithPort(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// --- isRunningInContainer: env var combinations ---
+// --- system.IsRunningInContainer: env var combinations ---
 
 func TestIsRunningInContainer_ChromeEnvsAreNotAContainerSignal(t *testing.T) {
 	// CHROME_BIN/CHROME_PATH point at the Chrome binary location and are set
@@ -81,7 +82,7 @@ func TestIsRunningInContainer_ChromeEnvsAreNotAContainerSignal(t *testing.T) {
 		}
 	}()
 
-	result := isRunningInContainer(afero.NewMemMapFs())
+	result := system.IsRunningInContainer(afero.NewMemMapFs())
 	assert.False(t, result, "CHROME_BIN/CHROME_PATH must not imply a container")
 }
 

--- a/internal/scraper/dmm/browser_miss_test.go
+++ b/internal/scraper/dmm/browser_miss_test.go
@@ -180,3 +180,22 @@ func TestFetchWithBrowser_ContainerDetectionViaChromePath(t *testing.T) {
 	_, err := fetchWithBrowser(context.Background(), "https://www.dmm.co.jp/", 1, nil, os.Getenv, afero.NewOsFs())
 	_ = err
 }
+
+// TestFetchWithBrowser_ContainerDetectedDisablesSandbox exercises the
+// `IsRunningInContainer(fs) == true` branch of fetchWithBrowser by injecting an
+// in-memory filesystem with /.dockerenv. On a non-container CI runner the real
+// filesystem returns false, so without this test the no-sandbox flag path
+// (the container-detected true branch) is never covered. The call still fails
+// when chromedp tries to launch Chrome — we only need it to reach past the
+// container-detection branch, mirroring the ViaChromeBin/ViaChromePath tests
+// above.
+func TestFetchWithBrowser_ContainerDetectedDisablesSandbox(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	if err := afero.WriteFile(fs, "/.dockerenv", []byte(""), 0o644); err != nil {
+		t.Fatalf("create /.dockerenv: %v", err)
+	}
+	require.True(t, system.IsRunningInContainer(fs), "test setup: fs must read as container")
+
+	_, err := fetchWithBrowser(context.Background(), "https://www.dmm.co.jp/", 1, nil, os.Getenv, fs)
+	_ = err
+}

--- a/internal/scraper/dmm/browser_test.go
+++ b/internal/scraper/dmm/browser_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/javinizer/javinizer-go/internal/system"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,7 +59,7 @@ func TestIsRunningInContainer(t *testing.T) {
 			tt.setup()
 			defer tt.cleanup()
 
-			result := isRunningInContainer(afero.NewOsFs())
+			result := system.IsRunningInContainer(afero.NewOsFs())
 			assert.Equal(t, tt.expected, result, tt.description)
 		})
 	}

--- a/internal/system/environment.go
+++ b/internal/system/environment.go
@@ -1,0 +1,103 @@
+package system
+
+import (
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+// Environment classifies how javinizer is running so features can adapt:
+// docker images cannot self-upgrade (read-only image layers), desktop apps
+// are native bundles (.app/.exe/.AppImage) that need a whole-bundle swap, and
+// CLI builds are plain binaries that self-replace in place.
+type Environment string
+
+const (
+	// EnvironmentDocker means the process is inside a container. The image is
+	// read-only, so upgrade = `docker pull` + recreate the container, never a
+	// self-swap.
+	EnvironmentDocker Environment = "docker"
+	// EnvironmentDesktop means the build is a clickable native app bundle.
+	// Upgrade = download a new bundle (a bare binary swap would orphan the
+	// bundle wrapper and lose the embedded icon/Info.plist/.desktop metadata).
+	EnvironmentDesktop Environment = "desktop"
+	// EnvironmentCLI means a plain binary install (manual/homebrew/scoop). The
+	// existing self-upgrade path replaces the binary in place (or hands off
+	// to the package manager for brew/scoop).
+	EnvironmentCLI Environment = "cli"
+)
+
+// dockerImageRef is the published container image. Embedded in the docker
+// upgrade instructions so users get a copy-pasteable `docker pull` command
+// without having to look it up. Must stay in sync with the image name pushed
+// by .github/workflows/cli-release.yml (ghcr.io/javinizer/javinizer-go).
+const dockerImageRef = "ghcr.io/javinizer/javinizer-go"
+
+// IsRunningInContainer reports whether the process is inside a Docker (or
+// containerd/k8s) container. Detection is best-effort: it checks /.dockerenv
+// (the file Docker creates in every container) and /proc/1/cgroup (Linux
+// control groups name the container runtime). Extracted from
+// internal/scraper/dmm so the upgrade path and the Chrome sandbox logic share
+// one source of truth for container detection.
+//
+// On non-Linux hosts both probes miss and the function returns false, which is
+// correct: a macOS/Windows desktop or CLI build is never "in a container".
+func IsRunningInContainer(fs afero.Fs) bool {
+	if _, err := fs.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if data, err := afero.ReadFile(fs, "/proc/1/cgroup"); err == nil {
+		content := string(data)
+		if strings.Contains(content, "docker") ||
+			strings.Contains(content, "containerd") ||
+			strings.Contains(content, "kubepods") {
+			return true
+		}
+	}
+	return false
+}
+
+// DetectEnvironment classifies the running build into docker / desktop / cli.
+// Desktop is checked first (a cheap ldflags-injected var, passed in by the
+// caller as isDesktop so this package stays a leaf with no desktop import):
+// the desktop app is a native bundle and is never run inside a container, so
+// the docker probe is skipped for it. Otherwise the container probes run; a
+// hit means docker, and the default is the plain CLI binary.
+//
+// The filesystem is injected so tests can simulate /.dockerenv or a cgroup
+// file without touching the real root.
+func DetectEnvironment(fs afero.Fs, isDesktop bool) Environment {
+	if isDesktop {
+		return EnvironmentDesktop
+	}
+	if IsRunningInContainer(fs) {
+		return EnvironmentDocker
+	}
+	return EnvironmentCLI
+}
+
+// UpgradeInstructions returns environment-specific guidance for getting the
+// latest version. The API surfaces this verbatim in the version status
+// response so the Web UI can render the right command without hardcoding the
+// image ref or rebuild steps per environment.
+//
+//   - docker:  `docker pull <image>:latest` then recreate the container
+//     (compose users: `docker compose pull && docker compose up -d`).
+//   - desktop: download the new bundle from the GitHub releases page; a
+//     self-swap would replace only the inner binary and break the bundle.
+//   - cli:     run `javinizer upgrade` (or `brew upgrade javinizer` /
+//     `scoop update javinizer` for package-managed installs).
+func UpgradeInstructions(env Environment) string {
+	switch env {
+	case EnvironmentDocker:
+		return "Running in Docker. Pull the latest image and recreate the container:\n" +
+			"  docker pull " + dockerImageRef + ":latest\n" +
+			"  # docker compose users: docker compose pull && docker compose up -d"
+	case EnvironmentDesktop:
+		return "Desktop app: download the new bundle from https://github.com/javinizer/javinizer-go/releases " +
+			"and replace your existing app. In-app self-update is not yet supported."
+	default:
+		return "Run `javinizer upgrade` to update. " +
+			"If installed via Homebrew or Scoop, use `brew upgrade javinizer` or `scoop update javinizer` instead."
+	}
+}

--- a/internal/system/environment.go
+++ b/internal/system/environment.go
@@ -33,17 +33,37 @@ const (
 // by .github/workflows/cli-release.yml (ghcr.io/javinizer/javinizer-go).
 const dockerImageRef = "ghcr.io/javinizer/javinizer-go"
 
-// IsRunningInContainer reports whether the process is inside a Docker (or
-// containerd/k8s) container. Detection is best-effort: it checks /.dockerenv
-// (the file Docker creates in every container) and /proc/1/cgroup (Linux
-// control groups name the container runtime). Extracted from
+// IsRunningInContainer reports whether the process is inside a container.
+// Detection is best-effort and checks three independent markers, short-
+// circuiting on the first hit:
+//
+//   - /.dockerenv — the file Docker creates in every container (reliable for
+//     `docker run` / compose, the primary deployment path this project ships).
+//   - /run/.containerenv — created by podman/nerdctl-style containers that do
+//     not write /.dockerenv. Without this, a bare podman/nerdctl container
+//     would misclassify as CLI and attempt a self-swap the image would lose
+//     on recreate.
+//   - /proc/1/cgroup substring match (docker/containerd/kubepods) — a legacy
+//     fallback for cgroup v1 hosts.
+//
+// Known limitation: on cgroup v2 hosts with cgroup namespaces enabled (the
+// default for modern Docker/containerd since ~2021), /proc/1/cgroup inside
+// the container reads just `0::/` with no runtime identifier, so the substring
+// match misses. The /.dockerenv and /run/.containerenv file markers cover the
+// common runtimes, but a bare containerd/k8s pod without either marker will
+// classify as CLI. The failure mode is conservative — a wasted self-swap that
+// the next container recreate reverts — rather than a dangerous false
+// positive, so this is accepted as best-effort. Extracted from
 // internal/scraper/dmm so the upgrade path and the Chrome sandbox logic share
 // one source of truth for container detection.
 //
-// On non-Linux hosts both probes miss and the function returns false, which is
+// On non-Linux hosts all probes miss and the function returns false, which is
 // correct: a macOS/Windows desktop or CLI build is never "in a container".
 func IsRunningInContainer(fs afero.Fs) bool {
 	if _, err := fs.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if _, err := fs.Stat("/run/.containerenv"); err == nil {
 		return true
 	}
 	if data, err := afero.ReadFile(fs, "/proc/1/cgroup"); err == nil {

--- a/internal/system/environment_test.go
+++ b/internal/system/environment_test.go
@@ -20,6 +20,22 @@ func TestIsRunningInContainer(t *testing.T) {
 		}
 	})
 
+	t.Run("containerenv file present (podman/nerdctl)", func(t *testing.T) {
+		t.Parallel()
+		// Podman and nerdctl create /run/.containerenv instead of /.dockerenv.
+		// Without this marker a podman container would fall through to the
+		// cgroup substring match, which on cgroup v2 reads just `0::/` and
+		// misses — misclassifying the container as CLI and attempting a
+		// self-swap the image would lose on recreate.
+		fs := afero.NewMemMapFs()
+		if _, err := fs.Create("/run/.containerenv"); err != nil {
+			t.Fatalf("create /run/.containerenv: %v", err)
+		}
+		if !IsRunningInContainer(fs) {
+			t.Fatal("expected container detection when /run/.containerenv exists")
+		}
+	})
+
 	t.Run("cgroup mentions docker", func(t *testing.T) {
 		t.Parallel()
 		fs := afero.NewMemMapFs()

--- a/internal/system/environment_test.go
+++ b/internal/system/environment_test.go
@@ -1,0 +1,150 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+func TestIsRunningInContainer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dockerenv file present", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		if _, err := fs.Create("/.dockerenv"); err != nil {
+			t.Fatalf("create /.dockerenv: %v", err)
+		}
+		if !IsRunningInContainer(fs) {
+			t.Fatal("expected container detection when /.dockerenv exists")
+		}
+	})
+
+	t.Run("cgroup mentions docker", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		if err := afero.WriteFile(fs, "/proc/1/cgroup", []byte("0::/docker/abcdef123456"), 0o644); err != nil {
+			t.Fatalf("write cgroup: %v", err)
+		}
+		if !IsRunningInContainer(fs) {
+			t.Fatal("expected container detection when cgroup mentions docker")
+		}
+	})
+
+	t.Run("cgroup mentions containerd", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		if err := afero.WriteFile(fs, "/proc/1/cgroup", []byte("0::/system.slice/containerd.service"), 0o644); err != nil {
+			t.Fatalf("write cgroup: %v", err)
+		}
+		if !IsRunningInContainer(fs) {
+			t.Fatal("expected container detection when cgroup mentions containerd")
+		}
+	})
+
+	t.Run("cgroup mentions kubepods", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		if err := afero.WriteFile(fs, "/proc/1/cgroup", []byte("12:cpuset:/kubepods/podabc"), 0o644); err != nil {
+			t.Fatalf("write cgroup: %v", err)
+		}
+		if !IsRunningInContainer(fs) {
+			t.Fatal("expected container detection when cgroup mentions kubepods")
+		}
+	})
+
+	t.Run("bare host: no dockerenv, no cgroup", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		if IsRunningInContainer(fs) {
+			t.Fatal("expected no container detection on a bare host")
+		}
+	})
+
+	t.Run("cgroup without container markers", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		if err := afero.WriteFile(fs, "/proc/1/cgroup", []byte("0::/system.slice/sshd.service"), 0o644); err != nil {
+			t.Fatalf("write cgroup: %v", err)
+		}
+		if IsRunningInContainer(fs) {
+			t.Fatal("expected no container detection for an ordinary cgroup")
+		}
+	})
+}
+
+func TestDetectEnvironment(t *testing.T) {
+	t.Parallel()
+
+	t.Run("desktop short-circuits before docker probe", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		if _, err := fs.Create("/.dockerenv"); err != nil {
+			t.Fatalf("create /.dockerenv: %v", err)
+		}
+		got := DetectEnvironment(fs, true)
+		if got != EnvironmentDesktop {
+			t.Fatalf("DetectEnvironment(isDesktop=true) = %q, want %q", got, EnvironmentDesktop)
+		}
+	})
+
+	t.Run("cli build in container is docker", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		if _, err := fs.Create("/.dockerenv"); err != nil {
+			t.Fatalf("create /.dockerenv: %v", err)
+		}
+		got := DetectEnvironment(fs, false)
+		if got != EnvironmentDocker {
+			t.Fatalf("DetectEnvironment(isDesktop=false, in container) = %q, want %q", got, EnvironmentDocker)
+		}
+	})
+
+	t.Run("cli build on bare host is cli", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		got := DetectEnvironment(fs, false)
+		if got != EnvironmentCLI {
+			t.Fatalf("DetectEnvironment(isDesktop=false, bare host) = %q, want %q", got, EnvironmentCLI)
+		}
+	})
+}
+
+func TestUpgradeInstructions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		env  Environment
+		want string
+	}{
+		{"docker mentions docker pull", EnvironmentDocker, "docker pull"},
+		{"docker mentions image ref", EnvironmentDocker, "ghcr.io/javinizer/javinizer-go"},
+		{"desktop mentions releases", EnvironmentDesktop, "releases"},
+		{"cli mentions javinizer upgrade", EnvironmentCLI, "javinizer upgrade"},
+		{"cli mentions brew fallback", EnvironmentCLI, "brew upgrade javinizer"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := UpgradeInstructions(tc.env)
+			if !contains(got, tc.want) {
+				t.Fatalf("UpgradeInstructions(%q) = %q, want substring %q", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/update/upgrade.go
+++ b/internal/update/upgrade.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/javinizer/javinizer-go/internal/httpclient"
 	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/javinizer/javinizer-go/internal/system"
 )
 
 const (
@@ -148,6 +149,13 @@ type UpgradeOptions struct {
 	ExePath string
 	// Out receives progress messages (default os.Stdout).
 	Out io.Writer
+	// Environment classifies how javinizer is running (docker/desktop/cli),
+	// set by the caller (cmd layer) via system.DetectEnvironment. The library
+	// can't import internal/desktop to compute it itself (import cycle), so the
+	// command layer injects it. Docker and desktop builds can't self-swap and
+	// get an environment-specific handoff instead. Zero value ("") behaves as
+	// CLI to keep backward compatibility for callers that don't set it.
+	Environment system.Environment
 }
 
 // UpgradeResult is the outcome of an Upgrade run.
@@ -158,10 +166,12 @@ type UpgradeResult struct {
 	AssetName      string
 	UpToDate       bool
 	Upgraded       bool
-	// Handoff is true when the install is managed by a package manager and the
-	// caller was told to run `brew upgrade` / `scoop update` instead.
-	Handoff       bool
-	InstallMethod InstallMethod
+	// Handoff is true when the install is managed by a package manager OR the
+	// running environment can't self-swap (docker image / desktop bundle), and
+	// the caller was told the right upgrade command instead.
+	Handoff            bool
+	InstallMethod      InstallMethod
+	InstallEnvironment system.Environment
 }
 
 // Upgrade checks for, downloads, and applies the latest release, replacing the
@@ -217,6 +227,23 @@ func Upgrade(ctx context.Context, opts UpgradeOptions) (*UpgradeResult, error) {
 
 	if result.UpToDate && !opts.Force {
 		_, _ = fmt.Fprintf(out, "Already up to date: %s\n", opts.CurrentVersion)
+		return result, nil
+	}
+
+	// Record the running environment on the result so callers (and tests) can
+	// see which path was taken even when no swap happens.
+	result.InstallEnvironment = opts.Environment
+
+	// Environment-aware handoff: docker images are read-only (an in-place
+	// binary replace would be lost on container recreate) and desktop builds
+	// are native bundles whose inner binary can't be swapped without orphaning
+	// the .app/.exe/.AppImage wrapper. In both cases, defer to the right
+	// upgrade path instead of attempting a self-swap that would silently fail
+	// or break the install. This runs after the up-to-date check so a no-op
+	// upgrade still reports "already up to date" without a handoff.
+	if opts.Environment == system.EnvironmentDocker || opts.Environment == system.EnvironmentDesktop {
+		result.Handoff = true
+		_, _ = fmt.Fprintf(out, "%s\n", system.UpgradeInstructions(opts.Environment))
 		return result, nil
 	}
 

--- a/internal/update/upgrade_test.go
+++ b/internal/update/upgrade_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/javinizer/javinizer-go/internal/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -184,6 +185,64 @@ func TestUpgrade_HomebrewHandoff(t *testing.T) {
 	assert.False(t, res.Upgraded)
 	assert.Equal(t, InstallMethodHomebrew, res.InstallMethod)
 	assert.Contains(t, out.String(), "brew upgrade javinizer")
+}
+
+// TestUpgrade_DockerHandoff verifies a docker build never attempts an in-place
+// self-swap (the image is read-only; the replace would be lost on recreate).
+// Instead it hands off with the `docker pull` instruction. The exe path is a
+// manual install path to prove the docker check short-circuits BEFORE the
+// brew/scoop/manual install-method detection.
+func TestUpgrade_DockerHandoff(t *testing.T) {
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v0.0.1",
+		Checker:        &stubChecker{version: "v9.9.9"},
+		ExePath:        "/usr/local/bin/javinizer",
+		Environment:    system.EnvironmentDocker,
+		Out:            &out,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Handoff, "docker must hand off, not self-swap")
+	assert.False(t, res.Upgraded)
+	assert.Equal(t, system.EnvironmentDocker, res.InstallEnvironment)
+	assert.Contains(t, out.String(), "docker pull")
+	assert.Contains(t, out.String(), "ghcr.io/javinizer/javinizer-go")
+}
+
+// TestUpgrade_DesktopHandoff verifies a desktop bundle never attempts an
+// inner-binary swap (it would orphan the .app/.exe/.AppImage wrapper). It
+// hands off pointing at the GitHub releases page instead.
+func TestUpgrade_DesktopHandoff(t *testing.T) {
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v0.0.1",
+		Checker:        &stubChecker{version: "v9.9.9"},
+		ExePath:        "/Applications/Javinizer.app/Contents/MacOS/javinizer",
+		Environment:    system.EnvironmentDesktop,
+		Out:            &out,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Handoff, "desktop must hand off, not self-swap")
+	assert.False(t, res.Upgraded)
+	assert.Equal(t, system.EnvironmentDesktop, res.InstallEnvironment)
+	assert.Contains(t, out.String(), "releases")
+}
+
+// TestUpgrade_DockerUpToDateNoHandoff confirms the environment handoff only
+// fires when an upgrade would actually happen — an up-to-date docker install
+// reports "already up to date" without telling the user to docker pull.
+func TestUpgrade_DockerUpToDateNoHandoff(t *testing.T) {
+	var out bytes.Buffer
+	res, err := Upgrade(context.Background(), UpgradeOptions{
+		CurrentVersion: "v9.9.9",
+		Checker:        &stubChecker{version: "v9.9.9"},
+		Environment:    system.EnvironmentDocker,
+		Out:            &out,
+	})
+	require.NoError(t, err)
+	assert.False(t, res.Handoff, "up-to-date must not hand off")
+	assert.True(t, res.UpToDate)
+	assert.Contains(t, out.String(), "Already up to date")
 }
 
 // newAssetServer serves a release asset plus its checksums.txt from a fake

--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -1175,6 +1175,8 @@ export interface VersionStatusResponse {
 	prerelease: boolean;
 	checked_at: string;
 	source: string;
+	install_environment: 'docker' | 'desktop' | 'cli';
+	upgrade_instructions?: string;
 	error?: string;
 }
 

--- a/web/frontend/src/lib/components/UpdateIndicator.svelte
+++ b/web/frontend/src/lib/components/UpdateIndicator.svelte
@@ -2,7 +2,7 @@
 	import { cubicOut } from 'svelte/easing';
 	import { fly } from 'svelte/transition';
 	import { createMutation, useQueryClient } from '@tanstack/svelte-query';
-	import { ArrowUpCircle, RefreshCw, ExternalLink, ChevronDown } from 'lucide-svelte';
+	import { ArrowUpCircle, RefreshCw, ExternalLink, ChevronDown, Container, Monitor, Terminal } from 'lucide-svelte';
 	import { createVersionStatusQuery } from '$lib/query/queries';
 	import { apiClient } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast';
@@ -77,6 +77,21 @@
 	const releaseUrl = $derived(
 		status?.latest ? `${REPO_RELEASE_TAG_URL}/${status.latest}` : REPO_RELEASES_URL
 	);
+
+	// Environment label + icon for the "running in" badge. The backend classifies
+	// docker/desktop/cli so the notification can tell a Docker user to `docker pull`
+	// (an in-app self-upgrade is impossible for a read-only image) instead of
+	// pointing them at a binary release asset they can't use.
+	const envBadge = $derived.by(() => {
+		switch (status?.install_environment) {
+			case 'docker':
+				return { label: 'Running in Docker', icon: Container, tone: 'bg-sky-500/15 text-sky-700 dark:text-sky-300' };
+			case 'desktop':
+				return { label: 'Desktop app', icon: Monitor, tone: 'bg-violet-500/15 text-violet-700 dark:text-violet-300' };
+			default:
+				return { label: 'CLI install', icon: Terminal, tone: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300' };
+		}
+	});
 </script>
 
 <svelte:window onclick={handleClickOutside} onkeydown={(e) => { if (e.key === 'Escape' && popoverOpen) popoverOpen = false; }} />
@@ -131,8 +146,29 @@
 								prerelease
 							</span>
 						{/if}
+						{#if status?.install_environment}
+							{@const Badge = envBadge.icon}
+							<span
+								class="inline-flex items-center gap-1 mt-2 px-1.5 py-0.5 rounded text-[10px] font-medium {envBadge.tone}"
+								title={envBadge.label}
+							>
+								<Badge class="h-3 w-3" />
+							{envBadge.label}
+							</span>
+						{/if}
 					</div>
 				</div>
+
+				{#if status?.upgrade_instructions}
+					<!-- Backend-provided, environment-specific guidance: docker users see
+					`docker pull`, desktop users see the releases link, CLI users see
+					`javinizer upgrade`. Rendered verbatim (pre-wrap) so the indented
+					commands stay readable. -->
+					<pre
+						class="mt-2 px-2 py-1.5 rounded text-[11px] leading-relaxed whitespace-pre-wrap break-all bg-muted text-muted-foreground border border-border"
+					>{status.upgrade_instructions}</pre
+					>
+				{/if}
 
 				<div class="mt-3 flex items-center gap-2">
 					<a

--- a/web/frontend/src/lib/components/UpdateIndicator.test.ts
+++ b/web/frontend/src/lib/components/UpdateIndicator.test.ts
@@ -50,6 +50,7 @@ function makeStatus(overrides: Partial<VersionStatusResponse> = {}): VersionStat
 		prerelease: true,
 		checked_at: '2026-06-27T23:21:20Z',
 		source: 'fresh',
+		install_environment: 'cli',
 		...overrides,
 	};
 }
@@ -129,6 +130,32 @@ describe('UpdateIndicator', () => {
 			expect(container.textContent).toContain('prerelease');
 			expect(container.textContent).toContain('View release');
 			expect(container.textContent).toContain('Check again');
+		});
+	});
+
+	it('shows docker pull guidance when running in Docker', async () => {
+		const { container } = renderWithClient(
+			makeStatus({
+				install_environment: 'docker',
+				upgrade_instructions:
+					'Running in Docker. Pull the latest image and recreate the container:\n  docker pull ghcr.io/javinizer/javinizer-go:latest',
+				prerelease: false,
+				latest: 'v1.1.0',
+			}),
+		);
+		let button: HTMLButtonElement | null = null;
+		await waitFor(() => {
+			button = container.querySelector('button[aria-label="Update available"]');
+			expect(button).toBeTruthy();
+		});
+		await fireEvent.click(button!);
+
+		await waitFor(() => {
+			// Environment badge labels the install type so the user knows why the
+			// guidance differs from a normal self-upgrade.
+			expect(container.textContent).toContain('Running in Docker');
+			// The backend-provided instructions surface the copy-pasteable command.
+			expect(container.textContent).toContain('docker pull ghcr.io/javinizer/javinizer-go');
 		});
 	});
 


### PR DESCRIPTION
## Summary

The upgrade notification now adapts to **how javinizer is running**, so a Docker user is told to `docker pull` (not pointed at a binary asset they cannot use), a desktop-app user is sent to the releases page, and a CLI user keeps the existing self-upgrade path.

## Why

PR #84 shipped a clickable desktop app and the project already ships a Docker image, but `javinizer upgrade` and the Web UI update notification assumed a plain self-swappable binary. That meant:
- **Docker**: an in-place binary replace is silently lost on container recreate, and the UI offered a release download the user cannot use inside a container.
- **Desktop**: an inner-binary swap would orphan the `.app`/`.exe`/`.AppImage` wrapper (lost icon, Info.plist, `.desktop` metadata).
- **CLI**: existing behavior (manual self-swap or brew/scoop handoff) is correct and unchanged.

## Changes

| Layer | Change |
|-------|--------|
| `internal/system` (new) | `DetectEnvironment(fs, isDesktop)` classifies docker/desktop/cli. Docker detection (`/.dockerenv` + `/proc/1/cgroup`) extracted from `internal/scraper/dmm` so the upgrade path and Chrome sandbox logic share one source. `system` is a leaf package (no `desktop` import → no import cycle); `isDesktop` is passed in by callers. |
| `api/v1/version` | Response now carries `install_environment` (`docker`/`desktop`/`cli`) + `upgrade_instructions` (environment-specific: docker → `docker pull ghcr.io/javinizer/javinizer-go:latest`, desktop → releases link, cli → `javinizer upgrade`). Wired via `CoreDeps.SetInstallEnvironment` at the two bootstrap chokepoints (`api` command + desktop `StartServer`); the API layer cannot import `internal/desktop` itself (cycle through `api/server`). |
| `javinizer upgrade` | Docker and desktop builds no longer attempt an in-place self-swap. They hand off with the right command instead (`Handoff=true`). CLI keeps the existing self-upgrade / brew / scoop behavior. |
| `UpdateIndicator` (Web UI) | Shows a "Running in Docker" / "Desktop app" / "CLI install" badge and renders the backend-provided upgrade instructions verbatim, so a Docker user sees the `docker pull` command rather than a release asset link. |

## Test coverage
- `internal/system`: container detection (dockerenv / cgroup docker/containerd/kubepods / bare host), `DetectEnvironment` desktop short-circuit, `UpgradeInstructions` per env.
- `internal/api/version`: response stamps `install_environment` + `upgrade_instructions` on every path (disabled/none/cached); default CLI when unset.
- `internal/update`: docker + desktop handoff (no self-swap, correct instructions); up-to-date docker does NOT hand off.
- `UpdateIndicator.test.ts`: docker environment renders the "Running in Docker" badge + `docker pull` guidance.

## Verification
- `go build ./...`, `gofmt`, `go vet`, `golangci-lint` (0 issues) on all changed packages
- `go test -short` + race detector pass on affected packages
- `svelte-check` 0 errors, `vitest` UpdateIndicator suite 9/9
- swagger regenerated (new response fields)

## Out of scope (future PRs)
- Desktop **bundle-level self-update** (download new `.app`/`.exe`/`.AppImage` and swap in place) — tracked as a later phase; for now desktop hands off to the releases page.
- One-click "Update & restart" button in the Web UI for desktop (depends on the bundle-swap engine).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detected install-environment support (Docker/desktop/CLI), exposing environment-specific upgrade instructions in the version/update flow.
  * Updated the Web UI update indicator to show an environment badge and display upgrade guidance when available.
* **Bug Fixes**
  * Prevented unsupported in-place self-upgrades for Docker and desktop installs.
  * Improved browser URL validation (scheme/host/port) and container detection to better configure sandbox behavior.
* **Documentation**
  * Updated self-upgrade and desktop-app docs with environment-specific upgrade instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->