### PR TITLE
feat(desktop): UI + API for managing allowed_directories

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1675,6 +1675,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/config/security": {
+            "put": {
+                "description": "Update the operator-editable api.security block (allowed_directories, denied_directories, allow_unc, allowed_unc_servers) and hot-reload the server. Other security fields are preserved. Requires an authenticated operator session.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Update security settings",
+                "parameters": [
+                    {
+                        "description": "Security block fields to persist",
+                        "name": "security",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_system.SecurityUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Persisted security block after reload",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_system.securityResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/desktop/upgrade": {
             "post": {
                 "description": "Download, verify, and stage the latest desktop bundle, then relaunch the app. Desktop builds only.",
@@ -7366,6 +7412,32 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_api_system.SecurityUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "allow_unc": {
+                    "type": "boolean"
+                },
+                "allowed_directories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "allowed_unc_servers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "denied_directories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "internal_api_system.UpdateConfigRequest": {
             "type": "object",
             "properties": {
@@ -7413,6 +7485,14 @@ const docTemplate = `{
                 },
                 "webui": {
                     "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_config.webUIConfig"
+                }
+            }
+        },
+        "internal_api_system.securityResponse": {
+            "type": "object",
+            "properties": {
+                "security": {
+                    "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_config.SecurityConfig"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1673,6 +1673,52 @@
                 }
             }
         },
+        "/api/v1/config/security": {
+            "put": {
+                "description": "Update the operator-editable api.security block (allowed_directories, denied_directories, allow_unc, allowed_unc_servers) and hot-reload the server. Other security fields are preserved. Requires an authenticated operator session.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Update security settings",
+                "parameters": [
+                    {
+                        "description": "Security block fields to persist",
+                        "name": "security",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_system.SecurityUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Persisted security block after reload",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_system.securityResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/desktop/upgrade": {
             "post": {
                 "description": "Download, verify, and stage the latest desktop bundle, then relaunch the app. Desktop builds only.",
@@ -7364,6 +7410,32 @@
                 }
             }
         },
+        "internal_api_system.SecurityUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "allow_unc": {
+                    "type": "boolean"
+                },
+                "allowed_directories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "allowed_unc_servers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "denied_directories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "internal_api_system.UpdateConfigRequest": {
             "type": "object",
             "properties": {
@@ -7411,6 +7483,14 @@
                 },
                 "webui": {
                     "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_config.webUIConfig"
+                }
+            }
+        },
+        "internal_api_system.securityResponse": {
+            "type": "object",
+            "properties": {
+                "security": {
+                    "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_config.SecurityConfig"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2788,6 +2788,23 @@ definitions:
       start_time:
         type: string
     type: object
+  internal_api_system.SecurityUpdateRequest:
+    properties:
+      allow_unc:
+        type: boolean
+      allowed_directories:
+        items:
+          type: string
+        type: array
+      allowed_unc_servers:
+        items:
+          type: string
+        type: array
+      denied_directories:
+        items:
+          type: string
+        type: array
+    type: object
   internal_api_system.UpdateConfigRequest:
     properties:
       api:
@@ -2820,6 +2837,11 @@ definitions:
         $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_config.SystemConfig'
       webui:
         $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_config.webUIConfig'
+    type: object
+  internal_api_system.securityResponse:
+    properties:
+      security:
+        $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_config.SecurityConfig'
     type: object
   internal_api_token.createTokenRequest:
     properties:
@@ -4039,6 +4061,38 @@ paths:
           schema:
             $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse'
       summary: Update configuration
+      tags:
+      - system
+  /api/v1/config/security:
+    put:
+      consumes:
+      - application/json
+      description: Update the operator-editable api.security block (allowed_directories,
+        denied_directories, allow_unc, allowed_unc_servers) and hot-reload the server.
+        Other security fields are preserved. Requires an authenticated operator session.
+      parameters:
+      - description: Security block fields to persist
+        in: body
+        name: security
+        required: true
+        schema:
+          $ref: '#/definitions/internal_api_system.SecurityUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Persisted security block after reload
+          schema:
+            $ref: '#/definitions/internal_api_system.securityResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse'
+      summary: Update security settings
       tags:
       - system
   /api/v1/desktop/upgrade:

--- a/internal/api/apperrors/environment.go
+++ b/internal/api/apperrors/environment.go
@@ -1,0 +1,71 @@
+package apperrors
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/system"
+)
+
+type envContextKey struct{}
+
+var installEnvironmentKey = envContextKey{}
+
+// WithInstallEnvironment returns a copy of ctx carrying the install environment
+// so downstream error handlers can surface environment-aware operator guidance
+// without the error site itself needing to know how javinizer was installed.
+// The middleware layer (which has the CoreDeps reader) stamps this once per
+// request; path-validation errors are re-stamped at the write seam.
+func WithInstallEnvironment(ctx context.Context, env system.Environment) context.Context {
+	return context.WithValue(ctx, installEnvironmentKey, env)
+}
+
+// InstallEnvironmentFromContext extracts the install environment stamped by
+// WithInstallEnvironment. Returns ok=false when unset (callers fall back to
+// the sentinel's default OperatorMessage).
+func InstallEnvironmentFromContext(ctx context.Context) (system.Environment, bool) {
+	env, ok := ctx.Value(installEnvironmentKey).(system.Environment)
+	return env, ok
+}
+
+// AllowedDirsEmptyOperatorMessage returns install-environment-aware guidance for
+// the "no allowed directories configured" failure. Desktop users can fix this
+// from the UI (Settings → Security), CLI users edit config.yaml, and Docker
+// users must mount a directory and reference it. The default CLI guidance is
+// kept on the ErrAllowedDirsEmpty sentinel for callers without an environment.
+func AllowedDirsEmptyOperatorMessage(env system.Environment) string {
+	switch env {
+	case system.EnvironmentDesktop:
+		return "Open Settings → Security to add directories to the allowed list"
+	case system.EnvironmentDocker:
+		return "Mount a directory into the container and add it to api.security.allowed_directories in your configuration file"
+	default:
+		return ErrAllowedDirsEmpty.OperatorMessage
+	}
+}
+
+// operatorMessageFor returns the operator-facing guidance for a path error,
+// substituting environment-aware text when the request carried an install
+// environment and the error is the allowlist-empty failure. For all other
+// errors the sentinel's OperatorMessage is returned unchanged.
+func operatorMessageFor(err *PathError, ctx context.Context) string {
+	if ctx == nil {
+		return err.OperatorMessage
+	}
+	if err.Code == CodeAllowedDirsEmpty {
+		if env, ok := InstallEnvironmentFromContext(ctx); ok {
+			return AllowedDirsEmptyOperatorMessage(env)
+		}
+	}
+	return err.OperatorMessage
+}
+
+// requestContext safely extracts the request context from a gin.Context,
+// returning nil when the request is unset (e.g. unit tests that build a
+// context via gin.CreateTestContext without assigning c.Request).
+func requestContext(c *gin.Context) context.Context {
+	if c == nil || c.Request == nil {
+		return nil
+	}
+	return c.Request.Context()
+}

--- a/internal/api/apperrors/environment_test.go
+++ b/internal/api/apperrors/environment_test.go
@@ -1,0 +1,102 @@
+package apperrors
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/system"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllowedDirsEmptyOperatorMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      system.Environment
+		contains string
+	}{
+		{
+			name:     "desktop points to Settings UI",
+			env:      system.EnvironmentDesktop,
+			contains: "Settings → Security",
+		},
+		{
+			name:     "docker mentions mounting a directory",
+			env:      system.EnvironmentDocker,
+			contains: "Mount a directory",
+		},
+		{
+			name:     "cli falls back to config.yaml editing",
+			env:      system.EnvironmentCLI,
+			contains: "configuration file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := AllowedDirsEmptyOperatorMessage(tt.env)
+			assert.Contains(t, msg, tt.contains)
+		})
+	}
+}
+
+func TestAllowedDirsEmptyOperatorMessage_DefaultMatchesSentinel(t *testing.T) {
+	assert.Equal(
+		t,
+		ErrAllowedDirsEmpty.OperatorMessage,
+		AllowedDirsEmptyOperatorMessage(system.EnvironmentCLI),
+	)
+}
+
+func TestInstallEnvironmentFromContext_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	_, ok := InstallEnvironmentFromContext(ctx)
+	require.False(t, ok, "unset environment should report ok=false")
+
+	ctx = WithInstallEnvironment(ctx, system.EnvironmentDesktop)
+	got, ok := InstallEnvironmentFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, system.EnvironmentDesktop, got)
+}
+
+func TestOperatorMessageFor_AllowedDirsEmptyUsesEnvironment(t *testing.T) {
+	ctx := WithInstallEnvironment(context.Background(), system.EnvironmentDesktop)
+	got := operatorMessageFor(ErrAllowedDirsEmpty, ctx)
+	assert.Contains(t, got, "Settings → Security")
+	assert.NotEqual(t, ErrAllowedDirsEmpty.OperatorMessage, got, "desktop message should differ from CLI default")
+}
+
+func TestOperatorMessageFor_AllowedDirsEmptyFallsBackWithoutEnv(t *testing.T) {
+	got := operatorMessageFor(ErrAllowedDirsEmpty, context.Background())
+	assert.Equal(t, ErrAllowedDirsEmpty.OperatorMessage, got)
+}
+
+func TestOperatorMessageFor_OtherErrorsIgnoreEnvironment(t *testing.T) {
+	ctx := WithInstallEnvironment(context.Background(), system.EnvironmentDesktop)
+	got := operatorMessageFor(ErrPathOutsideAllowed, ctx)
+	assert.Equal(t, ErrPathOutsideAllowed.OperatorMessage, got)
+}
+
+func TestWriteAPIError_EnvironmentAwareOperatorGuidance(t *testing.T) {
+	// The response body never includes OperatorMessage (it's operator-only),
+	// so this test asserts the environment-aware path is exercised end-to-end
+	// without leaking guidance to the API consumer. A real gin.Context is used
+	// because logOperatorGuidance reads c.Request.Context().
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/browse", nil)
+	c.Request = c.Request.WithContext(WithInstallEnvironment(c.Request.Context(), system.EnvironmentDesktop))
+
+	// Capture the logged guidance by redirecting logging output is fragile;
+	// instead assert the helper logOperatorGuidance calls returns without
+	// panic and the selected message (via operatorMessageFor) is desktop-aware.
+	c.Request = c.Request.WithContext(WithInstallEnvironment(c.Request.Context(), system.EnvironmentDesktop))
+	assert.NotPanics(t, func() { logOperatorGuidance(c, ErrAllowedDirsEmpty) })
+
+	selected := operatorMessageFor(ErrAllowedDirsEmpty, c.Request.Context())
+	assert.Contains(t, selected, "Settings → Security")
+}

--- a/internal/api/apperrors/handler.go
+++ b/internal/api/apperrors/handler.go
@@ -42,5 +42,5 @@ func logOperatorGuidance(c *gin.Context, err *PathError) {
 	if err.Path != "" {
 		pathInfo = fmt.Sprintf(" (path: %s)", err.Path)
 	}
-	logging.Infof("Path validation error: %s%s", err.OperatorMessage, pathInfo)
+	logging.Infof("Path validation error: %s%s", operatorMessageFor(err, requestContext(c)), pathInfo)
 }

--- a/internal/api/middleware/install_environment.go
+++ b/internal/api/middleware/install_environment.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/api/apperrors"
+	"github.com/javinizer/javinizer-go/internal/commandutil"
+	"github.com/javinizer/javinizer-go/internal/system"
+)
+
+// InstallEnvironmentInjector stamps the bootstrap-detected install environment
+// (desktop/docker/cli) into each request's context so error handlers can tailor
+// operator guidance to how javinizer is running. The environment is a
+// process-level constant read from CoreDeps; nil deps fall back to CLI.
+func InstallEnvironmentInjector(deps commandutil.CoreDepsReader) gin.HandlerFunc {
+	var env system.Environment
+	if deps != nil {
+		env = deps.InstallEnvironment()
+	} else {
+		env = system.EnvironmentCLI
+	}
+	return func(c *gin.Context) {
+		c.Request = c.Request.WithContext(apperrors.WithInstallEnvironment(c.Request.Context(), env))
+		c.Next()
+	}
+}

--- a/internal/api/middleware/install_environment.go
+++ b/internal/api/middleware/install_environment.go
@@ -11,7 +11,7 @@ import (
 // (desktop/docker/cli) into each request's context so error handlers can tailor
 // operator guidance to how javinizer is running. The environment is a
 // process-level constant read from CoreDeps; nil deps fall back to CLI.
-func InstallEnvironmentInjector(deps commandutil.CoreDepsReader) gin.HandlerFunc {
+func InstallEnvironmentInjector(deps *commandutil.CoreDeps) gin.HandlerFunc {
 	var env system.Environment
 	if deps != nil {
 		env = deps.InstallEnvironment()

--- a/internal/api/middleware/install_environment_test.go
+++ b/internal/api/middleware/install_environment_test.go
@@ -65,3 +65,27 @@ func TestInstallEnvironmentInjector_NilDepsDefaultsToCLI(t *testing.T) {
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
+
+// TestInstallEnvironmentInjector_TypedNilDepsDefaultsToCLI guards against the
+// typed-nil interface pitfall: a (*commandutil.CoreDeps)(nil) stored in an
+// interface satisfies != nil, so a plain `deps != nil` guard would call
+// deps.InstallEnvironment() on a nil pointer and panic. The injector accepts
+// the concrete pointer directly so the nil check works.
+func TestInstallEnvironmentInjector_TypedNilDepsDefaultsToCLI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var typedNil *commandutil.CoreDeps
+	router := gin.New()
+	router.Use(InstallEnvironmentInjector(typedNil))
+	router.GET("/test", func(c *gin.Context) {
+		got, ok := apperrors.InstallEnvironmentFromContext(c.Request.Context())
+		require.True(t, ok)
+		assert.Equal(t, system.EnvironmentCLI, got)
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/api/middleware/install_environment_test.go
+++ b/internal/api/middleware/install_environment_test.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/api/apperrors"
+	"github.com/javinizer/javinizer-go/internal/commandutil"
+	"github.com/javinizer/javinizer-go/internal/system"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstallEnvironmentInjector_StampsContext(t *testing.T) {
+	tests := []struct {
+		name   string
+		env    system.Environment
+		wantOK bool
+		want   system.Environment
+	}{
+		{"desktop", system.EnvironmentDesktop, true, system.EnvironmentDesktop},
+		{"docker", system.EnvironmentDocker, true, system.EnvironmentDocker},
+		{"cli", system.EnvironmentCLI, true, system.EnvironmentCLI},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			deps := &commandutil.CoreDeps{}
+			deps.SetInstallEnvironment(tt.env)
+
+			router := gin.New()
+			router.Use(InstallEnvironmentInjector(deps))
+			router.GET("/test", func(c *gin.Context) {
+				got, ok := apperrors.InstallEnvironmentFromContext(c.Request.Context())
+				require.Equal(t, tt.wantOK, ok)
+				assert.Equal(t, tt.want, got)
+				c.Status(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}
+
+func TestInstallEnvironmentInjector_NilDepsDefaultsToCLI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(InstallEnvironmentInjector(nil))
+	router.GET("/test", func(c *gin.Context) {
+		got, ok := apperrors.InstallEnvironmentFromContext(c.Request.Context())
+		require.True(t, ok)
+		assert.Equal(t, system.EnvironmentCLI, got)
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/api/server/routes.go
+++ b/internal/api/server/routes.go
@@ -122,6 +122,7 @@ func registerAPIV1Routes(router *gin.Engine, rt *core.APIRuntime) {
 
 	protected := v1.Group("")
 	protected.Use(auth.RequireTokenOrSession(deps))
+	protected.Use(middleware.InstallEnvironmentInjector(deps.CoreDeps))
 
 	var rateLimiter *middleware.IPRateLimiter
 	apiCfg := rt.GetAPIConfig()

--- a/internal/api/server/server_test.go
+++ b/internal/api/server/server_test.go
@@ -89,6 +89,7 @@ func TestNewServer(t *testing.T) {
 		"/api/v1/actresses/merge/preview",
 		"/api/v1/actresses/merge",
 		"/api/v1/config",
+		"/api/v1/config/security",
 		"/api/v1/scrapers",
 		"/api/v1/proxy/test",
 		"/api/v1/scan",
@@ -262,6 +263,7 @@ func TestNewServer_RouteParity(t *testing.T) {
 		"POST /api/v1/words/replacements/import",
 		"PUT /api/v1/actresses/:id",
 		"PUT /api/v1/config",
+		"PUT /api/v1/config/security",
 		"PUT /api/v1/genres/replacements",
 		"PUT /api/v1/words/replacements",
 	}

--- a/internal/api/system/routes.go
+++ b/internal/api/system/routes.go
@@ -9,6 +9,7 @@ import (
 func RegisterRoutes(protected *gin.RouterGroup, rt *core.APIRuntime) {
 	protected.GET("/config", getConfig(rt.Deps()))
 	protected.PUT("/config", updateConfig(rt))
+	protected.PUT("/config/security", updateSecurityConfig(rt))
 	protected.GET("/scrapers", getAvailableScrapers(rt))
 	protected.POST("/proxy/test", testProxy(rt))
 	protected.POST("/translation/models", getTranslationModels(rt.Deps()))

--- a/internal/api/system/security_config.go
+++ b/internal/api/system/security_config.go
@@ -1,0 +1,74 @@
+package system
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	contracts "github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/config"
+)
+
+// SecurityUpdateRequest carries the operator-editable subset of the api.security
+// block. The frontend Security settings section PUTs this narrow payload (rather
+// than the whole config) so a single-section save never risks clobbering
+// unrelated fields with a stale GET snapshot. All other security fields
+// (rate_limit, trusted_proxies, force_secure_cookies, allowed_origins,
+// max_files_per_scan, scan_timeout_seconds) are preserved from the running config.
+type SecurityUpdateRequest struct {
+	AllowedDirectories []string `json:"allowed_directories"`
+	DeniedDirectories  []string `json:"denied_directories"`
+	AllowUNC           bool     `json:"allow_unc"`
+	AllowedUNCServers  []string `json:"allowed_unc_servers"`
+}
+
+// securityResponse echoes the persisted security block so the frontend can
+// confirm what landed on disk after Prepare/normalization runs.
+type securityResponse struct {
+	Security config.SecurityConfig `json:"security"`
+}
+
+// updateSecurityConfig godoc
+// @Summary Update security settings
+// @Description Update the operator-editable api.security block (allowed_directories, denied_directories, allow_unc, allowed_unc_servers) and hot-reload the server. Other security fields are preserved. Requires an authenticated operator session.
+// @Tags system
+// @Accept json
+// @Produce json
+// @Param security body SecurityUpdateRequest true "Security block fields to persist"
+// @Success 200 {object} securityResponse "Persisted security block after reload"
+// @Failure 400 {object} contracts.ErrorResponse
+// @Failure 500 {object} contracts.ErrorResponse
+// @Router /api/v1/config/security [put]
+func updateSecurityConfig(rt *core.APIRuntime) gin.HandlerFunc {
+	deps := rt.Deps()
+	svc := NewConfigUpdateService(rt, deps.ConfigFile)
+
+	return func(c *gin.Context) {
+		var req SecurityUpdateRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: "Invalid security configuration format"})
+			return
+		}
+
+		rt.GetRuntime().ConfigUpdateMu.Lock()
+		defer rt.GetRuntime().ConfigUpdateMu.Unlock()
+
+		oldCfg := deps.CoreDeps.GetConfig()
+		newCfg := oldCfg.Clone()
+		newCfg.API.Security.AllowedDirectories = req.AllowedDirectories
+		newCfg.API.Security.DeniedDirectories = req.DeniedDirectories
+		newCfg.API.Security.AllowUNC = req.AllowUNC
+		newCfg.API.Security.AllowedUNCServers = req.AllowedUNCServers
+
+		if err := svc.ValidateAndApply(oldCfg, newCfg, nil); err != nil {
+			status, msg := mapConfigErrorToHTTP(err)
+			c.JSON(status, contracts.ErrorResponse{Error: msg})
+			return
+		}
+
+		c.JSON(http.StatusOK, securityResponse{
+			Security: deps.CoreDeps.GetConfig().API.Security,
+		})
+	}
+}

--- a/internal/api/system/security_config.go
+++ b/internal/api/system/security_config.go
@@ -1,6 +1,8 @@
 package system
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -45,8 +47,27 @@ func updateSecurityConfig(rt *core.APIRuntime) gin.HandlerFunc {
 	svc := NewConfigUpdateService(rt, deps.ConfigFile)
 
 	return func(c *gin.Context) {
+		body, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: "Invalid security configuration format"})
+			return
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(body, &raw); err != nil {
+			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: "Invalid security configuration format"})
+			return
+		}
+
+		for _, key := range []string{"allowed_directories", "denied_directories", "allow_unc", "allowed_unc_servers"} {
+			if _, ok := raw[key]; !ok {
+				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: "Missing required field: " + key})
+				return
+			}
+		}
+
 		var req SecurityUpdateRequest
-		if err := c.ShouldBindJSON(&req); err != nil {
+		if err := json.Unmarshal(body, &req); err != nil {
 			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: "Invalid security configuration format"})
 			return
 		}

--- a/internal/api/system/security_config_test.go
+++ b/internal/api/system/security_config_test.go
@@ -134,6 +134,68 @@ func TestUpdateSecurityConfig_PreservesOtherSections(t *testing.T) {
 	assert.Equal(t, []string{"/new"}, saved.API.Security.AllowedDirectories)
 }
 
+// TestUpdateSecurityConfig_MissingFieldRejected verifies that a partial payload
+// missing one of the four required keys is rejected with 400 and does NOT wipe
+// the existing security config on disk. Without the raw-JSON key check, a body
+// like {"allow_unc": true} would unmarshal with allowed_directories=nil and
+// silently clear the allowlist.
+func TestUpdateSecurityConfig_MissingFieldRejected(t *testing.T) {
+	initial := config.DefaultConfig(nil, nil)
+	initial.API.Security.AllowedDirectories = []string{"/keep"}
+	initial.API.Security.DeniedDirectories = []string{"/deny"}
+	initial.API.Security.AllowUNC = false
+	initial.API.Security.AllowedUNCServers = []string{"\\\\srv\\share"}
+
+	tempConfigFile := t.TempDir() + "/config.yaml"
+	coreDeps := createTestDeps(t, initial, tempConfigFile)
+	deps := systemDepsFromCore(coreDeps)
+
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{
+			name:    "missing allowed_directories",
+			payload: `{"denied_directories":[],"allow_unc":false,"allowed_unc_servers":[]}`,
+		},
+		{
+			name:    "missing denied_directories",
+			payload: `{"allowed_directories":[],"allow_unc":false,"allowed_unc_servers":[]}`,
+		},
+		{
+			name:    "missing allow_unc",
+			payload: `{"allowed_directories":[],"denied_directories":[],"allowed_unc_servers":[]}`,
+		},
+		{
+			name:    "missing allowed_unc_servers",
+			payload: `{"allowed_directories":[],"denied_directories":[],"allow_unc":false}`,
+		},
+		{
+			name:    "only allow_unc present",
+			payload: `{"allow_unc":true}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			router := gin.New()
+			router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+			req := httptest.NewRequest(http.MethodPut, "/config/security", bytes.NewBufferString(tc.payload))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+			assert.Contains(t, w.Body.String(), "Missing required field")
+		})
+	}
+
+	saved := deps.CoreDeps.GetConfig()
+	assert.Equal(t, []string{"/keep"}, saved.API.Security.AllowedDirectories, "allowlist must not be wiped by a rejected payload")
+	assert.Equal(t, []string{"/deny"}, saved.API.Security.DeniedDirectories)
+	assert.False(t, saved.API.Security.AllowUNC)
+	assert.Equal(t, []string{"\\\\srv\\share"}, saved.API.Security.AllowedUNCServers)
+}
+
 // TestUpdateSecurityConfig_ValidateAndApplyError exercises the ValidateAndApply
 // error branch in updateSecurityConfig — the path that calls
 // mapConfigErrorToHTTP and returns the mapped status. A persist failure (config

--- a/internal/api/system/security_config_test.go
+++ b/internal/api/system/security_config_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -130,4 +132,43 @@ func TestUpdateSecurityConfig_PreservesOtherSections(t *testing.T) {
 	assert.Equal(t, "1.2.3.4", saved.Server.Host, "non-security sections preserved")
 	assert.Equal(t, 9999, saved.Server.Port)
 	assert.Equal(t, []string{"/new"}, saved.API.Security.AllowedDirectories)
+}
+
+// TestUpdateSecurityConfig_ValidateAndApplyError exercises the ValidateAndApply
+// error branch in updateSecurityConfig — the path that calls
+// mapConfigErrorToHTTP and returns the mapped status. A persist failure (config
+// file path whose parent directory cannot be created) yields a persistError,
+// which mapConfigErrorToHTTP maps to HTTP 500 — the non-400 path that the happy
+// and invalid-JSON tests do not cover.
+func TestUpdateSecurityConfig_ValidateAndApplyError(t *testing.T) {
+	initial := config.DefaultConfig(nil, nil)
+	initial.API.Security.AllowedDirectories = []string{"/old"}
+
+	// Block the config file's parent directory by creating a regular file at
+	// that path, then point the config file underneath it. config.Save calls
+	// MkdirAll on the parent, which fails with "not a directory" — the storage
+	// layer wraps this as a persistError (mapped to 500 by mapConfigErrorToHTTP).
+	parentBlocker := filepath.Join(t.TempDir(), "not_a_dir")
+	require.NoError(t, os.WriteFile(parentBlocker, []byte("blocker"), 0644))
+	configFile := filepath.Join(parentBlocker, "config.yaml")
+
+	coreDeps := createTestDeps(t, initial, configFile)
+	deps := systemDepsFromCore(coreDeps)
+
+	router := gin.New()
+	router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+	body, err := json.Marshal(SecurityUpdateRequest{
+		AllowedDirectories: []string{"/videos"},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/config/security", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "Failed to save configuration",
+		"should surface the persistError message from mapConfigErrorToHTTP")
 }

--- a/internal/api/system/security_config_test.go
+++ b/internal/api/system/security_config_test.go
@@ -1,0 +1,133 @@
+package system
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+	"github.com/javinizer/javinizer-go/internal/config"
+)
+
+func TestUpdateSecurityConfig_PersistsSecurityBlock(t *testing.T) {
+	initial := config.DefaultConfig(nil, nil)
+	initial.API.Security.AllowedDirectories = []string{"/old"}
+	initial.API.Security.DeniedDirectories = []string{"/tmp"}
+	initial.API.Security.AllowUNC = false
+	initial.API.Security.AllowedUNCServers = []string{"\\\\oldserver\\share"}
+	initial.API.Security.MaxFilesPerScan = 500
+
+	tempConfigFile := t.TempDir() + "/config.yaml"
+	coreDeps := createTestDeps(t, initial, tempConfigFile)
+	deps := systemDepsFromCore(coreDeps)
+
+	router := gin.New()
+	router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+	body, err := json.Marshal(SecurityUpdateRequest{
+		AllowedDirectories: []string{"/videos", "/media"},
+		DeniedDirectories:  []string{"/etc"},
+		AllowUNC:           true,
+		AllowedUNCServers:  []string{"\\\\nas\\share"},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/config/security", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp securityResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, []string{"/videos", "/media"}, resp.Security.AllowedDirectories)
+	assert.Equal(t, []string{"/etc"}, resp.Security.DeniedDirectories)
+	assert.True(t, resp.Security.AllowUNC)
+	assert.Equal(t, []string{"\\\\nas\\share"}, resp.Security.AllowedUNCServers)
+
+	saved := deps.CoreDeps.GetConfig()
+	assert.Equal(t, []string{"/videos", "/media"}, saved.API.Security.AllowedDirectories)
+	assert.Equal(t, 500, saved.API.Security.MaxFilesPerScan, "non-editable security fields preserved")
+}
+
+func TestUpdateSecurityConfig_EmptyAllowlistAllowed(t *testing.T) {
+	initial := config.DefaultConfig(nil, nil)
+	initial.API.Security.AllowedDirectories = []string{"/keep"}
+
+	tempConfigFile := t.TempDir() + "/config.yaml"
+	coreDeps := createTestDeps(t, initial, tempConfigFile)
+	deps := systemDepsFromCore(coreDeps)
+
+	router := gin.New()
+	router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+	body, err := json.Marshal(SecurityUpdateRequest{
+		AllowedDirectories: []string{},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/config/security", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	saved := deps.CoreDeps.GetConfig()
+	assert.Empty(t, saved.API.Security.AllowedDirectories)
+}
+
+func TestUpdateSecurityConfig_InvalidJSON(t *testing.T) {
+	initial := config.DefaultConfig(nil, nil)
+	tempConfigFile := t.TempDir() + "/config.yaml"
+	coreDeps := createTestDeps(t, initial, tempConfigFile)
+	deps := systemDepsFromCore(coreDeps)
+
+	router := gin.New()
+	router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+	req := httptest.NewRequest(http.MethodPut, "/config/security", bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid security configuration format")
+}
+
+func TestUpdateSecurityConfig_PreservesOtherSections(t *testing.T) {
+	initial := config.DefaultConfig(nil, nil)
+	initial.Server.Host = "1.2.3.4"
+	initial.Server.Port = 9999
+	initial.API.Security.AllowedDirectories = []string{"/old"}
+
+	tempConfigFile := t.TempDir() + "/config.yaml"
+	coreDeps := createTestDeps(t, initial, tempConfigFile)
+	deps := systemDepsFromCore(coreDeps)
+
+	router := gin.New()
+	router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+	body, err := json.Marshal(SecurityUpdateRequest{
+		AllowedDirectories: []string{"/new"},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/config/security", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	saved := deps.CoreDeps.GetConfig()
+	assert.Equal(t, "1.2.3.4", saved.Server.Host, "non-security sections preserved")
+	assert.Equal(t, 9999, saved.Server.Port)
+	assert.Equal(t, []string{"/new"}, saved.API.Security.AllowedDirectories)
+}

--- a/internal/api/system/security_config_test.go
+++ b/internal/api/system/security_config_test.go
@@ -3,6 +3,7 @@ package system
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -234,3 +235,59 @@ func TestUpdateSecurityConfig_ValidateAndApplyError(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "Failed to save configuration",
 		"should surface the persistError message from mapConfigErrorToHTTP")
 }
+
+// TestUpdateSecurityConfig_BodyReadError covers the io.ReadAll error branch in
+// updateSecurityConfig. A request body whose Read returns an error drives the
+// handler into the "Invalid security configuration format" 400 path before the
+// raw-JSON key check runs. The default httptest request body never fails Read,
+// so we inject a failing io.ReadCloser directly.
+func TestUpdateSecurityConfig_BodyReadError(t *testing.T) {
+	initial := config.DefaultConfig(nil, nil)
+	tempConfigFile := t.TempDir() + "/config.yaml"
+	coreDeps := createTestDeps(t, initial, tempConfigFile)
+	deps := systemDepsFromCore(coreDeps)
+
+	router := gin.New()
+	router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+	req := httptest.NewRequest(http.MethodPut, "/config/security", failingBody{})
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "Invalid security configuration format")
+}
+
+// TestUpdateSecurityConfig_TypeMismatch covers the second json.Unmarshal error
+// branch — the one that decodes into SecurityUpdateRequest after the raw-map
+// key-presence check already passed. A body that is a valid JSON object
+// containing all four required keys but with a value of the wrong type (a
+// string where []string is expected) clears the key check, then fails the
+// typed unmarshal, exercising the 400 "Invalid security configuration format"
+// path that the InvalidJSON and MissingField tests do not reach.
+func TestUpdateSecurityConfig_TypeMismatch(t *testing.T) {
+	initial := config.DefaultConfig(nil, nil)
+	tempConfigFile := t.TempDir() + "/config.yaml"
+	coreDeps := createTestDeps(t, initial, tempConfigFile)
+	deps := systemDepsFromCore(coreDeps)
+
+	router := gin.New()
+	router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+	payload := `{"allowed_directories":"not-an-array","denied_directories":[],"allow_unc":false,"allowed_unc_servers":[]}`
+	req := httptest.NewRequest(http.MethodPut, "/config/security", bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "Invalid security configuration format")
+}
+
+// failingBody is an io.ReadCloser whose Read always returns an error, used to
+// exercise the io.ReadAll failure branch of updateSecurityConfig.
+type failingBody struct{}
+
+func (failingBody) Read(p []byte) (int, error) { return 0, errors.New("synthetic read failure") }
+func (failingBody) Close() error               { return nil }

--- a/web/frontend/src/lib/api/client.ts
+++ b/web/frontend/src/lib/api/client.ts
@@ -345,6 +345,9 @@ class APIClient {
 	async getDeepLUsage(request: Parameters<ConfigClient['getDeepLUsage']>[0]) {
 		return this.config.getDeepLUsage(request);
 	}
+	async updateSecurityConfig(request: Parameters<ConfigClient['updateSecurityConfig']>[0]) {
+		return this.config.updateSecurityConfig(request);
+	}
 }
 
 export const apiClient = new APIClient();

--- a/web/frontend/src/lib/api/clients/config.ts
+++ b/web/frontend/src/lib/api/clients/config.ts
@@ -6,6 +6,8 @@ import type {
 	TranslationModelsResponse,
 	DeepLUsageRequest,
 	DeepLUsageResponse,
+	SecurityUpdateRequest,
+	SecurityUpdateResponse,
 } from '../types';
 import { BaseClient } from './common';
 
@@ -34,6 +36,13 @@ export class ConfigClient extends BaseClient {
 	async getDeepLUsage(request: DeepLUsageRequest): Promise<DeepLUsageResponse> {
 		return this.request<DeepLUsageResponse>('/api/v1/translation/deepl/usage', {
 			method: 'POST',
+			body: JSON.stringify(request),
+		});
+	}
+
+	async updateSecurityConfig(request: SecurityUpdateRequest): Promise<SecurityUpdateResponse> {
+		return this.request<SecurityUpdateResponse>('/api/v1/config/security', {
+			method: 'PUT',
 			body: JSON.stringify(request),
 		});
 	}

--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -719,6 +719,17 @@ export interface SecurityConfig {
 	force_secure_cookies: boolean;
 }
 
+export interface SecurityUpdateRequest {
+	allowed_directories: string[];
+	denied_directories: string[];
+	allow_unc: boolean;
+	allowed_unc_servers: string[];
+}
+
+export interface SecurityUpdateResponse {
+	security: SecurityConfig;
+}
+
 export interface APIConfig {
 	security: SecurityConfig;
 }

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
@@ -8,7 +8,7 @@
 	import PathInput from '$lib/components/PathInput.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import { FolderPlus, Trash2, Save, Star, Folder } from 'lucide-svelte';
-	import type { SettingsConfig, SecurityUpdateRequest } from '$lib/api/types';
+	import type { Config, SettingsConfig, SecurityUpdateRequest } from '$lib/api/types';
 
 	interface Props {
 		config: SettingsConfig;
@@ -26,8 +26,8 @@
 		allowed_unc_servers: string[];
 	};
 
-	function snapshot(): SecurityDraft {
-		const sec = config?.api?.security;
+	function snapshot(cfg: SettingsConfig): SecurityDraft {
+		const sec = cfg?.api?.security;
 		return {
 			allowed_directories: [...(sec?.allowed_directories ?? [])],
 			denied_directories: [...(sec?.denied_directories ?? [])],
@@ -36,13 +36,20 @@
 		};
 	}
 
-	let draft = $state<SecurityDraft>(snapshot());
-
+	let hydratedConfig = $state<SettingsConfig | null>(null);
 	let lastConfigRef: SettingsConfig | null = null;
+	let draft = $state<SecurityDraft>({
+		allowed_directories: [],
+		denied_directories: [],
+		allow_unc: false,
+		allowed_unc_servers: [],
+	});
+
 	$effect(() => {
-		if (config !== lastConfigRef) {
-			lastConfigRef = config;
-			draft = snapshot();
+		const cfg = hydratedConfig ?? config;
+		if (cfg !== lastConfigRef) {
+			lastConfigRef = cfg;
+			draft = snapshot(cfg);
 		}
 	});
 
@@ -51,10 +58,15 @@
 	let newUncServer = $state('');
 
 	let dirty = $derived(
-		!arrayEqual(draft.allowed_directories, config?.api?.security?.allowed_directories ?? []) ||
-			!arrayEqual(draft.denied_directories, config?.api?.security?.denied_directories ?? []) ||
-			draft.allow_unc !== (config?.api?.security?.allow_unc ?? false) ||
-			!arrayEqual(draft.allowed_unc_servers, config?.api?.security?.allowed_unc_servers ?? []),
+		(() => {
+			const sec = (hydratedConfig ?? config)?.api?.security;
+			return (
+				!arrayEqual(draft.allowed_directories, sec?.allowed_directories ?? []) ||
+				!arrayEqual(draft.denied_directories, sec?.denied_directories ?? []) ||
+				draft.allow_unc !== (sec?.allow_unc ?? false) ||
+				!arrayEqual(draft.allowed_unc_servers, sec?.allowed_unc_servers ?? [])
+			);
+		})(),
 	);
 
 	function arrayEqual(a: string[], b: string[]): boolean {
@@ -120,7 +132,13 @@
 				allowed_unc_servers: [...(data.security.allowed_unc_servers ?? [])],
 			};
 			toastStore.success('Security settings saved and reloaded', 4000);
-			void queryClient.invalidateQueries({ queryKey: ['config'] });
+			void queryClient.invalidateQueries({ queryKey: ['config'] }).then(async () => {
+				const fresh = await queryClient.fetchQuery<Config>({
+					queryKey: ['config'],
+					queryFn: () => apiClient.getConfig(),
+				});
+				hydratedConfig = fresh as unknown as SettingsConfig;
+			});
 		},
 		onError: (err: Error) => {
 			toastStore.error(err.message || 'Failed to save security settings', 5000);

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
@@ -1,0 +1,299 @@
+<script lang="ts">
+	import { createMutation, useQueryClient } from '@tanstack/svelte-query';
+	import { apiClient } from '$lib/api/client';
+	import { toastStore } from '$lib/stores/toast';
+	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
+	import SettingsSubsection from '$lib/components/settings/SettingsSubsection.svelte';
+	import FormToggle from '$lib/components/settings/FormToggle.svelte';
+	import PathInput from '$lib/components/PathInput.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import { FolderPlus, Trash2, Save, Star, Folder } from 'lucide-svelte';
+	import type { SettingsConfig, SecurityUpdateRequest } from '$lib/api/types';
+
+	interface Props {
+		config: SettingsConfig;
+		inputClass: string;
+	}
+
+	let { config, inputClass }: Props = $props();
+
+	const queryClient = useQueryClient();
+
+	type SecurityDraft = {
+		allowed_directories: string[];
+		denied_directories: string[];
+		allow_unc: boolean;
+		allowed_unc_servers: string[];
+	};
+
+	function snapshot(): SecurityDraft {
+		const sec = config?.api?.security;
+		return {
+			allowed_directories: [...(sec?.allowed_directories ?? [])],
+			denied_directories: [...(sec?.denied_directories ?? [])],
+			allow_unc: sec?.allow_unc ?? false,
+			allowed_unc_servers: [...(sec?.allowed_unc_servers ?? [])],
+		};
+	}
+
+	let draft = $state<SecurityDraft>(snapshot());
+
+	let lastConfigRef: SettingsConfig | null = null;
+	$effect(() => {
+		if (config !== lastConfigRef) {
+			lastConfigRef = config;
+			draft = snapshot();
+		}
+	});
+
+	let newAllowedDir = $state('');
+	let newDeniedDir = $state('');
+	let newUncServer = $state('');
+
+	let dirty = $derived(
+		!arrayEqual(draft.allowed_directories, config?.api?.security?.allowed_directories ?? []) ||
+			!arrayEqual(draft.denied_directories, config?.api?.security?.denied_directories ?? []) ||
+			draft.allow_unc !== (config?.api?.security?.allow_unc ?? false) ||
+			!arrayEqual(draft.allowed_unc_servers, config?.api?.security?.allowed_unc_servers ?? []),
+	);
+
+	function arrayEqual(a: string[], b: string[]): boolean {
+		if (a.length !== b.length) return false;
+		for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+		return true;
+	}
+
+	function addAllowedDir() {
+		const path = newAllowedDir.trim();
+		if (!path) return;
+		if (draft.allowed_directories.includes(path)) {
+			toastStore.error('Directory already in the allowed list', 3000);
+			return;
+		}
+		draft.allowed_directories = [...draft.allowed_directories, path];
+		newAllowedDir = '';
+	}
+
+	function removeAllowedDir(index: number) {
+		draft.allowed_directories = draft.allowed_directories.filter((_, i) => i !== index);
+	}
+
+	function addDeniedDir() {
+		const path = newDeniedDir.trim();
+		if (!path) return;
+		if (draft.denied_directories.includes(path)) {
+			toastStore.error('Directory already in the denied list', 3000);
+			return;
+		}
+		draft.denied_directories = [...draft.denied_directories, path];
+		newDeniedDir = '';
+	}
+
+	function removeDeniedDir(index: number) {
+		draft.denied_directories = draft.denied_directories.filter((_, i) => i !== index);
+	}
+
+	function addUncServer() {
+		const server = newUncServer.trim();
+		if (!server) return;
+		if (draft.allowed_unc_servers.includes(server)) {
+			toastStore.error('Server already in the allow list', 3000);
+			return;
+		}
+		draft.allowed_unc_servers = [...draft.allowed_unc_servers, server];
+		newUncServer = '';
+	}
+
+	function removeUncServer(index: number) {
+		draft.allowed_unc_servers = draft.allowed_unc_servers.filter((_, i) => i !== index);
+	}
+
+	const saveMutation = createMutation(() => ({
+		mutationFn: async (req: SecurityUpdateRequest) => {
+			return apiClient.updateSecurityConfig(req);
+		},
+		onSuccess: (data) => {
+			draft = {
+				allowed_directories: [...(data.security.allowed_directories ?? [])],
+				denied_directories: [...(data.security.denied_directories ?? [])],
+				allow_unc: data.security.allow_unc,
+				allowed_unc_servers: [...(data.security.allowed_unc_servers ?? [])],
+			};
+			toastStore.success('Security settings saved and reloaded', 4000);
+			void queryClient.invalidateQueries({ queryKey: ['config'] });
+		},
+		onError: (err: Error) => {
+			toastStore.error(err.message || 'Failed to save security settings', 5000);
+		},
+	}));
+
+	function handleSave() {
+		saveMutation.mutate({
+			allowed_directories: draft.allowed_directories,
+			denied_directories: draft.denied_directories,
+			allow_unc: draft.allow_unc,
+			allowed_unc_servers: draft.allowed_unc_servers,
+		});
+	}
+</script>
+
+<SettingsSection
+	title="Security / Allowed Directories"
+	description="Control which directories Javinizer can scan and write to. The first allowed directory is the default scan path. Changes are saved and hot-reloaded immediately."
+	defaultExpanded={false}
+>
+	<SettingsSubsection title="Allowed Directories">
+		<p class="text-xs text-muted-foreground mb-3">
+			Javinizer will only scan and operate inside these directories. With no allowed directories configured, all file operations are blocked.
+		</p>
+
+		{#if draft.allowed_directories.length === 0}
+			<div class="rounded-lg border border-dashed border-border p-4 text-center text-sm text-muted-foreground">
+				No allowed directories configured. Add one below to enable scanning.
+			</div>
+		{:else}
+			<ul class="space-y-2 mb-3">
+				{#each draft.allowed_directories as dir, index (dir + '-' + index)}
+					<li class="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2">
+						{#if index === 0}
+							<span
+								class="inline-flex items-center gap-1 rounded bg-amber-500/15 text-amber-700 dark:text-amber-400 text-xs font-medium px-2 py-0.5 shrink-0"
+								title="The first allowed directory is used as the default scan path"
+							>
+								<Star class="h-3 w-3" />
+								Default
+							</span>
+						{:else}
+							<Folder class="h-4 w-4 text-muted-foreground shrink-0" />
+						{/if}
+						<span class="flex-1 min-w-0 truncate font-mono text-sm">{dir}</span>
+						<button
+							type="button"
+							class="text-muted-foreground hover:text-destructive transition-colors shrink-0"
+							title="Remove directory"
+							aria-label="Remove allowed directory {dir}"
+							onclick={() => removeAllowedDir(index)}
+						>
+							<Trash2 class="h-4 w-4" />
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+
+		<div class="flex items-start gap-2">
+			<PathInput
+				bind:value={newAllowedDir}
+				placeholder="Add a directory (e.g. /mnt/videos)"
+				whitelistPaths={draft.allowed_directories}
+				class="flex-1"
+			/>
+			<Button variant="outline" size="sm" onclick={addAllowedDir} disabled={!newAllowedDir.trim()} title="Add allowed directory">
+				{#snippet children()}
+					<FolderPlus class="h-4 w-4" />
+				{/snippet}
+			</Button>
+		</div>
+		<p class="text-xs text-muted-foreground mt-1">
+			Autocomplete uses the current allowed directories. Type the first path manually if the list is empty.
+		</p>
+	</SettingsSubsection>
+
+	<SettingsSubsection title="Denied Directories">
+		<p class="text-xs text-muted-foreground mb-3">
+			Paths here are always blocked, even if they fall under an allowed directory. Built-in system directories (/proc, /sys, /dev) are always denied.
+		</p>
+
+		{#if draft.denied_directories.length > 0}
+			<ul class="space-y-2 mb-3">
+				{#each draft.denied_directories as dir, index (dir + '-' + index)}
+					<li class="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2">
+						<Folder class="h-4 w-4 text-muted-foreground shrink-0" />
+						<span class="flex-1 min-w-0 truncate font-mono text-sm">{dir}</span>
+						<button
+							type="button"
+							class="text-muted-foreground hover:text-destructive transition-colors shrink-0"
+							title="Remove directory"
+							aria-label="Remove denied directory {dir}"
+							onclick={() => removeDeniedDir(index)}
+						>
+							<Trash2 class="h-4 w-4" />
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+
+		<div class="flex items-start gap-2">
+			<PathInput
+				bind:value={newDeniedDir}
+				placeholder="Add a directory to deny (e.g. /sensitive)"
+				whitelistPaths={draft.allowed_directories}
+				class="flex-1"
+			/>
+			<Button variant="outline" size="sm" onclick={addDeniedDir} disabled={!newDeniedDir.trim()} title="Add denied directory">
+				{#snippet children()}
+					<FolderPlus class="h-4 w-4" />
+				{/snippet}
+			</Button>
+		</div>
+	</SettingsSubsection>
+
+	<SettingsSubsection title="UNC / Network Paths (Windows)">
+		<FormToggle
+			id="security-allow-unc"
+			label="Allow UNC paths"
+			description="Permit \\\\server\\share paths. UNC paths can leak NTLM credentials; enable only with trusted servers."
+			checked={draft.allow_unc}
+			onchange={(val) => { draft.allow_unc = val; }}
+		/>
+
+		{#if draft.allow_unc}
+			<div class="mt-3">
+				<label class="block text-sm font-medium mb-2" for="security-unc-servers">Allowed UNC servers</label>
+				{#if draft.allowed_unc_servers.length > 0}
+					<ul class="space-y-2 mb-3">
+						{#each draft.allowed_unc_servers as server, index (server + '-' + index)}
+							<li class="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2">
+								<span class="flex-1 min-w-0 truncate font-mono text-sm">{server}</span>
+								<button
+									type="button"
+									class="text-muted-foreground hover:text-destructive transition-colors shrink-0"
+									title="Remove server"
+									aria-label="Remove UNC server {server}"
+									onclick={() => removeUncServer(index)}
+								>
+									<Trash2 class="h-4 w-4" />
+								</button>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+				<div class="flex items-start gap-2">
+					<input
+						id="security-unc-servers"
+						type="text"
+						bind:value={newUncServer}
+						onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addUncServer(); } }}
+						placeholder="\\server\share"
+						class="{inputClass} flex-1 font-mono text-sm"
+					/>
+					<Button variant="outline" size="sm" onclick={addUncServer} disabled={!newUncServer.trim()} title="Add UNC server">
+						{#snippet children()}
+							<FolderPlus class="h-4 w-4" />
+						{/snippet}
+					</Button>
+				</div>
+			</div>
+		{/if}
+	</SettingsSubsection>
+
+	<div class="flex items-center justify-end gap-2 pt-4 border-t border-border">
+		<Button onclick={handleSave} disabled={!dirty || saveMutation.isPending}>
+			{#snippet children()}
+				<Save class="h-4 w-4 mr-2" />
+				{saveMutation.isPending ? 'Saving...' : 'Save Security'}
+			{/snippet}
+		</Button>
+	</div>
+</SettingsSection>

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import SecuritySettingsSection from './SecuritySettingsSection.svelte';
+import QueryClientWrapper from '$lib/components/QueryClientWrapper.svelte';
+import type { SettingsConfig } from '$lib/api/types';
+import { toastStore } from '$lib/stores/toast';
+
+vi.mock('$lib/api/client', () => ({
+	apiClient: {
+		updateSecurityConfig: vi.fn(),
+	},
+}));
+
+const mod = await import('$lib/api/client');
+const mockUpdateSecurityConfig = vi.mocked(mod.apiClient.updateSecurityConfig);
+
+if (!Element.prototype.animate) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(Element.prototype as any).animate = function () {
+		const anim = {
+			onfinish: null as (() => void) | null,
+			oncancel: null as (() => void) | null,
+			effect: null as unknown,
+			playState: 'finished' as const,
+			currentTime: 0,
+			cancel() {},
+			finish() {
+				anim.onfinish?.();
+			},
+			addEventListener() {},
+			removeEventListener() {},
+		};
+		queueMicrotask(() => anim.onfinish?.());
+		return anim;
+	};
+}
+
+function makeConfig(overrides: Partial<SettingsConfig['api']['security']> = {}): SettingsConfig {
+	return {
+		server: { host: '0.0.0.0', port: 8080 },
+		api: {
+			security: {
+				allowed_directories: [],
+				denied_directories: [],
+				max_files_per_scan: 0,
+				scan_timeout_seconds: 0,
+				allowed_origins: [],
+				allow_unc: false,
+				allowed_unc_servers: [],
+				rate_limit: { requests_per_minute: 0 },
+				trusted_proxies: [],
+				force_secure_cookies: false,
+				...overrides,
+			},
+		},
+		system: { umask: '', version_check_enabled: false, version_check_interval_hours: 0, temp_dir: '' },
+		scrapers: {} as never,
+		metadata: {} as never,
+		file_matching: { regex_enabled: false, regex_pattern: '' },
+		output: {} as never,
+		database: {} as never,
+		logging: {} as never,
+		performance: {} as never,
+	} as unknown as SettingsConfig;
+}
+
+import { QueryClient } from '@tanstack/svelte-query';
+function renderSection(config: SettingsConfig) {
+	return render(
+		SecuritySettingsSection,
+		{ config, inputClass: 'w-full' },
+		{
+			wrapper: QueryClientWrapper,
+			wrapperProps: { client: new QueryClient({ defaultOptions: { queries: { retry: false } } }) },
+		},
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+async function expandSection(container: HTMLElement): Promise<void> {
+	const header = container.querySelector('button[aria-expanded="false"]') as HTMLButtonElement;
+	if (header) {
+		await fireEvent.click(header);
+		await waitFor(() => expect(header.getAttribute('aria-expanded')).toBe('true'));
+	}
+}
+
+describe('SecuritySettingsSection', () => {
+	it('renders the empty-state hint when no allowed directories are configured', async () => {
+		const { container } = renderSection(makeConfig());
+		await expandSection(container);
+		expect(container.textContent).toContain('No allowed directories configured');
+	});
+
+	it('lists configured allowed directories', async () => {
+		const { container } = renderSection(
+			makeConfig({ allowed_directories: ['/mnt/videos', '/mnt/media'] }),
+		);
+		await expandSection(container);
+		expect(container.textContent).toContain('/mnt/videos');
+		expect(container.textContent).toContain('/mnt/media');
+	});
+
+	it('marks the first allowed directory as the default scan path', async () => {
+		const { container } = renderSection(
+			makeConfig({ allowed_directories: ['/mnt/videos', '/mnt/media'] }),
+		);
+		await expandSection(container);
+		expect(container.textContent).toContain('Default');
+	});
+
+	it('adds an allowed directory from the path input', async () => {
+		const { container } = renderSection(makeConfig());
+		await expandSection(container);
+		const input = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
+		expect(input).toBeTruthy();
+		await fireEvent.input(input, { target: { value: '/new/dir' } });
+		const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
+		await fireEvent.click(addBtn);
+		expect(container.textContent).toContain('/new/dir');
+	});
+
+	it('disables the Save button until the draft is dirty', async () => {
+		const { container } = renderSection(
+			makeConfig({ allowed_directories: ['/existing'] }),
+		);
+		await expandSection(container);
+		const buttons = Array.from(container.querySelectorAll('button'));
+		const save = buttons.find((b) => b.textContent?.includes('Save Security')) as HTMLButtonElement;
+		expect(save).toBeTruthy();
+		expect(save.hasAttribute('disabled')).toBe(true);
+	});
+
+	it('enables Save and persists the security block via the dedicated endpoint', async () => {
+		const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
+		await expandSection(container);
+		const buttons = Array.from(container.querySelectorAll('button'));
+		let save = buttons.find((b) => b.textContent?.includes('Save Security')) as HTMLButtonElement;
+		expect(save).toBeTruthy();
+		expect(save.hasAttribute('disabled')).toBe(true);
+
+		const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
+		expect(removeBtn).toBeTruthy();
+		await fireEvent.click(removeBtn);
+
+		save = Array.from(container.querySelectorAll('button')).find(
+			(b) => b.textContent?.includes('Save Security'),
+		) as HTMLButtonElement;
+		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
+
+		mockUpdateSecurityConfig.mockResolvedValue({
+			security: {
+				allowed_directories: [],
+				denied_directories: [],
+				max_files_per_scan: 0,
+				scan_timeout_seconds: 0,
+				allowed_origins: [],
+				allow_unc: false,
+				allowed_unc_servers: [],
+				rate_limit: { requests_per_minute: 0 },
+				trusted_proxies: [],
+				force_secure_cookies: false,
+			},
+		});
+		const successSpy = vi.spyOn(toastStore, 'success');
+		await fireEvent.click(save);
+
+		await waitFor(() => expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1));
+		expect(mockUpdateSecurityConfig).toHaveBeenCalledWith(
+			expect.objectContaining({ allowed_directories: [] }),
+		);
+		await waitFor(() => expect(successSpy).toHaveBeenCalled());
+	});
+
+	it('toasts an error when the save fails', async () => {
+		mockUpdateSecurityConfig.mockRejectedValue(new Error('server refused'));
+		const errorSpy = vi.spyOn(toastStore, 'error');
+		const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
+		await expandSection(container);
+
+		const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
+		await fireEvent.click(removeBtn);
+
+		const save = Array.from(container.querySelectorAll('button')).find(
+			(b) => b.textContent?.includes('Save Security'),
+		) as HTMLButtonElement;
+		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
+		await fireEvent.click(save);
+
+		await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+		expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1);
+	});
+});

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
@@ -8,11 +8,13 @@ import { toastStore } from '$lib/stores/toast';
 vi.mock('$lib/api/client', () => ({
 	apiClient: {
 		updateSecurityConfig: vi.fn(),
+		getConfig: vi.fn(),
 	},
 }));
 
 const mod = await import('$lib/api/client');
 const mockUpdateSecurityConfig = vi.mocked(mod.apiClient.updateSecurityConfig);
+const mockGetConfig = vi.mocked(mod.apiClient.getConfig);
 
 if (!Element.prototype.animate) {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -78,6 +80,7 @@ function renderSection(config: SettingsConfig) {
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	mockGetConfig.mockResolvedValue(makeConfig() as unknown as SettingsConfig);
 });
 
 afterEach(() => {
@@ -198,3 +201,43 @@ describe('SecuritySettingsSection', () => {
 		expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1);
 	});
 });
+
+	it('rehydrates the draft from the fresh config query after a successful save', async () => {
+		mockUpdateSecurityConfig.mockResolvedValue({
+			security: {
+				allowed_directories: ['/persisted'],
+				denied_directories: [],
+				max_files_per_scan: 0,
+				scan_timeout_seconds: 0,
+				allowed_origins: [],
+				allow_unc: true,
+				allowed_unc_servers: ['\\\\srv\\share'],
+				rate_limit: { requests_per_minute: 0 },
+				trusted_proxies: [],
+				force_secure_cookies: false,
+			},
+		});
+		mockGetConfig.mockResolvedValue(
+			makeConfig({
+				allowed_directories: ['/persisted'],
+				allow_unc: true,
+				allowed_unc_servers: ['\\\\srv\\share'],
+			}) as unknown as SettingsConfig,
+		);
+
+		const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
+		await expandSection(container);
+
+		const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
+		await fireEvent.click(removeBtn);
+
+		const save = Array.from(container.querySelectorAll('button')).find(
+			(b) => b.textContent?.includes('Save Security'),
+		) as HTMLButtonElement;
+		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
+		await fireEvent.click(save);
+
+		await waitFor(() => expect(mockGetConfig).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(container.textContent).toContain('/persisted'));
+		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(true));
+	});

--- a/web/frontend/src/routes/settings/+page.svelte
+++ b/web/frontend/src/routes/settings/+page.svelte
@@ -8,6 +8,7 @@
 	import MetadataPriority from '$lib/components/priority/MetadataPriority.svelte';
 	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
 	import ServerSettingsSection from '$lib/components/settings/sections/ServerSettingsSection.svelte';
+	import SecuritySettingsSection from '$lib/components/settings/sections/SecuritySettingsSection.svelte';
 	import ScraperSettingsSection from '$lib/components/settings/sections/ScraperSettingsSection.svelte';
 	import FileOperationsSettingsSection from '$lib/components/settings/sections/FileOperationsSettingsSection.svelte';
 	import OutputSettingsSection from '$lib/components/settings/sections/OutputSettingsSection.svelte';
@@ -121,6 +122,8 @@
 			</Card>
 		{:else if settings.settingsConfig}
 			<ServerSettingsSection config={settings.settingsConfig} inputClass={settings.inputClass} />
+
+		<SecuritySettingsSection config={settings.settingsConfig} inputClass={settings.inputClass} />
 
 			<SettingsSection title="Scraper Defaults" description="Default settings applied to all scrapers unless overridden per-scraper" defaultExpanded={false}>
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">


### PR DESCRIPTION
Closes the desktop-UX gap where editing `api.security.allowed_directories` required hand-editing YAML: the frontend had 17 settings sections but no Security section, there was no API for persisting just the security block, and the `ErrAllowedDirsEmpty` operator guidance was CLI-oriented ("Edit config.yaml").

## Background

The desktop app writes config to a portable path (Windows `%APPDATA%`, macOS `~/Library/Application Support/`, Linux `/`), but desktop users had no in-app way to manage which directories Javinizer can scan. The first allowed directory is also the default scan path (`internal/api/file/scan.go` uses `AllowedDirectories[0]`), so misconfiguring it breaks scanning entirely. This is a follow-up to #91/#92 (canonicalizePath fix) — all changes here are additive and do not touch `path_validator.go`.

## Part 1 — Frontend: Security / Allowed Directories section

- New `SecuritySettingsSection.svelte` mirroring the existing section pattern (FileOperationsSection direct-mutation + ApiTokensSection self-contained save).
- Lists `allowed_directories` with add/remove; the **first entry is badged "Default"** to surface that it is the default scan path. Uses the existing `PathInput` autocomplete (which gracefully degrades to manual typing when the allowlist is empty — the browse/autocomplete APIs validate against the allowlist, so the first path must be typed).
- Also manages `denied_directories`, `allow_unc`, and `allowed_unc_servers` (the last only shown when `allow_unc` is on).
- Saves via the new dedicated endpoint below (not the whole-config `PUT /api/v1/config`), so a single-section edit can't clobber unrelated fields with a stale GET snapshot; invalidates the `config` query on success.
- Registered in `routes/settings/+page.svelte` alongside the other 17 sections.
- `snake_case` JSON throughout (`allowed_directories`, not `AllowedDirectories`).
- Vitest (`SecuritySettingsSection.test.ts`): empty-state render, list render, default badge, add via PathInput, save disabled until dirty, save persists via the endpoint + success toast, error toast on failure.

## Part 2 — Backend: `PUT /api/v1/config/security`

- New handler in `internal/api/system/security_config.go` accepting a narrow `SecurityUpdateRequest` (`allowed_directories`, `denied_directories`, `allow_unc`, `allowed_unc_servers`) — the operator-editable subset only.
- Reuses the existing `ConfigUpdateService.ValidateAndApply` for save + hot-reload (the same atomic, rollback-capable path the full-config PUT uses). Clones the running config, patches only the four security fields, so all other config (rate_limit, trusted_proxies, allowed_origins, server, scrapers, …) is preserved.
- Gated by `RequireTokenOrSession` on the `protected` router group (operator-authenticated) — desktop is single-user local, so the existing auth model suffices; no new desktop-only gate needed.
- Registered in `internal/api/system/routes.go`; route-parity assertions added to `server_test.go` (both the path-only and method+path lists).
- Handler tests (`security_config_test.go`): persists + reloads the block, empty allowlist is allowed, invalid JSON → 400, non-security sections preserved.
- Swagger annotations on the handler; `make swagger` regenerated `docs/swagger/*` (pre-commit hook enforces this).

## Part 3 — Desktop-aware error guidance

- `ErrAllowedDirsEmpty.OperatorMessage` now branches by install environment:
  - **desktop** → "Open Settings → Security to add directories to the allowed list"
  - **docker** → "Mount a directory into the container and add it to `api.security.allowed_directories` in your configuration file"
  - **cli** → unchanged ("Add directories to `api.security.allowed_directories` in your configuration file")
- New `middleware/install_environment.go` stamps the bootstrap-detected environment (`internal/system.Environment`, the same env detection wired in #89) into each protected request's context. `apperrors.WriteAPIError` selects the environment-aware message at the logging seam (`operatorMessageFor`) without touching `path_validator.go`'s canonicalizePath logic (#91/#92's domain). The response body is unchanged — operator guidance is logged, never leaked to API consumers.
- Tests: `apperrors/environment_test.go` (per-environment messages, context round-trip, nil-safety, non-AllowDirsEmpty errors ignore env) and `middleware/install_environment_test.go` (desktop/docker/cli stamping, nil-deps → CLI).

## Verification

```
go build ./...                                  ✓
go vet ./...                                    ✓
go test -count=1 -short ./...                   ✓ all pass
go test -race -count=1 -short ./internal/api/... ✓ all pass
golangci-lint run ./internal/api/... ./internal/system/... ✓ 0 issues
GOOS=windows go vet ./internal/api/...          ✓ (only pre-existing sqlite3 CGo errors in internal/database, unrelated)
gofmt -l                                       ✓ empty
make swagger                                   ✓ regenerated + idempotent
cd web/frontend && npm run build               ✓
npm run test -- --run UpdateIndicator          ✓ 12 pass
npm run test (full)                            ✓ 332 pass (incl. 7 new SecuritySettingsSection)
npx svelte-check --threshold error             ✓ 0 errors
pre-commit hook                                ✓ all checks passed
```

No existing issue tracks this, so no `Closes #N` keyword.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Security settings section to manage allowed/denied directories and (on supported systems) UNC/network path access.
  * Added support for updating security configuration via a new protected API endpoint.
  * Frontend now lets you edit and save security changes from the settings page (with live reload on success).

* **Bug Fixes**
  * Improved operator error guidance to adapt to the current installation environment for clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->