### PR TITLE
fix(auth): give Remember me sessions a longer TTL than ephemeral ones

### DIFF
--- a/internal/api/auth/manager_coverage_test.go
+++ b/internal/api/auth/manager_coverage_test.go
@@ -40,6 +40,35 @@ func TestNewAuthManager_Coverage_NegativeTTL(t *testing.T) {
 	assert.Equal(t, DefaultSessionTTL, manager.SessionTTL())
 }
 
+func TestNewAuthManager_Coverage_PersistentTTLDefault(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yaml")
+
+	manager, err := NewAuthManager(configFile, time.Hour)
+	require.NoError(t, err)
+	require.NotNil(t, manager)
+	assert.Equal(t, time.Hour, manager.SessionTTL())
+	assert.Equal(t, DefaultPersistentSessionTTL, manager.PersistentSessionTTL(),
+		"persistent TTL must default to DefaultPersistentSessionTTL when the ephemeral TTL is shorter")
+}
+
+func TestNewAuthManager_Coverage_PersistentTTLClampedToEphemeral(t *testing.T) {
+	// Defensive guard: if the caller passes an ephemeral sessionTTL LONGER
+	// than DefaultPersistentSessionTTL, the persistent TTL is clamped up to
+	// match it (so remember-me is never SHORTER than ephemeral). Covers the
+	// `if persistentTTL < sessionTTL` branch in NewAuthManager.
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yaml")
+
+	longTTL := DefaultPersistentSessionTTL + 24*time.Hour
+	manager, err := NewAuthManager(configFile, longTTL)
+	require.NoError(t, err)
+	require.NotNil(t, manager)
+	assert.Equal(t, longTTL, manager.SessionTTL())
+	assert.Equal(t, longTTL, manager.PersistentSessionTTL(),
+		"persistent TTL must be clamped up to the ephemeral TTL when the ephemeral is longer")
+}
+
 func TestNewAuthManager_Coverage_SetupAndLogin(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "config.yaml")

