### PR TITLE
feat(desktop): add allowed_directories to first-run setup

### DIFF
--- a/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
+++ b/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import PathInput from '$lib/components/PathInput.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import { toastStore } from '$lib/stores/toast';
+	import { FolderPlus, Trash2, Star, Folder } from 'lucide-svelte';
+
+	interface Props {
+		directories: string[];
+		placeholder?: string;
+		emptyHint?: string;
+		showDefaultBadge?: boolean;
+		whitelistPaths?: string[];
+		class?: string;
+	}
+
+	let {
+		directories = $bindable(),
+		placeholder = 'Add a directory (e.g. /mnt/videos)',
+		emptyHint = 'No allowed directories configured. Add one below to enable scanning.',
+		showDefaultBadge = true,
+		whitelistPaths = [],
+		class: className = '',
+	}: Props = $props();
+
+	let newDir = $state('');
+
+	function addDir() {
+		const path = newDir.trim();
+		if (!path) return;
+		if (directories.includes(path)) {
+			toastStore.error('Directory already in the allowed list', 3000);
+			return;
+		}
+		directories = [...directories, path];
+		newDir = '';
+	}
+
+	function removeDir(index: number) {
+		directories = directories.filter((_, i) => i !== index);
+	}
+</script>
+
+<div class={className}>
+	{#if directories.length === 0}
+		<div class="rounded-lg border border-dashed border-border p-4 text-center text-sm text-muted-foreground">
+			{emptyHint}
+		</div>
+	{:else}
+		<ul class="space-y-2 mb-3">
+			{#each directories as dir, index (dir + '-' + index)}
+				<li class="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2">
+					{#if showDefaultBadge && index === 0}
+						<span
+							class="inline-flex items-center gap-1 rounded bg-amber-500/15 text-amber-700 dark:text-amber-400 text-xs font-medium px-2 py-0.5 shrink-0"
+							title="The first allowed directory is used as the default scan path"
+						>
+							<Star class="h-3 w-3" />
+							Default
+						</span>
+					{:else}
+						<Folder class="h-4 w-4 text-muted-foreground shrink-0" />
+					{/if}
+					<span class="flex-1 min-w-0 truncate font-mono text-sm">{dir}</span>
+					<button
+						type="button"
+						class="text-muted-foreground hover:text-destructive transition-colors shrink-0"
+						title="Remove directory"
+						aria-label="Remove allowed directory {dir}"
+						onclick={() => removeDir(index)}
+					>
+						<Trash2 class="h-4 w-4" />
+					</button>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+
+	<div class="flex items-start gap-2">
+		<PathInput
+			bind:value={newDir}
+			{placeholder}
+			{whitelistPaths}
+			class="flex-1"
+		/>
+		<Button variant="outline" size="sm" onclick={addDir} disabled={!newDir.trim()} title="Add allowed directory">
+			{#snippet children()}
+				<FolderPlus class="h-4 w-4" />
+			{/snippet}
+		</Button>
+	</div>
+	<p class="text-xs text-muted-foreground mt-1">
+		Autocomplete uses the current allowed directories. Type the first path manually if the list is empty.
+	</p>
+</div>

--- a/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
+++ b/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
@@ -81,6 +81,7 @@
 			{placeholder}
 			{whitelistPaths}
 			class="flex-1"
+			onnavigate={() => addDir()}
 		/>
 		<Button variant="outline" size="sm" onclick={addDir} disabled={!newDir.trim()} title="Add allowed directory">
 			{#snippet children()}

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
@@ -6,8 +6,9 @@
 	import SettingsSubsection from '$lib/components/settings/SettingsSubsection.svelte';
 	import FormToggle from '$lib/components/settings/FormToggle.svelte';
 	import PathInput from '$lib/components/PathInput.svelte';
+	import AllowedDirectoriesEditor from '$lib/components/AllowedDirectoriesEditor.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	import { FolderPlus, Trash2, Save, Star, Folder } from 'lucide-svelte';
+	import { FolderPlus, Trash2, Save, Folder } from 'lucide-svelte';
 	import type { Config, SettingsConfig, SecurityUpdateRequest } from '$lib/api/types';
 
 	interface Props {
@@ -53,7 +54,6 @@
 		}
 	});
 
-	let newAllowedDir = $state('');
 	let newDeniedDir = $state('');
 	let newUncServer = $state('');
 
@@ -73,21 +73,6 @@
 		if (a.length !== b.length) return false;
 		for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
 		return true;
-	}
-
-	function addAllowedDir() {
-		const path = newAllowedDir.trim();
-		if (!path) return;
-		if (draft.allowed_directories.includes(path)) {
-			toastStore.error('Directory already in the allowed list', 3000);
-			return;
-		}
-		draft.allowed_directories = [...draft.allowed_directories, path];
-		newAllowedDir = '';
-	}
-
-	function removeAllowedDir(index: number) {
-		draft.allowed_directories = draft.allowed_directories.filter((_, i) => i !== index);
 	}
 
 	function addDeniedDir() {
@@ -165,56 +150,10 @@
 			Javinizer will only scan and operate inside these directories. With no allowed directories configured, all file operations are blocked.
 		</p>
 
-		{#if draft.allowed_directories.length === 0}
-			<div class="rounded-lg border border-dashed border-border p-4 text-center text-sm text-muted-foreground">
-				No allowed directories configured. Add one below to enable scanning.
-			</div>
-		{:else}
-			<ul class="space-y-2 mb-3">
-				{#each draft.allowed_directories as dir, index (dir + '-' + index)}
-					<li class="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2">
-						{#if index === 0}
-							<span
-								class="inline-flex items-center gap-1 rounded bg-amber-500/15 text-amber-700 dark:text-amber-400 text-xs font-medium px-2 py-0.5 shrink-0"
-								title="The first allowed directory is used as the default scan path"
-							>
-								<Star class="h-3 w-3" />
-								Default
-							</span>
-						{:else}
-							<Folder class="h-4 w-4 text-muted-foreground shrink-0" />
-						{/if}
-						<span class="flex-1 min-w-0 truncate font-mono text-sm">{dir}</span>
-						<button
-							type="button"
-							class="text-muted-foreground hover:text-destructive transition-colors shrink-0"
-							title="Remove directory"
-							aria-label="Remove allowed directory {dir}"
-							onclick={() => removeAllowedDir(index)}
-						>
-							<Trash2 class="h-4 w-4" />
-						</button>
-					</li>
-				{/each}
-			</ul>
-		{/if}
-
-		<div class="flex items-start gap-2">
-			<PathInput
-				bind:value={newAllowedDir}
-				placeholder="Add a directory (e.g. /mnt/videos)"
-				whitelistPaths={draft.allowed_directories}
-				class="flex-1"
-			/>
-			<Button variant="outline" size="sm" onclick={addAllowedDir} disabled={!newAllowedDir.trim()} title="Add allowed directory">
-				{#snippet children()}
-					<FolderPlus class="h-4 w-4" />
-				{/snippet}
-			</Button>
-		</div>
-		<p class="text-xs text-muted-foreground mt-1">
-			Autocomplete uses the current allowed directories. Type the first path manually if the list is empty.
-		</p>
+		<AllowedDirectoriesEditor
+			bind:directories={draft.allowed_directories}
+			whitelistPaths={draft.allowed_directories}
+		/>
 	</SettingsSubsection>
 
 	<SettingsSubsection title="Denied Directories">

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -98,6 +98,7 @@
 			loginPassword = '';
 			await refreshAuthStatus();
 			if (authAuthenticated) {
+				setupNeedsDirs = true;
 				try {
 					const fresh = await apiClient.getConfig();
 					const sec = fresh?.api?.security;
@@ -107,15 +108,17 @@
 						allowed_unc_servers: [...(sec?.allowed_unc_servers ?? [])],
 					};
 					setupDirs = [...(sec?.allowed_directories ?? [])];
-				} catch {
+				} catch (error) {
 					setupSecurityDefaults = {
 						denied_directories: [],
 						allow_unc: false,
 						allowed_unc_servers: [],
 					};
 					setupDirs = [];
+					authError = error instanceof Error
+						? `Failed to load current security settings: ${error.message}. You can still save allowed directories below.`
+						: 'Failed to load current security settings. You can still save allowed directories below.';
 				}
-				setupNeedsDirs = true;
 			}
 		} catch (error) {
 			authError = error instanceof Error ? error.message : 'Failed to initialize authentication';

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -9,11 +9,15 @@
 	import DialogContainer from '$lib/components/ui/DialogContainer.svelte';
 	import BackgroundJobIndicator from '$lib/components/BackgroundJobIndicator.svelte';
 	import ProgressModal from '$lib/components/ProgressModal.svelte';
+	import AllowedDirectoriesEditor from '$lib/components/AllowedDirectoriesEditor.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { apiClient } from '$lib/api/client';
 	import { websocketStore } from '$lib/stores/websocket';
+	import { toastStore } from '$lib/stores/toast';
 	import { getBackgroundJobState, reopenModal, dismiss, closeModal } from '$lib/stores/background-job.svelte';
 	import { getQueryClient } from '$lib/query/client';
 	import { getThemeStore } from '$lib/stores/theme.svelte';
+	import { Save, FolderCheck, ArrowRight } from 'lucide-svelte';
 	import '../app.css';
 
 	let { children } = $props();
@@ -34,6 +38,14 @@
 	let loginUsername = $state('');
 	let loginPassword = $state('');
 	let loginRememberMe = $state(true);
+	let setupNeedsDirs = $state(false);
+	let setupDirs = $state<string[]>([]);
+	let setupDirsSubmitting = $state(false);
+	let setupSecurityDefaults = $state({
+		denied_directories: [] as string[],
+		allow_unc: false,
+		allowed_unc_servers: [] as string[],
+	});
 
 	function syncWebSocketAuthState() {
 		if (authAuthenticated) {
@@ -85,11 +97,61 @@
 			setupPasswordConfirm = '';
 			loginPassword = '';
 			await refreshAuthStatus();
+			if (authAuthenticated) {
+				try {
+					const fresh = await apiClient.getConfig();
+					const sec = fresh?.api?.security;
+					setupSecurityDefaults = {
+						denied_directories: [...(sec?.denied_directories ?? [])],
+						allow_unc: sec?.allow_unc ?? false,
+						allowed_unc_servers: [...(sec?.allowed_unc_servers ?? [])],
+					};
+					setupDirs = [...(sec?.allowed_directories ?? [])];
+				} catch {
+					setupSecurityDefaults = {
+						denied_directories: [],
+						allow_unc: false,
+						allowed_unc_servers: [],
+					};
+					setupDirs = [];
+				}
+				setupNeedsDirs = true;
+			}
 		} catch (error) {
 			authError = error instanceof Error ? error.message : 'Failed to initialize authentication';
 		} finally {
 			authSubmitting = false;
 		}
+	}
+
+	async function handleSetupDirsSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		authError = null;
+		setupDirsSubmitting = true;
+		try {
+			await apiClient.updateSecurityConfig({
+				allowed_directories: setupDirs,
+				denied_directories: setupSecurityDefaults.denied_directories,
+				allow_unc: setupSecurityDefaults.allow_unc,
+				allowed_unc_servers: setupSecurityDefaults.allowed_unc_servers,
+			});
+			setupNeedsDirs = false;
+			if (setupDirs.length > 0) {
+				toastStore.success('Allowed directories saved. Ready to scan.', 4000);
+			} else {
+				toastStore.info('You can add allowed directories later in Settings → Security.', 5000);
+			}
+		} catch (error) {
+			authError = error instanceof Error ? error.message : 'Failed to save allowed directories';
+		} finally {
+			setupDirsSubmitting = false;
+		}
+	}
+
+	function handleSetupDirsSkip() {
+		setupNeedsDirs = false;
+		setupDirs = [];
+		toastStore.info('You can add allowed directories later in Settings → Security.', 5000);
 	}
 
 	async function handleLoginSubmit(event: SubmitEvent) {
@@ -289,6 +351,48 @@
 					</button>
 				</form>
 			{/if}
+		</div>
+	</div>
+{:else if setupNeedsDirs}
+	<div class="min-h-screen bg-background flex items-center justify-center px-4 py-10">
+		<div class="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm space-y-4">
+			<div class="space-y-1">
+				<h1 class="text-2xl font-bold">Add Allowed Directories</h1>
+				<p class="text-sm text-muted-foreground">
+					Add the folders you want to scan for videos; you can change this later in Settings → Security.
+					With no allowed directories configured, all file operations are blocked.
+				</p>
+			</div>
+
+			{#if authError}
+				<div class="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+					{authError}
+				</div>
+			{/if}
+
+			<AllowedDirectoriesEditor
+				bind:directories={setupDirs}
+				whitelistPaths={setupDirs}
+				emptyHint="No directories added yet. Add one below to enable scanning, or skip and add later."
+			/>
+
+			<form class="space-y-2" onsubmit={handleSetupDirsSubmit}>
+				<Button type="submit" disabled={setupDirsSubmitting} class="w-full">
+					{#snippet children()}
+						<FolderCheck class="h-4 w-4 mr-2" />
+						{setupDirsSubmitting ? 'Saving...' : 'Save & Continue'}
+					{/snippet}
+				</Button>
+			</form>
+			<button
+				type="button"
+				disabled={setupDirsSubmitting}
+				onclick={handleSetupDirsSkip}
+				class="w-full inline-flex items-center justify-center gap-1 rounded-md px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground disabled:opacity-60"
+			>
+				Skip for now
+				<ArrowRight class="h-3.5 w-3.5" />
+			</button>
 		</div>
 	</div>
 {:else}

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -189,6 +189,49 @@ describe('first-run setup allowed directories step', () => {
 		await waitFor(() => expect(vi.mocked(toastStore.success)).toHaveBeenCalled());
 	});
 
+	it('commits a typed directory on Enter without clicking the add button', async () => {
+		apiClient.getAuthStatus
+			.mockResolvedValueOnce(uninitializedStatus())
+			.mockResolvedValueOnce(authenticatedStatus());
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
+		apiClient.getConfig.mockResolvedValue(freshConfig());
+		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse(['/mnt/videos']));
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+
+		const username = container.querySelector('#setup-username') as HTMLInputElement;
+		const password = container.querySelector('#setup-password') as HTMLInputElement;
+		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
+		await fireEvent.input(username, { target: { value: 'admin' } });
+		await fireEvent.input(password, { target: { value: 'password123' } });
+		await fireEvent.input(confirm, { target: { value: 'password123' } });
+		await fireEvent.submit(username.closest('form') as HTMLFormElement);
+
+		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
+
+		const dirInput = container.querySelector(
+			'input[placeholder*="Add a directory"]',
+		) as HTMLInputElement;
+		expect(dirInput).toBeTruthy();
+		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
+		await fireEvent.keyDown(dirInput, { key: 'Enter' });
+		await tick();
+
+		const save = Array.from(container.querySelectorAll('button')).find((b) =>
+			b.textContent?.includes('Save & Continue'),
+		) as HTMLButtonElement;
+		await fireEvent.click(save);
+
+		await waitFor(() =>
+			expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
+				expect.objectContaining({ allowed_directories: ['/mnt/videos'] }),
+			),
+		);
+	});
+
 	it('sends all four security fields including current defaults', async () => {
 		apiClient.getAuthStatus
 			.mockResolvedValueOnce(uninitializedStatus())

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -52,11 +52,15 @@ if (!Element.prototype.animate) {
 }
 
 function uninitializedStatus() {
-	return { initialized: false, authenticated: false, username: null } as unknown as Awaited<ReturnType<typeof apiClient.getAuthStatus>>;
+	return { initialized: false, authenticated: false, username: null } as unknown as Awaited<
+		ReturnType<typeof apiClient.getAuthStatus>
+	>;
 }
 
 function authenticatedStatus() {
-	return { initialized: true, authenticated: true, username: 'admin' } as unknown as Awaited<ReturnType<typeof apiClient.getAuthStatus>>;
+	return { initialized: true, authenticated: true, username: 'admin' } as unknown as Awaited<
+		ReturnType<typeof apiClient.getAuthStatus>
+	>;
 }
 
 function freshConfig(allowed: string[] = []) {
@@ -108,7 +112,9 @@ describe('first-run setup allowed directories step', () => {
 		apiClient.getAuthStatus
 			.mockResolvedValueOnce(uninitializedStatus())
 			.mockResolvedValueOnce(authenticatedStatus());
-		apiClient.setupAuth.mockResolvedValue(authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>);
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
 		apiClient.getConfig.mockResolvedValue(freshConfig());
 		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse());
 
@@ -135,7 +141,9 @@ describe('first-run setup allowed directories step', () => {
 		apiClient.getAuthStatus
 			.mockResolvedValueOnce(uninitializedStatus())
 			.mockResolvedValueOnce(authenticatedStatus());
-		apiClient.setupAuth.mockResolvedValue(authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>);
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
 		apiClient.getConfig.mockResolvedValue(freshConfig());
 		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse(['/mnt/videos']));
 
@@ -152,15 +160,19 @@ describe('first-run setup allowed directories step', () => {
 
 		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
 
-		const dirInput = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
+		const dirInput = container.querySelector(
+			'input[placeholder*="Add a directory"]',
+		) as HTMLInputElement;
 		expect(dirInput).toBeTruthy();
 		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
-		const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
+		const addBtn = container.querySelector(
+			'button[title="Add allowed directory"]',
+		) as HTMLButtonElement;
 		await fireEvent.click(addBtn);
 		await tick();
 
-		const save = Array.from(container.querySelectorAll('button')).find(
-			(b) => b.textContent?.includes('Save & Continue'),
+		const save = Array.from(container.querySelectorAll('button')).find((b) =>
+			b.textContent?.includes('Save & Continue'),
 		) as HTMLButtonElement;
 		expect(save).toBeTruthy();
 		await fireEvent.click(save);
@@ -181,7 +193,9 @@ describe('first-run setup allowed directories step', () => {
 		apiClient.getAuthStatus
 			.mockResolvedValueOnce(uninitializedStatus())
 			.mockResolvedValueOnce(authenticatedStatus());
-		apiClient.setupAuth.mockResolvedValue(authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>);
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
 		apiClient.getConfig.mockResolvedValue({
 			api: {
 				security: {
@@ -192,11 +206,13 @@ describe('first-run setup allowed directories step', () => {
 				},
 			},
 		} as unknown as Awaited<ReturnType<typeof apiClient.getConfig>>);
-		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse(['/mnt/videos'], {
-			denied_directories: ['/sensitive'],
-			allow_unc: true,
-			allowed_unc_servers: ['\\\\srv\\share'],
-		}));
+		apiClient.updateSecurityConfig.mockResolvedValue(
+			securityResponse(['/mnt/videos'], {
+				denied_directories: ['/sensitive'],
+				allow_unc: true,
+				allowed_unc_servers: ['\\\\srv\\share'],
+			}),
+		);
 
 		const { container } = render(Layout);
 		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
@@ -211,13 +227,17 @@ describe('first-run setup allowed directories step', () => {
 
 		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
 
-		const dirInput = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
+		const dirInput = container.querySelector(
+			'input[placeholder*="Add a directory"]',
+		) as HTMLInputElement;
 		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
-		await fireEvent.click(container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement);
+		await fireEvent.click(
+			container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement,
+		);
 		await tick();
 
-		const save = Array.from(container.querySelectorAll('button')).find(
-			(b) => b.textContent?.includes('Save & Continue'),
+		const save = Array.from(container.querySelectorAll('button')).find((b) =>
+			b.textContent?.includes('Save & Continue'),
 		) as HTMLButtonElement;
 		await fireEvent.click(save);
 
@@ -236,7 +256,9 @@ describe('first-run setup allowed directories step', () => {
 		apiClient.getAuthStatus
 			.mockResolvedValueOnce(uninitializedStatus())
 			.mockResolvedValueOnce(authenticatedStatus());
-		apiClient.setupAuth.mockResolvedValue(authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>);
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
 		apiClient.getConfig.mockResolvedValue(freshConfig());
 
 		const { container } = render(Layout);
@@ -252,17 +274,46 @@ describe('first-run setup allowed directories step', () => {
 
 		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
 
-		const skipBtn = Array.from(container.querySelectorAll('button')).find(
-			(b) => b.textContent?.includes('Skip for now'),
+		const skipBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+			b.textContent?.includes('Skip for now'),
 		) as HTMLButtonElement;
 		expect(skipBtn).toBeTruthy();
 		await fireEvent.click(skipBtn);
 
-		await waitFor(() => expect(vi.mocked(toastStore.info)).toHaveBeenCalledWith(
-			expect.stringContaining('Settings → Security'),
-			expect.any(Number),
-		));
+		await waitFor(() =>
+			expect(vi.mocked(toastStore.info)).toHaveBeenCalledWith(
+				expect.stringContaining('Settings → Security'),
+				expect.any(Number),
+			),
+		);
 		await waitFor(() => expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled());
 		expect(vi.mocked(toastStore.info)).toHaveBeenCalled();
+	});
+
+	it('surfaces a visible error when config loading fails but keeps the dirs gate stable', async () => {
+		apiClient.getAuthStatus
+			.mockResolvedValueOnce(uninitializedStatus())
+			.mockResolvedValueOnce(authenticatedStatus());
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
+		apiClient.getConfig.mockRejectedValue(new Error('network down'));
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+
+		const username = container.querySelector('#setup-username') as HTMLInputElement;
+		const password = container.querySelector('#setup-password') as HTMLInputElement;
+		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
+		await fireEvent.input(username, { target: { value: 'admin' } });
+		await fireEvent.input(password, { target: { value: 'password123' } });
+		await fireEvent.input(confirm, { target: { value: 'password123' } });
+		await fireEvent.submit(username.closest('form') as HTMLFormElement);
+
+		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
+		expect(container.textContent).toContain('Failed to load current security settings');
+		expect(container.textContent).toContain('network down');
+		expect(apiClient.getConfig).toHaveBeenCalledTimes(1);
+		expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled();
 	});
 });

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import Layout from './+layout.svelte';
+import { tick } from 'svelte';
+
+vi.mock('$lib/api/client', () => ({
+	apiClient: {
+		getAuthStatus: vi.fn(),
+		setupAuth: vi.fn(),
+		loginAuth: vi.fn(),
+		logoutAuth: vi.fn(),
+		getConfig: vi.fn(),
+		updateSecurityConfig: vi.fn(),
+	},
+}));
+
+vi.mock('$lib/stores/websocket', () => ({
+	websocketStore: { connect: vi.fn(), disconnect: vi.fn() },
+}));
+
+vi.mock('$lib/stores/background-job.svelte', () => ({
+	getBackgroundJobState: () => ({ jobId: null, showModal: false }),
+	reopenModal: vi.fn(),
+	dismiss: vi.fn(),
+	closeModal: vi.fn(),
+}));
+
+vi.mock('$lib/stores/theme.svelte', () => ({
+	getThemeStore: () => ({ initTheme: vi.fn(), destroyTheme: vi.fn() }),
+}));
+
+import { toastStore } from '$lib/stores/toast';
+
+const mod = await import('$lib/api/client');
+const apiClient = vi.mocked(mod.apiClient);
+
+if (!Element.prototype.animate) {
+	Element.prototype.animate = function () {
+		const anim = {
+			onfinish: null as (() => void) | null,
+			oncancel: null as (() => void) | null,
+			cancel() {},
+			finish() {
+				anim.onfinish?.();
+			},
+			addEventListener() {},
+			removeEventListener() {},
+		};
+		queueMicrotask(() => anim.onfinish?.());
+		return anim as unknown as Animation;
+	};
+}
+
+function uninitializedStatus() {
+	return { initialized: false, authenticated: false, username: null } as unknown as Awaited<ReturnType<typeof apiClient.getAuthStatus>>;
+}
+
+function authenticatedStatus() {
+	return { initialized: true, authenticated: true, username: 'admin' } as unknown as Awaited<ReturnType<typeof apiClient.getAuthStatus>>;
+}
+
+function freshConfig(allowed: string[] = []) {
+	return {
+		api: {
+			security: {
+				allowed_directories: allowed,
+				denied_directories: [],
+				allow_unc: false,
+				allowed_unc_servers: [],
+			},
+		},
+	} as unknown as Awaited<ReturnType<typeof apiClient.getConfig>>;
+}
+
+function securityResponse(allowed: string[] = [], overrides: Record<string, unknown> = {}) {
+	return {
+		security: {
+			allowed_directories: allowed,
+			denied_directories: [],
+			allow_unc: false,
+			allowed_unc_servers: [],
+			...overrides,
+		},
+	} as unknown as Awaited<ReturnType<typeof apiClient.updateSecurityConfig>>;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	apiClient.getAuthStatus.mockResolvedValue(uninitializedStatus());
+	toastStore.clear();
+	vi.spyOn(toastStore, 'success');
+	vi.spyOn(toastStore, 'info');
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('first-run setup allowed directories step', () => {
+	it('shows the credentials form before auth is initialized', async () => {
+		const { container, getByText } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+		expect(container.textContent).toContain('Create the default username and password');
+		expect(getByText('Create Credentials')).toBeTruthy();
+	});
+
+	it('transitions to the allowed directories step after credentials are created', async () => {
+		apiClient.getAuthStatus
+			.mockResolvedValueOnce(uninitializedStatus())
+			.mockResolvedValueOnce(authenticatedStatus());
+		apiClient.setupAuth.mockResolvedValue(authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>);
+		apiClient.getConfig.mockResolvedValue(freshConfig());
+		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse());
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+
+		const username = container.querySelector('#setup-username') as HTMLInputElement;
+		const password = container.querySelector('#setup-password') as HTMLInputElement;
+		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
+		await fireEvent.input(username, { target: { value: 'admin' } });
+		await fireEvent.input(password, { target: { value: 'password123' } });
+		await fireEvent.input(confirm, { target: { value: 'password123' } });
+
+		const form = username.closest('form') as HTMLFormElement;
+		await fireEvent.submit(form);
+
+		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
+		expect(container.textContent).toContain('you can change this later in Settings');
+		expect(apiClient.getConfig).toHaveBeenCalledTimes(1);
+		expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled();
+	});
+
+	it('persists allowed directories via the security endpoint on submit', async () => {
+		apiClient.getAuthStatus
+			.mockResolvedValueOnce(uninitializedStatus())
+			.mockResolvedValueOnce(authenticatedStatus());
+		apiClient.setupAuth.mockResolvedValue(authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>);
+		apiClient.getConfig.mockResolvedValue(freshConfig());
+		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse(['/mnt/videos']));
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+
+		const username = container.querySelector('#setup-username') as HTMLInputElement;
+		const password = container.querySelector('#setup-password') as HTMLInputElement;
+		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
+		await fireEvent.input(username, { target: { value: 'admin' } });
+		await fireEvent.input(password, { target: { value: 'password123' } });
+		await fireEvent.input(confirm, { target: { value: 'password123' } });
+		await fireEvent.submit(username.closest('form') as HTMLFormElement);
+
+		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
+
+		const dirInput = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
+		expect(dirInput).toBeTruthy();
+		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
+		const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
+		await fireEvent.click(addBtn);
+		await tick();
+
+		const save = Array.from(container.querySelectorAll('button')).find(
+			(b) => b.textContent?.includes('Save & Continue'),
+		) as HTMLButtonElement;
+		expect(save).toBeTruthy();
+		await fireEvent.click(save);
+
+		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
+		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
+			expect.objectContaining({
+				allowed_directories: ['/mnt/videos'],
+				denied_directories: [],
+				allow_unc: false,
+				allowed_unc_servers: [],
+			}),
+		);
+		await waitFor(() => expect(vi.mocked(toastStore.success)).toHaveBeenCalled());
+	});
+
+	it('sends all four security fields including current defaults', async () => {
+		apiClient.getAuthStatus
+			.mockResolvedValueOnce(uninitializedStatus())
+			.mockResolvedValueOnce(authenticatedStatus());
+		apiClient.setupAuth.mockResolvedValue(authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>);
+		apiClient.getConfig.mockResolvedValue({
+			api: {
+				security: {
+					allowed_directories: [],
+					denied_directories: ['/sensitive'],
+					allow_unc: true,
+					allowed_unc_servers: ['\\\\srv\\share'],
+				},
+			},
+		} as unknown as Awaited<ReturnType<typeof apiClient.getConfig>>);
+		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse(['/mnt/videos'], {
+			denied_directories: ['/sensitive'],
+			allow_unc: true,
+			allowed_unc_servers: ['\\\\srv\\share'],
+		}));
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+
+		const username = container.querySelector('#setup-username') as HTMLInputElement;
+		const password = container.querySelector('#setup-password') as HTMLInputElement;
+		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
+		await fireEvent.input(username, { target: { value: 'admin' } });
+		await fireEvent.input(password, { target: { value: 'password123' } });
+		await fireEvent.input(confirm, { target: { value: 'password123' } });
+		await fireEvent.submit(username.closest('form') as HTMLFormElement);
+
+		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
+
+		const dirInput = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
+		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
+		await fireEvent.click(container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement);
+		await tick();
+
+		const save = Array.from(container.querySelectorAll('button')).find(
+			(b) => b.textContent?.includes('Save & Continue'),
+		) as HTMLButtonElement;
+		await fireEvent.click(save);
+
+		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
+		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
+			expect.objectContaining({
+				allowed_directories: ['/mnt/videos'],
+				denied_directories: ['/sensitive'],
+				allow_unc: true,
+				allowed_unc_servers: ['\\\\srv\\share'],
+			}),
+		);
+	});
+
+	it('skips the step without calling the security endpoint and toasts guidance', async () => {
+		apiClient.getAuthStatus
+			.mockResolvedValueOnce(uninitializedStatus())
+			.mockResolvedValueOnce(authenticatedStatus());
+		apiClient.setupAuth.mockResolvedValue(authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>);
+		apiClient.getConfig.mockResolvedValue(freshConfig());
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+
+		const username = container.querySelector('#setup-username') as HTMLInputElement;
+		const password = container.querySelector('#setup-password') as HTMLInputElement;
+		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
+		await fireEvent.input(username, { target: { value: 'admin' } });
+		await fireEvent.input(password, { target: { value: 'password123' } });
+		await fireEvent.input(confirm, { target: { value: 'password123' } });
+		await fireEvent.submit(username.closest('form') as HTMLFormElement);
+
+		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
+
+		const skipBtn = Array.from(container.querySelectorAll('button')).find(
+			(b) => b.textContent?.includes('Skip for now'),
+		) as HTMLButtonElement;
+		expect(skipBtn).toBeTruthy();
+		await fireEvent.click(skipBtn);
+
+		await waitFor(() => expect(vi.mocked(toastStore.info)).toHaveBeenCalledWith(
+			expect.stringContaining('Settings → Security'),
+			expect.any(Number),
+		));
+		await waitFor(() => expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled());
+		expect(vi.mocked(toastStore.info)).toHaveBeenCalled();
+	});
+});

--- a/web/frontend/test/stubs/app/environment.ts
+++ b/web/frontend/test/stubs/app/environment.ts
@@ -1,0 +1,1 @@
+export const browser = false;

--- a/web/frontend/test/stubs/app/state.ts
+++ b/web/frontend/test/stubs/app/state.ts
@@ -1,0 +1,1 @@
+export const page = { url: { pathname: "/" } };

--- a/web/frontend/test/stubs/app/stores.ts
+++ b/web/frontend/test/stubs/app/stores.ts
@@ -1,0 +1,2 @@
+import { readable } from "svelte/store";
+export const page = readable({ url: { pathname: "/" } });

--- a/web/frontend/vitest.config.ts
+++ b/web/frontend/vitest.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
 		alias: {
 			$lib: path.resolve(__dirname, 'src/lib'),
 			'$app/navigation': path.resolve(__dirname, 'test/stubs/app/navigation.ts'),
+			'$app/state': path.resolve(__dirname, 'test/stubs/app/state.ts'),
+			'$app/environment': path.resolve(__dirname, 'test/stubs/app/environment.ts'),
+			'$app/stores': path.resolve(__dirname, 'test/stubs/app/stores.ts'),
 		},
 	},
 	test: {


### PR DESCRIPTION
## Summary

Extends the first-time setup flow with an allowed-directories step, reusing the PR #93 `SecuritySettingsSection` UI and the `PUT /api/v1/config/security` endpoint. Closes the UX gap where a new desktop user creates credentials, lands in an empty app with no scan paths, and hits a confusing "access denied: no allowed directories configured" error on their first scan.

## Changes

- **`AllowedDirectoriesEditor.svelte`** (new): Extracts the PathInput + directory-browse + add/remove list UI (with the "Default" badge for the first entry) into a reusable component.
- **`SecuritySettingsSection.svelte`**: Refactored to use `AllowedDirectoriesEditor` for the allowed-directories list, so the settings section and the setup step share a single implementation and stay in sync. The denied-directories and UNC sections are unchanged.
- **`+layout.svelte`** first-run flow: After `setupAuth` succeeds and the user is authenticated, fetch the current security block via `getConfig`, then transition to a new "Add Allowed Directories" step. The user can:
  - add one or more scan paths and **Save & Continue** → `PUT /api/v1/config/security` with all four fields (their chosen `allowed_directories` + the current `denied_directories`/`allow_unc`/`allowed_unc_servers` defaults), then enter the app; or
  - **Skip for now** → enter the app with zero directories (secure-by-default) and a toast guiding them to Settings → Security.
- **`layout.test.ts`** (new): Vitest covering the credentials form, the transition to the dirs step, persistence via the security endpoint with all four fields (including current defaults), and the skip path.
- **vitest stubs**: Added `$app/state`, `$app/environment`, and `$app/stores` test stubs (mirroring the existing `$app/navigation` stub) so the layout can render under jsdom.

## Verification

- `go build ./...`, `go vet ./...`, `go test -count=1 -short ./...` — 0 FAIL
- `gofmt -l` empty; `golangci-lint run` — 0 issues
- `cd web/frontend && npm run build` — OK
- `cd web/frontend && npm run test` — 338 passed (incl. 8 `SecuritySettings` + 5 new `layout` tests)
- `cd web/frontend && npx svelte-check --threshold error` — 0 errors
- Pre-commit hook (gofmt + go vet + go test -short + build + golangci-lint + swagger + svelte-check) — all passed

## Notes

- Reuses PR #93's component + endpoint; no new directory-browse or config-write path invented.
- The `PUT /api/v1/config/security` endpoint requires all 4 keys (full-replace validation from PR #93 `a7ccdc1`) — the setup step sends all four, defaulting the non-allowed fields to the values fetched from the running config.
- The existing first-run auth setup (`handleSetupSubmit`, `handleLoginSubmit`) is extended, not replaced — the credentials form is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an allowed-directories editor (add/remove, empty-state, autocomplete, default labeling).
  * Introduced a first-time setup step to review and save allowed directories with “Save & Continue” and “Skip for now”.
* **Bug Fixes**
  * Prevents duplicate directory entries and shows user feedback when a directory already exists.
* **Tests**
  * Updated frontend test stubs and Vitest aliases to support the new setup flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->