### PR TITLE
test(e2e): expand fullstack coverage to scrape pipeline + APIs

### DIFF
--- a/cmd/javinizer-e2e/main.go
+++ b/cmd/javinizer-e2e/main.go
@@ -230,6 +230,13 @@ func loadConfig() (*config.Config, error) {
 	cfg.Output.Template.FolderFormat = "<ID>"
 	cfg.Output.Template.FileFormat = "<ID>"
 	cfg.Output.Operation.RenameFile = true
+	// Enable revert so the full-stack Playwright suite can exercise the
+	// /jobs/:id revert UI flow (RevertConfirmationModal + OperationRow). The
+	// flag is opt-in by default (false) for safety; the e2e backend turns it
+	// on because the revert pipeline is a first-class user-visible feature
+	// that needs real-backend coverage. Specs that don't revert are
+	// unaffected — the flag only gates the revert endpoints + UI button.
+	cfg.Output.Operation.AllowRevert = true
 	cfg.Output.MediaFormat.PosterFormat = "<ID>-poster.jpg"
 	cfg.Output.MediaFormat.FanartFormat = "<ID>-fanart.jpg"
 	cfg.Output.MediaFormat.ScreenshotFolder = "extrafanart"

--- a/web/frontend/src/routes/jobs/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/jobs/[jobId]/+page.svelte
@@ -42,7 +42,7 @@
 	let revertFileCount = $state(0);
 	let revertingMovieIds = $state<Set<string>>(new Set());
 
-	const pendingCount = $derived(operations.filter((o) => o.revert_status === 'pending' || o.revert_status === 'failed').length);
+	const pendingCount = $derived(operations.filter((o) => o.revert_status === 'applied' || o.revert_status === 'failed').length);
 
 	const revertBatchMutation = createMutation(() => ({
 		mutationFn: () => apiClient.revertBatchJob(jobId),

--- a/web/frontend/src/routes/jobs/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/jobs/[jobId]/+page.svelte
@@ -42,7 +42,7 @@
 	let revertFileCount = $state(0);
 	let revertingMovieIds = $state<Set<string>>(new Set());
 
-	const pendingCount = $derived(operations.filter((o) => o.revert_status === 'applied' || o.revert_status === 'failed').length);
+	const revertEligibleCount = $derived(operations.filter((o) => o.revert_status === 'applied' || o.revert_status === 'failed').length);
 
 	const revertBatchMutation = createMutation(() => ({
 		mutationFn: () => apiClient.revertBatchJob(jobId),
@@ -94,7 +94,7 @@
 
 	function openBatchRevertModal() {
 		revertModalMode = 'batch';
-		revertFileCount = pendingCount;
+		revertFileCount = revertEligibleCount;
 		revertTargetMovieId = '';
 		revertTargetFileName = '';
 		revertModalOpen = true;
@@ -210,7 +210,7 @@
 					</div>
 
 					<!-- Batch revert button -->
-					{#if pendingCount > 0 && jobStatus.toLowerCase() === 'organized' && config?.output?.allow_revert}
+					{#if revertEligibleCount > 0 && jobStatus.toLowerCase() === 'organized' && config?.output?.allow_revert}
 						<div class="mt-4 pt-4 border-t flex justify-end">
 							<Button
 								variant="destructive"
@@ -218,7 +218,7 @@
 								onclick={openBatchRevertModal}
 							>
 								<Undo2 class="h-4 w-4 mr-1.5" />
-								Revert Batch ({pendingCount} file{pendingCount !== 1 ? 's' : ''})
+								Revert Batch ({revertEligibleCount} file{revertEligibleCount !== 1 ? 's' : ''})
 							</Button>
 						</div>
 					{/if}

--- a/web/frontend/tests/fullstack/regressions/actresses-crud.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/actresses-crud.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * /actresses page full-stack UI spec.
+ *
+ * Pins the actress CRUD UI end-to-end against the real e2emock backend:
+ * create via the form, list render, search filter, delete via the confirm
+ * dialog. Every action goes through the real rendered page (real SvelteKit
+ * /actresses) → real /api/v1/actresses (proxied to cmd/javinizer-e2e) →
+ * real :memory: SQLite. No page.route mocking.
+ *
+ * Why this matters: the /actresses page is the most complex CRUD surface
+ * in the app (store-backed, three view modes, merge modal, pagination,
+ * search with apply/clear). It had zero Playwright coverage. A regression
+ * in the actress store's create/delete mutation wiring, the form binding,
+ * the search activeQuery flow, or the confirm-dialog dismissal is
+ * invisible without this spec.
+ *
+ * Uniqueness: each test uses a timestamp-suffixed first_name to avoid
+ * collisions with prior runs (the suite is serial against one backend).
+ * afterEach cleans up any leftover test actresses via the API.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { BACKEND_BASE, loginAgainstRealBackend } from '../helpers';
+
+const TEST_PREFIX = 'E2E-Actress-';
+const HEADING = 'Actress Database';
+
+interface Actress {
+	id: number;
+	first_name: string;
+	last_name: string;
+	japanese_name: string;
+}
+
+async function listActresses(api: APIRequestContext): Promise<Actress[]> {
+	const resp = await api.get(`${BACKEND_BASE}/api/v1/actresses?limit=1000`);
+	expect(resp.ok(), `list actresses failed: ${resp.status()}`).toBeTruthy();
+	const body = (await resp.json()) as { actresses: Actress[] };
+	return body.actresses ?? [];
+}
+
+async function deleteActress(api: APIRequestContext, id: number): Promise<void> {
+	const resp = await api.delete(`${BACKEND_BASE}/api/v1/actresses/${id}`);
+	expect(resp.ok(), `delete actress ${id} failed: ${resp.status()}`).toBeTruthy();
+}
+
+async function cleanupTestActresses(api: APIRequestContext): Promise<void> {
+	const all = await listActresses(api);
+	await Promise.all(
+		all
+			.filter((a) => a.first_name.startsWith(TEST_PREFIX))
+			.map((a) => deleteActress(api, a.id).catch(() => {})),
+	);
+}
+
+async function navigateToActresses(page: Page): Promise<void> {
+	await page.goto('/actresses');
+	await expect(page.getByRole('heading', { name: HEADING })).toBeVisible({ timeout: 15_000 });
+	// The form renders (the "New Actress" button + the form card).
+	await expect(page.getByPlaceholder('Yui')).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe('/actresses: real CRUD UI against the e2emock backend', () => {
+	test.afterEach(async ({ request }: { request: APIRequestContext }) => {
+		await cleanupTestActresses(request);
+	});
+
+	test('create → list renders the actress → search filters → delete removes the row', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		await navigateToActresses(page);
+
+		// ── 1. Create an actress via the form ────────────────────────────
+		// The form is always visible. Fill first_name (unique per run) +
+		// japanese_name, then click "Create" (the Save button's label when
+		// not editing). The createMutation invalidates the list query.
+		const firstName = `${TEST_PREFIX}${Date.now()}`;
+		const japaneseName = 'テスト女優';
+		await page.getByPlaceholder('Yui').fill(firstName);
+		await page.getByPlaceholder('波多野結衣').fill(japaneseName);
+		await page.getByRole('button', { name: /^Create$/ }).click();
+
+		// The actress card renders with getDisplayName. With only first_name
+		// set, getDisplayName returns the first_name. The card's <h3> holds it.
+		await expect(page.getByRole('heading', { name: firstName })).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// ── 2. Search filters to the actress ─────────────────────────────
+		// The toolbar's search uses queryInput (bound) + activeQuery (set on
+		// Apply). Typing + Enter triggers onApplySearch. The list query
+		// re-fetches with q=firstName → only the matching actress renders.
+		const searchInput = page.getByPlaceholder('Search by English or Japanese name');
+		await searchInput.fill(firstName);
+		await searchInput.press('Enter');
+
+		await expect(page.getByRole('heading', { name: firstName })).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// Clear search → the full list re-renders (our actress still present).
+		// Scope to the toolbar's Clear button (the form also has a Clear). The
+		// input is nested input → div.relative → div.flex-1; the Search/Clear
+		// buttons are siblings of div.flex-1, so go up two levels.
+		await searchInput.locator('xpath=../../following-sibling::button[contains(.,"Clear")]').click();
+		await expect(page.getByRole('heading', { name: firstName })).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// ── 3. Delete the actress via the confirm dialog ─────────────────
+		// The card's delete button has accessible name "Delete" (text + icon).
+	// It opens a confirmDialog (role="alertdialog") with a "Delete" confirm
+		// button. Scope to the card's Delete button via the heading's ancestor
+		// flex-1 container (holds both the name row + the action row).
+		const heading = page.getByRole('heading', { name: firstName });
+		await heading.locator('xpath=ancestor::div[contains(@class,"flex-1")]//button[contains(., "Delete")]').click();
+
+		// The dialog renders; click its "Delete" confirm button.
+		const dialog = page.getByRole('alertdialog');
+		await expect(dialog).toBeVisible({ timeout: 5_000 });
+		await dialog.getByRole('button', { name: /^Delete$/ }).click();
+
+		// The deleteMutation invalidates → the card disappears.
+		await expect(page.getByRole('heading', { name: firstName })).toHaveCount(0, {
+			timeout: 10_000,
+		});
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/auth-ui.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/auth-ui.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Auth UI full-stack spec.
+ *
+ * Pins the authentication UI flow end-to-end against the real e2emock
+ * backend: the login screen render (when unauthenticated), the login
+ * form submit (real POST /api/v1/auth/login), the post-login redirect to
+ * the app shell (Navigation with the username + Logout button), the
+ * logout button click (real POST /api/v1/auth/logout), + the post-logout
+ * return to the login screen.
+ *
+ * Why this matters: the existing auth.spec.ts covers the auth API
+ * contract (401 without cookie, login success/failure, session cookie)
+ * via the `request` fixture — it never renders the browser. The login
+ * screen is the entry point to the entire app, + the +layout.svelte auth
+ * guard (authLoading → authUnavailable → login/setup → authenticated) is
+ * the most user-facing auth logic. A regression in the layout's
+ * refreshAuthStatus wiring, the login form binding, the post-login
+ * authAuthenticated state flip, or the Navigation logout button is
+ * invisible to the API-only spec.
+ *
+ * Technique: the fullstack config's chromium project auto-authenticates
+ * every test via storageState (the global-setup's saved cookie). To test
+ * the unauthenticated login screen, these tests override storageState to
+ * undefined — Playwright creates a fresh browser context with NO cookies,
+ * so the layout's refreshAuthStatus finds no session + renders the login
+ * screen. This is the documented Playwright pattern for per-test auth
+ * overrides.
+ *
+ * Note on the setup screen: the e2e backend is pre-bootstrapped
+ * (initialized=true) by cmd/javinizer-e2e, so the "First-Time Setup"
+ * screen is not reachable without tearing down the backend's auth state.
+ * This spec covers the login screen (the realistic daily-use path) + the
+ * logout flow. The setup screen is left to the API-level coverage.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { BACKEND_BASE } from '../helpers';
+
+// Override the project-level storageState for these tests — start with a
+// clean (unauthenticated) browser context so the layout renders the login
+// screen instead of auto-redirecting to the authenticated app. Passing an
+// explicit empty object (not undefined) is required: undefined is treated
+// as "not set" + falls back to the project's saved auth-state.json.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const LOGIN_HEADING = 'Login Required';
+const DASHBOARD_HEADING = 'Javinizer Control Center';
+const USERNAME = 'admin';
+const PASSWORD = 'adminpassword123';
+
+test.describe('Auth UI: login + logout against the real e2emock backend', () => {
+	test('unauthenticated visit renders the login screen (not the app)', async ({
+		page,
+	}: {
+		page: Page;
+	}) => {
+		// Navigate to the root. The layout's onMount calls refreshAuthStatus
+		// → GET /api/v1/auth/status. With no cookie, authenticated=false +
+		// initialized=true → the "Login Required" screen renders.
+		await page.goto('/');
+		await expect(page.getByRole('heading', { name: LOGIN_HEADING })).toBeVisible({
+			timeout: 15_000,
+		});
+
+		// The login form renders with username + password fields + the
+		// "Sign In" button. Asserting these pins the form mounted.
+		await expect(page.locator('#login-username')).toBeVisible({ timeout: 10_000 });
+		await expect(page.locator('#login-password')).toBeVisible();
+		await expect(page.getByRole('button', { name: /^Sign In$/ })).toBeVisible();
+
+		// The app shell (Navigation + dashboard) does NOT render.
+		await expect(page.getByRole('heading', { name: DASHBOARD_HEADING })).toHaveCount(0);
+	});
+
+	test('login with valid credentials → app shell renders + logout button shows the username', async ({
+		page,
+	}: {
+		page: Page;
+	}) => {
+		await page.goto('/');
+		await expect(page.getByRole('heading', { name: LOGIN_HEADING })).toBeVisible({
+			timeout: 15_000,
+		});
+
+		// Fill + submit the login form. handleLoginSubmit calls
+		// apiClient.loginAuth (real POST /api/v1/auth/login) → on success,
+		// refreshAuthStatus flips authAuthenticated=true → the layout
+		// re-renders the authenticated app shell (Navigation + page).
+		await page.locator('#login-username').fill(USERNAME);
+		await page.locator('#login-password').fill(PASSWORD);
+		await page.getByRole('button', { name: /^Sign In$/ }).click();
+
+		// The dashboard renders (the root route is the control center).
+		// This pins the authAuthenticated state flipped + the layout
+		// transitioned from the login screen to the app shell.
+		await expect(page.getByRole('heading', { name: DASHBOARD_HEADING })).toBeVisible({
+			timeout: 15_000,
+		});
+
+		// The Navigation's logout button renders with the username. The
+		// button text is "{username} · Logout" (md+ screens) or "Logout"
+		// (narrow). Assert the combined text to pin the username propagated
+		// from refreshAuthStatus → authUsername → Navigation.
+		await expect(page.getByTitle('Logout')).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByTitle('Logout')).toContainText(USERNAME);
+	});
+
+	test('login with WRONG password → error renders + app shell does NOT', async ({
+		page,
+	}: {
+		page: Page;
+	}) => {
+		await page.goto('/');
+		await expect(page.getByRole('heading', { name: LOGIN_HEADING })).toBeVisible({
+			timeout: 15_000,
+		});
+
+		await page.locator('#login-username').fill(USERNAME);
+		await page.locator('#login-password').fill('wrong-password');
+		await page.getByRole('button', { name: /^Sign In$/ }).click();
+
+		// handleLoginSubmit's catch sets authError → the error banner renders
+		// (a div with text-destructive). The login screen stays (not the app).
+		// Assert the error banner is visible + the dashboard is not. The
+		// banner's class is border-destructive/40 (Tailwind opacity modifier),
+		// so match via the text-destructive class which is stable.
+		await expect(page.locator('div.text-destructive').first()).toBeVisible({
+			timeout: 10_000,
+		});
+		await expect(page.getByRole('heading', { name: DASHBOARD_HEADING })).toHaveCount(0);
+		// The login heading is still visible (still on the login screen).
+		await expect(page.getByRole('heading', { name: LOGIN_HEADING })).toBeVisible();
+	});
+
+	test('logout button → POST /auth/logout → returns to the login screen', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		// ── 1. Log in via the UI (reuse the valid-login flow) ────────────
+		await page.goto('/');
+		await expect(page.getByRole('heading', { name: LOGIN_HEADING })).toBeVisible({
+			timeout: 15_000,
+		});
+		await page.locator('#login-username').fill(USERNAME);
+		await page.locator('#login-password').fill(PASSWORD);
+		await page.getByRole('button', { name: /^Sign In$/ }).click();
+		await expect(page.getByRole('heading', { name: DASHBOARD_HEADING })).toBeVisible({
+			timeout: 15_000,
+		});
+
+		// ── 2. Click the Logout button ──────────────────────────────────
+		// handleLogout calls apiClient.logoutAuth (real POST /api/v1/auth/
+		// logout) → on completion, authAuthenticated=false → the layout
+		// re-renders the login screen.
+		await page.getByTitle('Logout').click();
+
+		// The login screen re-renders (auth guard flipped back).
+		await expect(page.getByRole('heading', { name: LOGIN_HEADING })).toBeVisible({
+			timeout: 15_000,
+		});
+		await expect(page.getByRole('heading', { name: DASHBOARD_HEADING })).toHaveCount(0);
+
+		// ── 3. Cross-check: the session cookie is now invalid ───────────
+		// After logout, an authenticated API call with the (now-invalid)
+		// cookie should be rejected. This pins the logout actually hit the
+		// backend (not just a client-side state flip). We can't read the
+		// browser cookie easily here, so assert via the page's auth status
+		// fetch: navigating again still shows the login screen (cookie dead).
+		await page.goto('/browse');
+		await expect(page.getByRole('heading', { name: LOGIN_HEADING })).toBeVisible({
+			timeout: 15_000,
+		});
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/browse-launch-scrape.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/browse-launch-scrape.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * /browse → launch-scrape → /review/[jobId] full-stack UI spec.
+ *
+ * This is the PRIMARY user-path spec the fullstack suite was missing: it
+ * drives a REAL browser through the real SvelteKit /browse page → real
+ * FileBrowser directory listing (real /api/v1/file/browse) → real file
+ * selection → real "Scrape" action button → real ProgressModal polling
+ * → real auto-redirect to /review/[jobId] → real review-page render of
+ * the e2emock-scraped metadata. Every other fullstack spec drives the
+ * backend via the `request` fixture (API-only); this one proves the
+ * rendered Svelte UI can actually bootstrap a scrape job + land the user
+ * on the review page with real scraped data.
+ *
+ * Real stack: browser → Vite dev server (real SvelteKit /browse render)
+ * → real /api/v1/file/browse + /api/v1/file/scan + /api/v1/batch/scrape
+ * (proxied to cmd/javinizer-e2e) → real e2emock scraper → real :memory:
+ * SQLite → real ProgressModal job-polling → real goto('/review/:id').
+ *
+ * Why this matters: a regression in any link of the browse→scrape→review
+ * chain (FileBrowser path resolution, file-selection state, the action
+ * button's startBatchScrape wiring, ProgressModal completion detection,
+ * or the review page's post-redirect data fetch) is invisible to the
+ * API-only specs. This spec is the only one that renders /browse at all.
+ *
+ * Determinism: the e2emock scraper returns Title "E2E Movie GOOD-001" +
+ * Maker "E2E Test Studio" for the GOOD-001 ID (see
+ * internal/scraper/e2emock/e2emock.go successResult). The fixture file
+ * GOOD-001.mp4 is seeded into DEFAULT_INPUT_DIR by global-setup. The
+ * scrape phase reaches `completed` (organize is a separate explicit
+ * step — see organize.spec.ts), so the ProgressModal's terminal-state
+ * redirect fires + lands on /review/[jobId].
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+
+import {
+	DEFAULT_INPUT_DIR,
+	DEFAULT_OUTPUT_DIR,
+	loginAgainstRealBackend,
+	waitForJobCompletion,
+} from '../helpers';
+
+/**
+ * Placeholder text on the FileBrowser's editable path input (PathInput
+ * default placeholder — the browse page does not override it).
+ */
+const SOURCE_PATH_PLACEHOLDER = 'Enter path (e.g., /path/to/videos)';
+
+/**
+ * Placeholder text on the "Output Destination" PathInput (set explicitly
+ * in browse/+page.svelte). Used to disambiguate from the FileBrowser's
+ * path input — both are PathInput instances but only the destination
+ * one carries this placeholder.
+ */
+const DEST_PATH_PLACEHOLDER = 'Enter destination path (e.g., /path/to/output)';
+
+test.describe('/browse → launch scrape → /review/[jobId]', () => {
+	test('selecting a file + clicking Scrape redirects to the review page with scraped metadata', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// ── 1. Open /browse + let the page hydrate ───────────────────────────
+		// networkidle waits for the cwd query + config/scrapers queries that
+		// feed the FileBrowser's initialPath + the destination default. We
+		// override both explicitly below, but waiting avoids a race where the
+		// hydration $effect rewrites our inputs after we fill them.
+		await page.goto('/browse');
+		await page.waitForLoadState('domcontentloaded');
+		await page.waitForLoadState('networkidle');
+
+		// ── 2. Navigate the FileBrowser to the seeded input dir ─────────────
+		// The FileBrowser's initial path is the backend CWD (the repo root
+		// when run via `go run ./cmd/javinizer-e2e`), which is NOT in the
+		// e2e backend's AllowedDirectories — so the initial listing is
+		// denied/empty. Type the allowed fixture dir + Enter to browse it.
+		const sourcePathInput = page.getByPlaceholder(SOURCE_PATH_PLACEHOLDER).first();
+		await sourcePathInput.fill(DEFAULT_INPUT_DIR);
+		await sourcePathInput.press('Enter');
+
+		// The browse endpoint returns the fixture files; GOOD-001.mp4 is the
+		// canonical scrape-success fixture. Wait for its row to render before
+		// selecting — guards against a stale "Empty directory" state.
+		const goodFileRow = page.getByText('GOOD-001.mp4', { exact: true }).first();
+		await expect(goodFileRow, 'GOOD-001.mp4 must render in the FileBrowser listing').toBeVisible({
+			timeout: 10_000,
+		});
+
+		// ── 3. Select GOOD-001.mp4 ──────────────────────────────────────────
+		// Clicking the file-name text toggles the row's selected state (the
+		// text lives inside the row's <button>, so the click reaches the
+		// toggle handler). The sticky action bar + the "Selected Files" card
+		// both react to the selection.
+		await goodFileRow.click();
+
+		// The sticky bar shows "<N> file(s) selected"; for exactly one file
+		// the text is "1 file selected". The "Selected Files" card heading
+		// ("1 File Selected for Scraping") also contains the substring, so
+		// match exactly to disambiguate. Asserting this pins that the click
+		// actually toggled selection state (vs. e.g. a bubbling bug).
+		await expect(page.getByText('1 file selected', { exact: true })).toBeVisible({
+			timeout: 5_000,
+		});
+
+		// ── 4. Set a valid output destination ───────────────────────────────
+		// The scrape phase itself doesn't write to the destination, but the
+		// browse page sends `destination` on the batch-scrape request + the
+		// backend validates it against AllowedDirectories. The default
+		// destination (CWD / repo root) is NOT allowed → would 4xx the
+		// scrape. Point it at the allowed output fixture dir.
+		const destPathInput = page.getByPlaceholder(DEST_PATH_PLACEHOLDER).first();
+		await destPathInput.fill(DEFAULT_OUTPUT_DIR);
+		// Blur to commit the onchange handler (persists to localStorage).
+		await destPathInput.press('Tab');
+
+		// ── 5. Click "Scrape 1 File" → ProgressModal ────────────────────────
+		// The action button's label is "Scrape {N} File{s}" — for one file,
+		// "Scrape 1 File". Clicking fires startBatchScrape → POST
+		// /api/v1/batch/scrape → startJob(job_id) → ProgressModal mounts +
+		// polls the job until terminal.
+		const scrapeButton = page.getByRole('button', { name: /Scrape 1 File/i });
+		await expect(scrapeButton).toBeEnabled({ timeout: 5_000 });
+		await scrapeButton.click();
+
+		// The ProgressModal header confirms the scrape was enqueued (vs. an
+		// error toast). Don't over-assert here — the redirect below is the
+		// load-bearing signal.
+		await expect(page.getByText('Batch Scraping Progress')).toBeVisible({ timeout: 10_000 });
+
+		// ── 6. Wait for the auto-redirect to /review/[jobId] ────────────────
+		// ProgressModal polls the job; on `completed` (scrape phase done —
+		// organize is a separate step) it starts a 3s countdown then
+		// goto('/review/:jobId'). Waiting on the URL is race-free vs.
+		// clicking "View Results Now" (which competes with the countdown).
+		await page.waitForURL(/\/review\/[^/]+/, { timeout: 30_000 });
+
+		// ── 7. Assert the review page rendered the scraped metadata ─────────
+		// The review page does post-mount fetches (/batch/:id, /movies,
+		// /scrapers) before rendering the movie card. networkidle gates the
+		// text assertion so it doesn't race the fetch.
+		await page.waitForLoadState('domcontentloaded');
+		await page.waitForLoadState('networkidle');
+
+		// e2emock returns Title "E2E Movie GOOD-001" — rendered by the review
+		// page in both grid (ReviewGridCard) + detail (MovieMetadataCard)
+		// views. Asserting the title pins the full chain: scrape produced
+		// real metadata → job result persisted → review page fetched + rendered it.
+		const reviewBody = page.locator('body');
+		await expect(reviewBody).toContainText('E2E Movie GOOD-001', { timeout: 15_000 });
+
+		// ── 8. Cross-check: the URL's jobId maps to a real completed job ────
+		// Ties the browser navigation to the backend job state — catches a
+		// regression where the redirect lands on a stale/wrong jobId.
+		const jobId = new URL(page.url()).pathname.split('/review/')[1];
+		expect(jobId, 'review URL must carry a jobId').toBeTruthy();
+
+		const job = await waitForJobCompletion(request, jobId);
+		const results = Object.values(job.results);
+		expect(results.length, 'job must have exactly one result for GOOD-001.mp4').toBe(1);
+		expect(results[0].movie_id, 'scraped movie_id must be GOOD-001').toBe('GOOD-001');
+		expect(
+			results[0].movie?.title ?? '',
+			'scraped title must carry the e2emock marker',
+		).toContain('E2E Movie GOOD-001');
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/genres-crud.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/genres-crud.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * /genres page full-stack UI spec.
+ *
+ * Pins the genre-replacement CRUD UI end-to-end against the real e2emock
+ * backend: list render, add, edit, search, sort, delete. Every action
+ * goes through the real rendered page (real SvelteKit /genres) → real
+ * /api/v1/genres/replacements (proxied to cmd/javinizer-e2e) → real
+ * :memory: SQLite. No page.route mocking.
+ *
+ * Why this matters: the existing import-export.spec.ts covers import +
+ * export against a developer-run backend, but the core CRUD table
+ * interactions (add row, inline edit, delete, search filter, sort
+ * toggle) had zero Playwright coverage. A regression in the
+ * GenreReplacement mutation wiring, the table render, the search filter,
+ * or the sort toggle is invisible without this spec.
+ *
+ * Uniqueness: each test uses a timestamp-suffixed `original` to avoid
+ * collisions with prior runs (the suite is serial against one backend).
+ * afterEach cleans up any leftover test replacements via the API.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { BACKEND_BASE, loginAgainstRealBackend } from '../helpers';
+
+const TEST_PREFIX = 'E2E-GENRE-';
+const HEADING = 'Genre Replacements';
+
+interface GenreReplacement {
+	id: number;
+	original: string;
+	replacement: string;
+}
+
+async function listGenreReplacements(api: APIRequestContext): Promise<GenreReplacement[]> {
+	const resp = await api.get(`${BACKEND_BASE}/api/v1/genres/replacements?limit=1000`);
+	expect(resp.ok(), `list genres failed: ${resp.status()}`).toBeTruthy();
+	const body = (await resp.json()) as { replacements: GenreReplacement[] };
+	return body.replacements ?? [];
+}
+
+async function createGenreReplacement(
+	api: APIRequestContext,
+	original: string,
+	replacement: string,
+): Promise<GenreReplacement> {
+	const resp = await api.post(`${BACKEND_BASE}/api/v1/genres/replacements`, {
+		data: { original, replacement },
+	});
+	expect(resp.ok(), `create genre failed: ${resp.status()} ${await resp.text()}`).toBeTruthy();
+	return (await resp.json()) as GenreReplacement;
+}
+
+async function deleteGenreReplacement(api: APIRequestContext, id: number): Promise<void> {
+	const resp = await api.delete(`${BACKEND_BASE}/api/v1/genres/replacements?id=${id}`);
+	expect(resp.ok(), `delete genre ${id} failed: ${resp.status()}`).toBeTruthy();
+}
+
+async function cleanupTestReplacements(api: APIRequestContext): Promise<void> {
+	const all = await listGenreReplacements(api);
+	await Promise.all(
+		all
+			.filter((r) => r.original.startsWith(TEST_PREFIX))
+			.map((r) => deleteGenreReplacement(api, r.id).catch(() => {})),
+	);
+}
+
+async function navigateToGenres(page: Page): Promise<void> {
+	await page.goto('/genres');
+	// Wait for the query to resolve + the table to render (the heading is
+	// always present; the "Add" card renders after the query settles).
+	await expect(page.getByRole('heading', { name: HEADING })).toBeVisible({ timeout: 15_000 });
+	await expect(page.getByPlaceholder('e.g., HD')).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe('/genres: real CRUD UI against the e2emock backend', () => {
+	test.afterEach(async ({ request }: { request: APIRequestContext }) => {
+		await cleanupTestReplacements(request);
+	});
+
+	test('list renders a pre-created replacement row', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		const original = `${TEST_PREFIX}LIST-${Date.now()}`;
+		const replacement = 'High Definition';
+		await createGenreReplacement(request, original, replacement);
+
+		await navigateToGenres(page);
+
+		// The row renders both the original + replacement cells. The
+		// table is a CSS grid (not a <table>), so locate the row by text.
+		await expect(page.getByText(original, { exact: true })).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByText(replacement, { exact: true })).toBeVisible();
+	});
+
+	test('add → row renders → edit → replacement updates → delete → row gone', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		await navigateToGenres(page);
+
+		// ── 1. Add a replacement via the UI ──────────────────────────────
+		const original = `${TEST_PREFIX}CRUD-${Date.now()}`;
+		const replacement = 'First Replacement';
+		await page.getByPlaceholder('e.g., HD').fill(original);
+		await page.getByPlaceholder('e.g., High Definition').fill(replacement);
+		await page.getByRole('button', { name: /^Add$/ }).click();
+
+		// The addMutation invalidates the query → the new row renders.
+		await expect(page.getByText(original, { exact: true })).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByText(replacement, { exact: true })).toBeVisible();
+
+		// ── 2. Edit the replacement inline ───────────────────────────────
+		// Click the row's edit button (title="Edit"). The original-text cell
+		// is unique; its following-sibling div holds the Actions cell (Edit +
+		// Delete buttons). Scoping via xpath avoids matching ancestor
+		// container divs that would resolve to multiple buttons.
+		const originalCell = page.getByText(original, { exact: true });
+		await originalCell.locator('xpath=following-sibling::div//button[@title="Edit"]').click();
+
+		// The edit-replacement input renders (the original is disabled).
+		const editInput = page.locator('input.font-mono:not([disabled])').last();
+		await editInput.fill('Edited Replacement');
+		await page.getByRole('button', { name: /^Save$/ }).click();
+
+		// The updateMutation invalidates → the edited replacement renders.
+		await expect(page.getByText('Edited Replacement', { exact: true })).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// ── 3. Delete the row ────────────────────────────────────────────
+		// Re-resolve the original cell (the row re-rendered after the edit).
+		const originalCellAfter = page.getByText(original, { exact: true });
+		await originalCellAfter.locator('xpath=following-sibling::div//button[@title="Delete"]').click();
+
+		// The deleteMutation invalidates → the row disappears.
+		await expect(page.getByText(original, { exact: true })).toHaveCount(0, { timeout: 10_000 });
+	});
+
+	test('search filters the list + sort toggles the order', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		// Seed two replacements with distinct originals for search/sort.
+		const a = await createGenreReplacement(request, `${TEST_PREFIX}ALPHA-${Date.now()}`, 'A-Rep');
+		const b = await createGenreReplacement(request, `${TEST_PREFIX}BETA-${Date.now()}`, 'B-Rep');
+
+		await navigateToGenres(page);
+
+		// Both rows render initially.
+		await expect(page.getByText(a.original, { exact: true })).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByText(b.original, { exact: true })).toBeVisible();
+
+		// ── 1. Search filters to the matching row ────────────────────────
+		await page.getByPlaceholder('Search by original or replacement...').fill('ALPHA');
+		await expect(page.getByText(a.original, { exact: true })).toBeVisible();
+		await expect(page.getByText(b.original, { exact: true })).toHaveCount(0);
+
+		// Clear search → both visible again.
+		await page.getByTitle('Clear search').click();
+		await expect(page.getByText(b.original, { exact: true })).toBeVisible({ timeout: 10_000 });
+
+		// ── 2. Sort toggle flips A-Z ↔ Z-A ───────────────────────────────
+		// The sort button shows "A-Z" or "Z-A". Default is asc (A-Z).
+		const sortBtn = page.getByTitle('Toggle sort order');
+		await expect(sortBtn).toContainText('A-Z');
+
+		// ALPHA < BETA alphabetically. After toggling to Z-A, BETA should
+		// come first. We assert the toggle text flipped + both rows still
+		// render (the order is hard to assert precisely without DOM
+		// traversal; the toggle text + row presence pins the behavior).
+		await sortBtn.click();
+		await expect(sortBtn).toContainText('Z-A');
+		await expect(page.getByText(a.original, { exact: true })).toBeVisible();
+		await expect(page.getByText(b.original, { exact: true })).toBeVisible();
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/history-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/history-api.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * History API full-stack spec.
+ *
+ * Pins the history API contract end-to-end against the real e2emock
+ * backend: GET /history (list + pagination + filters + empty-state),
+ * GET /history/stats (empty-state shape), DELETE /history/:id (404 on
+ * missing), DELETE /history (bulk — 400 on missing params, 0-deleted on
+ * no match). Every action hits the real /api/v1/history endpoints
+ * (proxied to cmd/javinizer-e2e) → real HistoryRepository → real
+ * :memory: SQLite. No page.route mocking.
+ *
+ * Why this matters: the history API is an entire CRUD surface (list,
+ * stats, single delete, bulk delete) with ZERO fullstack coverage. The
+ * dashboard's "Total Operations" + "Success Rate (7d)" + "Failures (7d)"
+ * metrics all depend on GET /history/stats; the "Recent Runs" list
+ * depends on GET /history. A regression in the history handlers, the
+ * pagination parser, the filter wiring, or the HistoryRepository query
+ * methods is invisible without this spec.
+ *
+ * Known limitation — the empty-state contract: nothing in the codebase
+ * calls HistoryRepo.Create, so the history table is always empty in the
+ * e2e backend (scrape/organize do not record history). This spec
+ * therefore pins the empty-state contract + the error paths (404 on
+ * missing-id delete, 400 on missing-params bulk delete, filter
+ * pagination behavior). The happy-path "list has records + delete
+ * removes one" can't be exercised until the write side is wired — that's
+ * a product gap, not a test gap, and is documented in the assertions
+ * below (the empty-state is asserted as the current correct behavior).
+ *
+ * Dashboard dependency: the root / page's statsQuery + recentRunsQuery
+ * hit these endpoints. If GET /history/stats 500s or returns the wrong
+ * shape, the dashboard's metrics render '-' / '0' — this spec guards
+ * that contract.
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { BACKEND_BASE, loginAgainstRealBackend } from '../helpers';
+
+interface HistoryListResponse {
+	records: unknown[];
+	total: number;
+	limit: number;
+	offset: number;
+}
+
+interface HistoryStats {
+	total: number;
+	success: number;
+	failed: number;
+	reverted: number;
+	by_operation: {
+		scrape: number;
+		organize: number;
+		download: number;
+		nfo: number;
+	};
+}
+
+async function getHistory(
+	api: APIRequestContext,
+	params?: Record<string, string | number>,
+): Promise<HistoryListResponse> {
+	const query = params
+		? `?${new URLSearchParams(
+				Object.fromEntries(Object.entries(params).map(([k, v]) => [k, String(v)])),
+			).toString()}`
+		: '';
+	const resp = await api.get(`${BACKEND_BASE}/api/v1/history${query}`);
+	expect(resp.ok(), `GET /history failed: ${resp.status()}`).toBeTruthy();
+	return (await resp.json()) as HistoryListResponse;
+}
+
+async function getHistoryStats(api: APIRequestContext): Promise<HistoryStats> {
+	const resp = await api.get(`${BACKEND_BASE}/api/v1/history/stats`);
+	expect(resp.ok(), `GET /history/stats failed: ${resp.status()}`).toBeTruthy();
+	return (await resp.json()) as HistoryStats;
+}
+
+test.describe('History API: real contract against the e2emock backend', () => {
+	test('GET /history returns the well-formed empty-state response', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// The history table is empty (nothing writes to it — see spec header).
+		// The empty-state contract: records is an empty array (not null),
+		// total is 0, + limit/offset echo the request. The dashboard's
+		// "Recent Runs" list renders "No operations recorded yet." off this.
+		const body = await getHistory(request, { limit: 10, offset: 0 });
+		expect(body.records, 'records must be an array (not null)').toEqual([]);
+		expect(body.total, 'total must be 0 in the empty state').toBe(0);
+		expect(body.limit, 'limit must echo the request').toBe(10);
+		expect(body.offset, 'offset must echo the request').toBe(0);
+	});
+
+	test('GET /history respects limit + offset pagination params', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// Even in the empty state, the handler must parse + echo pagination
+		// (core.ParsePagination). limit=5 + offset=3 → echoed in the response.
+		// A regression in ParsePagination (e.g., ignoring params, or clamping
+		// incorrectly) would surface here.
+		const body = await getHistory(request, { limit: 5, offset: 3 });
+		expect(body.limit, 'limit must echo 5').toBe(5);
+		expect(body.offset, 'offset must echo 3').toBe(3);
+		expect(body.records, 'records must still be an array').toEqual([]);
+	});
+
+	test('GET /history accepts operation + status + movie_id filters without 500', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// The filters route to CountByOperation/ListByOperation (operation),
+		// CountByStatus/ListByStatus (status), + CountByMovieID/ListByMovieID
+		// (movie_id). Each must resolve without 500 even when the filtered
+		// set is empty. A regression in any filter branch (e.g., a nil repo
+		// method, a bad query) would 500 here.
+		for (const params of [
+			{ operation: 'scrape' },
+			{ operation: 'organize' },
+			{ status: 'success' },
+			{ status: 'failed' },
+			{ status: 'reverted' },
+			{ movie_id: 'NONEXISTENT-999' },
+		]) {
+			const body = await getHistory(request, params);
+			expect(body.records, `${JSON.stringify(params)}: records must be an array`).toEqual([]);
+			expect(body.total, `${JSON.stringify(params)}: total must be 0`).toBe(0);
+		}
+	});
+
+	test('GET /history/stats returns the well-formed zero-stats shape', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// The dashboard's "Total Operations" / "Success Rate (7d)" /
+		// "Failures (7d)" metrics read this endpoint. The shape must be
+		// stable: total/success/failed/reverted as numbers + by_operation
+		// with all four operation keys present (the dashboard iterates them).
+		const stats = await getHistoryStats(request);
+		expect(typeof stats.total, 'total must be a number').toBe('number');
+		expect(typeof stats.success, 'success must be a number').toBe('number');
+		expect(typeof stats.failed, 'failed must be a number').toBe('number');
+		expect(typeof stats.reverted, 'reverted must be a number').toBe('number');
+		expect(stats.by_operation, 'by_operation must be present').toBeTruthy();
+		for (const op of ['scrape', 'organize', 'download', 'nfo']) {
+			expect(
+				typeof stats.by_operation[op as keyof HistoryStats['by_operation']],
+				`by_operation.${op} must be a number`,
+			).toBe('number');
+		}
+		// Empty state: all zero.
+		expect(stats.total).toBe(0);
+	});
+
+	test('DELETE /history/:id with a non-existent id returns 404', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// The handler does FindByID first → 404 if missing. A valid uint that
+		// doesn't exist exercises this path. (A non-numeric id would 400.)
+		const resp = await api_deleteHistory(request, '999999');
+		expect(resp.status(), 'deleting a non-existent history id must 404').toBe(404);
+		const body = await resp.json();
+		expect(body.error, 'the 404 must carry an error message').toBeTruthy();
+	});
+
+	test('DELETE /history/:id with a non-numeric id returns 400', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		const resp = await api_deleteHistory(request, 'not-a-number');
+		expect(resp.status(), 'a non-numeric id must 400 (not 404, not 500)').toBe(400);
+	});
+
+	test('DELETE /history (bulk) without params returns 400', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// The bulk delete requires either older_than_days or movie_id. With
+		// neither, it must 400 (not silently delete nothing, not 500).
+		const resp = await api_deleteHistoryBulk(request, {});
+		expect(resp.status(), 'bulk delete without params must 400').toBe(400);
+		const body = await resp.json();
+		expect(body.error, 'the 400 must explain the required params').toContain(
+			'older_than_days',
+		);
+	});
+
+	test('DELETE /history (bulk) with movie_id returns 200 + deleted=0 for no match', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// Bulk delete by a non-existent movie_id: FindByMovieID returns empty
+		// → deleted=0 → 200. This pins the happy-path bulk contract (the
+		// count-then-delete flow) without mutating real data.
+		const resp = await api_deleteHistoryBulk(request, { movie_id: 'NONEXISTENT-999' });
+		expect(resp.ok(), 'bulk delete by movie_id must succeed (200)').toBeTruthy();
+		const body = await resp.json();
+		expect(body.deleted, 'deleted must be 0 for a non-existent movie_id').toBe(0);
+	});
+
+	test('DELETE /history (bulk) with older_than_days returns 200 + deleted=0', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// Bulk delete by older_than_days: count-before vs count-after. With an
+		// empty table, both are 0 → deleted=0 → 200. Pins the count-diff flow.
+		const resp = await api_deleteHistoryBulk(request, { older_than_days: 30 });
+		expect(resp.ok(), 'bulk delete by older_than_days must succeed (200)').toBeTruthy();
+		const body = await resp.json();
+		expect(body.deleted, 'deleted must be 0 on an empty table').toBe(0);
+	});
+
+	test('DELETE /history (bulk) with older_than_days=0 returns 400', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// The handler rejects days < 1 (0 + negatives). Pins the input guard.
+		const resp = await api_deleteHistoryBulk(request, { older_than_days: 0 });
+		expect(resp.status(), 'older_than_days=0 must 400').toBe(400);
+	});
+});
+
+/** Raw DELETE /history/:id — exposes the response for status assertions. */
+async function api_deleteHistory(
+	api: APIRequestContext,
+	id: string,
+): ReturnType<APIRequestContext['delete']> {
+	return api.delete(`${BACKEND_BASE}/api/v1/history/${id}`);
+}
+
+/** Raw DELETE /history — exposes the response for status assertions. */
+async function api_deleteHistoryBulk(
+	api: APIRequestContext,
+	params: Record<string, string | number>,
+): ReturnType<APIRequestContext['delete']> {
+	const query = Object.keys(params).length
+		? `?${new URLSearchParams(
+				Object.fromEntries(Object.entries(params).map(([k, v]) => [k, String(v)])),
+			).toString()}`
+		: '';
+	return api.delete(`${BACKEND_BASE}/api/v1/history${query}`);
+}

--- a/web/frontend/tests/fullstack/regressions/job-detail-revert.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/job-detail-revert.spec.ts
@@ -1,0 +1,210 @@
+/**
+ * /jobs/[jobId] revert full-stack UI spec.
+ *
+ * Pins the revert flow end-to-end: organize a job (real apply phase moves
+ * files on disk) → navigate to /jobs/[jobId] → click "Revert Batch" →
+ * confirm in RevertConfirmationModal → assert the job reaches `reverted`
+ * status + the organized files are removed from disk + the original file
+ * is restored to its source path.
+ *
+ * Real stack: browser → Vite dev server (real SvelteKit /jobs/[jobId]
+ * render) → real /api/v1/jobs/:id/operations + /api/v1/jobs/:id/revert
+ * (proxied to cmd/javinizer-e2e) → real history.Reverter → real
+ * filesystem rename (move back) → real :memory: SQLite.
+ *
+ * Why this matters: the revert flow was entirely untested by the fullstack
+ * suite — no spec visited /jobs/[jobId], no spec hit the revert endpoints,
+ * and the RevertConfirmationModal + OperationRow components had zero
+ * real-backend coverage. A regression in the revert pipeline (wrong
+ * operation type guard, broken file-rename-back, stale revert_status
+ * persistence, or the UI button not rendering) would sail through.
+ *
+ * Setup via API helpers (not UI): the scrape + organize setup uses the
+ * `request` fixture directly because the browse→scrape UI path is already
+ * covered by browse-launch-scrape.spec.ts. This spec's focus is the
+ * /jobs/[jobId] revert UI, so setup is fast API calls; the assertions are
+ * all against the rendered page + real disk state.
+ *
+ * Dedicated fixture (GOOD-901.mp4): the canonical GOOD-001.mp4 is shared
+ * across specs. Organize with `copy_only: false` MOVES the file out of
+ * the input dir — if this spec failed midway, GOOD-001.mp4 would be
+ * missing for subsequent specs (the suite runs serially against one
+ * backend). GOOD-901.mp4 is seeded per-test via seedInputFiles + re-seeded
+ * in afterEach as a safety net, so canonical fixtures are never touched.
+ *
+ * Disk semantics: organize (move) relocates GOOD-901.mp4 from
+ * DEFAULT_INPUT_DIR to <destination>/GOOD-901/GOOD-901.mp4. Revert
+ * renames it back to DEFAULT_INPUT_DIR/GOOD-901.mp4 + cleans up the
+ * empty <destination>/GOOD-901/ directory. The spec asserts both halves.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+	BACKEND_BASE,
+	DEFAULT_INPUT_DIR,
+	DEFAULT_OUTPUT_DIR,
+	loginAgainstRealBackend,
+	seedInputFiles,
+	submitOrganize,
+	submitScrape,
+	waitForJobCompletion,
+} from '../helpers';
+
+/** Dedicated fixture — avoids touching the canonical GOOD-001.mp4. */
+const REVERT_FIXTURE = 'GOOD-901.mp4';
+const REVERT_MOVIE_ID = 'GOOD-901';
+const REVERT_SOURCE = `${DEFAULT_INPUT_DIR}/${REVERT_FIXTURE}`;
+
+test.describe('/jobs/[jobId] revert: real Reverter moves files back on disk', () => {
+	test.beforeEach(async () => {
+		// Seed the dedicated fixture fresh for each test. seedInputFiles
+		// removes any stale copy first, so this is deterministic regardless
+		// of whether a prior run's revert completed.
+		await seedInputFiles([REVERT_FIXTURE]);
+	});
+
+	test.afterEach(async () => {
+		// Safety net: re-seed the fixture so a failed test doesn't leave
+		// GOOD-901.mp4 missing from the input dir for the next test. Cheap
+		// (1-byte write) + idempotent.
+		await seedInputFiles([REVERT_FIXTURE]);
+	});
+
+	test('organize → /jobs/[id] → Revert Batch → job reaches reverted + files restored on disk', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// ── 1. Setup: scrape + organize (move) to a unique destination ──────
+		// copy_only: false (the submitOrganize default) → OperationTypeMove,
+		// which is the only copy-mode revertible operation type (copy/hardlink/
+		// symlink are rejected by the reverter's guardDoubleRevert).
+		const job_id = await submitScrape(request, { files: [REVERT_SOURCE] });
+		await waitForJobCompletion(request, job_id);
+
+		const destination = `${DEFAULT_OUTPUT_DIR}/revert-ui-${Date.now()}`;
+		expect(existsSync(destination), 'precondition: destination must not pre-exist').toBeFalsy();
+
+		await submitOrganize(request, job_id, destination);
+		const organized_job = await waitForJobCompletion(request, job_id, {
+			expectStatus: 'organized',
+		});
+
+		// The organize phase must have reached `organized` (not just
+		// `completed`) — revert rejects any other status with 400. This pins
+		// that the move operation fully succeeded for the 1-byte fixture.
+		expect(organized_job.status, 'job must be organized before revert').toBe('organized');
+
+		// Disk precondition: the file was moved to the destination. The e2e
+		// config's FolderFormat="<ID>" + the default SubfolderFormat=["<ID>"]
+		// produce a double-nested layout: destination/<ID>/<ID>/<ID>.mp4.
+		const organized_file = join(destination, REVERT_MOVIE_ID, REVERT_MOVIE_ID, `${REVERT_MOVIE_ID}.mp4`);
+		expect(existsSync(organized_file), 'organized file must exist at destination before revert').toBeTruthy();
+		expect(
+			existsSync(REVERT_SOURCE),
+			'source file must be gone after a move organize',
+		).toBeFalsy();
+
+		// ── 2. Navigate to /jobs/[jobId] ────────────────────────────────────
+		await page.goto(`/jobs/${job_id}`);
+		await page.waitForLoadState('domcontentloaded');
+		await page.waitForLoadState('networkidle');
+
+		// The page header renders the truncated job ID — confirms the detail
+		// page mounted + fetched the job.
+		const short_id = job_id.slice(0, 8);
+		await expect(page.getByRole('heading', { name: `Job ${short_id}` })).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// ── 3. Assert the "Revert Batch" button is visible ─────────────────
+		// The button only renders when ALL three conditions hold:
+		//   pendingCount > 0  AND  jobStatus === 'organized'  AND  config.output.allow_revert
+		// The e2e backend sets allow_revert = true (cmd/javinizer-e2e). If the
+		// button is missing, one of those conditions failed — the most likely
+		// regression is the config flag not flowing through to the frontend's
+		// config query.
+		const revertBatchBtn = page.getByRole('button', { name: /Revert Batch/i });
+		await expect(revertBatchBtn, 'Revert Batch button must render for an organized job').toBeVisible({
+			timeout: 10_000,
+		});
+
+		// The OperationRow for GOOD-901 must render with a per-file "Revert
+		// File" button — pins the operations list fetched + rendered.
+		const revertFileBtn = page.getByRole('button', { name: /Revert File/i }).first();
+		await expect(revertFileBtn).toBeVisible({ timeout: 10_000 });
+
+		// ── 4. Click "Revert Batch" → RevertConfirmationModal ──────────────
+		await revertBatchBtn.click();
+
+		// The modal renders in batch mode ("Revert Batch?" heading + a
+		// "Revert N Files" confirm button).
+		const modal = page.getByRole('dialog');
+		await expect(modal).toBeVisible({ timeout: 5_000 });
+		await expect(modal.getByText(/Revert Batch\?/)).toBeVisible();
+
+		// The confirm button's label is "Revert {N} File{s}" — for one file,
+		// "Revert 1 File". Its aria-label is "Revert 1 files".
+		const confirmBtn = modal.getByRole('button', { name: /Revert 1 File/i });
+		await expect(confirmBtn).toBeVisible();
+
+		// ── 5. Confirm revert ──────────────────────────────────────────────
+		await confirmBtn.click();
+
+		// The modal closes on success (revertBatchMutation.onSuccess sets
+		// revertModalOpen = false). Wait for it to disappear — proves the
+		// mutation fired + returned 200 (a 4xx/5xx would fire onError which
+		// also closes the modal, but the API poll below catches that).
+		await expect(modal).not.toBeVisible({ timeout: 10_000 });
+
+		// ── 6. Assert job reaches `reverted` via API ───────────────────────
+		// The UI invalidates the job/operations queries on success, but
+		// polling the API directly is the durable signal that the reverter
+		// ran + the job row was updated. Reverted is terminal.
+		const reverted_job = await waitForJobCompletion(request, job_id, {
+			expectStatus: 'reverted',
+			timeoutMs: 15_000,
+		});
+		expect(reverted_job.status, 'job status must be reverted after the UI revert').toBe('reverted');
+
+		// ── 7. Assert disk state: file restored + destination cleaned ──────
+		// The reverter's revertPrimaryFileFS renames the file from
+		// <destination>/GOOD-901/GOOD-901.mp4 back to DEFAULT_INPUT_DIR/GOOD-901.mp4,
+		// then cleanupEmptyDir removes the now-empty <destination>/GOOD-901/.
+		expect(
+			existsSync(REVERT_SOURCE),
+			'source file must be restored to its original path after revert',
+		).toBeTruthy();
+		expect(
+			existsSync(organized_file),
+			'organized file must be gone from destination after revert',
+		).toBeFalsy();
+
+		// The per-movie subfolder tree (<ID>/<ID>/) should be cleaned up by
+		// cleanupEmptyDir, which walks from filepath.Dir(NewPath) up to destRoot.
+		const movie_subfolder = join(destination, REVERT_MOVIE_ID);
+		expect(
+			existsSync(movie_subfolder),
+			'per-movie subfolder must be cleaned up after revert',
+		).toBeFalsy();
+
+		// ── 8. Assert the UI reflects the reverted state ───────────────────
+		// Reload to let the page re-fetch with fresh data (the query
+		// invalidation fires, but a reload is the surest way to assert the
+		// post-revert render). The OperationRow should show "Reverted ✓" and
+		// the "Revert Batch" button should be gone (pendingCount === 0).
+		await page.reload();
+		await page.waitForLoadState('networkidle');
+
+		await expect(page.getByText('Reverted', { exact: false }).first()).toBeVisible({
+			timeout: 10_000,
+		});
+		await expect(revertBatchBtn).not.toBeVisible({ timeout: 5_000 });
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/logs-viewer.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/logs-viewer.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * /logs page full-stack UI spec.
+ *
+ * Pins the event-logs viewer UI end-to-end against the real e2emock
+ * backend: page render, type-filter chips, severity/type badges, search.
+ * Every action goes through the real rendered page (real SvelteKit /logs)
+ * → real /api/v1/events (proxied to cmd/javinizer-e2e) → real
+ * EventRepository.List → real :memory: SQLite. No page.route mocking.
+ *
+ * Why this matters: the /logs page is the only observability surface in
+ * the app — it renders system/scrape/organize events with type + severity
+ * filters, search, date range, + live mode. It had zero Playwright
+ * coverage. The existing events.spec.ts covers the /events API contract
+ * (response shape, pagination, offset) but never renders the page. A
+ * regression in the logs page's loadEvents wiring, the type-filter chip
+ * state, the search filter, or the event-row render (severity badge,
+ * type badge, message) is invisible without this spec.
+ *
+ * Event data: the fullstack suite is serial — by the time this spec runs,
+ * prior specs (scrape, organize, revert) + the global-setup auth login
+ * have emitted real events into the :memory: SQLite. The spec asserts
+ * structural elements (filter chips, badges) without depending on
+ * specific event content.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { BACKEND_BASE, loginAgainstRealBackend } from '../helpers';
+
+const HEADING = 'Logs';
+const TYPE_FILTERS = ['All', 'Scraper', 'Organize', 'System'] as const;
+
+interface EventItem {
+	id: number;
+	event_type: string;
+	severity: string;
+	message: string;
+}
+
+async function listEvents(api: APIRequestContext): Promise<EventItem[]> {
+	const resp = await api.get(`${BACKEND_BASE}/api/v1/events?limit=100`);
+	expect(resp.ok(), `list events failed: ${resp.status()}`).toBeTruthy();
+	const body = (await resp.json()) as { events: EventItem[] };
+	return body.events ?? [];
+}
+
+async function navigateToLogs(page: Page): Promise<void> {
+	await page.goto('/logs');
+	await expect(page.getByRole('heading', { name: HEADING })).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe('/logs: real event viewer UI against the e2emock backend', () => {
+	test('page renders with type-filter chips + event rows', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		const events = await listEvents(request);
+
+		await navigateToLogs(page);
+
+		// ── 1. The type-filter chips render (All, Scraper, Organize, System)
+		// Each button's accessible name includes the count, e.g. "Scraper (5)",
+		// so match by leading word boundary.
+		for (const label of TYPE_FILTERS) {
+			await expect(
+				page.getByRole('button', { name: new RegExp(`^${label}\\s*\\(`) }),
+			).toBeVisible({ timeout: 10_000 });
+		}
+
+		// ── 2. Events render with severity + type badges ─────────────────
+		// Each event row renders a severity badge (raw severity text, e.g.
+		// "info") + a type badge (raw event_type, e.g. "system"). Assert at
+		// least one event row is present when the backend has events.
+		if (events.length > 0) {
+			const firstEvent = events[0];
+			await expect(page.getByText(firstEvent.severity, { exact: true }).first()).toBeVisible({
+				timeout: 10_000,
+			});
+			await expect(page.getByText(firstEvent.event_type, { exact: true }).first()).toBeVisible();
+		}
+	});
+
+	test('clicking a type filter refetches + the active button reflects the state', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		await navigateToLogs(page);
+
+		// ── Click the "Scraper" type filter ───────────────────────────────
+		// This triggers loadEvents with type=scraper. The active button
+		// switches to variant="default" (bg-primary). Assert the page still
+		// renders the heading after the refetch (no crash on the filter).
+		const scraperBtn = page.getByRole('button', { name: /^Scraper\s*\(/ });
+		await expect(scraperBtn).toBeVisible({ timeout: 10_000 });
+		await scraperBtn.click();
+
+		// The page re-renders after the refetch. The heading stays visible.
+		await expect(page.getByRole('heading', { name: HEADING })).toBeVisible({ timeout: 10_000 });
+
+		// ── Click "All" to clear the filter ──────────────────────────────
+		const allBtn = page.getByRole('button', { name: /^All\s*\(/ });
+		await allBtn.click();
+		await expect(page.getByRole('heading', { name: HEADING })).toBeVisible({ timeout: 10_000 });
+	});
+
+	test('search text filters the rendered event list', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		const events = await listEvents(request);
+		// Skip if no events exist (guards against a fresh-backend edge case).
+		test.skip(events.length === 0, 'no events in the backend to search');
+
+		await navigateToLogs(page);
+
+		// Pick a search term from the first event's message. getDisplayEvents
+		// filters client-side by substring match on the message.
+		const searchTerm = events[0].message.slice(0, Math.min(8, events[0].message.length));
+		const searchInput = page.getByPlaceholder('Search messages...');
+		await expect(searchInput).toBeVisible({ timeout: 10_000 });
+		await searchInput.fill(searchTerm);
+
+		// The matching event's severity badge still renders (the row didn't
+		// all disappear — the filter kept the matching event).
+		await expect(page.getByText(events[0].severity, { exact: true }).first()).toBeVisible({
+			timeout: 10_000,
+		});
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/manual-scrape.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/manual-scrape.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * /manual scrape full-stack UI spec.
+ *
+ * Pins the manual-scrape flow end-to-end: /browse (enable Manual Scrape) →
+ * select a file → "Continue to manual review" → /manual renders the file
+ * row → override the ID → "Start manual scrape" → ProgressModal →
+ * auto-redirect to /review/[jobId] → review page renders the
+ * OVERRIDDEN ID's scraped metadata.
+ *
+ * Real stack: browser → Vite dev server (real SvelteKit /browse + /manual
+ * render) → real /api/v1/file/browse + /api/v1/batch/scrape (proxied to
+ * cmd/javinizer-e2e) → real e2emock scraper → real :memory: SQLite →
+ * real ProgressModal job-polling → real goto('/review/:id').
+ *
+ * Why this matters: the /manual page is the ONLY entry point for the
+ * manual-input override feature (manual_inputs map in the BatchScrapeRequest).
+ * A regression in the pending-scrape store handoff (/browse → /manual), the
+ * buildManualScrapeRequest plumbing, or the override input's bind:value
+ * would silently drop overrides — the scrape would use the filename-derived
+ * ID instead of the user's override, and no other spec catches this because
+ * no other spec exercises /manual.
+ *
+ * The override assertion is the load-bearing one: the fixture file is
+ * GOOD-902.mp4 but the override sends "GOOD-903" as the manual ID. The
+ * e2emock scraper keys its response off the MovieID it receives, so the
+ * review page must render "E2E Movie GOOD-903" (not "E2E Movie GOOD-902").
+ * That proves the manual_inputs override reached the backend's matcher +
+ * the scraper received the overridden ID.
+ *
+ * Dedicated fixture (GOOD-902.mp4): scrape-only (no organize), so the file
+ * isn't moved — but the dedicated fixture keeps the spec self-contained +
+ * avoids any shared-state coupling to the canonical GOOD-001.mp4.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+
+import {
+	DEFAULT_INPUT_DIR,
+	DEFAULT_OUTPUT_DIR,
+	loginAgainstRealBackend,
+	seedInputFiles,
+	waitForJobCompletion,
+} from '../helpers';
+
+/** Dedicated fixture — scrape-only, not moved by organize. */
+const REVERT_FIXTURE = 'GOOD-902.mp4';
+const REVERT_SOURCE = `${DEFAULT_INPUT_DIR}/${REVERT_FIXTURE}`;
+/** Manual ID override — the scrape must use THIS ID, not the filename's. */
+const OVERRIDDEN_ID = 'GOOD-903';
+
+/** Placeholder on the FileBrowser's editable path input. */
+const SOURCE_PATH_PLACEHOLDER = 'Enter path (e.g., /path/to/videos)';
+/** Placeholder on the /manual override input (per file row). */
+const MANUAL_INPUT_PLACEHOLDER = 'Auto — type ID or URL to override';
+
+test.describe('/manual scrape: manual ID override flows through to the scraped result', () => {
+	test.beforeEach(async () => {
+		await seedInputFiles([REVERT_FIXTURE]);
+	});
+
+	test('/browse → enable Manual Scrape → /manual → override ID → scrape → /review shows the overridden ID metadata', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// ── 1. /browse → enable Manual Scrape ───────────────────────────────
+		await page.goto('/browse');
+		await page.waitForLoadState('domcontentloaded');
+		await page.waitForLoadState('networkidle');
+
+		// Open the expandable Options panel (the "Manual Scrape" checkbox
+		// lives inside it). The panel toggles on the "Options" button.
+		await page.getByRole('button', { name: /^Options$/i }).click();
+
+		// Toggle the "Manual Scrape" checkbox by clicking its label text.
+		// The <label> wraps the checkbox + the "Manual Scrape" span, so
+		// clicking the text flips the bound manualScrapeMode state.
+		await page.getByText('Manual Scrape', { exact: true }).click();
+
+		// The action button's label switches from "Scrape N File(s)" to
+		// "Continue to manual review" when manualScrapeMode is on. Asserting
+		// it visible pins the toggle took effect before we proceed.
+		const continueBtn = page.getByRole('button', { name: /Continue to manual review/i });
+		await expect(continueBtn).toBeVisible({ timeout: 5_000 });
+
+		// ── 2. Navigate FileBrowser to the input dir + select the fixture ──
+		const sourcePathInput = page.getByPlaceholder(SOURCE_PATH_PLACEHOLDER).first();
+		await sourcePathInput.fill(DEFAULT_INPUT_DIR);
+		await sourcePathInput.press('Enter');
+
+		const fixtureRow = page.getByText(REVERT_FIXTURE, { exact: true }).first();
+		await expect(fixtureRow, 'fixture must render in the FileBrowser listing').toBeVisible({
+			timeout: 10_000,
+		});
+		await fixtureRow.click();
+		await expect(page.getByText('1 file selected', { exact: true })).toBeVisible({
+			timeout: 5_000,
+		});
+
+		// Set a valid destination (allowed dir) so the batch-scrape request
+		// doesn't 4xx on destination validation.
+		const destPathInput = page.getByPlaceholder('Enter destination path (e.g., /path/to/output)').first();
+		await destPathInput.fill(DEFAULT_OUTPUT_DIR);
+		await destPathInput.press('Tab');
+
+		// ── 3. "Continue to manual review" → /manual ───────────────────────
+		// continueToManual() builds the PendingScrape snapshot, stashes it in
+		// the store + sessionStorage, then goto('/manual'). The /manual page
+		// hydrates from the store in onMount; without it, it redirects back
+		// to /browse — so landing on /manual (not /browse) pins the handoff.
+		await continueBtn.click();
+		await page.waitForURL('**/manual', { timeout: 10_000 });
+		await page.waitForLoadState('domcontentloaded');
+		await page.waitForLoadState('networkidle');
+
+		// ── 4. Assert the /manual file row renders ─────────────────────────
+		// The row shows the fixture's basename. The "Manual Scrape" heading
+		// confirms the page mounted (not redirected back to /browse).
+		await expect(page.getByRole('heading', { name: 'Manual Scrape' })).toBeVisible();
+		await expect(page.getByText(REVERT_FIXTURE, { exact: true }).first()).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// The badge on an empty input reads "Auto" (matcher derives ID from
+		// the filename). Pinning this before the override proves the input
+		// starts empty + the tri-state classifier works. The badge is a
+		// [role="status"] span containing an SVG icon + the text, so use
+		// toContainText rather than an exact-match filter.
+		const badge = page.getByRole('status').first();
+		await expect(badge).toContainText('Auto', { timeout: 5_000 });
+
+		// ── 5. Override the ID ─────────────────────────────────────────────
+		// The override input's aria-label includes the file path. Fill it
+		// with a different ID — the scrape must use THIS ID, not the one
+		// derived from the fixture filename.
+		const overrideInput = page.getByPlaceholder(MANUAL_INPUT_PLACEHOLDER).first();
+		await overrideInput.fill(OVERRIDDEN_ID);
+
+		// The badge flips from "Auto" to "ID" (classifyInput → manual-id).
+		// This pins the input's bind:value reached the classifier + the
+		// row's reactive state updated. Re-query the badge (same element,
+		// but its text reacted to the input change).
+		await expect(badge).toContainText('ID', { timeout: 5_000 });
+
+		// ── 6. "Start manual scrape" → ProgressModal → /review/[jobId] ─────
+		const startBtn = page.getByRole('button', { name: /Start manual scrape/i });
+		await expect(startBtn).toBeEnabled({ timeout: 5_000 });
+		await startBtn.click();
+
+		// ProgressModal mounts on startJob (submit → apiClient.batchScrape →
+		// startJob(res.job_id)). The modal header confirms the scrape was
+		// enqueued vs. an error toast.
+		await expect(page.getByText('Batch Scraping Progress')).toBeVisible({ timeout: 10_000 });
+
+		// On `completed` (scrape phase done), ProgressModal starts a 3s
+		// countdown then goto('/review/:jobId'). Waiting on the URL is
+		// race-free vs. clicking "View Results Now".
+		await page.waitForURL(/\/review\/[^/]+/, { timeout: 30_000 });
+		await page.waitForLoadState('domcontentloaded');
+		await page.waitForLoadState('networkidle');
+
+		// ── 7. Assert the OVERRIDDEN ID's metadata rendered ────────────────
+		// e2emock keys its response off the MovieID it receives. The override
+		// sent "GOOD-903" (not the filename's "GOOD-902"), so the review page
+		// must render "E2E Movie GOOD-903". If it shows "E2E Movie GOOD-902",
+		// the manual_inputs override was dropped somewhere in the pipeline
+		// (store handoff, buildManualScrapeRequest, or backend matcher).
+		await expect(page.locator('body')).toContainText('E2E Movie GOOD-903', { timeout: 15_000 });
+
+		// ── 8. Cross-check: the job's result movie_id is the overridden ID ─
+		// Ties the browser render to the backend job state — the job's
+		// FileResult.movie_id must be GOOD-903 (the override), NOT GOOD-902
+		// (the filename-derived ID). This is the durable backend-side proof
+		// the override reached the matcher + scraper.
+		const jobId = new URL(page.url()).pathname.split('/review/')[1];
+		expect(jobId, 'review URL must carry a jobId').toBeTruthy();
+
+		const job = await waitForJobCompletion(request, jobId);
+		const results = Object.values(job.results);
+		expect(results.length, 'job must have exactly one result').toBe(1);
+		expect(
+			results[0].movie_id,
+			'movie_id must be the OVERRIDDEN ID (GOOD-903), not the filename-derived ID',
+		).toBe(OVERRIDDEN_ID);
+		expect(
+			results[0].movie?.title ?? '',
+			'scraped title must carry the overridden ID marker',
+		).toContain('E2E Movie GOOD-903');
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/review-organize-fullstack.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/review-organize-fullstack.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * /review/[jobId] organize full-stack UI spec.
+ *
+ * Pins the organize-from-review-page flow end-to-end: scrape via API →
+ * navigate browser to /review/[jobId] → fill the destination → click
+ * "Organize N Files" → the real apply phase runs → OrganizeStatusCard
+ * renders "Organization Complete!" → real files appear on disk.
+ *
+ * Real stack: browser → Vite dev server (real SvelteKit /review render)
+ * → real /api/v1/batch/:id/organize (proxied to cmd/javinizer-e2e) →
+ * real apply phase + organizer workflow → real filesystem write to the
+ * destination directory → real :memory: SQLite.
+ *
+ * Why this matters: the existing organize.spec.ts is API-only — it POSTs
+ * to /batch/:id/organize via the `request` fixture + asserts the folder
+ * exists on disk, but never renders the review page. The mocked
+ * review-page.spec.ts renders the review page but against a mocked API
+ * (page.route), so it can't verify the real apply phase writes files.
+ * This spec bridges the two: real browser render of /review/[jobId] +
+ * real backend apply phase + real disk assertions. A regression in the
+ * review page's organize wiring (ReviewActionBar → organizeController →
+ * api.organizeBatchJob), the destination-path binding, or the
+ * OrganizeStatusCard success render is invisible to both existing specs.
+ *
+ * Setup via API (submitScrape): the scrape setup uses the `request`
+ * fixture directly because the browse→scrape UI path is already covered
+ * by browse-launch-scrape.spec.ts. This spec's focus is the review page's
+ * organize UI, so setup is a fast API call; the assertions are all
+ * against the rendered page + real disk state.
+ *
+ * Dedicated fixture (GOOD-904.mp4): organize with `move` relocates the
+ * file out of the input dir — a dedicated fixture keeps the spec
+ * self-contained + avoids touching canonical fixtures shared across specs.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+	DEFAULT_INPUT_DIR,
+	DEFAULT_OUTPUT_DIR,
+	loginAgainstRealBackend,
+	seedInputFiles,
+	submitScrape,
+	waitForJobCompletion,
+	navigateToReviewPage,
+} from '../helpers';
+
+/** Dedicated fixture — organize (move) relocates it, so don't touch shared fixtures. */
+const ORGANIZE_FIXTURE = 'GOOD-904.mp4';
+const ORGANIZE_MOVIE_ID = 'GOOD-904';
+const ORGANIZE_SOURCE = `${DEFAULT_INPUT_DIR}/${ORGANIZE_FIXTURE}`;
+
+/** Placeholder on the DestinationSettingsCard's path input. */
+const DEST_PLACEHOLDER = 'Enter destination path (e.g., /path/to/output)';
+
+test.describe('/review/[jobId] organize: real apply phase creates files on disk', () => {
+	test.beforeEach(async () => {
+		await seedInputFiles([ORGANIZE_FIXTURE]);
+	});
+
+	test.afterEach(async () => {
+		// Safety net: re-seed in case a failed test left the fixture moved
+		// out of the input dir. Cheap (1-byte write) + idempotent.
+		await seedInputFiles([ORGANIZE_FIXTURE]);
+	});
+
+	test('scrape → /review/[id] → Organize → OrganizeStatusCard shows complete + files exist on disk', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// ── 1. Setup: scrape the fixture (reaches `completed`, not organized) ─
+		// The review page's organize button is the entry point to the apply
+		// phase — scrape-only setup means the job is at `completed` + the
+		// files are still in the input dir, the exact pre-organize state.
+		const job_id = await submitScrape(request, { files: [ORGANIZE_SOURCE] });
+		await waitForJobCompletion(request, job_id);
+
+		const destination = `${DEFAULT_OUTPUT_DIR}/review-organize-${Date.now()}`;
+		expect(existsSync(destination), 'precondition: destination must not pre-exist').toBeFalsy();
+
+		// ── 2. Navigate browser to /review/[jobId] ──────────────────────────
+		await navigateToReviewPage(page, job_id);
+
+		// The review page restores viewMode from localStorage — a prior spec
+		// (or this one's previous run) may have left it on 'grid-poster',
+		// where the DestinationSettingsCard + ReviewActionBar don't render.
+		// Force the detail view: it's the only view that surfaces the organize
+		// UI. The Detail button is in the ReviewHeader view toggle.
+		await page.getByRole('button', { name: /^Detail$/i }).click();
+
+		// The review page renders the scraped movie's data. GOOD-904's ID
+		// (from e2emock) appears in the detail-view navigation card
+		// ("Movie 1 of 1" + the ID badge) + the Source File card. Asserting
+		// the ID visible pins the page mounted + fetched the real job results.
+		// (The title "E2E Movie GOOD-904" shows in grid-poster view's card,
+		// but the detail view's Title field is an editable input whose value
+		// isn't in textContent — the ID is the reliable mount signal here.)
+		await expect(page.locator('body')).toContainText('GOOD-904', { timeout: 15_000 });
+
+		// ── 3. Fill the destination path ───────────────────────────────────
+		// The DestinationSettingsCard renders when canOrganize (= operation
+		// mode is `organize`, the config default). The Organize button is
+		// disabled until destinationPath is non-empty, so filling it is a
+		// precondition for the click below.
+		const destInput = page.getByPlaceholder(DEST_PLACEHOLDER).first();
+		await expect(destInput, 'destination input must render in organize mode').toBeVisible({
+			timeout: 10_000,
+		});
+		await destInput.fill(destination);
+
+		// ── 4. Click "Organize 1 File" ──────────────────────────────────────
+		// The button label is "Organize {N} File{s}" — for one file,
+		// "Organize 1 File". The ReviewActionBar renders twice (main column +
+		// a sticky bar), so target the first. Clicking fires
+		// organizeController.organizeAll → api.organizeBatchJob (real POST
+		// /batch/:id/organize) + starts the completion polling.
+		const organizeBtn = page.getByRole('button', { name: /^Organize 1 File$/i }).first();
+		await expect(organizeBtn).toBeEnabled({ timeout: 5_000 });
+		await organizeBtn.click();
+
+		// ── 5. Wait for OrganizeStatusCard "Organization Complete!" ─────────
+		// The organize-controller polls the job; on terminal organize status
+		// it sets organizeStatus='completed', which renders the green success
+		// card with "Organization Complete!" + "Redirecting to browse page...".
+		// This is the UI-side signal the apply phase finished. 30s timeout
+		// is generous — the apply phase for one 1-byte file is near-instant,
+		// but the polling cadence + WS round-trip add latency.
+		await expect(page.getByText('Organization Complete!')).toBeVisible({ timeout: 30_000 });
+
+		// ── 6. Assert real files exist on disk ─────────────────────────────
+		// The e2e config's FolderFormat="<ID>" + default SubfolderFormat=
+		// ["<ID>"] produce destination/<ID>/<ID>/<ID>.mp4. The apply phase
+		// ran for real (not just enqueued) — the file exists on disk.
+		expect(existsSync(destination), 'destination directory must exist after organize').toBeTruthy();
+		const entries = readdirSync(destination);
+		expect(entries, 'destination must contain a per-movie subfolder').toContain(ORGANIZE_MOVIE_ID);
+
+		const organized_file = join(
+			destination,
+			ORGANIZE_MOVIE_ID,
+			ORGANIZE_MOVIE_ID,
+			`${ORGANIZE_MOVIE_ID}.mp4`,
+		);
+		expect(
+			existsSync(organized_file),
+			'organized video file must exist at the template-resolved path',
+		).toBeTruthy();
+
+		// ── 7. Cross-check: the job reaches `organized` via the API ─────────
+		// Ties the UI success render to the backend job state. The
+		// organize-controller's success render fires on the WS/REST poll
+		// detecting terminal status — asserting the API job status is
+		// `organized` confirms the success card wasn't a false positive.
+		const organized_job = await waitForJobCompletion(request, job_id, {
+			expectStatus: 'organized',
+			timeoutMs: 15_000,
+		});
+		expect(organized_job.status, 'job status must be organized after the UI organize').toBe(
+			'organized',
+		);
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/scrape-edge-cases.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/scrape-edge-cases.spec.ts
@@ -1,0 +1,384 @@
+/**
+ * Scrape pipeline edge-cases spec.
+ *
+ * Pins the scrape pipeline's behavior under non-happy-path inputs against
+ * the real e2emock backend: mixed batches (partial failure), empty file
+ * lists, duplicate paths, non-existent scrapers, missing files on disk,
+ * force-refresh, and cache idempotency. Every action hits the real
+ * /api/v1/batch/scrape endpoint (proxied to cmd/javinizer-e2e) → real
+ * worker.ScrapePhase → real e2emock scraper. No page.route mocking.
+ *
+ * Why this matters: the existing scrape specs (browse-launch-scrape,
+ * manual-scrape, multipart, rescrape, batch-rescrape, field-drop) all
+ * drive the SINGLE-file happy path or a single-error path. Real users
+ * select batches of 10–50 files where some match + some don't. The
+ * pipeline's partial-failure handling — does a failed file poison the
+ * batch? does the job status reflect per-file failures? are successful
+ * results preserved alongside failed ones? — had ZERO coverage. The
+ * input-validation edge cases (empty list, duplicates, bad scraper
+ * names) likewise had no coverage, so a regression that silently
+ * accepted or silently dropped them would go unnoticed.
+ *
+ * All behaviors below were verified empirically against the running
+ * e2emock backend before writing the assertions — the spec pins the
+ * CURRENT correct behavior so future changes are intentional.
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { BACKEND_BASE, loginAgainstRealBackend, submitScrape, submitOrganize } from '../helpers';
+import { waitForJobCompletion } from '../helpers';
+import { DEFAULT_INPUT_DIR, DEFAULT_OUTPUT_DIR, seedInputFiles } from '../helpers';
+import type { BatchJobResponse, FileResult } from '../helpers';
+
+const GOOD_FILE = `${DEFAULT_INPUT_DIR}/GOOD-001.mp4`;
+const FAIL_FILE = `${DEFAULT_INPUT_DIR}/FAIL-002.mp4`;
+
+interface JobSummary {
+	status: string;
+	totalFiles: number;
+	results: Record<string, FileResult>;
+}
+
+async function scrapeAndAwait(
+	api: APIRequestContext,
+	files: string[],
+	opts: { force?: boolean; selectedScrapers?: string[] } = {},
+): Promise<JobSummary> {
+	const jobId = await submitScrape(api, {
+		files,
+		...opts,
+	});
+	const job = await waitForJobCompletion(api, jobId, { timeoutMs: 30_000 });
+	return {
+		status: job.status,
+		totalFiles: job.total_files,
+		results: job.results,
+	};
+}
+
+test.describe('Scrape pipeline edge cases: real e2emock backend', () => {
+	test.describe('mixed batches (partial failure)', () => {
+		test('GOOD + FAIL in one job → job completes, per-file statuses independent, success not poisoned by failure', async ({
+			request,
+		}: {
+			request: APIRequestContext;
+		}) => {
+			await loginAgainstRealBackend(request);
+
+			// The most realistic real-world scenario: a user selects a batch
+			// where some files scrape successfully + some fail. The pipeline
+			// must NOT abort the whole batch on the first failure, must NOT
+			// mark the successful files as failed, + must surface the failed
+			// file's verbose per-scraper error verbatim.
+			const { status, totalFiles, results } = await scrapeAndAwait(request, [
+				GOOD_FILE,
+				FAIL_FILE,
+			]);
+
+			// ── 1. Job-level: the job COMPLETES (status=completed), not failed.
+			// A mixed batch is a successful batch scrape — individual file
+			// failures are per-file, not job-level. (If this flipped to
+			// "failed", the review UI would never show the successful results.)
+			expect(status, 'a mixed batch must complete (not fail) at the job level').toBe(
+				'completed',
+			);
+
+			// ── 2. Both files are present in the results (no file dropped).
+			expect(totalFiles, 'total_files must reflect both input files').toBe(2);
+			expect(Object.keys(results).length, 'results must contain both files').toBe(2);
+			expect(results[GOOD_FILE], 'the GOOD file must have a result').toBeTruthy();
+			expect(results[FAIL_FILE], 'the FAIL file must have a result').toBeTruthy();
+
+			// ── 3. The GOOD file succeeded — its result is NOT poisoned by the
+			// sibling failure. The movie payload (title) must be present.
+			const goodResult = results[GOOD_FILE];
+			expect(goodResult.status, 'the GOOD file must be status=completed').toBe('completed');
+			expect(goodResult.movie_id, 'the GOOD file must carry its movie_id').toBe('GOOD-001');
+			expect(goodResult.movie, 'the GOOD file must carry its scraped movie payload').toBeTruthy();
+			expect(goodResult.movie?.title, 'the GOOD movie title must be the scraped value').toContain(
+				'E2E Movie GOOD-001',
+			);
+			expect(goodResult.error, 'a successful scrape must have no error').toBeFalsy();
+
+			// ── 4. The FAIL file failed — its verbose per-scraper error
+			// survives end-to-end (the "e2emock:" substring from the scraper
+			// must NOT be collapsed to a hardcoded "no result"). This guards
+			// the commit 42d89e65 regression class.
+			const failResult = results[FAIL_FILE];
+			expect(failResult.status, 'the FAIL file must be status=failed').toBe('failed');
+			expect(failResult.movie_id, 'the FAIL file must still carry its movie_id').toBe('FAIL-002');
+			expect(failResult.error, 'the FAIL file must carry a verbose error').toBeTruthy();
+			expect(failResult.error, 'the verbose per-scraper error must survive verbatim').toContain(
+				'e2emock',
+			);
+			expect(failResult.movie, 'a failed scrape must not carry a movie payload').toBeFalsy();
+		});
+
+		test('2 GOOD + 1 FAIL → multiple successes preserved, failure isolated', async ({
+			request,
+		}: {
+			request: APIRequestContext;
+		}) => {
+			await loginAgainstRealBackend(request);
+
+			// A larger mixed batch: two successful files + one failure. Proves
+			// the partial-failure handling scales beyond 1+1 — no off-by-one
+			// in the result tracker, no cross-contamination between the two
+			// successful results. Uses GOOD-001 + GOOD-001 (duplicate path,
+			// deduped to one result — see the duplicate-paths test) + a second
+			// GOOD file seeded ad-hoc.
+			await seedInputFiles(['GOOD-099.mp4']);
+			const goodFile2 = `${DEFAULT_INPUT_DIR}/GOOD-099.mp4`;
+
+			const { status, results } = await scrapeAndAwait(request, [
+				GOOD_FILE,
+				goodFile2,
+				FAIL_FILE,
+			]);
+
+			expect(status, 'the mixed batch must complete').toBe('completed');
+			expect(Object.keys(results).length, 'all three files must have results').toBe(3);
+
+			// Both GOOD files succeeded with their own movie payloads.
+			expect(results[GOOD_FILE].status, 'first GOOD file must succeed').toBe('completed');
+			expect(results[GOOD_FILE].movie?.title).toContain('GOOD-001');
+			expect(results[goodFile2].status, 'second GOOD file must succeed').toBe('completed');
+			expect(results[goodFile2].movie?.title).toContain('GOOD-099');
+
+			// The FAIL file is isolated — its failure doesn't bleed into
+			// either successful result.
+			expect(results[FAIL_FILE].status, 'the FAIL file must be failed in isolation').toBe(
+				'failed',
+			);
+			expect(results[FAIL_FILE].error).toContain('e2emock');
+		});
+	});
+
+	test.describe('input validation edge cases', () => {
+		test('empty files array → job created + completes with 0 results (current behavior)', async ({
+			request,
+		}: {
+			request: APIRequestContext;
+		}) => {
+			await loginAgainstRealBackend(request);
+
+			// `files` has `binding:"required"` — but Go's binding "required" on
+			// a slice only rejects nil/missing, NOT an empty slice. So
+			// files:[] is accepted + creates a job that completes with zero
+			// results. This pins the CURRENT behavior: if a future change
+			// tightens this to 400 (arguably more correct), this test will
+			// fail + prompt an intentional update.
+			const { status, totalFiles, results } = await scrapeAndAwait(request, []);
+
+			expect(status, 'an empty batch must still reach a terminal status').toBe('completed');
+			expect(totalFiles, 'an empty batch must report 0 files').toBe(0);
+			expect(Object.keys(results).length, 'an empty batch must produce 0 results').toBe(0);
+		});
+
+		test('duplicate file paths → results deduped by path key (one result, not two)', async ({
+			request,
+		}: {
+			request: APIRequestContext;
+		}) => {
+			await loginAgainstRealBackend(request);
+
+			// Submitting the same file path twice: total_files counts both
+			// submissions, but the results map is keyed by file path, so only
+			// one result row exists. The single result is the successful
+			// scrape. This pins the dedup-by-key behavior — a regression that
+			// produced two results for the same path (or panicked on the
+			// duplicate key) would surface here.
+			const { status, totalFiles, results } = await scrapeAndAwait(request, [
+				GOOD_FILE,
+				GOOD_FILE,
+			]);
+
+			expect(status, 'a duplicate-path batch must complete').toBe('completed');
+			expect(totalFiles, 'total_files must count both submissions').toBe(2);
+			expect(
+				Object.keys(results).length,
+				'results must dedupe to one entry by path key',
+			).toBe(1);
+			expect(results[GOOD_FILE].status, 'the deduped result must be the successful scrape').toBe(
+				'completed',
+			);
+		});
+
+		test('non-existent scraper name → file fails with "No results from any scraper" (no 400)', async ({
+			request,
+		}: {
+			request: APIRequestContext;
+		}) => {
+			await loginAgainstRealBackend(request);
+
+			// selected_scrapers=['nonexistent'] is NOT validated at the API
+			// layer — the job is created + the scrape runs, but no scraper
+			// matches the name, so the file fails with "No results from any
+			// scraper". This pins the current silent-acceptance behavior: a
+			// future change that 400s on an unknown scraper name would fail
+			// this test + prompt an intentional update.
+			const { status, results } = await scrapeAndAwait(request, [GOOD_FILE], {
+				selectedScrapers: ['nonexistent-scraper'],
+			});
+
+			expect(status, 'the job must still complete (per-file failure, not job failure)').toBe(
+				'completed',
+			);
+			const result = results[GOOD_FILE];
+			expect(result, 'the file must have a result').toBeTruthy();
+			expect(result.status, 'the file must fail (no scraper matched)').toBe('failed');
+			expect(result.error, 'the error must explain no scraper produced results').toContain(
+				'No results',
+			);
+		});
+
+		test('file not on disk → scrape still runs (matcher extracts ID from filename)', async ({
+			request,
+		}: {
+			request: APIRequestContext;
+		}) => {
+			await loginAgainstRealBackend(request);
+
+			// A file path that doesn't exist on disk is still accepted: the
+			// scrape pipeline derives the MovieID from the FILENAME via the
+			// matcher (it never reads the file content — the e2emock scraper
+			// is keyed on ID). The file's directory is allowed (it's in the
+			// input dir), so the security check passes; the scrape then runs
+			// + fails with the e2emock's "unrecognized ID" error (since the
+			// nonexistent filename doesn't carry a GOOD-/FAIL-/etc. prefix).
+			//
+			// This pins that the scrape does NOT require the file to exist —
+			// only the filename matters for ID extraction. A regression that
+			// added a stat-before-scrape guard (rejecting missing files) would
+			// surface here.
+			const missingFile = `${DEFAULT_INPUT_DIR}/NONEXISTENT-999.mp4`;
+			const { status, results } = await scrapeAndAwait(request, [missingFile]);
+
+			expect(status, 'the job must complete (per-file failure)').toBe('completed');
+			const result = results[missingFile];
+			expect(result, 'the missing file must still get a result row').toBeTruthy();
+			expect(result.status, 'the scrape must fail (unrecognized ID)').toBe('failed');
+			expect(result.error, 'the error must be the verbose per-scraper message').toBeTruthy();
+		});
+	});
+
+	test.describe('mixed batch → organize (full pipeline with partial failure)', () => {
+		test('organize skips the failed scrape result + organizes only the successful one', async ({
+			request,
+		}: {
+			request: APIRequestContext;
+		}) => {
+			await loginAgainstRealBackend(request);
+
+			// The full pipeline edge case: scrape a mixed batch (GOOD + FAIL),
+			// then organize. The apply phase filters at line 78 of
+			// apply_phase.go: `if fileResult.Status != completed || Movie == nil`.
+			// So the FAIL file (status=failed from scrape) is SKIPPED by organize —
+			// it's never touched, its error is preserved. Only the GOOD file is
+			// organized. The job reaches "organized" status with completed=1,
+			// failed=1. This guards the partial-failure organize contract: a
+			// regression that tried to organize a failed-scrape file (and 500'd
+			// on its nil Movie) would surface here.
+			//
+			// Uses a unique GOOD file (GOOD-077) + a unique destination dir so
+			// the organize phase always succeeds even when run after other
+			// organize specs that already organized GOOD-001 to the default
+			// output dir (a file-exists collision would make orgCount=0/
+			// failCount>0 → MarkCompleted instead of MarkOrganized, masking
+			// the contract under test).
+			await seedInputFiles(['GOOD-077.mp4']);
+			const goodFile = `${DEFAULT_INPUT_DIR}/GOOD-077.mp4`;
+			const uniqueDest = `${DEFAULT_OUTPUT_DIR}/edge-${Date.now()}`;
+			const jobId = await submitScrape(request, { files: [goodFile, FAIL_FILE] });
+			const scraped = await waitForJobCompletion(request, jobId, { timeoutMs: 30_000 });
+			expect(scraped.status, 'the mixed batch scrape must complete').toBe('completed');
+
+			// ── 1. Submit organize on the mixed-batch job ─────────────────────
+			await submitOrganize(request, jobId, uniqueDest);
+
+			// ── 2. Wait for the organize phase to finish ──────────────────────
+			// The job transitions completed → organized (MarkOrganized). Poll
+			// until terminal.
+			const organized = await waitForJobCompletion(request, jobId, {
+				timeoutMs: 30_000,
+			});
+			expect(organized.status, 'the job must reach "organized" after apply').toBe('organized');
+			expect(organized.completed, 'completed count must be 1 (the GOOD file)').toBe(1);
+			expect(organized.failed, 'failed count must be 1 (the FAIL file, skipped)').toBe(1);
+
+			// ── 3. The GOOD file was organized — status stays "completed" ────
+			// (the apply phase doesn't flip a successful file's status to
+			// "organized"; it stays "completed" + the job-level status reflects
+			// the organize outcome). The movie payload is still present.
+			const goodResult = organized.results[goodFile];
+			expect(goodResult, 'the GOOD file must still have a result').toBeTruthy();
+			expect(goodResult.status, 'the organized GOOD file stays completed').toBe('completed');
+			expect(goodResult.movie, 'the GOOD movie payload must survive organize').toBeTruthy();
+			expect(goodResult.error, 'the GOOD file must have no error').toBeFalsy();
+
+			// ── 4. The FAIL file was SKIPPED by organize ─────────────────────
+			// Its status is still "failed" (from the scrape phase), + its verbose
+			// scrape error is preserved verbatim — organize didn't touch it,
+			// didn't clear the error, didn't try to organize a nil Movie.
+			const failResult = organized.results[FAIL_FILE];
+			expect(failResult, 'the FAIL file must still have a result').toBeTruthy();
+			expect(failResult.status, 'the skipped FAIL file stays failed').toBe('failed');
+			expect(failResult.error, 'the FAIL scrape error must be preserved').toContain('e2emock');
+			expect(failResult.movie, 'the FAIL file must still have no movie').toBeFalsy();
+		});
+	});
+
+	test.describe('force refresh + cache', () => {
+		test('force=true on initial scrape → cache bypass, job completes with the result', async ({
+			request,
+		}: {
+			request: APIRequestContext;
+		}) => {
+			await loginAgainstRealBackend(request);
+
+			// force=true sets ForceRefresh on the ScrapeCmd, bypassing the
+			// scraper cache. The e2emock is deterministic, so the result is
+			// identical to a non-force scrape — but the point is that the
+			// force path doesn't error + still produces the result. The
+			// batch-rescrape spec covers force on the RESCRAPE path; this
+			// covers force on the INITIAL scrape path.
+			const { status, results } = await scrapeAndAwait(request, [GOOD_FILE], {
+				force: true,
+			});
+
+			expect(status, 'a force-refresh scrape must complete').toBe('completed');
+			expect(results[GOOD_FILE].status, 'the file must succeed under force').toBe('completed');
+			expect(results[GOOD_FILE].movie?.title).toContain('E2E Movie GOOD-001');
+		});
+
+		test('re-scrape the same ID without force → same result (cache idempotency)', async ({
+			request,
+		}: {
+			request: APIRequestContext;
+		}) => {
+			await loginAgainstRealBackend(request);
+
+			// Scrape GOOD-001 once, then scrape it again. The second scrape
+			// (without force) hits the cache + returns the same result. This
+			// pins that re-scraping an already-cached ID is idempotent — no
+			// error, no duplicate, the same movie payload. A regression in
+			// the cache lookup (e.g., a cache-miss that re-scrapes + produces
+			// a conflicting result) would surface as a title mismatch.
+			const first = await scrapeAndAwait(request, [GOOD_FILE]);
+			const second = await scrapeAndAwait(request, [GOOD_FILE]);
+
+			expect(first.status, 'the first scrape must complete').toBe('completed');
+			expect(second.status, 'the second (cached) scrape must complete').toBe('completed');
+
+			const firstMovie = first.results[GOOD_FILE].movie;
+			const secondMovie = second.results[GOOD_FILE].movie;
+			expect(firstMovie, 'the first scrape must produce a movie').toBeTruthy();
+			expect(secondMovie, 'the cached re-scrape must produce a movie').toBeTruthy();
+			expect(secondMovie?.title, 'the cached result must match the first scrape').toBe(
+				firstMovie?.title,
+			);
+			expect(secondMovie?.id, 'the cached result must carry the same movie ID').toBe(
+				firstMovie?.id,
+			);
+		});
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/settings-page.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/settings-page.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * /settings page full-stack UI spec.
+ *
+ * Pins the settings page UI end-to-end against the real e2emock backend:
+ * page render, config load (section headers render only after the config
+ * query resolves), + collapsible section expansion (Scraper Settings +
+ * Metadata Priority). Every assertion goes through the real rendered page
+ * (real SvelteKit /settings) → real /api/v1/config + /api/v1/scrapers
+ * (proxied to cmd/javinizer-e2e) → real :memory: SQLite. No page.route
+ * mocking.
+ *
+ * Why this matters: the /settings page is the largest UI surface in the
+ * app — 16+ collapsible sections backed by the full config struct + the
+ * scraper registry. It had zero Playwright coverage. A regression in the
+ * config load, the scraper list render, or the SettingsSection collapse/
+ * expand wiring is invisible without this spec. The existing token-
+ * management.spec.ts covers the API tokens CRUD but never renders the
+ * settings page shell.
+ *
+ * Structure: every section is wrapped in a SettingsSection with
+ * defaultExpanded={false} — there are no always-visible section bodies.
+ * The section headers (h3 titles inside <button aria-expanded>) render
+ * only after settings.settingsConfig populates (GET /api/v1/config
+ * resolved), so asserting their presence pins the config query succeeded.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { loginAgainstRealBackend } from '../helpers';
+
+const HEADING = 'Settings';
+const E2EMOCK_DISPLAY = 'Deterministic E2E mock scraper';
+
+async function navigateToSettings(page: Page): Promise<void> {
+	await page.goto('/settings');
+	// Use exact: true — 12 section headings end in "Settings" (e.g. "Server
+	// Settings"), so a substring match resolves to 13 elements.
+	await expect(page.getByRole('heading', { name: HEADING, exact: true })).toBeVisible({
+		timeout: 15_000,
+	});
+}
+
+test.describe('/settings: real page shell + sections against the e2emock backend', () => {
+	test('page renders with collapsible section headers (config loaded)', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		await navigateToSettings(page);
+
+		// ── Section headers render → config query resolved ──────────────
+		// The section headers are inside {:else if settings.settingsConfig},
+		// so their presence pins GET /api/v1/config succeeded + the config
+		// populated. Assert a few stable section titles.
+		for (const title of ['Server Settings', 'Scraper Settings', 'Metadata Priority']) {
+			await expect(
+				page.getByRole('button', { name: new RegExp(`^${title}`) }).first(),
+			).toBeVisible({ timeout: 15_000 });
+		}
+	});
+
+	test('Scraper Settings section expands → renders the e2emock scraper', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		await navigateToSettings(page);
+
+		// ── Expand the "Scraper Settings" section ────────────────────────
+		// ScraperSettingsSection wraps itself in a SettingsSection with
+		// defaultExpanded={false}. The header is a <button> with
+		// aria-expanded. Expand it to reveal the scraper list.
+		const scraperHeader = page.getByRole('button', { name: /^Scraper Settings/ }).first();
+		await expect(scraperHeader).toBeVisible({ timeout: 15_000 });
+		await expect(scraperHeader).toHaveAttribute('aria-expanded', 'false');
+
+		await scraperHeader.click();
+		await expect(scraperHeader).toHaveAttribute('aria-expanded', 'true');
+
+		// The scraper list renders with "Available Scrapers" + each scraper's
+		// displayName. The e2emock scraper's display_title is "Deterministic
+		// E2E mock scraper — never hits the network" (not the raw name).
+		await expect(page.getByText('Available Scrapers')).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByText(E2EMOCK_DISPLAY)).toBeVisible({
+			timeout: 10_000,
+		});
+	});
+
+	test('Metadata Priority section expands → priority content renders', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		await navigateToSettings(page);
+
+		// ── Expand the "Metadata Priority" section ──────────────────────
+		const priorityHeader = page.getByRole('button', { name: /^Metadata Priority/ }).first();
+		await expect(priorityHeader).toBeVisible({ timeout: 15_000 });
+		await expect(priorityHeader).toHaveAttribute('aria-expanded', 'false');
+
+		await priorityHeader.click();
+		await expect(priorityHeader).toHaveAttribute('aria-expanded', 'true');
+
+		// The MetadataPriority component renders. Assert a stable element
+		// from its body: the "Per-Field Overrides" heading or a category
+		// group heading ("Primary" / "Metadata"). These render after the
+		// component mounts inside the expanded section.
+		await expect(page.getByText(/per-field overrides|primary|metadata/i).first()).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// Collapse back — aria-expanded flips to false.
+		await priorityHeader.click();
+		await expect(priorityHeader).toHaveAttribute('aria-expanded', 'false');
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/temp-image-security.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/temp-image-security.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * Temp image API full-stack spec.
+ *
+ * Pins the security guards on the temp-image + poster-serving endpoints
+ * end-to-end against the real e2emock backend: path-traversal rejection
+ * (serveTempPoster, serveCroppedPoster), .jpg extension enforcement,
+ * missing-URL rejection, invalid-URL rejection, + SSRF protection
+ * (serveTempImage). Every assertion hits the real /api/v1/temp/* +
+ * /api/v1/posters/* endpoints (proxied to cmd/javinizer-e2e).
+ *
+ * Why this matters: these endpoints serve files from disk + fetch remote
+ * URLs — path traversal + SSRF are the two highest-severity risks in the
+ * API surface. The guards (isSafePathSegment, ssrf.CheckURL, the .jpg
+ * suffix check, the posterDir prefix defense-in-depth) had ZERO e2e
+ * coverage. A regression that weakens any guard (e.g., removing the
+ * filepath.Base check, allowing a non-.jpg extension, or bypassing
+ * ssrf.CheckURL) would open a security hole with no test signal. This
+ * spec pins the rejection contract for each guard.
+ *
+ * Scope: these tests exercise the GUARDS (the rejection paths), which
+ * fire before any file/URL fetch — so they don't need real poster files
+ * or network egress. The happy-path "serve a real temp poster" is
+ * covered indirectly by poster-cover-reactivity.spec.ts (which crops a
+ * poster + views it). This spec focuses on the security-relevant
+ * rejections that have no coverage.
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { BACKEND_BASE, loginAgainstRealBackend } from '../helpers';
+
+test.describe('Temp image API: security guards reject path traversal + invalid URLs', () => {
+	test('GET /temp/posters/:jobId/:filename rejects path traversal in jobId', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// jobId=".." would resolve posters/.. to the temp root — the
+		// isSafePathSegment guard rejects "." + ".." + any path separator.
+		// The guard fires before the .jpg check, so the filename is valid here
+		// to isolate the jobId guard.
+		const resp = await request.get(`${BACKEND_BASE}/api/v1/temp/posters/../poster.jpg`);
+		expect(resp.status(), 'jobId=".." must be rejected (404, not 200/500)').toBe(404);
+	});
+
+	test('GET /temp/posters/:jobId/:filename rejects path traversal in filename', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// filename="../etc/passwd" — the isSafePathSegment guard rejects
+		// path separators. Even with a .jpg-less filename, the guard fires
+		// first + returns 404.
+		const resp = await request.get(
+			`${BACKEND_BASE}/api/v1/temp/posters/validjob/..%2Fetc%2Fpasswd`,
+		);
+		expect(resp.status(), 'filename with path separators must be rejected').toBe(404);
+	});
+
+	test('GET /temp/posters/:jobId/:filename rejects non-.jpg extensions', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// A safe-path filename with a non-.jpg extension (e.g., .png) is
+		// rejected by the .jpg suffix check. This prevents serving arbitrary
+		// file types from the temp dir.
+		const resp = await request.get(`${BACKEND_BASE}/api/v1/temp/posters/validjob/poster.png`);
+		expect(resp.status(), 'non-.jpg extensions must be rejected').toBe(404);
+	});
+
+	test('GET /posters/:filename rejects path traversal', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// serveCroppedPoster has the same isSafePathSegment guard. filename
+		// with a path separator is rejected before the posterDir prefix check.
+		const resp = await request.get(`${BACKEND_BASE}/api/v1/posters/..%2Fsecret.jpg`);
+		expect(resp.status(), 'path traversal in /posters/:filename must be rejected').toBe(404);
+	});
+
+	test('GET /posters/:filename rejects non-.jpg extensions', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		const resp = await request.get(`${BACKEND_BASE}/api/v1/posters/poster.txt`);
+		expect(resp.status(), 'non-.jpg extensions in /posters must be rejected').toBe(404);
+	});
+
+	test('GET /temp/image without a url param returns 400', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// serveTempImage requires ?url=... — missing it returns 400 (not 500).
+		const resp = await request.get(`${BACKEND_BASE}/api/v1/temp/image`);
+		expect(resp.status(), 'missing url param must 400').toBe(400);
+		const body = await resp.json();
+		expect(body.error, 'the 400 must explain the required param').toContain('url');
+	});
+
+	test('GET /temp/image with a non-http(s) scheme returns 400', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// file:// + empty host are rejected by the scheme/host validation
+		// (before the SSRF check). This blocks javascript:/data:/file: URLs.
+		const resp = await request.get(`${BACKEND_BASE}/api/v1/temp/image?url=file:///etc/passwd`);
+		expect(resp.status(), 'non-http(s) schemes must 400').toBe(400);
+	});
+
+	test('GET /temp/image with a malformed URL returns 400', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// A non-parseable URL string is rejected.
+		const resp = await request.get(`${BACKEND_BASE}/api/v1/temp/image?url=not-a-url`);
+		expect(resp.status(), 'malformed URLs must 400').toBe(400);
+	});
+
+	test('GET /temp/image with a localhost URL is rejected by SSRF guard (403)', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// A well-formed http:// URL pointing at localhost/loopback is
+		// rejected by ssrf.CheckURL (403). This is the core SSRF guard —
+		// without it, an attacker could proxy requests to internal services.
+		// The exact status is 403 (Forbidden) from the SSRF check, distinct
+		// from the 400 (Bad Request) input-validation rejections above.
+		const resp = await request.get(
+			`${BACKEND_BASE}/api/v1/temp/image?url=http://127.0.0.1:18080/api/v1/health`,
+		);
+		expect(resp.status(), 'localhost URLs must be rejected by the SSRF guard').toBe(403);
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/token-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/token-api.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * Token API full-stack spec.
+ *
+ * Pins the API token CRUD contract end-to-end against the real e2emock
+ * backend: list (empty + populated), create (with + without a name),
+ * revoke (single), regenerate. Every action hits the real
+ * /api/v1/tokens endpoints (proxied to cmd/javinizer-e2e) → real
+ * ApiTokenRepository → real :memory: SQLite. No page.route mocking.
+ *
+ * Why this matters: the token API gates programmatic API access (an
+ * alternative to session-cookie auth used by the WebUI). The existing
+ * token-management.spec.ts covers the /settings API Tokens section UI
+ * against a developer-run backend (tests/e2e/ config — NOT the fullstack
+ * e2emock). A regression in the token handler wiring (create/revoke/
+ * regenerate), the TokenService, or the ApiTokenRepository is invisible
+ * to the fullstack suite. This spec ports the core contract to the
+ * stabilized fullstack infra so it runs in CI with the rest of the suite.
+ *
+ * Uniqueness: each test uses a timestamp-suffixed name to avoid collisions
+ * with prior runs (the suite is serial against one backend). afterEach
+ * cleans up any leftover test tokens via the API.
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { BACKEND_BASE, loginAgainstRealBackend } from '../helpers';
+
+const TEST_PREFIX = 'e2e-token-';
+
+interface TokenListItem {
+	id: string;
+	name: string;
+	token_prefix: string;
+}
+
+interface CreateTokenResponse {
+	token: string;
+	id: string;
+	name: string;
+	token_prefix: string;
+}
+
+interface TokenListResponse {
+	tokens: TokenListItem[];
+	count: number;
+}
+
+async function listTokens(api: APIRequestContext): Promise<TokenListResponse> {
+	const resp = await api.get(`${BACKEND_BASE}/api/v1/tokens`);
+	expect(resp.ok(), `list tokens failed: ${resp.status()}`).toBeTruthy();
+	return (await resp.json()) as TokenListResponse;
+}
+
+async function createToken(
+	api: APIRequestContext,
+	name?: string,
+): Promise<CreateTokenResponse> {
+	const resp = await api.post(`${BACKEND_BASE}/api/v1/tokens`, {
+		data: name !== undefined ? { name } : {},
+	});
+	expect(resp.ok(), `create token failed: ${resp.status()} ${await resp.text()}`).toBeTruthy();
+	return (await resp.json()) as CreateTokenResponse;
+}
+
+async function revokeToken(api: APIRequestContext, id: string): Promise<void> {
+	const resp = await api.delete(`${BACKEND_BASE}/api/v1/tokens/${id}`);
+	expect(resp.ok(), `revoke token ${id} failed: ${resp.status()}`).toBeTruthy();
+}
+
+async function regenerateToken(
+	api: APIRequestContext,
+	id: string,
+): Promise<CreateTokenResponse> {
+	const resp = await api.post(`${BACKEND_BASE}/api/v1/tokens/${id}/regenerate`);
+	expect(resp.ok(), `regenerate token ${id} failed: ${resp.status()}`).toBeTruthy();
+	return (await resp.json()) as CreateTokenResponse;
+}
+
+async function cleanupTestTokens(api: APIRequestContext): Promise<void> {
+	const { tokens } = await listTokens(api);
+	await Promise.all(
+		tokens
+			.filter((t) => t.name.startsWith(TEST_PREFIX))
+			.map((t) => revokeToken(api, t.id).catch(() => {})),
+	);
+}
+
+test.describe('Token API: real CRUD against the e2emock backend', () => {
+	test.afterEach(async ({ request }: { request: APIRequestContext }) => {
+		await cleanupTestTokens(request);
+	});
+
+	test('create with a name → list shows it → revoke removes it', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// ── 1. Create a token with a name ────────────────────────────────
+		// POST /tokens returns 201 + the full token (only ever shown once),
+		// the id, the name, + a token_prefix (for later display).
+		const name = `${TEST_PREFIX}crud-${Date.now()}`;
+		const created = await createToken(request, name);
+		expect(created.token, 'create must return the full token string').toBeTruthy();
+		expect(created.token.length, 'token must be a non-trivial string').toBeGreaterThan(20);
+		expect(created.id, 'create must return an id').toBeTruthy();
+		expect(created.name, 'create must echo the name').toBe(name);
+		expect(created.token_prefix, 'create must return a token_prefix').toBeTruthy();
+
+		// ── 2. List shows the new token ──────────────────────────────────
+		// The full token is NOT in the list (only the prefix). The list
+		// response carries count + the tokenListItem array.
+		const listed = await listTokens(request);
+		expect(listed.count, 'count must reflect the list length').toBe(listed.tokens.length);
+		const found = listed.tokens.find((t) => t.id === created.id);
+		expect(found, 'the new token must appear in the list').toBeTruthy();
+		expect(found?.name, 'the listed name must match').toBe(name);
+		expect(found?.token_prefix, 'the listed prefix must match').toBe(created.token_prefix);
+		// The full token must NOT be present in the list response (security:
+		// the full token is only returned once at create/regenerate time).
+		expect(JSON.stringify(listed), 'list must not leak the full token').not.toContain(
+			created.token,
+		);
+
+		// ── 3. Revoke removes it ─────────────────────────────────────────
+		// DELETE /tokens/:id returns 200 + the token is gone from the list.
+		await revokeToken(request, created.id);
+		const afterRevoke = await listTokens(request);
+		expect(
+			afterRevoke.tokens.find((t) => t.id === created.id),
+			'the revoked token must not appear in the list',
+		).toBeUndefined();
+	});
+
+	test('create without a name → list shows it with an empty/default name', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// POST /tokens with an empty body creates a token with no name.
+		// The UI displays these as "Unnamed" — the API stores an empty string.
+		const created = await createToken(request, '');
+		expect(created.id, 'create must return an id').toBeTruthy();
+		expect(created.token, 'create must return the full token').toBeTruthy();
+
+		const listed = await listTokens(request);
+		const found = listed.tokens.find((t) => t.id === created.id);
+		expect(found, 'the unnamed token must appear in the list').toBeTruthy();
+		// The name is stored as an empty string (the UI renders "Unnamed").
+		expect(found?.name, 'the stored name must be empty').toBe('');
+	});
+
+	test('regenerate → new token string + prefix, same id + name', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// ── 1. Create a token ────────────────────────────────────────────
+		const name = `${TEST_PREFIX}regen-${Date.now()}`;
+		const created = await createToken(request, name);
+		const originalToken = created.token;
+		const originalPrefix = created.token_prefix;
+
+		// ── 2. Regenerate it ─────────────────────────────────────────────
+		// POST /tokens/:id/regenerate issues a NEW full token string under
+		// the SAME id + name. The old token string is invalidated (the
+		// prefix may change as well, since the prefix is derived from the
+		// token's first N chars).
+		const regenerated = await regenerateToken(request, created.id);
+		expect(regenerated.id, 'regenerate must preserve the id').toBe(created.id);
+		expect(regenerated.name, 'regenerate must preserve the name').toBe(name);
+		expect(regenerated.token, 'regenerate must return a new token').toBeTruthy();
+		expect(regenerated.token, 'the new token must differ from the original').not.toBe(
+			originalToken,
+		);
+		// The prefix is derived from the token, so it typically changes too —
+		// but assert it's present (a same-prefix collision is possible but
+		// rare; we only require the prefix is well-formed).
+		expect(regenerated.token_prefix, 'regenerate must return a prefix').toBeTruthy();
+
+		// ── 3. The list reflects the (possibly new) prefix ───────────────
+		const listed = await listTokens(request);
+		const found = listed.tokens.find((t) => t.id === created.id);
+		expect(found, 'the token must still be in the list').toBeTruthy();
+		expect(found?.token_prefix, 'the list must reflect the regenerated prefix').toBe(
+			regenerated.token_prefix,
+		);
+		// The original token string must NOT appear anywhere in the list
+		// (it was invalidated by the regeneration).
+		expect(JSON.stringify(listed), 'list must not leak the old token').not.toContain(
+			originalToken,
+		);
+	});
+
+	test('revoke a non-existent token → 404', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// DELETE /tokens/:id with an unknown id returns 404 (not 200 + not 500).
+		const resp = await api_deleteToken(request, 'nonexistent-token-id-12345');
+		expect(resp.status(), 'revoking a non-existent token must 404').toBe(404);
+	});
+});
+
+/** Wrapper to expose the raw response (the helper above asserts + throws). */
+async function api_deleteToken(
+	api: APIRequestContext,
+	id: string,
+): ReturnType<APIRequestContext['delete']> {
+	return api.delete(`${BACKEND_BASE}/api/v1/tokens/${id}`);
+}

--- a/web/frontend/tests/fullstack/regressions/words-crud.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/words-crud.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * /words page full-stack UI spec.
+ *
+ * Pins the word-replacement CRUD UI end-to-end against the real e2emock
+ * backend: list render, add, edit, search, sort, delete. Every action
+ * goes through the real rendered page (real SvelteKit /words) → real
+ * /api/v1/words/replacements (proxied to cmd/javinizer-e2e) → real
+ * :memory: SQLite. No page.route mocking.
+ *
+ * Why this matters: the /words page is structurally identical to /genres
+ * (same CRUD table, same search/sort, same import/export), but it hits a
+ * distinct API surface (word replacements, not genre replacements) with
+ * its own backend handler + repo. A regression specific to the word-
+ * replacement wiring (e.g., a renamed query key, a swapped endpoint) is
+ * invisible to the genres spec. This spec mirrors the genres coverage
+ * against the word-replacement contract.
+ *
+ * Uniqueness: each test uses a timestamp-suffixed `original` to avoid
+ * collisions with prior runs (the suite is serial against one backend).
+ * afterEach cleans up any leftover test replacements via the API.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { BACKEND_BASE, loginAgainstRealBackend } from '../helpers';
+
+const TEST_PREFIX = 'E2E-WORD-';
+const HEADING = 'Word Replacements';
+
+interface WordReplacement {
+	id: number;
+	original: string;
+	replacement: string;
+}
+
+async function listWordReplacements(api: APIRequestContext): Promise<WordReplacement[]> {
+	const resp = await api.get(`${BACKEND_BASE}/api/v1/words/replacements?limit=1000`);
+	expect(resp.ok(), `list words failed: ${resp.status()}`).toBeTruthy();
+	const body = (await resp.json()) as { replacements: WordReplacement[] };
+	return body.replacements ?? [];
+}
+
+async function createWordReplacement(
+	api: APIRequestContext,
+	original: string,
+	replacement: string,
+): Promise<WordReplacement> {
+	const resp = await api.post(`${BACKEND_BASE}/api/v1/words/replacements`, {
+		data: { original, replacement },
+	});
+	expect(resp.ok(), `create word failed: ${resp.status()} ${await resp.text()}`).toBeTruthy();
+	return (await resp.json()) as WordReplacement;
+}
+
+async function deleteWordReplacement(api: APIRequestContext, id: number): Promise<void> {
+	const resp = await api.delete(`${BACKEND_BASE}/api/v1/words/replacements?id=${id}`);
+	expect(resp.ok(), `delete word ${id} failed: ${resp.status()}`).toBeTruthy();
+}
+
+async function cleanupTestReplacements(api: APIRequestContext): Promise<void> {
+	const all = await listWordReplacements(api);
+	await Promise.all(
+		all
+			.filter((r) => r.original.startsWith(TEST_PREFIX))
+			.map((r) => deleteWordReplacement(api, r.id).catch(() => {})),
+	);
+}
+
+async function navigateToWords(page: Page): Promise<void> {
+	await page.goto('/words');
+	await expect(page.getByRole('heading', { name: HEADING })).toBeVisible({ timeout: 15_000 });
+	await expect(page.getByPlaceholder('e.g., R**e')).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe('/words: real CRUD UI against the e2emock backend', () => {
+	test.afterEach(async ({ request }: { request: APIRequestContext }) => {
+		await cleanupTestReplacements(request);
+	});
+
+	test('list renders a pre-created replacement row', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		const original = `${TEST_PREFIX}LIST-${Date.now()}`;
+		const replacement = 'Uncensored';
+		await createWordReplacement(request, original, replacement);
+
+		await navigateToWords(page);
+
+		await expect(page.getByText(original, { exact: true })).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByText(replacement, { exact: true })).toBeVisible();
+	});
+
+	test('add → row renders → edit → replacement updates → delete → row gone', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		await navigateToWords(page);
+
+		// ── 1. Add a replacement via the UI ──────────────────────────────
+		const original = `${TEST_PREFIX}CRUD-${Date.now()}`;
+		const replacement = 'First Replacement';
+		await page.getByPlaceholder('e.g., R**e').fill(original);
+		await page.getByPlaceholder('e.g., Rape').fill(replacement);
+		await page.getByRole('button', { name: /^Add$/ }).click();
+
+		await expect(page.getByText(original, { exact: true })).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByText(replacement, { exact: true })).toBeVisible();
+
+		// ── 2. Edit the replacement inline ───────────────────────────────
+		// The original-text cell's following-sibling div holds the Actions
+		// cell (Edit + Delete buttons). Scoping via xpath avoids matching
+		// ancestor container divs that would resolve to multiple buttons.
+		const originalCell = page.getByText(original, { exact: true });
+		await originalCell.locator('xpath=following-sibling::div//button[@title="Edit"]').click();
+
+		const editInput = page.locator('input.font-mono:not([disabled])').last();
+		await editInput.fill('Edited Replacement');
+		await page.getByRole('button', { name: /^Save$/ }).click();
+
+		await expect(page.getByText('Edited Replacement', { exact: true })).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// ── 3. Delete the row ────────────────────────────────────────────
+		const originalCellAfter = page.getByText(original, { exact: true });
+		await originalCellAfter.locator('xpath=following-sibling::div//button[@title="Delete"]').click();
+
+		await expect(page.getByText(original, { exact: true })).toHaveCount(0, { timeout: 10_000 });
+	});
+
+	test('search filters the list + sort toggles the order', async ({
+		page,
+		request,
+	}: {
+		page: Page;
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+		const a = await createWordReplacement(request, `${TEST_PREFIX}ALPHA-${Date.now()}`, 'A-Rep');
+		const b = await createWordReplacement(request, `${TEST_PREFIX}BETA-${Date.now()}`, 'B-Rep');
+
+		await navigateToWords(page);
+
+		await expect(page.getByText(a.original, { exact: true })).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByText(b.original, { exact: true })).toBeVisible();
+
+		// ── 1. Search filters to the matching row ────────────────────────
+		await page.getByPlaceholder('Search by original or replacement...').fill('ALPHA');
+		await expect(page.getByText(a.original, { exact: true })).toBeVisible();
+		await expect(page.getByText(b.original, { exact: true })).toHaveCount(0);
+
+		await page.getByTitle('Clear search').click();
+		await expect(page.getByText(b.original, { exact: true })).toBeVisible({ timeout: 10_000 });
+
+		// ── 2. Sort toggle flips A-Z ↔ Z-A ───────────────────────────────
+		const sortBtn = page.getByTitle('Toggle sort order');
+		await expect(sortBtn).toContainText('A-Z');
+		await sortBtn.click();
+		await expect(sortBtn).toContainText('Z-A');
+		await expect(page.getByText(a.original, { exact: true })).toBeVisible();
+		await expect(page.getByText(b.original, { exact: true })).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Summary

Expands the fullstack e2e suite from **24 → 127 passing tests** by adding real-browser coverage for every route page, the scrape pipeline's edge cases, and the previously-uncovered API surfaces (token, history, temp-image, auth UI). All specs drive the real browser → SvelteKit → Go → e2emock scraper stack — no `page.route` mocking.

## What's added

### Route-page coverage (all 11 `/routes` pages now have real-browser specs)
- `actresses-crud`, `genres-crud`, `words-crud` — CRUD against real SQLite
- `browse-launch-scrape`, `manual-scrape`, `settings-page`, `logs-viewer` — page render + interaction
- `job-detail-revert`, `review-organize-fullstack` — full pipeline through the apply phase + revert
- `movies-list`, `movies-detail` — read-side rendering

### Scrape pipeline edge cases (`scrape-edge-cases.spec.ts`)
Pins behavior under non-happy-path inputs (all verified empirically first):
- **Mixed batch (GOOD + FAIL)** — job completes, per-file statuses independent, success not poisoned by sibling failure, verbose per-scraper error survives verbatim
- **Mixed batch → organize** — apply phase skips failed-scrape results, organizes only successful ones
- **Empty files array**, **duplicate file paths**, **non-existent scraper name**, **file not on disk** — input-validation edge cases
- **Force refresh** + **cache idempotency** on initial scrape

### Previously-uncovered APIs
- `token-api.spec.ts` — token CRUD (create named/unnamed, list with no token leak, revoke, regenerate, 404 on missing)
- `history-api.spec.ts` — history contract (empty-state list/stats, pagination echo, filters, single/bulk delete error paths)
- `temp-image-security.spec.ts` — security guards (path traversal rejection, .jpg enforcement, SSRF protection, invalid-URL rejection)
- `auth-ui.spec.ts` — first browser-render coverage of the auth flow (login screen, valid/wrong login, logout, session-cookie death)

## Changes to non-test files

- **`cmd/javinizer-e2e/main.go`** — enable `AllowRevert = true` so the fullstack suite can exercise the revert UI flow (RevertConfirmationModal + OperationRow). Opt-in by default for safety; the e2e backend turns it on because revert is a first-class user-visible feature.
- **`web/frontend/src/routes/jobs/[jobId]/+page.svelte`** — fix the `revert_status` filter (`'pending'` → `'applied'`). This was a production bug caught by the `job-detail-revert` spec: the pending-count badge was filtering on a status value that doesn't exist in the apply phase's output, so it never counted pending reverts.

## Test plan

- [x] Full suite green: **127 passed, 1 skipped, 0 failed** in ~1.5m
- [x] Pre-commit hooks pass (gofmt, golangci-lint, go vet, go test -short, build, swagger)
- [x] New specs pass in isolation and in the full suite (no state-interaction leaks)
- [x] The `revert_status` fix verified against the running backend (pending badge now counts correctly)

## Notes

- The history API spec documents a product gap: nothing in the codebase calls `HistoryRepo.Create`, so the history table is always empty (scrape/organize never record history). The spec pins the empty-state contract + error paths. Tracked separately in #85.
- Scrape edge-case behaviors (empty list accepted, non-existent scraper silently fails) are pinned as **current** behavior — the specs will fail if these are intentionally tightened to 400s, prompting a deliberate update rather than a silent regression.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Revert Batch” file count so it now reflects the correct items when opening the revert modal.
  * Updated revert-related job details to better match the current state of files after a revert attempt.
* **Tests**
  * Expanded end-to-end coverage to exercise the revert flow end-to-end, ensuring the revert UI/actions are validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->