--- a/internal/api/auth/manager_sessions.go
+++ b/internal/api/auth/manager_sessions.go
@@ -92,9 +92,14 @@ func (m *AuthManager) Login(username, password string, rememberMe bool) (string,
 
 	m.enforceSessionLimitLocked()
 
+	ttl := m.sessionTTL
+	if rememberMe {
+		ttl = m.persistentSessionTTL
+	}
+
 	m.sessions[sessionID] = sessionRecord{
 		Username:   m.credentials.Username,
-		ExpiresAt:  now.Add(m.sessionTTL),
+		ExpiresAt:  now.Add(ttl),
 		Persistent: rememberMe,
 	}
 

--- a/internal/api/auth/manager_test.go
+++ b/internal/api/auth/manager_test.go
@@ -154,6 +154,87 @@ func TestAuthManager_NonRememberedSessionDoesNotPersistAcrossReload(t *testing.T
 	assert.ErrorIs(t, err, ErrInvalidSession)
 }
 
+func TestAuthManager_RememberedSessionOutlivesEphemeralTTL(t *testing.T) {
+	// Regression test for the "Remember me" login persistency bug: a
+	// remember-me session must outlive an ephemeral (non-remembered)
+	// session. Users selecting "Remember me" expect to stay logged in
+	// across server restarts for a long window (weeks), not the same
+	// short TTL as an ephemeral session. Before this fix, both paths used
+	// the same sessionTTL — so a server restart after the TTL window
+	// expired the session + prompted the user to log in again, despite
+	// "Remember me" being selected.
+	t.Parallel()
+
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	manager, err := NewAuthManager(configFile, time.Hour)
+	require.NoError(t, err)
+	require.NoError(t, manager.Setup("admin", "password123"))
+
+	// Fixed clock so we can fast-forward deterministically.
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	manager.nowFn = func() time.Time { return base }
+
+	ephemeralID, err := manager.Login("admin", "password123", false)
+	require.NoError(t, err)
+
+	rememberedID, err := manager.Login("admin", "password123", true)
+	require.NoError(t, err)
+
+	// Both sessions are valid at T0.
+	_, err = manager.AuthenticateSession(ephemeralID)
+	require.NoError(t, err)
+	_, err = manager.AuthenticateSession(rememberedID)
+	require.NoError(t, err)
+
+	// Fast-forward past the ephemeral TTL (1h). The ephemeral session
+	// must expire; the remember-me session must STILL be valid.
+	base = base.Add(2 * time.Hour)
+
+	_, err = manager.AuthenticateSession(ephemeralID)
+	assert.ErrorIs(t, err, ErrInvalidSession, "ephemeral session must expire after its TTL")
+
+	_, err = manager.AuthenticateSession(rememberedID)
+	assert.NoError(t, err, "remember-me session must outlive the ephemeral TTL")
+}
+
+func TestAuthManager_RememberedSessionSurvivesRestartPastEphemeralTTL(t *testing.T) {
+	// Regression test for the user-reported symptom: "despite selecting
+	// Remember me, I get prompted to login after server restarts." A
+	// remember-me session must survive a server restart EVEN when the
+	// restart happens past the ephemeral TTL window — because the
+	// persistent session has a longer lifetime. Before the fix, the
+	// persisted session carried the ephemeral TTL, so loadSessionsFromDisk
+	// pruned it during the reload (the now.After(expiresAt) guard).
+	t.Parallel()
+
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	manager, err := NewAuthManager(configFile, time.Hour)
+	require.NoError(t, err)
+	require.NoError(t, manager.Setup("admin", "password123"))
+
+	// Use real time as the base so loadSessionsFromDisk (which runs inside
+	// NewAuthManager with time.Now before nowFn can be overridden) sees the
+	// persisted session as non-expired during the reload below.
+	base := time.Now()
+	manager.nowFn = func() time.Time { return base }
+
+	rememberedID, err := manager.Login("admin", "password123", true)
+	require.NoError(t, err)
+
+	// Simulate a server restart past the ephemeral TTL: fast-forward 2h,
+	// then construct a fresh manager (loads sessions from disk). The
+	// persisted session must still be valid because remember-me grants a
+	// longer TTL.
+	base = base.Add(2 * time.Hour)
+
+	reloaded, err := NewAuthManager(configFile, time.Hour)
+	require.NoError(t, err)
+	reloaded.nowFn = func() time.Time { return base }
+
+	_, err = reloaded.AuthenticateSession(rememberedID)
+	assert.NoError(t, err, "remember-me session must survive a restart past the ephemeral TTL")
+}
+
 func TestAuthManager_LoadMalformedCredentialFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/auth/manager_types.go
+++ b/internal/api/auth/manager_types.go
@@ -35,8 +35,18 @@ const (
 	loginLockoutDuration   = 5 * time.Minute
 )
 
-// DefaultSessionTTL is the default authenticated session lifetime.
+// DefaultSessionTTL is the default authenticated session lifetime for an
+// ephemeral (non-remembered) session — one that lives only for the current
+// browser session and is not persisted across server restarts.
 const DefaultSessionTTL = 24 * time.Hour
+
+// DefaultPersistentSessionTTL is the session lifetime for a "Remember me"
+// session. It is deliberately longer than the ephemeral TTL so users who
+// select "Remember me" stay logged in across server restarts for weeks,
+// not hours. Before this constant existed, both paths shared the same 24h
+// TTL — so a restart after 24h expired the session and prompted the user
+// to log in again, despite "Remember me" being selected.
+const DefaultPersistentSessionTTL = 30 * 24 * time.Hour
 
 // Sentinel errors returned by the auth manager.
 var (
@@ -94,17 +104,18 @@ type sessionFileItem struct {
 
 // AuthManager manages single-user credentials and in-memory sessions.
 type AuthManager struct {
-	mu             sync.RWMutex
-	credentialPath string
-	sessionPath    string
-	credentials    *storedCredentials
-	sessions       map[string]sessionRecord
-	sessionTTL     time.Duration
-	nowFn          func() time.Time
-	randReader     io.Reader
-	apiTokenRepo   database.ApiTokenRepositoryInterface
-	fs             afero.Fs
-	envLookup      func(key string) (string, bool)
+	mu                   sync.RWMutex
+	credentialPath       string
+	sessionPath          string
+	credentials          *storedCredentials
+	sessions             map[string]sessionRecord
+	sessionTTL           time.Duration
+	persistentSessionTTL time.Duration
+	nowFn                func() time.Time
+	randReader           io.Reader
+	apiTokenRepo         database.ApiTokenRepositoryInterface
+	fs                   afero.Fs
+	envLookup            func(key string) (string, bool)
 
 	failedLoginCount       int
 	failedLoginWindowStart time.Time
@@ -193,16 +204,21 @@ func NewAuthManager(configFile string, sessionTTL time.Duration, envLookup ...fu
 	if sessionTTL <= 0 {
 		sessionTTL = DefaultSessionTTL
 	}
+	persistentTTL := DefaultPersistentSessionTTL
+	if persistentTTL < sessionTTL {
+		persistentTTL = sessionTTL
+	}
 
 	manager := &AuthManager{
-		credentialPath: credentialPathForConfig(configFile),
-		sessionPath:    sessionPathForConfig(configFile),
-		sessions:       make(map[string]sessionRecord),
-		sessionTTL:     sessionTTL,
-		nowFn:          time.Now,
-		randReader:     rand.Reader,
-		fs:             afero.NewOsFs(),
-		envLookup:      lookup,
+		credentialPath:       credentialPathForConfig(configFile),
+		sessionPath:          sessionPathForConfig(configFile),
+		sessions:             make(map[string]sessionRecord),
+		sessionTTL:           sessionTTL,
+		persistentSessionTTL: persistentTTL,
+		nowFn:                time.Now,
+		randReader:           rand.Reader,
+		fs:                   afero.NewOsFs(),
+		envLookup:            lookup,
 	}
 
 	if err := manager.loadCredentialsFromDisk(); err != nil {
@@ -229,9 +245,16 @@ func NewAuthManager(configFile string, sessionTTL time.Duration, envLookup ...fu
 	return manager, nil
 }
 
-// SessionTTL returns the configured session lifetime.
+// SessionTTL returns the configured ephemeral session lifetime.
 func (m *AuthManager) SessionTTL() time.Duration {
 	return m.sessionTTL
+}
+
+// PersistentSessionTTL returns the session lifetime for a "Remember me"
+// session. Used by the HTTP layer to set the cookie's MaxAge/Expires so the
+// cookie lifetime matches the server-side session lifetime.
+func (m *AuthManager) PersistentSessionTTL() time.Duration {
+	return m.persistentSessionTTL
 }
 
 // IsInitialized reports whether credentials exist.

--- a/internal/api/auth/session.go
+++ b/internal/api/auth/session.go
@@ -134,7 +134,7 @@ func setupAuth(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		setSessionCookie(c, sessionID, deps.Auth.SessionTTL(), true, securityConfig(rt))
+		setSessionCookie(c, sessionID, deps.Auth.PersistentSessionTTL(), true, securityConfig(rt))
 		c.JSON(http.StatusOK, contracts.AuthStatusResponse{
 			Initialized:   true,
 			Authenticated: true,
@@ -189,7 +189,11 @@ func loginAuth(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		setSessionCookie(c, sessionID, deps.Auth.SessionTTL(), req.RememberMe, securityConfig(rt))
+		sessionTTL := deps.Auth.SessionTTL()
+		if req.RememberMe {
+			sessionTTL = deps.Auth.PersistentSessionTTL()
+		}
+		setSessionCookie(c, sessionID, sessionTTL, req.RememberMe, securityConfig(rt))
 		c.JSON(http.StatusOK, contracts.AuthStatusResponse{
 			Initialized:   true,
 			Authenticated: true,

--- a/internal/api/core/dependencies_test.go
+++ b/internal/api/core/dependencies_test.go
@@ -347,6 +347,10 @@ func (m *mockAuthProvider) SessionTTL() time.Duration {
 	return 24 * time.Hour
 }
 
+func (m *mockAuthProvider) PersistentSessionTTL() time.Duration {
+	return 30 * 24 * time.Hour
+}
+
 func (m *mockAuthProvider) IsInitialized() bool {
 	return m.initialized
 }

--- a/internal/api/testkit/helpers.go
+++ b/internal/api/testkit/helpers.go
@@ -116,6 +116,9 @@ type NoOpAuth struct{}
 // SessionTTL returns a fixed one-hour TTL. Unused on the pass-through path.
 func (NoOpAuth) SessionTTL() time.Duration { return time.Hour }
 
+// PersistentSessionTTL returns a fixed 30-day TTL. Unused on the pass-through path.
+func (NoOpAuth) PersistentSessionTTL() time.Duration { return 30 * 24 * time.Hour }
+
 // IsInitialized always reports true. Unused on the pass-through path.
 func (NoOpAuth) IsInitialized() bool { return true }
 

--- a/internal/api/testkit/helpers_test.go
+++ b/internal/api/testkit/helpers_test.go
@@ -94,6 +94,7 @@ func TestNoOpAuth_InterfaceMethods(t *testing.T) {
 	auth := NoOpAuth{}
 
 	assert.Equal(t, time.Hour, auth.SessionTTL())
+	assert.Equal(t, 30*24*time.Hour, auth.PersistentSessionTTL())
 	assert.True(t, auth.IsInitialized())
 
 	username, err := auth.AuthenticateSession("any-session")

--- a/internal/commandutil/dependencies.go
+++ b/internal/commandutil/dependencies.go
@@ -22,6 +22,7 @@ import (
 // AuthProvider is the minimal auth contract used by API handlers.
 type AuthProvider interface {
 	SessionTTL() time.Duration
+	PersistentSessionTTL() time.Duration
 	IsInitialized() bool
 	AuthenticateSession(sessionID string) (string, error)
 	Setup(username, password string) error

--- a/web/frontend/tests/fullstack/regressions/login-persistency.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/login-persistency.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * Login persistency full-stack spec.
+ *
+ * Pins the "Remember me" session-persistency contract end-to-end: a session
+ * created with Remember me=true must survive a real server restart, so the
+ * user is NOT prompted to log in again. This is the user-reported regression:
+ * "despite selecting Remember me, I get prompted to login after server
+ * restarts."
+ *
+ * How it works: the Playwright-managed backend (port 18080) is a single
+ * long-lived process. To test restart-persistency without disrupting the
+ * suite's shared backend, this spec spawns a SECOND e2e backend instance on
+ * a different port (18081) from the SAME working directory. Both instances
+ * share the auth.sessions.json + auth.credentials.json files (stored in the
+ * repo root, gitignored). The second instance's NewAuthManager →
+ * loadSessionsFromDisk() loads the persisted session, so the cookie from the
+ * first instance authenticates against the second.
+ *
+ * What this guards:
+ *   1. The login handler persists remember-me sessions to disk
+ *      (writePersistentSessionsLocked).
+ *   2. The cookie value is a stable session ID (not process-specific).
+ *   3. A fresh process loads persisted sessions on startup
+ *      (loadSessionsFromDisk in NewAuthManager).
+ *   4. The loaded session authenticates (AuthenticateSession returns the
+ *      username, not ErrInvalidSession).
+ *
+ * The TTL bug (remember-me sessions used the same 24h TTL as ephemeral
+ * sessions, so they expired between daily restarts) is covered by the Go
+ * unit tests in internal/api/auth/manager_test.go
+ * (TestAuthManager_RememberedSessionOutlivesEphemeralTTL +
+ * TestAuthManager_RememberedSessionSurvivesRestartPastEphemeralTTL). This
+ * spec covers the restart-persistency contract at the HTTP layer.
+ */
+import { spawn, type ChildProcess } from 'node:child_process';
+import { resolve } from 'node:path';
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { BACKEND_BASE, loginAgainstRealBackend } from '../helpers';
+
+const RESTART_PORT = 18081;
+const RESTART_BASE = `http://127.0.0.1:${RESTART_PORT}`;
+// Playwright runs from web/frontend; the repo root (where cmd/ + the shared
+// auth.sessions.json live) is two levels up.
+const REPO_ROOT = resolve(process.cwd(), '../..');
+
+/** Kill any stale process bound to RESTART_PORT so the spawn gets a clean port. */
+async function freeRestartPort(): Promise<void> {
+	// lsof + kill via a shell one-liner; ignore errors (nothing to kill).
+	const { execFileSync } = await import('node:child_process');
+	try {
+		const pids = execFileSync('lsof', ['-ti', `:${RESTART_PORT}`], { encoding: 'utf8' })
+			.trim()
+			.split('\n')
+			.filter(Boolean);
+		for (const pid of pids) {
+			try {
+				process.kill(Number(pid), 'SIGKILL');
+			} catch {
+				// already gone
+			}
+		}
+		if (pids.length) await new Promise((r) => setTimeout(r, 500));
+	} catch {
+		// lsof exits non-zero when nothing is listening — expected
+	}
+}
+
+/**
+ * Spawn a second e2e backend on RESTART_PORT. Returns the ChildProcess.
+ * Spawned with detached:true so afterEach can kill the whole process group
+ * (go run spawns a child binary that survives killing the go parent).
+ */
+function spawnRestartBackend(): ChildProcess {
+	return spawn('go', ['run', './cmd/javinizer-e2e'], {
+		cwd: REPO_ROOT,
+		detached: true,
+		env: {
+			...process.env,
+			JAVINIZER_E2E_PORT: String(RESTART_PORT),
+			JAVINIZER_E2E_AUTH: 'true',
+			JAVINIZER_E2E_USERNAME: 'admin',
+			JAVINIZER_E2E_PASSWORD: 'adminpassword123',
+		},
+		stdio: 'ignore',
+	});
+}
+
+/** Kill the spawned backend's whole process group (go parent + binary child). */
+function killRestartBackend(child: ChildProcess | undefined): void {
+	if (!child || child.pid === undefined) return;
+	try {
+		// Negative PID kills the entire process group (detached:true makes the
+		// child a group leader). SIGKILL because SIGTERM to `go run` doesn't
+		// propagate to the compiled binary child.
+		process.kill(-child.pid, 'SIGKILL');
+	} catch {
+		// process group may already be gone
+	}
+}
+
+/** Poll /health until the restarted backend is ready (or timeout). */
+async function waitForBackendReady(base: string, timeoutMs = 90_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			const resp = await fetch(`${base}/health`);
+			if (resp.ok) return;
+		} catch {
+			// not up yet
+		}
+		await new Promise((r) => setTimeout(r, 500));
+	}
+	throw new Error(`restarted backend at ${base} did not become ready within ${timeoutMs}ms`);
+}
+
+/** Extract the raw session cookie value from a login response. */
+async function loginAndCaptureCookie(
+	api: APIRequestContext,
+): Promise<string> {
+	const resp = await api.post(`${BACKEND_BASE}/api/v1/auth/login`, {
+		data: { username: 'admin', password: 'adminpassword123', remember_me: true },
+	});
+	expect(resp.ok(), `login failed: ${resp.status()}`).toBeTruthy();
+	const setCookie = resp.headers()['set-cookie'];
+	expect(setCookie, 'login must set a session cookie').toBeTruthy();
+	// Parse "javinizer_session=<value>; Path=/; ..."
+	const match = /javinizer_session=([^;]+)/.exec(setCookie);
+	expect(match, 'the cookie must be javinizer_session').toBeTruthy();
+	return match![1];
+}
+
+test.describe('Login persistency: Remember me survives server restart', () => {
+	// Spawning a second e2e backend (go run + DB migration + scraper setup)
+	// takes ~20-40s; allow 120s per test.
+	test.setTimeout(120_000);
+	let restartedBackend: ChildProcess | undefined;
+
+	test.afterEach(() => {
+		killRestartBackend(restartedBackend);
+		restartedBackend = undefined;
+	});
+
+	test('a remember-me session authenticates against a freshly-started backend', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// ── 1. Log in with Remember me against the Playwright-managed backend.
+		// The session is persisted to auth.sessions.json on disk.
+		const cookieValue = await loginAndCaptureCookie(request);
+
+		// Sanity: the session is valid on the original backend.
+		const originalStatus = await request.get(`${BACKEND_BASE}/api/v1/auth/status`, {
+			headers: { Cookie: `javinizer_session=${cookieValue}` },
+		});
+		expect(originalStatus.ok()).toBeTruthy();
+		const originalBody = await originalStatus.json();
+		expect(originalBody.authenticated, 'session must be valid on the original backend').toBe(true);
+
+		// ── 2. Spawn a SECOND e2e backend on a different port, same CWD.
+		// The second instance shares the repo-root working directory, so its
+		// NewAuthManager("") resolves auth.sessions.json + auth.credentials.json
+		// to the same files the first instance wrote. loadSessionsFromDisk()
+		// runs inside NewAuthManager, loading the persisted session before the
+		// test can interact with it.
+		await freeRestartPort();
+		restartedBackend = spawnRestartBackend();
+
+		await waitForBackendReady(RESTART_BASE);
+
+		// ── 3. The same cookie must authenticate against the restarted backend.
+		// This is the core persistency assertion: the session survived the
+		// process restart because it was persisted to disk + reloaded on
+		// startup. If this fails, the user sees a login prompt after a restart.
+		const restartedStatus = await request.get(`${RESTART_BASE}/api/v1/auth/status`, {
+			headers: { Cookie: `javinizer_session=${cookieValue}` },
+		});
+		expect(restartedStatus.ok(), `auth/status on restarted backend failed: ${restartedStatus.status()}`).toBeTruthy();
+		const restartedBody = await restartedStatus.json();
+		expect(restartedBody.authenticated, 'remember-me session must survive server restart').toBe(true);
+		expect(restartedBody.username, 'the restarted backend must recognize the session username').toBe('admin');
+
+		// ── 4. An authenticated endpoint also works on the restarted backend.
+		// Proves the session isn't just "recognized" but actually gates a
+		// protected route (the /batch list requires RequireTokenOrSession).
+		const protectedResp = await request.get(`${RESTART_BASE}/api/v1/batch`, {
+			headers: { Cookie: `javinizer_session=${cookieValue}` },
+		});
+		expect(protectedResp.ok(), 'a protected endpoint must accept the persisted session').toBeTruthy();
+	});
+
+	test('a non-remember-me session does NOT survive server restart', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		// ── 1. Log in WITHOUT Remember me. The session is in-memory only —
+		// not persisted to auth.sessions.json. The cookie still carries the
+		// session ID, but no other process can validate it.
+		const resp = await request.post(`${BACKEND_BASE}/api/v1/auth/login`, {
+			data: { username: 'admin', password: 'adminpassword123', remember_me: false },
+		});
+		expect(resp.ok()).toBeTruthy();
+		const setCookie = resp.headers()['set-cookie'];
+		const match = /javinizer_session=([^;]+)/.exec(setCookie);
+		expect(match).toBeTruthy();
+		const cookieValue = match![1];
+
+		// ── 2. Spawn a fresh backend (shares the session file, but the
+		// non-remembered session was never written to it).
+		await freeRestartPort();
+		restartedBackend = spawnRestartBackend();
+		await waitForBackendReady(RESTART_BASE);
+
+		// ── 3. The ephemeral session must NOT authenticate on the restarted
+		// backend. This is the inverse contract: only remember-me sessions
+		// survive restarts. A regression that persisted ALL sessions (not just
+		// remember-me ones) would surface here.
+		const restartedStatus = await request.get(`${RESTART_BASE}/api/v1/auth/status`, {
+			headers: { Cookie: `javinizer_session=${cookieValue}` },
+		});
+		expect(restartedStatus.ok()).toBeTruthy();
+		const restartedBody = await restartedStatus.json();
+		expect(restartedBody.authenticated, 'ephemeral session must NOT survive restart').toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem

Users selecting "Remember me" at login still get prompted to log in again after server restarts — "now and then," depending on timing. The root cause: **remember-me sessions shared the same 24h TTL as ephemeral (non-remembered) sessions**. The `Persistent` flag only controlled whether the session was written to disk, not its lifetime.

So if the server restarted more than 24h after the last login, the session had expired and was pruned during `loadSessionsFromDisk` on startup — prompting the user to log in again, despite "Remember me" being selected. "Now and then" = restarts that fell outside the 24h window.

## Fix

Added a separate `DefaultPersistentSessionTTL = 30 * 24 * time.Hour` (30 days) used when `rememberMe=true`:

- **`Login()`** sets `ExpiresAt = now + persistentSessionTTL` for remember-me sessions (`manager_sessions.go`)
- **`loginAuth` + `setupAuth` handlers** set the cookie's `MaxAge`/`Expires` to the persistent TTL so the cookie lifetime matches the server-side session (`session.go`)
- New **`PersistentSessionTTL()`** accessor on the `AuthProvider` interface so the HTTP layer can read it (`dependencies.go`, `manager_types.go`)
- Mock implementations updated (`testkit/helpers.go`, `core/dependencies_test.go`)

## Tests

### Go regression tests (`internal/api/auth/manager_test.go`)
Both failed before the fix, pass after:
- `TestAuthManager_RememberedSessionOutlivesEphemeralTTL` — fast-forwards past the ephemeral TTL (uses injectable `nowFn`); the ephemeral session expires, the remember-me session stays valid
- `TestAuthManager_RememberedSessionSurvivesRestartPastEphemeralTTL` — simulates a server restart past the ephemeral TTL via a fresh `NewAuthManager` reload; the persisted remember-me session is loaded + still authenticates

### E2e spec (`web/frontend/tests/fullstack/regressions/login-persistency.spec.ts`)
Real restart-persistency at the HTTP layer:
- **Remember-me session survives restart** — logs in with `remember_me: true` against the Playwright-managed backend, spawns a **second e2e backend** on port 18081 (same working directory → shares `auth.sessions.json`), asserts the same cookie authenticates against the fresh instance + gates a protected route (`/api/v1/batch`)
- **Ephemeral session does NOT survive restart** — the inverse contract: `remember_me: false` sessions aren't persisted to disk, so the cookie doesn't authenticate against the restarted backend

The e2e spec uses `detached: true` + process-group kill (`process.kill(-pid, 'SIGKILL')`) in `afterEach` to clean up the `go run` child binary, plus a `freeRestartPort()` pre-check to kill any stale process on 18081.

## Test plan
- [x] Go auth tests pass: `go test ./internal/api/auth/`
- [x] Full Go test suite passes (pre-commit hooks green)
- [x] E2e spec passes in isolation + in the full suite (no leftovers on port 18081)
- [x] Both regression tests fail on the pre-fix code (confirmed before applying the fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “Remember me” sessions now stay signed in for a longer period, while standard logins keep the shorter session duration.
  * Session cookie lifetime now matches the selected login persistence option more closely.

* **Bug Fixes**
  * Fixed inconsistent expiration timing between authenticated sessions and their cookies, reducing unexpected sign-outs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->