### PR TITLE
fix(desktop): Windows launch, WebSocket progress, and browse security model

### DIFF
--- a/cmd/javinizer/console_other.go
+++ b/cmd/javinizer/console_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package main
+
+func attachParentConsole() {}

--- a/cmd/javinizer/console_other.go
+++ b/cmd/javinizer/console_other.go
@@ -2,4 +2,8 @@
 
 package main
 
-func attachParentConsole() {}
+// attachParentConsole is a no-op on non-Windows: those platforms don't use a
+// GUI subsystem flag, so the process inherits the parent terminal's stdio
+// directly. It is a var (not a func) so tests can assert the desktop-build
+// branch in run() takes it.
+var attachParentConsole = func() {}

--- a/cmd/javinizer/console_windows.go
+++ b/cmd/javinizer/console_windows.go
@@ -7,28 +7,29 @@ import (
 	"syscall"
 )
 
+// AttachConsole is not exposed by the stdlib syscall package, so bind it
+// manually from kernel32. GetStdHandle + the STD_* constants are stdlib.
 var (
 	kernel32          = syscall.NewLazyDLL("kernel32.dll")
 	procAttachConsole = kernel32.NewProc("AttachConsole")
-	procGetStdHandle  = kernel32.NewProc("GetStdHandle")
 )
 
-const (
-	attachParentProcess = ^uintptr(0)
-	stdOutputHandle     = ^uintptr(10)
-	stdErrorHandle      = ^uintptr(11)
-	invalidHandleValue  = ^uintptr(0)
-)
+// attachParentProcess is the special handle value passed to AttachConsole to
+// attach to the console of the process that launched us (e.g. cmd.exe). It is
+// (DWORD)-1; the stdlib does not name it.
+const attachParentProcess = ^uintptr(0)
 
-func attachParentConsole() {
+// attachParentConsole is a var (not a func) so tests can assert the
+// desktop-build branch in run() takes it; on Windows it does the real work.
+var attachParentConsole = func() {
 	r, _, _ := procAttachConsole.Call(attachParentProcess)
 	if r == 0 {
 		return
 	}
-	if out, _, _ := procGetStdHandle.Call(stdOutputHandle); out != 0 && out != invalidHandleValue {
-		os.Stdout = os.NewFile(out, "stdout")
+	if h, err := syscall.GetStdHandle(syscall.STD_OUTPUT_HANDLE); err == nil && h != 0 && h != syscall.InvalidHandle {
+		os.Stdout = os.NewFile(uintptr(h), "stdout")
 	}
-	if err, _, _ := procGetStdHandle.Call(stdErrorHandle); err != 0 && err != invalidHandleValue {
-		os.Stderr = os.NewFile(err, "stderr")
+	if h, err := syscall.GetStdHandle(syscall.STD_ERROR_HANDLE); err == nil && h != 0 && h != syscall.InvalidHandle {
+		os.Stderr = os.NewFile(uintptr(h), "stderr")
 	}
 }

--- a/cmd/javinizer/console_windows.go
+++ b/cmd/javinizer/console_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+var (
+	kernel32          = syscall.NewLazyDLL("kernel32.dll")
+	procAttachConsole = kernel32.NewProc("AttachConsole")
+	procGetStdHandle  = kernel32.NewProc("GetStdHandle")
+)
+
+const (
+	attachParentProcess = ^uintptr(0)
+	stdOutputHandle     = ^uintptr(10)
+	stdErrorHandle      = ^uintptr(11)
+	invalidHandleValue  = ^uintptr(0)
+)
+
+func attachParentConsole() {
+	r, _, _ := procAttachConsole.Call(attachParentProcess)
+	if r == 0 {
+		return
+	}
+	if out, _, _ := procGetStdHandle.Call(stdOutputHandle); out != 0 && out != invalidHandleValue {
+		os.Stdout = os.NewFile(out, "stdout")
+	}
+	if err, _, _ := procGetStdHandle.Call(stdErrorHandle); err != 0 && err != invalidHandleValue {
+		os.Stderr = os.NewFile(err, "stderr")
+	}
+}

--- a/cmd/javinizer/main.go
+++ b/cmd/javinizer/main.go
@@ -3,11 +3,35 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+
+	"github.com/javinizer/javinizer-go/internal/desktop"
 )
 
 func main() {
+	if desktop.IsDesktopBuild() && len(os.Args) > 1 {
+		attachParentConsole()
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			writeCrashLog(fmt.Sprintf("panic: %v", r))
+			os.Exit(1)
+		}
+	}()
 	if err := Execute(); err != nil {
-		fmt.Println(err)
+		writeCrashLog(err.Error())
 		os.Exit(1)
 	}
+}
+
+func writeCrashLog(msg string) {
+	if !desktop.IsDesktopBuild() {
+		fmt.Println(msg)
+		return
+	}
+	dir, err := desktop.UserDataDir()
+	if err == nil {
+		_ = os.WriteFile(filepath.Join(dir, "crash.log"), []byte(msg+"\n"), 0o600)
+	}
+	_, _ = fmt.Fprintln(os.Stderr, msg)
 }

--- a/cmd/javinizer/main.go
+++ b/cmd/javinizer/main.go
@@ -4,34 +4,67 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
+	"time"
 
 	"github.com/javinizer/javinizer-go/internal/desktop"
 )
 
+// executeFn is the command entry point main() invokes. It is a package-level
+// var so tests can stub it: the real Execute runs cobra with process-wide
+// side effects (and main()'s os.Exit) that are impractical to exercise
+// directly. Production wires it to Execute at package init.
+var executeFn = Execute
+
+// osExit is os.Exit as a var so tests can call main() without terminating
+// the test process: main() becomes `osExit(run())`, and stubbing osExit to a
+// no-op lets a test exercise main()'s single statement.
+var osExit = os.Exit
+
 func main() {
+	osExit(run())
+}
+
+// run is the testable body of main: it returns the process exit code instead
+// of calling os.Exit, and recovers panics so a pre-GUI crash is recorded
+// (crash.log on desktop, stderr on CLI) rather than swallowed by the nil
+// stderr of a double-click-launched GUI-subsystem binary.
+func run() (exitCode int) {
 	if desktop.IsDesktopBuild() && len(os.Args) > 1 {
 		attachParentConsole()
 	}
 	defer func() {
 		if r := recover(); r != nil {
-			writeCrashLog(fmt.Sprintf("panic: %v", r))
-			os.Exit(1)
+			writeCrashLog(fmt.Sprintf("panic: %v\n%s", r, debug.Stack()))
+			exitCode = 1
 		}
 	}()
-	if err := Execute(); err != nil {
+	if err := executeFn(); err != nil {
 		writeCrashLog(err.Error())
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
+// writeCrashLog records a pre-GUI failure (panic or Execute error) so a
+// double-click-launched desktop app — whose stderr is nil — leaves a
+// diagnostic trail. It always also writes to stderr: for CLI builds stderr is
+// the conventional error stream, and for desktop builds stderr is harmless
+// (nil writes are no-ops) and helps when launched from a terminal.
 func writeCrashLog(msg string) {
+	_, _ = fmt.Fprintln(os.Stderr, msg)
 	if !desktop.IsDesktopBuild() {
-		fmt.Println(msg)
 		return
 	}
 	dir, err := desktop.UserDataDir()
-	if err == nil {
-		_ = os.WriteFile(filepath.Join(dir, "crash.log"), []byte(msg+"\n"), 0o600)
+	if err != nil {
+		return
 	}
-	_, _ = fmt.Fprintln(os.Stderr, msg)
+	path := filepath.Join(dir, "crash.log")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "%s %s\n", time.Now().Format(time.RFC3339), msg)
 }

--- a/cmd/javinizer/main_test.go
+++ b/cmd/javinizer/main_test.go
@@ -1,18 +1,222 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/javinizer/javinizer-go/internal/desktop"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestMainPackageCompiles is a placeholder test to ensure the main package compiles.
 // The main() function itself is not tested directly because:
 // 1. It would start the actual CLI which has side effects
 // 2. All functionality is tested through unit and integration tests in root_test.go
-// 3. main() is just a thin wrapper that calls Execute()
+// 3. main() is just a thin wrapper that calls run(), which IS tested below.
 func TestMainPackageCompiles(t *testing.T) {
-	// This test simply ensures the main package compiles correctly.
-	// All actual CLI testing is done in root_test.go and command tests.
 	assert.True(t, true, "Main package compiles successfully")
+}
+
+// withExecuteFn swaps the package-level executeFn for a test stub and restores
+// it on cleanup. Returns a pointer the stub can mutate so a test can simulate
+// Execute success, failure, or panic.
+func withExecuteFn(t *testing.T, stub func() error) *func() error {
+	t.Helper()
+	orig := executeFn
+	executeFn = stub
+	t.Cleanup(func() { executeFn = orig })
+	return &stub
+}
+
+// withDesktopBuild toggles desktop.BuildDesktop for the test and restores it.
+func withDesktopBuild(t *testing.T, on bool) {
+	t.Helper()
+	orig := desktop.BuildDesktop
+	if on {
+		desktop.BuildDesktop = "1"
+	} else {
+		desktop.BuildDesktop = "0"
+	}
+	t.Cleanup(func() { desktop.BuildDesktop = orig })
+}
+
+// withArgs swaps os.Args for the test and restores it on cleanup.
+func withArgs(t *testing.T, args ...string) {
+	t.Helper()
+	orig := os.Args
+	os.Args = args
+	t.Cleanup(func() { os.Args = orig })
+}
+
+func TestRun_ExecuteSuccessReturnsZero(t *testing.T) {
+	withExecuteFn(t, func() error { return nil })
+	withDesktopBuild(t, false)
+	assert.Equal(t, 0, run())
+}
+
+func TestRun_ExecuteErrorReturnsOne(t *testing.T) {
+	withExecuteFn(t, func() error { return assertFailErr })
+	withDesktopBuild(t, false)
+	assert.Equal(t, 1, run())
+}
+
+func TestRun_PanicRecoveredReturnsOne(t *testing.T) {
+	withExecuteFn(t, func() error { panic("boom") })
+	withDesktopBuild(t, false)
+	assert.Equal(t, 1, run())
+}
+
+// TestRun_DesktopBuildWithArgsAttachesConsole covers the attachParentConsole
+// branch: a desktop build launched with args (e.g. --help) must call it. On
+// non-Windows the stub is a no-op; the point is that the branch is taken.
+func TestRun_DesktopBuildWithArgsAttachesConsole(t *testing.T) {
+	called := false
+	orig := attachParentConsole
+	attachParentConsole = func() { called = true }
+	t.Cleanup(func() { attachParentConsole = orig })
+
+	withExecuteFn(t, func() error { return nil })
+	withDesktopBuild(t, true)
+	withArgs(t, "javinizer", "--help")
+	require.Equal(t, 0, run())
+	assert.True(t, called, "attachParentConsole must run for a desktop build with args")
+}
+
+// TestRun_DesktopBuildNoArgsSkipsConsole: with no args the GUI launches and
+// console attach is skipped (the window has no console to attach to).
+func TestRun_DesktopBuildNoArgsSkipsConsole(t *testing.T) {
+	called := false
+	orig := attachParentConsole
+	attachParentConsole = func() { called = true }
+	t.Cleanup(func() { attachParentConsole = orig })
+
+	withExecuteFn(t, func() error { return nil })
+	withDesktopBuild(t, true)
+	withArgs(t, "javinizer")
+	require.Equal(t, 0, run())
+	assert.False(t, called, "attachParentConsole must not run with no args")
+}
+
+// TestAttachParentConsole_NoOpIsSafe calls the real (non-overridden) no-op
+// stub directly. On non-Windows it does nothing; the test exists so the
+// empty body's coverage block is entered (count > 0) rather than reported as
+// an uncovered patch line.
+func TestAttachParentConsole_NoOpIsSafe(t *testing.T) {
+	assert.NotPanics(t, func() { attachParentConsole() })
+}
+
+var assertFailErr = &stringError{"simulated execute failure"}
+
+type stringError struct{ s string }
+
+func (e *stringError) Error() string { return e.s }
+
+func TestWriteCrashLog_CLIWritesStderrOnly(t *testing.T) {
+	withDesktopBuild(t, false)
+	// No crash.log should be written in CLI mode.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	writeCrashLog("cli error")
+	// The desktop data dir is created lazily; in CLI mode writeCrashLog
+	// returns before touching it, so no Javinizer dir should exist.
+	_, err := os.Stat(filepath.Join(tmp, "Library", "Application Support", "Javinizer", "crash.log"))
+	assert.True(t, os.IsNotExist(err), "CLI mode must not write crash.log")
+}
+
+func TestWriteCrashLog_DesktopAppendsTimestampedEntry(t *testing.T) {
+	withDesktopBuild(t, true)
+	t.Setenv("HOME", t.TempDir())
+
+	writeCrashLog("desktop boom")
+
+	dir, err := desktop.UserDataDir()
+	require.NoError(t, err)
+	data, err := os.ReadFile(filepath.Join(dir, "crash.log"))
+	require.NoError(t, err, "crash.log must be created in desktop mode")
+	content := string(data)
+	assert.Contains(t, content, "desktop boom")
+	// RFC3339 timestamp prefix: YYYY-MM-DDTHH:MM:SS...
+	assert.Regexp(t, `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`, strings.TrimSpace(content),
+		"each entry must be prefixed with an RFC3339 timestamp")
+}
+
+// TestWriteCrashLog_DesktopAppendsAcrossCalls verifies the file is appended,
+// not truncated, so a history of pre-GUI crashes is preserved.
+func TestWriteCrashLog_DesktopAppendsAcrossCalls(t *testing.T) {
+	withDesktopBuild(t, true)
+	t.Setenv("HOME", t.TempDir())
+
+	writeCrashLog("first")
+	writeCrashLog("second")
+
+	dir, err := desktop.UserDataDir()
+	require.NoError(t, err)
+	data, err := os.ReadFile(filepath.Join(dir, "crash.log"))
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, "first")
+	assert.Contains(t, content, "second")
+}
+
+// TestWriteCrashLog_DesktopUserDataDirErrorSkipsFile covers the early return
+// when UserDataDir fails: stderr still gets the message, but no file write is
+// attempted (no panic).
+func TestWriteCrashLog_DesktopUserDataDirErrorSkipsFile(t *testing.T) {
+	withDesktopBuild(t, true)
+	// An unset/unwritable HOME makes os.UserHomeDir fail on this platform;
+	// point HOME at a path inside a file (not a dir) so MkdirAll fails.
+	filePath := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o600))
+	t.Setenv("HOME", filePath)
+
+	writeCrashLog("no dir") // must not panic
+}
+
+// TestWriteCrashLog_DesktopOpenFileErrorSkipsWrite covers the early return
+// when the crash.log file cannot be opened for writing (e.g. the path is a
+// directory). stderr still receives the message; no panic.
+func TestWriteCrashLog_DesktopOpenFileErrorSkipsWrite(t *testing.T) {
+	withDesktopBuild(t, true)
+	t.Setenv("HOME", t.TempDir())
+
+	// Pre-create crash.log as a DIRECTORY so OpenFile(O_WRONLY) fails.
+	dir, err := desktop.UserDataDir()
+	require.NoError(t, err)
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "crash.log"), 0o700))
+
+	writeCrashLog("open fails") // must not panic
+}
+
+// TestMain_CallsRunAndExits exercises main()'s single statement (osExit(run()))
+// by stubbing both osExit (so the test process survives) and executeFn (so no
+// real cobra side effects). Captures the exit code osExit was called with.
+func TestMain_CallsRunAndExits(t *testing.T) {
+	withDesktopBuild(t, false)
+	withExecuteFn(t, func() error { return nil })
+
+	var gotCode int
+	origExit := osExit
+	osExit = func(code int) { gotCode = code }
+	t.Cleanup(func() { osExit = origExit })
+
+	main()
+	assert.Equal(t, 0, gotCode, "main must exit with run()'s code on success")
+}
+
+// TestMain_CallsRunAndExitsOnError confirms main propagates a non-zero exit
+// code from run() through osExit.
+func TestMain_CallsRunAndExitsOnError(t *testing.T) {
+	withDesktopBuild(t, false)
+	withExecuteFn(t, func() error { return assertFailErr })
+
+	var gotCode int
+	origExit := osExit
+	osExit = func(code int) { gotCode = code }
+	t.Cleanup(func() { osExit = origExit })
+
+	main()
+	assert.Equal(t, 1, gotCode, "main must exit 1 when run() returns 1")
 }

--- a/cmd/javinizer/main_test.go
+++ b/cmd/javinizer/main_test.go
@@ -43,6 +43,20 @@ func withDesktopBuild(t *testing.T, on bool) {
 	t.Cleanup(func() { desktop.BuildDesktop = orig })
 }
 
+// withIsolatedUserDataDir points all platform user-config env vars at a fresh
+// temp dir so desktop.UserDataDir() returns an isolated, writable path on
+// every platform (Linux: XDG_CONFIG_HOME, macOS: HOME, Windows: APPDATA).
+// Without this, tests on CI share the runner's real config dir and collide
+// (e.g. one test's crash.log file blocks another's os.Mkdir of the same path).
+func withIsolatedUserDataDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("APPDATA", dir)
+	return dir
+}
+
 // withArgs swaps os.Args for the test and restores it on cleanup.
 func withArgs(t *testing.T, args ...string) {
 	t.Helper()
@@ -116,19 +130,20 @@ func (e *stringError) Error() string { return e.s }
 
 func TestWriteCrashLog_CLIWritesStderrOnly(t *testing.T) {
 	withDesktopBuild(t, false)
-	// No crash.log should be written in CLI mode.
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	withIsolatedUserDataDir(t)
 	writeCrashLog("cli error")
-	// The desktop data dir is created lazily; in CLI mode writeCrashLog
-	// returns before touching it, so no Javinizer dir should exist.
-	_, err := os.Stat(filepath.Join(tmp, "Library", "Application Support", "Javinizer", "crash.log"))
+	// In CLI mode writeCrashLog writes only to stderr and returns before
+	// touching UserDataDir, so no crash.log should exist anywhere under the
+	// isolated data dir.
+	dir, err := desktop.UserDataDir()
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, "crash.log"))
 	assert.True(t, os.IsNotExist(err), "CLI mode must not write crash.log")
 }
 
 func TestWriteCrashLog_DesktopAppendsTimestampedEntry(t *testing.T) {
 	withDesktopBuild(t, true)
-	t.Setenv("HOME", t.TempDir())
+	withIsolatedUserDataDir(t)
 
 	writeCrashLog("desktop boom")
 
@@ -147,7 +162,7 @@ func TestWriteCrashLog_DesktopAppendsTimestampedEntry(t *testing.T) {
 // not truncated, so a history of pre-GUI crashes is preserved.
 func TestWriteCrashLog_DesktopAppendsAcrossCalls(t *testing.T) {
 	withDesktopBuild(t, true)
-	t.Setenv("HOME", t.TempDir())
+	withIsolatedUserDataDir(t)
 
 	writeCrashLog("first")
 	writeCrashLog("second")
@@ -166,11 +181,14 @@ func TestWriteCrashLog_DesktopAppendsAcrossCalls(t *testing.T) {
 // attempted (no panic).
 func TestWriteCrashLog_DesktopUserDataDirErrorSkipsFile(t *testing.T) {
 	withDesktopBuild(t, true)
-	// An unset/unwritable HOME makes os.UserHomeDir fail on this platform;
-	// point HOME at a path inside a file (not a dir) so MkdirAll fails.
+	// Point every platform's user-config env var at a path that is a FILE,
+	// not a directory, so desktop.UserDataDir's MkdirAll fails. (Setting only
+	// HOME is insufficient: Linux uses XDG_CONFIG_HOME, Windows uses APPDATA.)
 	filePath := filepath.Join(t.TempDir(), "not-a-dir")
 	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o600))
 	t.Setenv("HOME", filePath)
+	t.Setenv("XDG_CONFIG_HOME", filePath)
+	t.Setenv("APPDATA", filePath)
 
 	writeCrashLog("no dir") // must not panic
 }
@@ -180,7 +198,7 @@ func TestWriteCrashLog_DesktopUserDataDirErrorSkipsFile(t *testing.T) {
 // directory). stderr still receives the message; no panic.
 func TestWriteCrashLog_DesktopOpenFileErrorSkipsWrite(t *testing.T) {
 	withDesktopBuild(t, true)
-	t.Setenv("HOME", t.TempDir())
+	withIsolatedUserDataDir(t)
 
 	// Pre-create crash.log as a DIRECTORY so OpenFile(O_WRONLY) fails.
 	dir, err := desktop.UserDataDir()

--- a/cmd/javinizer/root.go
+++ b/cmd/javinizer/root.go
@@ -69,6 +69,14 @@ func initDesktopDefault() {
 // it is a no-op (cleanup_unix.go).
 
 func init() {
+	// Disable cobra's Windows "mousetrap": when a GUI app is launched by
+	// double-clicking in Explorer, cobra shows a "This is a command line tool.
+	// You need to open cmd.exe and run it from there." dialog and exits without
+	// running the command. The desktop build is a real GUI app (Wails window),
+	// so the mousetrap must be disabled for double-click launches to work.
+	if desktop.IsDesktopBuild() {
+		cobra.MousetrapHelpText = ""
+	}
 	// Customize version template
 	rootCmd.SetVersionTemplate(version.Info() + "\n")
 

--- a/cmd/javinizer/root.go
+++ b/cmd/javinizer/root.go
@@ -63,20 +63,25 @@ func initDesktopDefault() {
 	}
 }
 
+// disableMousetrapForDesktopBuild clears cobra's mousetrap help text for
+// desktop builds so double-click launches open the GUI instead of showing
+// cobra's "This is a command line tool..." dialog and exiting. Extracted from
+// init() so it can be tested: init() runs before any test can toggle
+// BuildDesktop, so the body would otherwise be unreachable in coverage.
+func disableMousetrapForDesktopBuild() {
+	if !desktop.IsDesktopBuild() {
+		return
+	}
+	cobra.MousetrapHelpText = ""
+}
+
 // cleanupStaleWindowsOldExe removes a leftover <exe>.old from a prior
 // interrupted desktop self-upgrade (Windows can't overwrite a running exe).
 // The Windows implementation lives in cleanup_windows.go; on other platforms
 // it is a no-op (cleanup_unix.go).
 
 func init() {
-	// Disable cobra's Windows "mousetrap": when a GUI app is launched by
-	// double-clicking in Explorer, cobra shows a "This is a command line tool.
-	// You need to open cmd.exe and run it from there." dialog and exits without
-	// running the command. The desktop build is a real GUI app (Wails window),
-	// so the mousetrap must be disabled for double-click launches to work.
-	if desktop.IsDesktopBuild() {
-		cobra.MousetrapHelpText = ""
-	}
+	disableMousetrapForDesktopBuild()
 	// Customize version template
 	rootCmd.SetVersionTemplate(version.Info() + "\n")
 

--- a/cmd/javinizer/root_desktop_test.go
+++ b/cmd/javinizer/root_desktop_test.go
@@ -163,3 +163,41 @@ func TestPersistentPreRun_DesktopBuildCustomConfigSkipsPortableEnv(t *testing.T)
 	assert.Empty(t, os.Getenv("JAVINIZER_DB"), "custom --config must skip SetupPortableEnv (no JAVINIZER_DB injection)")
 	assert.Empty(t, os.Getenv("JAVINIZER_LOG_DIR"), "custom --config must skip SetupPortableEnv (no JAVINIZER_LOG_DIR injection)")
 }
+
+// TestDisableMousetrapForDesktopBuild_CLIBuildNoOp verifies that in a CLI
+// build (BuildDesktop="0"), disableMousetrapForDesktopBuild leaves
+// cobra.MousetrapHelpText untouched — the mousetrap only applies to the
+// desktop (GUI) build.
+func TestDisableMousetrapForDesktopBuild_CLIBuildNoOp(t *testing.T) {
+	origBuild := desktop.BuildDesktop
+	origMousetrap := cobra.MousetrapHelpText
+	desktop.BuildDesktop = "0"
+	defer func() {
+		desktop.BuildDesktop = origBuild
+		cobra.MousetrapHelpText = origMousetrap
+	}()
+
+	cobra.MousetrapHelpText = "preset non-empty value"
+	disableMousetrapForDesktopBuild()
+	assert.Equal(t, "preset non-empty value", cobra.MousetrapHelpText,
+		"CLI build must not clear the mousetrap help text")
+}
+
+// TestDisableMousetrapForDesktopBuild_DesktopBuildClears verifies that in a
+// desktop build (BuildDesktop="1"), disableMousetrapForDesktopBuild clears
+// cobra.MousetrapHelpText so double-click launches open the GUI instead of
+// showing cobra's "this is a command line tool" dialog.
+func TestDisableMousetrapForDesktopBuild_DesktopBuildClears(t *testing.T) {
+	origBuild := desktop.BuildDesktop
+	origMousetrap := cobra.MousetrapHelpText
+	desktop.BuildDesktop = "1"
+	defer func() {
+		desktop.BuildDesktop = origBuild
+		cobra.MousetrapHelpText = origMousetrap
+	}()
+
+	cobra.MousetrapHelpText = "This is a command line tool..."
+	disableMousetrapForDesktopBuild()
+	assert.Empty(t, cobra.MousetrapHelpText,
+		"desktop build must clear the mousetrap help text for double-click launches")
+}

--- a/internal/api/core/path_validation.go
+++ b/internal/api/core/path_validation.go
@@ -44,6 +44,25 @@ func validateScanPath(userPath string, cfg *SecurityNarrowConfig) (string, error
 	return v.ValidateDir(userPath)
 }
 
+// validateBrowsePath mirrors validateScanPath but runs the browse validator,
+// which skips the allowlist gate. Used by the browse and autocomplete endpoints
+// so an admin can list directories to configure the allowlist — the bootstrap
+// operation that the (possibly empty or '.'-only) allowlist would otherwise
+// block. The allowlist is a safety guard for file operations (scan/organize),
+// not a restriction on browsing. The denylist still applies.
+func validateBrowsePath(userPath string, cfg *SecurityNarrowConfig) (string, error) {
+	if cfg == nil {
+		return "", fmt.Errorf("validateBrowsePath: security config is required")
+	}
+	v := NewPathValidatorBrowse(
+		afero.NewOsFs(),
+		cfg.DeniedDirectories,
+		cfg.AllowUNC,
+		cfg.AllowedUNCServers,
+	)
+	return v.ValidateDir(userPath)
+}
+
 // getDeniedDirectories returns a list of system directories that should never be scanned
 func getDeniedDirectories() []string {
 	return []string{
@@ -64,6 +83,15 @@ func ValidateScanPath(userPath string, cfg *SecurityNarrowConfig) (string, error
 	return validateScanPath(userPath, cfg)
 }
 
+// ValidateBrowsePath is the browse variant of ValidateScanPath: it skips the
+// allowlist gate so the browse/autocomplete endpoints can list directories
+// outside the allowlist (used to configure the allowlist/denylist). The
+// allowlist is enforced only at file-operation time (scan/organize). The
+// denylist still applies.
+func ValidateBrowsePath(userPath string, cfg *SecurityNarrowConfig) (string, error) {
+	return validateBrowsePath(userPath, cfg)
+}
+
 // ValidateAndOpenPath validates a user-provided path and returns an open *os.File
 // to the validated directory, along with its canonical path.
 //
@@ -81,7 +109,25 @@ func ValidateScanPath(userPath string, cfg *SecurityNarrowConfig) (string, error
 //	defer f.Close()
 //	// Use f.ReadDir() or path (file remains open, preventing swap)
 func ValidateAndOpenPath(userPath string, cfg *SecurityNarrowConfig) (*os.File, string, error) {
-	canonicalPath, err := validateScanPath(userPath, cfg)
+	return validateAndOpenPath(userPath, cfg, false)
+}
+
+// ValidateAndOpenBrowsePath is the browse variant of ValidateAndOpenPath: it
+// skips the allowlist gate so the browse endpoint can list directories outside
+// the allowlist (used to configure the allowlist). The allowlist is enforced
+// only at file-operation time (scan/organize). The denylist still applies.
+func ValidateAndOpenBrowsePath(userPath string, cfg *SecurityNarrowConfig) (*os.File, string, error) {
+	return validateAndOpenPath(userPath, cfg, true)
+}
+
+func validateAndOpenPath(userPath string, cfg *SecurityNarrowConfig, browse bool) (*os.File, string, error) {
+	var canonicalPath string
+	var err error
+	if browse {
+		canonicalPath, err = validateBrowsePath(userPath, cfg)
+	} else {
+		canonicalPath, err = validateScanPath(userPath, cfg)
+	}
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/api/core/path_validator.go
+++ b/internal/api/core/path_validator.go
@@ -40,6 +40,17 @@ type PathValidator struct {
 	// Windows UNC settings
 	allowUNC          bool
 	allowedUNCServers []string
+
+	// enforceAllowlist gates the allowlist checks (step 1 empty-allowlist gate
+	// and step 11 isAllowed). It is true for file-operation validators (scan,
+	// organize, movie compare) where the allowlist is a safety guard, and false
+	// for the browse/autocomplete validator, which lists directories so the
+	// admin can configure the allowlist — restricting listing to the allowlist
+	// would be a catch-22 (you can't browse to add the first directory). The
+	// denylist (built-in /proc, /sys, /dev + config) always applies, and all
+	// other validation (home expansion, cleaning, reserved names, UNC,
+	// canonicalize, exists + type) runs unchanged regardless of this flag.
+	enforceAllowlist bool
 }
 
 // NewPathValidator creates a PathValidator with the given filesystem and access lists.
@@ -47,9 +58,10 @@ type PathValidator struct {
 // An empty allow list denies all access (secure by default).
 func NewPathValidator(fs afero.Fs, allow, deny []string) *PathValidator {
 	return &PathValidator{
-		fs:    fs,
-		allow: allow,
-		deny:  deny,
+		fs:               fs,
+		allow:            allow,
+		deny:             deny,
+		enforceAllowlist: true,
 	}
 }
 
@@ -61,6 +73,24 @@ func NewPathValidatorWithUNC(fs afero.Fs, allow, deny []string, allowUNC bool, a
 		deny:              deny,
 		allowUNC:          allowUNC,
 		allowedUNCServers: allowedUNCServers,
+		enforceAllowlist:  true,
+	}
+}
+
+// NewPathValidatorBrowse creates a PathValidator for directory listing
+// (browse/autocomplete): the allowlist is not enforced, so any directory can
+// be listed. The denylist still applies. The allowlist is a safety guard for
+// file operations (scan/organize), not a restriction on browsing to
+// configure it — enforcing it on browse would be a catch-22 (you can't browse
+// to add the first allowed directory, or to add a directory on another drive).
+func NewPathValidatorBrowse(fs afero.Fs, deny []string, allowUNC bool, allowedUNCServers []string) *PathValidator {
+	return &PathValidator{
+		fs:                fs,
+		allow:             nil,
+		deny:              deny,
+		allowUNC:          allowUNC,
+		allowedUNCServers: allowedUNCServers,
+		enforceAllowlist:  false,
 	}
 }
 
@@ -86,19 +116,24 @@ const (
 
 // validate runs the shared pipeline and then checks the path type.
 func (v *PathValidator) validate(userPath string, target validateTarget) (string, error) {
-	// Step 1: Allowlist gate — deny by default when empty
-	if len(v.allow) == 0 {
-		return "", apperrors.ErrAllowedDirsEmpty
-	}
-	hasValidEntry := false
-	for _, dir := range v.allow {
-		if strings.TrimSpace(dir) != "" {
-			hasValidEntry = true
-			break
+	// Step 1: Allowlist gate — deny by default when empty. Skipped for the
+	// browse validator (enforceAllowlist=false), where the whole point is
+	// listing directories to configure the allowlist. The denylist (step 12)
+	// still applies.
+	if v.enforceAllowlist {
+		if len(v.allow) == 0 {
+			return "", apperrors.ErrAllowedDirsEmpty
 		}
-	}
-	if !hasValidEntry {
-		return "", apperrors.ErrAllowedDirsEmpty
+		hasValidEntry := false
+		for _, dir := range v.allow {
+			if strings.TrimSpace(dir) != "" {
+				hasValidEntry = true
+				break
+			}
+		}
+		if !hasValidEntry {
+			return "", apperrors.ErrAllowedDirsEmpty
+		}
 	}
 
 	// Step 2: Expand home directory
@@ -154,8 +189,8 @@ func (v *PathValidator) validate(userPath string, target validateTarget) (string
 	// Step 10: Windows — normalize path for platform comparison
 	canonicalPath = normalizePathForPlatform(canonicalPath)
 
-	// Step 11: Allowlist check
-	if !v.isAllowed(canonicalPath) {
+	// Step 11: Allowlist check. Skipped for the browse validator (see Step 1).
+	if v.enforceAllowlist && !v.isAllowed(canonicalPath) {
 		return "", apperrors.NewPathError(apperrors.ErrPathOutsideAllowed, canonicalPath)
 	}
 

--- a/internal/api/core/path_validator_browse_test.go
+++ b/internal/api/core/path_validator_browse_test.go
@@ -1,0 +1,112 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+// TestPathValidator_BrowseBypassesEmptyAllowlist is the catch-22 regression:
+// a non-picker validator with an empty allowlist rejects every path, so the
+// browse endpoint can never list a directory to add. Browse mode must accept
+// the same path (denylist still applies — see the next test).
+func TestPathValidator_BrowseBypassesEmptyAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &SecurityNarrowConfig{AllowedDirectories: nil, DeniedDirectories: nil}
+
+	if _, err := ValidateScanPath(dir, cfg); err == nil {
+		t.Fatal("non-picker ValidateScanPath with empty allowlist should reject, got nil error")
+	}
+	// macOS t.TempDir() lives under /var which symlinks to /private/var; the
+	// validator canonicalizes, so compare against the resolved path.
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		canonical = dir
+	}
+	if got, err := ValidateBrowsePath(dir, cfg); err != nil {
+		t.Fatalf("picker ValidateBrowsePath should accept with empty allowlist: %v", err)
+	} else if got != canonical {
+		t.Errorf("picker returned %q, want %q", got, canonical)
+	}
+}
+
+// TestPathValidator_BrowseStillEnforcesDenylist asserts that picker mode keeps
+// the denylist — even when browsing to configure the allowlist, sensitive
+// system directories (/proc, /sys, /dev) and config-denied paths stay blocked.
+func TestPathValidator_BrowseStillEnforcesDenylist(t *testing.T) {
+	allowed := t.TempDir()
+	denied := t.TempDir()
+	cfg := &SecurityNarrowConfig{
+		AllowedDirectories: []string{allowed},
+		DeniedDirectories:  []string{denied},
+	}
+
+	if _, err := ValidateBrowsePath(denied, cfg); err == nil {
+		t.Fatal("picker should still reject config-denied directories")
+	}
+}
+
+// TestPathValidator_BrowseRejectsNonExistent confirms picker mode still runs
+// the exists + is-dir checks (it is not an unconditional pass-through).
+func TestPathValidator_BrowseRejectsNonExistent(t *testing.T) {
+	cfg := &SecurityNarrowConfig{}
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if _, err := ValidateBrowsePath(missing, cfg); err == nil {
+		t.Fatal("picker should reject a non-existent path")
+	}
+}
+
+// TestValidateAndOpenBrowsePath_OpenHandle verifies the TOCTOU-safe picker
+// variant returns an open file handle the caller must close.
+func TestValidateAndOpenBrowsePath_OpenHandle(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &SecurityNarrowConfig{}
+	f, got, err := ValidateAndOpenBrowsePath(dir, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		canonical = dir
+	}
+	if got != canonical {
+		t.Errorf("returned path = %q, want %q", got, canonical)
+	}
+	if _, err := f.Stat(); err != nil {
+		t.Errorf("returned file is not usable: %v", err)
+	}
+}
+
+// TestNewPathValidatorBrowse_Flags asserts the constructor wires picker mode
+// without an allowlist but preserves the denylist + UNC settings.
+func TestNewPathValidatorBrowse_Flags(t *testing.T) {
+	v := NewPathValidatorBrowse(afero.NewOsFs(), []string{"/denied"}, true, []string{"srv"})
+	if !!v.enforceAllowlist {
+		t.Error("picker flag not set")
+	}
+	if len(v.allow) != 0 {
+		t.Errorf("allowlist should be empty, got %v", v.allow)
+	}
+	if len(v.deny) != 1 || v.deny[0] != "/denied" {
+		t.Errorf("denylist not preserved, got %v", v.deny)
+	}
+	if !v.allowUNC {
+		t.Error("allowUNC not preserved")
+	}
+}
+
+// TestValidateAndOpenBrowsePath_RealProcDenied is a smoke test that on Linux
+// the built-in denylist blocks /proc even in picker mode. Skipped on non-Linux
+// where /proc does not exist.
+func TestValidateAndOpenBrowsePath_RealProcDenied(t *testing.T) {
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("/proc not present on this platform")
+	}
+	cfg := &SecurityNarrowConfig{}
+	if _, err := ValidateBrowsePath("/proc", cfg); err == nil {
+		t.Fatal("picker should reject the built-in denied directory /proc")
+	}
+}

--- a/internal/api/core/path_validator_browse_test.go
+++ b/internal/api/core/path_validator_browse_test.go
@@ -58,6 +58,22 @@ func TestPathValidator_BrowseRejectsNonExistent(t *testing.T) {
 	}
 }
 
+// TestValidateBrowsePath_NilConfigErrors covers the nil-config guard: a nil
+// security config must produce an explicit error rather than dereferencing it.
+func TestValidateBrowsePath_NilConfigErrors(t *testing.T) {
+	if _, err := ValidateBrowsePath(t.TempDir(), nil); err == nil {
+		t.Fatal("ValidateBrowsePath with nil config must return an error")
+	}
+}
+
+// TestValidateAndOpenBrowsePath_NilConfigErrors covers the nil-config guard on
+// the TOCTOU-safe browse variant too.
+func TestValidateAndOpenBrowsePath_NilConfigErrors(t *testing.T) {
+	if _, _, err := ValidateAndOpenBrowsePath(t.TempDir(), nil); err == nil {
+		t.Fatal("ValidateAndOpenBrowsePath with nil config must return an error")
+	}
+}
+
 // TestValidateAndOpenBrowsePath_OpenHandle verifies the TOCTOU-safe picker
 // variant returns an open file handle the caller must close.
 func TestValidateAndOpenBrowsePath_OpenHandle(t *testing.T) {

--- a/internal/api/file/autocomplete.go
+++ b/internal/api/file/autocomplete.go
@@ -36,6 +36,9 @@ func autocompletePath(rt *core.APIRuntime) gin.HandlerFunc {
 		}
 
 		apiCfg := rt.GetAPIConfig()
+		// Autocomplete never enforces the allowlist (see browse.go): the allowlist
+		// is a safety guard for file operations, not for path completion. The
+		// denylist still applies.
 		basePath, fragment, err := resolveAutocompleteBasePath(req.Path, apiCfg.SecurityConfig())
 		if err != nil {
 			apperrors.WriteAPIError(c, err)
@@ -111,7 +114,9 @@ func resolveAutocompleteBasePath(userPath string, cfg *core.SecurityNarrowConfig
 		}
 	}
 
-	validBasePath, err := core.ValidateScanPath(basePath, cfg)
+	// Autocomplete never enforces the allowlist (see browse.go): the allowlist
+	// is a safety guard for file operations, not for path completion.
+	validBasePath, err := core.ValidateBrowsePath(basePath, cfg)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/api/file/browse.go
+++ b/internal/api/file/browse.go
@@ -31,12 +31,26 @@ func browseDirectory(rt *core.APIRuntime) gin.HandlerFunc {
 		}
 
 		if req.Path == "" {
-			req.Path, _ = os.Getwd()
+			// Default to the user's home — the most likely place for a videos
+			// folder — rather than the process CWD (which for the desktop app is
+			// wherever it launched from, often System32).
+			if home, err := os.UserHomeDir(); err == nil && home != "" {
+				req.Path = home
+			}
+			if req.Path == "" {
+				req.Path, _ = os.Getwd()
+			}
 		}
 
 		apiCfg := rt.GetAPIConfig()
 
-		dirFile, validPath, err := core.ValidateAndOpenPath(req.Path, apiCfg.SecurityConfig())
+		// Browse never enforces the allowlist: the allowlist is a safety guard
+		// for file operations (scan/organize), not a restriction on listing
+		// directories to configure it. Enforcing it here would be a catch-22
+		// (you can't browse to add the first allowed directory, or to add a
+		// directory on another drive like D:\). The denylist (/proc, /sys, /dev
+		// + config) still applies.
+		dirFile, validPath, err := core.ValidateAndOpenBrowsePath(req.Path, apiCfg.SecurityConfig())
 		if err != nil {
 			apperrors.WriteAPIError(c, err)
 			return

--- a/internal/api/file/browse_security_model_test.go
+++ b/internal/api/file/browse_security_model_test.go
@@ -1,0 +1,145 @@
+package file
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	contracts "github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+)
+
+// These tests encode the security model: the allowlist is a safety guard for
+// file OPERATIONS (scan/organize), not a restriction on BROWSING. Browse and
+// autocomplete never enforce the allowlist — otherwise configuring the
+// allowlist is a catch-22 (you can't browse to add the first directory, or to
+// add a directory on another drive like D:\). The denylist (/proc, /sys, /dev
+// + config) still applies. This holds regardless of install environment.
+
+func newBrowseTestRouter(t *testing.T, allowedDirs []string) (*gin.Engine, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "videos"), 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "movies"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("x"), 0644))
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.API.Security.AllowedDirectories = allowedDirs
+
+	deps := newTestDepsFromConfig(cfg)
+	router := gin.New()
+	router.POST("/browse", browseDirectory(testkit.GetTestRuntime(deps)))
+	router.POST("/browse/autocomplete", autocompletePath(testkit.GetTestRuntime(deps)))
+	return router, dir
+}
+
+// TestBrowse_NeverEnforcesAllowlist_EmptyAllowlist: first-time setup (no
+// allowed dirs) — browse must still list the directory.
+func TestBrowse_NeverEnforcesAllowlist_EmptyAllowlist(t *testing.T) {
+	router, dir := newBrowseTestRouter(t, nil)
+	canonical, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(contracts.BrowseRequest{Path: dir})
+	req := httptest.NewRequest("POST", "/browse", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var resp contracts.BrowseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, canonical, resp.CurrentPath)
+	assert.Len(t, resp.Items, 3, "videos, movies, readme.txt")
+}
+
+// TestBrowse_NeverEnforcesAllowlist_DotOnlyAllowlist: the default desktop
+// config (allowed_directories: ['.']) — browse must list a directory outside
+// the CWD (the Windows D:\ catch-22).
+func TestBrowse_NeverEnforcesAllowlist_DotOnlyAllowlist(t *testing.T) {
+	router, dir := newBrowseTestRouter(t, []string{"."})
+	canonical, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(contracts.BrowseRequest{Path: dir})
+	req := httptest.NewRequest("POST", "/browse", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code,
+		"browse must not enforce the allowlist even when it is '.'; body=%s", w.Body.String())
+	var resp contracts.BrowseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, canonical, resp.CurrentPath)
+}
+
+// TestAutocomplete_NeverEnforcesAllowlist: autocomplete must return
+// suggestions regardless of the allowlist (empty here).
+func TestAutocomplete_NeverEnforcesAllowlist(t *testing.T) {
+	router, dir := newBrowseTestRouter(t, nil)
+
+	// Trailing separator → list contents of dir, fragment "" → all dirs.
+	body, _ := json.Marshal(contracts.PathAutocompleteRequest{Path: dir + string(os.PathSeparator)})
+	req := httptest.NewRequest("POST", "/browse/autocomplete", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var resp contracts.PathAutocompleteResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	names := make([]string, 0, len(resp.Suggestions))
+	for _, s := range resp.Suggestions {
+		names = append(names, s.Name)
+	}
+	assert.Contains(t, names, "videos")
+	assert.Contains(t, names, "movies")
+	assert.NotContains(t, names, "readme.txt", "only directories are suggested")
+}
+
+// TestAutocomplete_NeverEnforcesAllowlist_FragmentFilter: typing a partial
+// path filters by the fragment even with an empty allowlist.
+func TestAutocomplete_NeverEnforcesAllowlist_FragmentFilter(t *testing.T) {
+	router, dir := newBrowseTestRouter(t, nil)
+
+	body, _ := json.Marshal(contracts.PathAutocompleteRequest{Path: filepath.Join(dir, "vi")})
+	req := httptest.NewRequest("POST", "/browse/autocomplete", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var resp contracts.PathAutocompleteResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Suggestions, 1, "only 'videos' matches fragment 'vi'")
+	assert.Equal(t, "videos", resp.Suggestions[0].Name)
+}
+
+// TestBrowse_StillEnforcesDenylist: even without the allowlist, the denylist
+// (built-in /proc, /sys, /dev) still blocks sensitive system directories.
+func TestBrowse_StillEnforcesDenylist(t *testing.T) {
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("/proc not present on this platform")
+	}
+	router, _ := newBrowseTestRouter(t, nil)
+
+	body, _ := json.Marshal(contracts.BrowseRequest{Path: "/proc"})
+	req := httptest.NewRequest("POST", "/browse", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusOK, w.Code,
+		"denylist must still block /proc even without the allowlist")
+}

--- a/internal/api/file/browse_security_model_test.go
+++ b/internal/api/file/browse_security_model_test.go
@@ -143,3 +143,27 @@ func TestBrowse_StillEnforcesDenylist(t *testing.T) {
 	assert.NotEqual(t, http.StatusOK, w.Code,
 		"denylist must still block /proc even without the allowlist")
 }
+
+// TestBrowse_EmptyPathFallsBackToGetwd covers the os.Getwd() fallback in the
+// empty-path branch: when os.UserHomeDir() is unavailable (HOME unset), the
+// handler must fall back to the process working directory rather than fail.
+func TestBrowse_EmptyPathFallsBackToGetwd(t *testing.T) {
+	router, _ := newBrowseTestRouter(t, nil)
+
+	// Force os.UserHomeDir() to fail so the Getwd fallback is taken. On Unix
+	// an empty HOME makes UserHomeDir return ("", error); on Windows the same
+	// applies via USERPROFILE. t.Setenv restores them after the test.
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+
+	body, _ := json.Marshal(contracts.BrowseRequest{Path: ""})
+	req := httptest.NewRequest("POST", "/browse", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// The test process's CWD is a real, non-denied directory, so the Getwd
+	// fallback must resolve it and return a listing (200), not an error.
+	assert.Equal(t, http.StatusOK, w.Code,
+		"empty path with no home dir must fall back to Getwd and succeed")
+}

--- a/internal/api/file/handlers_test.go
+++ b/internal/api/file/handlers_test.go
@@ -472,6 +472,18 @@ func TestBrowseDirectory(t *testing.T) {
 	}
 }
 
+// homeOutsideAllowlist returns a real directory outside the test's temp
+// allowlist on every platform: the user home dir (falling back to TempDir if
+// unset). Used by the browse allowlist tests so they run on Windows, where
+// /etc and /tmp don't exist.
+func homeOutsideAllowlist(t *testing.T) string {
+	t.Helper()
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return home
+	}
+	return os.TempDir()
+}
+
 func TestBrowseDirectory_AllowlistNotEnforced(t *testing.T) {
 	// Security model: browse never enforces the allowlist. The allowlist is a
 	// safety guard for file OPERATIONS (scan/organize), not a restriction on
@@ -494,8 +506,10 @@ func TestBrowseDirectory_AllowlistNotEnforced(t *testing.T) {
 		skipProc bool
 	}{
 		// Paths outside the allowlist but real and not denied → listed (200).
-		{"etc outside allowlist", "/etc", true, false},
-		{"tmp outside allowlist", "/tmp", true, false},
+		// /etc and /tmp are Unix-only; use TempDir/UserHomeDir so the cases
+		// run on Windows too (where those paths don't exist).
+		{"temp root outside allowlist", os.TempDir(), true, false},
+		{"home outside allowlist", homeOutsideAllowlist(t), true, false},
 		{"traversal resolves to parent", filepath.Join(tempDir, ".."), true, false},
 		// Denylist (built-in /dev) → rejected even without the allowlist.
 		{"dev is denied by denylist", "/dev", false, false},

--- a/internal/api/file/handlers_test.go
+++ b/internal/api/file/handlers_test.go
@@ -409,12 +409,12 @@ func TestBrowseDirectory(t *testing.T) {
 			expectedStatus: 400,
 		},
 		{
-			name: "browse with empty path defaults to cwd",
+			name: "browse with empty path defaults to home",
 			setupFiles: func(_ *testing.T, tempDir string) string {
 				return ""
 			},
 			requestBody:    contracts.BrowseRequest{Path: ""},
-			expectedStatus: 403,
+			expectedStatus: 200,
 		},
 		{
 			name: "invalid JSON",
@@ -472,36 +472,40 @@ func TestBrowseDirectory(t *testing.T) {
 	}
 }
 
-func TestBrowseDirectory_PathTraversalPrevention(t *testing.T) {
-	// CRITICAL: Create temp directory and configure allowlist
-	// DefaultConfig(nil, nil) has empty AllowedDirectories, which allows traversal to parent directories
-	// This test must verify that paths outside the allowlist are rejected
+func TestBrowseDirectory_AllowlistNotEnforced(t *testing.T) {
+	// Security model: browse never enforces the allowlist. The allowlist is a
+	// safety guard for file OPERATIONS (scan/organize), not a restriction on
+	// browsing to configure it. Paths outside the allowlist return 200 (the
+	// directory is listed). The denylist (/proc, /sys, /dev + config) still
+	// applies, and non-existent paths still error.
 	tempDir := t.TempDir()
 
 	cfg := config.DefaultConfig(nil, nil)
-	cfg.API.Security.AllowedDirectories = []string{tempDir} // Only allow tempDir
+	cfg.API.Security.AllowedDirectories = []string{tempDir} // allowlist covers only tempDir
 
 	deps := newTestDepsFromConfig(cfg)
 	router := gin.New()
 	router.POST("/browse", browseDirectory(testkit.GetTestRuntime(deps)))
 
-	maliciousPaths := []string{
-		// Relative traversal attempts (from tempDir context)
-		filepath.Join(tempDir, "../../../etc"),                           // Try to escape to /etc
-		filepath.Join(tempDir, "..\\..\\..\\windows"),                    // Windows-style escape
-		filepath.Join(tempDir, "..", "..", ".."),                         // Multiple parent dirs
-		filepath.Join(tempDir, "..", filepath.Base(tempDir), "..", ".."), // Navigate back then escape
-
-		// Absolute paths outside allowlist
-		"/etc",        // Unix system directory
-		"/tmp",        // Different directory
-		"C:\\Windows", // Windows system directory
-		"/Users",      // Common parent directory
+	cases := []struct {
+		name     string
+		path     string
+		wantOK   bool // true = expect 200, false = expect non-200 (denied/missing)
+		skipProc bool
+	}{
+		// Paths outside the allowlist but real and not denied → listed (200).
+		{"etc outside allowlist", "/etc", true, false},
+		{"tmp outside allowlist", "/tmp", true, false},
+		{"traversal resolves to parent", filepath.Join(tempDir, ".."), true, false},
+		// Denylist (built-in /dev) → rejected even without the allowlist.
+		{"dev is denied by denylist", "/dev", false, false},
+		// Non-existent path → error (not 200).
+		{"non-existent path errors", filepath.Join(tempDir, "no-such-dir"), false, false},
 	}
 
-	for _, maliciousPath := range maliciousPaths {
-		t.Run("PathTraversal:"+maliciousPath, func(t *testing.T) {
-			reqBody := contracts.BrowseRequest{Path: maliciousPath}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqBody := contracts.BrowseRequest{Path: tc.path}
 			body, err := json.Marshal(reqBody)
 			require.NoError(t, err)
 
@@ -511,25 +515,13 @@ func TestBrowseDirectory_PathTraversalPrevention(t *testing.T) {
 
 			router.ServeHTTP(w, req)
 
-			// Path traversal should be explicitly denied with 403 or 400, not just "not 500"
-			// This prevents regression where handler returns 200 with sensitive data
-			assert.True(t, w.Code == 403 || w.Code == 400,
-				"Expected 403 (Forbidden) or 400 (Bad Request) for path traversal attempt, got %d", w.Code)
-
-			// Verify error response contains appropriate message
-			var response contracts.ErrorResponse
-			err = json.Unmarshal(w.Body.Bytes(), &response)
-			require.NoError(t, err, "Response should be valid JSON error")
-			assert.NotEmpty(t, response.Error, "Error message should be present")
-
-			// Accept various security-related error messages (access denied, path not exist, etc.)
-			errorLower := strings.ToLower(response.Error)
-			hasSecurityError := strings.Contains(errorLower, "access denied") ||
-				strings.Contains(errorLower, "path does not exist") ||
-				strings.Contains(errorLower, "forbidden") ||
-				strings.Contains(errorLower, "not allowed")
-			assert.True(t, hasSecurityError,
-				"Error message should indicate security rejection for path: %s, got: %s", maliciousPath, response.Error)
+			if tc.wantOK {
+				assert.Equal(t, 200, w.Code,
+					"browse must not enforce the allowlist (path outside allowlist should still list); body=%s", w.Body.String())
+			} else {
+				assert.NotEqual(t, 200, w.Code,
+					"denylist/non-existent paths must not be listed; got %d for %q", w.Code, tc.path)
+			}
 		})
 	}
 }
@@ -642,8 +634,17 @@ func TestAutocompletePath(t *testing.T) {
 	})
 }
 
-func TestAutocompletePath_PathTraversalPrevention(t *testing.T) {
+func TestAutocompletePath_PathTraversalResolved(t *testing.T) {
+	// Under the security model, browse/autocomplete never enforce the allowlist
+	// (the allowlist is a safety guard for file OPERATIONS like scan/organize,
+	// not a restriction on browsing to configure it). Path traversal (..) is
+	// still canonicalized — so there is no hidden traversal — but it is not
+	// rejected; it resolves to the canonical parent. Allowlist enforcement lives
+	// at scan (see scan.go).
 	tempDir := t.TempDir()
+	parentDir := filepath.Dir(tempDir)
+	canonicalParent, err := filepath.EvalSymlinks(parentDir)
+	require.NoError(t, err)
 
 	cfg := config.DefaultConfig(nil, nil)
 	cfg.API.Security.AllowedDirectories = []string{tempDir}
@@ -664,11 +665,14 @@ func TestAutocompletePath_PathTraversalPrevention(t *testing.T) {
 
 	router.ServeHTTP(w, req)
 
-	assert.True(t, w.Code == 400 || w.Code == 403, "expected security rejection, got %d", w.Code)
-
-	var response contracts.ErrorResponse
+	// Browse does not reject traversal — it resolves it. The base path is the
+	// canonical parent (.. resolved), not the raw traversal string.
+	require.Equal(t, 200, w.Code, w.Body.String())
+	var response contracts.PathAutocompleteResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	assert.NotEmpty(t, response.Error)
+	assert.Equal(t, canonicalParent, response.BasePath,
+		".. must be canonicalized to the resolved parent, not left as a raw traversal")
+	assert.Equal(t, "etc", filepath.Base(reqBody.Path))
 }
 
 func TestScanDirectory_LargeDirectory(t *testing.T) {

--- a/internal/desktop/proxy.go
+++ b/internal/desktop/proxy.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strings"
 )
 
 // newReverseProxyHandler forwards every request from the Wails internal
@@ -46,7 +45,12 @@ func newReverseProxyHandler(target string) http.Handler {
 		},
 		ModifyResponse: rewriteSessionCookies,
 	}
-	wsURL := strings.Replace(target, "http://127.0.0.1", "ws://localhost", 1) + "/ws/progress"
+	// Derive the WS URL from the parsed target so it stays consistent with
+	// the proxy destination and doesn't depend on target's exact string
+	// prefix. The webview connects directly (the Wails AssetServer 501s WS
+	// upgrades); localhost (not 127.0.0.1) so the upgrader's CheckOrigin and
+	// the browser's same-origin policy are happy.
+	wsURL := (&url.URL{Scheme: "ws", Host: "localhost:" + parsed.Port(), Path: "/ws/progress"}).String()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/desktop/runtime" {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/desktop/proxy.go
+++ b/internal/desktop/proxy.go
@@ -1,9 +1,11 @@
 package desktop
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 )
 
 // newReverseProxyHandler forwards every request from the Wails internal
@@ -20,10 +22,10 @@ import (
 // WebSocket upgrades are NOT proxied: the Wails AssetServer answers any
 // "Upgrade: websocket" request with 501 Not Implemented in its own ServeHTTP
 // (pkg/assetserver/assetserver.go) before this handler — or any Middleware —
-// is invoked. Real-time progress via /ws/progress is therefore a known desktop
-// limitation; the REST API and SPA load normally. Restoring WS would require
-// either a Wails-level fix or the frontend connecting directly to
-// 127.0.0.1:PORT.
+// is invoked. Instead, the frontend fetches GET /desktop/runtime (handled
+// below) to learn the WS URL, then connects directly to
+// ws://localhost:PORT/ws/progress?session=SID. See ws_origin.go for the
+// upgrader override that accepts the cross-origin webview.
 //
 //nolint:unused // referenced only by app.go, which is //go:build desktop
 func newReverseProxyHandler(target string) http.Handler {
@@ -35,7 +37,7 @@ func newReverseProxyHandler(target string) http.Handler {
 			http.Error(w, "desktop: invalid proxy target", http.StatusBadGateway)
 		})
 	}
-	return &httputil.ReverseProxy{
+	proxy := &httputil.ReverseProxy{
 		Rewrite: func(req *httputil.ProxyRequest) {
 			req.SetURL(parsed)
 			req.SetXForwarded()
@@ -44,6 +46,15 @@ func newReverseProxyHandler(target string) http.Handler {
 		},
 		ModifyResponse: rewriteSessionCookies,
 	}
+	wsURL := strings.Replace(target, "http://127.0.0.1", "ws://localhost", 1) + "/ws/progress"
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/desktop/runtime" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"ws_url": wsURL})
+			return
+		}
+		proxy.ServeHTTP(w, r)
+	})
 }
 
 // rewriteSessionCookies rewrites Set-Cookie headers from the API server so the

--- a/internal/desktop/proxy_runtime_test.go
+++ b/internal/desktop/proxy_runtime_test.go
@@ -1,0 +1,77 @@
+package desktop
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewReverseProxyHandler_DesktopRuntimeReturnsWSURL(t *testing.T) {
+	// The proxy target mirrors ServerInstance.BaseURL: http://127.0.0.1:PORT.
+	// /desktop/runtime must surface ws://localhost:PORT/ws/progress so the
+	// frontend can connect directly (the Wails AssetServer 501s WS upgrades).
+	h := newReverseProxyHandler("http://127.0.0.1:62041")
+
+	req := httptest.NewRequest(http.MethodGet, "/desktop/runtime", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got struct {
+		WSURL string `json:"ws_url"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	want := "ws://localhost:62041/ws/progress"
+	if got.WSURL != want {
+		t.Errorf("ws_url = %q, want %q", got.WSURL, want)
+	}
+}
+
+func TestNewReverseProxyHandler_DesktopRuntimeNotForwarded(t *testing.T) {
+	// /desktop/runtime must be answered by the proxy itself, never forwarded
+	// to the API server (which does not know this route).
+	forwarded := false
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwarded = true
+	}))
+	defer backend.Close()
+
+	h := newReverseProxyHandler(backend.URL)
+	req := httptest.NewRequest(http.MethodGet, "/desktop/runtime", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if forwarded {
+		t.Error("/desktop/runtime was forwarded to the backend; the proxy must short-circuit it")
+	}
+}
+
+// TestNewReverseProxyHandler_NonRuntimePathsStillForward is a regression guard:
+// wrapping the reverse proxy to serve /desktop/runtime must not break normal
+// forwarding (the existing proxy tests cover this in detail; this asserts the
+// wrapper passes an arbitrary API path through).
+func TestNewReverseProxyHandler_NonRuntimePathsStillForward(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = io.WriteString(w, "backend-ok")
+	}))
+	defer backend.Close()
+
+	h := newReverseProxyHandler(backend.URL)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/status", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want %d (path should be forwarded)", w.Code, http.StatusTeapot)
+	}
+}

--- a/internal/desktop/server.go
+++ b/internal/desktop/server.go
@@ -88,6 +88,13 @@ func StartServer(ctx context.Context, configFile string) (*ServerInstance, error
 	deps.CoreDeps.SetInstallEnvironment(system.EnvironmentDesktop)
 
 	router := apiserver.NewServer(rt)
+
+	// The desktop webview connects to /ws/progress directly at 127.0.0.1:PORT
+	// (the Wails AssetServer returns 501 for WS upgrades, so the reverse proxy
+	// cannot carry them). That connection is cross-origin, so override the
+	// upgrader to accept the desktop webview origins. See ws_origin.go.
+	rt.EnsureRuntime().SetWebSocketUpgrader(desktopWSUpgrader())
+
 	apiserver.LogServerInfo(cfg)
 
 	srv := &http.Server{

--- a/internal/desktop/ws_origin.go
+++ b/internal/desktop/ws_origin.go
@@ -1,0 +1,52 @@
+package desktop
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+// desktopWSUpgrader returns a websocket.Upgrader whose CheckOrigin accepts the
+// desktop webview origins.
+//
+// The Wails AssetServer answers "Upgrade: websocket" requests with 501 before
+// any handler or middleware runs (pkg/assetserver/assetserver.go), so the
+// reverse proxy cannot carry WS upgrades. The frontend therefore connects to
+// /ws/progress directly at 127.0.0.1:PORT instead of through the proxy. That
+// connection is cross-origin — the webview loads from wails:// (macOS) or
+// http(s)://wails.localhost (Windows/Linux) — so the standard same-origin
+// CheckOrigin configured by apiserver.NewServer would reject it. This override
+// accepts the desktop webview origins.
+//
+// Relaxing the origin check is safe here: the server binds to 127.0.0.1 only
+// (never exposed to the network) and /ws/progress still requires a valid
+// session ID, which the frontend passes as a ?session= query parameter (the
+// browser cannot set custom headers on a WebSocket). A malicious site would
+// need both the random ephemeral port and a valid session to do anything.
+func desktopWSUpgrader() websocket.Upgrader {
+	return websocket.Upgrader{
+		CheckOrigin: checkDesktopWSOrigin,
+	}
+}
+
+func checkDesktopWSOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	// macOS WKWebView loads the SPA from a custom wails:// scheme.
+	if strings.EqualFold(u.Scheme, "wails") {
+		return true
+	}
+	switch u.Hostname() {
+	case "localhost", "127.0.0.1", "::1", "wails.localhost":
+		return true
+	}
+	return false
+}

--- a/internal/desktop/ws_origin_test.go
+++ b/internal/desktop/ws_origin_test.go
@@ -1,0 +1,46 @@
+package desktop
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckDesktopWSOrigin(t *testing.T) {
+	cases := []struct {
+		name   string
+		origin string
+		want   bool
+	}{
+		{"empty origin (non-browser client)", "", true},
+		{"macOS wails scheme", "wails://wails.localhost", true},
+		{"Windows wails.localhost http", "http://wails.localhost", true},
+		{"Linux wails.localhost https", "https://wails.localhost", true},
+		{"localhost", "http://localhost:5173", true},
+		{"loopback ipv4", "http://127.0.0.1:8080", true},
+		{"loopback ipv6", "http://[::1]:8080", true},
+		{"external site rejected", "https://evil.example.com", false},
+		{"malformed origin rejected", "://not-a-url", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			got := checkDesktopWSOrigin(req)
+			if got != tc.want {
+				t.Errorf("checkDesktopWSOrigin(origin=%q) = %v, want %v", tc.origin, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDesktopWSUpgrader_CheckOriginAcceptsWails(t *testing.T) {
+	u := desktopWSUpgrader()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "wails://wails.localhost")
+	if !u.CheckOrigin(req) {
+		t.Fatal("upgrader CheckOrigin must accept the macOS wails:// webview origin")
+	}
+}

--- a/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
+++ b/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
@@ -31,8 +31,6 @@
 	let browserPath = $state('');
 	let browserInitialPath = $state('');
 
-	let canBrowse = $derived(whitelistPaths.length > 0);
-
 	function addDir(e?: Event) {
 		e?.preventDefault();
 		const path = newDir.trim();
@@ -60,7 +58,10 @@
 	}
 
 	function openBrowser() {
-		browserInitialPath = newDir.trim() || whitelistPaths[0] || '/';
+		// Start at the typed path, else the first allowed dir, else the user's
+		// home (~) — a useful default when the allowlist is empty (first-time
+		// setup) rather than '/' which buries videos folders several levels deep.
+		browserInitialPath = newDir.trim() || whitelistPaths[0] || '~';
 		browserPath = browserInitialPath;
 		showBrowser = true;
 	}
@@ -131,21 +132,19 @@
 			class="flex-1"
 			onnavigate={() => addDir()}
 		/>
-		{#if canBrowse}
-			<Button
-				variant="outline"
-				size="sm"
-				type="button"
-				onclick={openBrowser}
-				title="Browse for a directory"
-				aria-label="Browse for a directory"
-			>
-				{#snippet children()}
-					<FolderOpen class="h-4 w-4" />
-					<span class="hidden sm:inline">Browse</span>
-				{/snippet}
-			</Button>
-		{/if}
+		<Button
+			variant="outline"
+			size="sm"
+			type="button"
+			onclick={openBrowser}
+			title="Browse for a directory"
+			aria-label="Browse for a directory"
+		>
+			{#snippet children()}
+				<FolderOpen class="h-4 w-4" />
+				<span class="hidden sm:inline">Browse</span>
+			{/snippet}
+		</Button>
 		<Button
 			variant="outline"
 			size="sm"

--- a/web/frontend/src/lib/stores/websocket.test.ts
+++ b/web/frontend/src/lib/stores/websocket.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Override the $app/environment stub (which hardcodes browser=false) so the
+// store takes the desktop branch. The wails: protocol makes isDesktopApp()
+// return true.
+vi.mock('$app/environment', () => ({ browser: true }));
+
+// Avoid toast side effects and provide a stable session id for the WS URL.
+vi.mock('$lib/stores/toast', () => ({
+	toastStore: { error: vi.fn(), success: vi.fn(), info: vi.fn(), warning: vi.fn() }
+}));
+vi.mock('$lib/api/clients/common', () => ({
+	BaseClient: { getSessionID: () => 'test-session' }
+}));
+
+// jsdom doesn't implement WebSocket; provide a minimal mock that records
+// constructions and lets a test drive readyState transitions.
+let constructedURLs: string[] = [];
+
+class MockWebSocket {
+	static OPEN = 1;
+	static CONNECTING = 0;
+	static CLOSING = 2;
+	static CLOSED = 3;
+	readyState = 0;
+	onopen: (() => void) | null = null;
+	onclose: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+	onmessage: ((ev: { data: string }) => void) | null = null;
+	constructor(public url: string) {
+		constructedURLs.push(url);
+	}
+	close() {
+		this.readyState = 3;
+		this.onclose?.();
+	}
+}
+
+describe('websocket store — desktop async-gap guard', () => {
+	let originalFetch: typeof globalThis.fetch;
+	let originalWebSocket: typeof globalThis.WebSocket;
+
+	beforeEach(() => {
+		// Fresh singleton per test: clears the cached desktopWSUrl + shouldReconnect
+		// so tests are independent.
+		vi.resetModules();
+		constructedURLs = [];
+		originalFetch = globalThis.fetch;
+		originalWebSocket = globalThis.WebSocket;
+		// @ts-expect-error installing a minimal mock
+		globalThis.WebSocket = MockWebSocket;
+		// Pretend we're in the Wails webview so isDesktopApp() is true.
+		Object.defineProperty(window, 'location', {
+			value: { protocol: 'wails:', hostname: 'wails.localhost', origin: 'wails://wails.localhost', href: 'wails://wails.localhost/' },
+			writable: true,
+			configurable: true
+		});
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		globalThis.WebSocket = originalWebSocket;
+		vi.restoreAllMocks();
+	});
+
+	it('opens a socket when /desktop/runtime resolves with a ws_url', async () => {
+		let resolveFetch!: (v: { ok: boolean; json: () => Promise<unknown> }) => void;
+		globalThis.fetch = vi.fn(() => new Promise((r) => { resolveFetch = r; })) as unknown as typeof globalThis.fetch;
+
+		const { websocketStore } = await import('$lib/stores/websocket');
+		websocketStore.connect();
+
+		// While the fetch is in flight, no socket yet.
+		expect(constructedURLs).toHaveLength(0);
+
+		resolveFetch({ ok: true, json: () => Promise.resolve({ ws_url: 'ws://localhost:9999/ws/progress' }) });
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(constructedURLs).toHaveLength(1);
+		expect(constructedURLs[0]).toContain('ws://localhost:9999/ws/progress');
+		expect(constructedURLs[0]).toContain('session=test-session');
+		websocketStore.disconnect();
+	});
+
+	it('does NOT open a socket if disconnect() runs during the /desktop/runtime fetch', async () => {
+		let resolveFetch!: (v: { ok: boolean; json: () => Promise<unknown> }) => void;
+		globalThis.fetch = vi.fn(() => new Promise((r) => { resolveFetch = r; })) as unknown as typeof globalThis.fetch;
+
+		const { websocketStore } = await import('$lib/stores/websocket');
+		websocketStore.connect();
+
+		// Component unmount / explicit disconnect while the fetch is still
+		// pending — the guard must abort openSocket so no socket leaks.
+		websocketStore.disconnect();
+
+		resolveFetch({ ok: true, json: () => Promise.resolve({ ws_url: 'ws://localhost:9999/ws/progress' }) });
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(constructedURLs).toHaveLength(0);
+	});
+
+	it('schedules a reconnect when /desktop/runtime resolves with no ws_url', async () => {
+		globalThis.fetch = vi.fn(() => Promise.resolve({
+			ok: true,
+			json: () => Promise.resolve({ ws_url: '' })
+		})) as unknown as typeof globalThis.fetch;
+
+		const { websocketStore } = await import('$lib/stores/websocket');
+		websocketStore.connect();
+		await new Promise((r) => setTimeout(r, 0));
+
+		// No socket opened (no URL), and no leak.
+		expect(constructedURLs).toHaveLength(0);
+		// A reconnect is scheduled (3s); disconnect to cancel it.
+		websocketStore.disconnect();
+	});
+
+	it('schedules a reconnect when /desktop/runtime fetch rejects', async () => {
+		globalThis.fetch = vi.fn(() => Promise.reject(new Error('network'))) as unknown as typeof globalThis.fetch;
+
+		const { websocketStore } = await import('$lib/stores/websocket');
+		websocketStore.connect();
+		await new Promise((r) => setTimeout(r, 0));
+
+		// Fetch failed: no socket, no leak.
+		expect(constructedURLs).toHaveLength(0);
+		websocketStore.disconnect();
+	});
+});

--- a/web/frontend/src/lib/stores/websocket.ts
+++ b/web/frontend/src/lib/stores/websocket.ts
@@ -2,23 +2,38 @@ import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
 import type { ProgressMessage } from '$lib/api/types';
 import { toastStore } from '$lib/stores/toast';
+import { BaseClient } from '$lib/api/clients/common';
 
-// Build WebSocket URL dynamically from browser location
-// This works for both local dev (localhost:8080) and Docker (any host)
-// Converts http -> ws and https -> wss automatically
+// Build WebSocket URL dynamically from browser location.
+// In the browser (dev server / Docker), the SPA and API are same-origin, so
+// the WS URL is derived from location.origin. In the desktop app the Wails
+// AssetServer returns 501 for WS upgrades, so the frontend cannot use a
+// same-origin WS URL through the reverse proxy; instead it fetches the direct
+// WS URL (ws://localhost:PORT/ws/progress) from GET /desktop/runtime, which
+// the desktop reverse proxy serves without forwarding.
+
 function isDesktopApp(): boolean {
 	if (!browser) return false;
 	if (location.protocol === 'wails:') return true;
 	return location.hostname === 'wails.localhost';
 }
 
-function getWebSocketURL(): string {
-	if (!browser) {
-		// During SSR, return a placeholder (won't be used)
-		return 'ws://localhost:8080/ws/progress';
-	}
-	// Replace http/https with ws/wss and append the WebSocket path
+function sameOriginWebSocketURL(): string {
+	// Replace http/https with ws/wss and append the WebSocket path.
 	return location.origin.replace(/^http/, 'ws') + '/ws/progress';
+}
+
+// Append the session ID as a query parameter. The browser cannot set custom
+// headers (e.g. X-Session-ID) on a WebSocket, and in the desktop app the
+// session cookie is stored against the webview origin — not 127.0.0.1:PORT —
+// so it is not sent on a direct WS connection. The auth middleware falls back
+// to the ?session= query parameter, which is how the desktop app authenticates
+// the WS upgrade.
+function withSessionParam(base: string): string {
+	const sid = BaseClient.getSessionID();
+	if (!sid) return base;
+	const sep = base.includes('?') ? '&' : '?';
+	return `${base}${sep}session=${encodeURIComponent(sid)}`;
 }
 
 interface WebSocketState {
@@ -41,31 +56,35 @@ function createWebSocketStore() {
 	let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
 	let shouldReconnect = false;
 	let lastErrorToastTime = 0;
+	// Cached direct WS URL for the desktop app. The port is fixed for the
+	// app's lifetime, so fetch once and reuse across reconnects.
+	let desktopWSUrl: string | null = null;
 
-	function connect() {
-		if (!browser) {
-			console.warn('WebSocket connection attempted during SSR, skipping');
-			return;
+	async function resolveDesktopWSUrl(): Promise<string | null> {
+		if (desktopWSUrl) return desktopWSUrl;
+		try {
+			const resp = await fetch('/desktop/runtime');
+			if (!resp.ok) return null;
+			const data = (await resp.json()) as { ws_url?: string };
+			if (typeof data.ws_url === 'string' && data.ws_url.length > 0) {
+				desktopWSUrl = data.ws_url;
+				return desktopWSUrl;
+			}
+		} catch {
+			// fall through to caller's error handling
 		}
+		return null;
+	}
 
-		if (isDesktopApp()) {
-			console.info('WebSocket: skipping connection in desktop app (Wails asset server does not proxy WS upgrades)');
-			update((state) => ({ ...state, skipped: true, error: undefined }));
-			return;
-		}
-		shouldReconnect = true;
-
-		if (reconnectTimeout) {
-			clearTimeout(reconnectTimeout);
+	function scheduleReconnect() {
+		if (!shouldReconnect || reconnectTimeout) return;
+		reconnectTimeout = setTimeout(() => {
 			reconnectTimeout = null;
-		}
+			connect();
+		}, 3000);
+	}
 
-		if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
-			return;
-		}
-
-		const wsUrl = getWebSocketURL();
-
+	function openSocket(wsUrl: string) {
 		try {
 			ws = new WebSocket(wsUrl);
 
@@ -76,19 +95,10 @@ function createWebSocketStore() {
 			ws.onclose = () => {
 				update((state) => ({ ...state, connected: false }));
 				ws = null;
-
-				if (!shouldReconnect) {
-					return;
-				}
-
-				// Attempt to reconnect after 3 seconds
-				reconnectTimeout = setTimeout(() => {
-					connect();
-				}, 3000);
+				scheduleReconnect();
 			};
 
-			ws.onerror = (error) => {
-				console.error('WebSocket error:', error);
+			ws.onerror = () => {
 				const now = Date.now();
 				if (now - lastErrorToastTime > 10000) {
 					toastStore.error('WebSocket connection error');
@@ -124,7 +134,46 @@ function createWebSocketStore() {
 			console.error('Failed to create WebSocket:', error);
 			toastStore.error('Failed to connect to server');
 			update((state) => ({ ...state, error: 'Failed to create WebSocket connection' }));
+			scheduleReconnect();
 		}
+	}
+
+	function connect() {
+		if (!browser) {
+			console.warn('WebSocket connection attempted during SSR, skipping');
+			return;
+		}
+
+		shouldReconnect = true;
+
+		if (reconnectTimeout) {
+			clearTimeout(reconnectTimeout);
+			reconnectTimeout = null;
+		}
+
+		if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+			return;
+		}
+
+		if (isDesktopApp()) {
+			// The Wails AssetServer returns 501 for WS upgrades, so connect
+			// directly to the embedded API server's WS endpoint. The URL (with
+			// the random localhost port) is served by the desktop reverse proxy
+			// at /desktop/runtime.
+			resolveDesktopWSUrl()
+				.then((base) => {
+					if (!base) {
+						update((state) => ({ ...state, error: 'WebSocket URL unavailable' }));
+						scheduleReconnect();
+						return;
+					}
+					openSocket(withSessionParam(base));
+				})
+				.catch(() => scheduleReconnect());
+			return;
+		}
+
+		openSocket(withSessionParam(sameOriginWebSocketURL()));
 	}
 
 	function disconnect() {

--- a/web/frontend/src/lib/stores/websocket.ts
+++ b/web/frontend/src/lib/stores/websocket.ts
@@ -162,6 +162,11 @@ function createWebSocketStore() {
 			// at /desktop/runtime.
 			resolveDesktopWSUrl()
 				.then((base) => {
+					// Re-check after the async gap: disconnect() may have run while
+					// the fetch was in flight (e.g. component unmount), in which
+					// case opening a socket now would leak a connection nothing
+					// can close. Also guards against overlapping connect() calls.
+					if (!shouldReconnect) return;
 					if (!base) {
 						update((state) => ({ ...state, error: 'WebSocket URL unavailable' }));
 						scheduleReconnect();
@@ -169,7 +174,9 @@ function createWebSocketStore() {
 					}
 					openSocket(withSessionParam(base));
 				})
-				.catch(() => scheduleReconnect());
+				.catch(() => {
+					if (shouldReconnect) scheduleReconnect();
+				});
 			return;
 		}
 


### PR DESCRIPTION
Three fixes for the desktop app, discovered while testing the Windows build.

## 1. Windows launch + CLI flags

The Windows `.exe` build (GUI subsystem, `-H windowsgui`) had two issues:

- **Double-click did nothing** — cobra's mousetrap shows a "this is a command line tool" dialog and exits, but with nil stdout (no console) the dialog never appeared and the app exited silently. Disabled `cobra.MousetrapHelpText` in `init()` for desktop builds.
- **`--help`/`-h`/subcommands printed nothing from CMD** — a GUI-subsystem app doesn't inherit the parent terminal's stdout/stderr, so cobra's output went to nil handles. Added `attachParentConsole()` (Windows-only, `AttachConsole(ATTACH_PARENT_PROCESS)`) when args are present so output is visible in CMD.
- **Pre-GUI panics were swallowed** — added a `crash.log` writer in `main()` so launch failures (before the window opens) are diagnosable in `%APPDATA%\Javinizer\crash.log`.

The desktop build is now a proper hybrid: double-click → GUI; `javinizer --help` from CMD → prints help; `javinizer scrape X` → CLI.

## 2. WebSocket progress

Real-time progress updates were silently dropped in the desktop app. The Wails `AssetServer.ServeHTTP` returns `501 Not Implemented` for any `Upgrade: websocket` request **before** the reverse proxy (or any middleware) runs, so WS upgrades can't be proxied — the frontend was skipping the WS connection entirely.

Fix: the frontend connects **directly** to the embedded API server's WS endpoint instead of through the proxy.

- `GET /desktop/runtime` — new proxy endpoint returning `{"ws_url":"ws://localhost:PORT/ws/progress"}` so the frontend can discover the random ephemeral port.
- `desktopWSUpgrader()` — override the WS upgrader in `StartServer` to accept cross-origin webview origins (`wails://` macOS, `wails.localhost` Windows/Linux). Safe: the server is loopback-only and `/ws/progress` still requires auth.
- Frontend fetches `/desktop/runtime`, appends `?session=SID` (the browser can't set headers on a WebSocket, and the session cookie is on the webview origin, not `127.0.0.1:PORT`), and connects directly.

## 3. Browse security model

`allowed_directories` is a safety guard for **file operations** (scan, organize, movie compare, scanner), not a restriction on **browsing** to configure it. Enforcing it on browse/autocomplete was a catch-22: the default desktop config ships `allowed_directories: ['.']`, so typing a path on another drive (e.g. `D:\`) was rejected as "outside allowed directories" — blocking the very operation that populates the allowlist.

- Added `NewPathValidatorBrowse` (denylist-only) + `ValidateBrowsePath` / `ValidateAndOpenBrowsePath` helpers. The allowlist gate (step 1) and `isAllowed` check (step 11) are skipped; the denylist (`/proc`, `/sys`, `/dev` + config) and all other validation (canonicalize, exists, type) remain.
- `browse` + `autocomplete` unconditionally use the browse validator.
- Removed the `picker` flag / frontend prop / desktop-env branching that an earlier iterative fix had added — the model is simpler and environment-independent.
- `AllowedDirectoriesEditor` always shows Browse; defaults to home (`~`).

The allowlist still fully applies at scan/organize time (6 enforcement points unchanged).

## Testing

- All Go tests pass (`go test -short ./...`); coverage 90.34% (CI minimum 75%).
- All 340 frontend tests pass; `svelte-check` 0 errors.
- Manually verified on Windows: double-click launches GUI, `--help` prints to CMD, `D:\` autocomplete works, Browse opens any drive.
- New tests: WS origin check (9 cases), `/desktop/runtime` endpoint, browse security model (allowlist not enforced, denylist + missing paths still error).

Closes the desktop browse/autocomplete catch-22 reported during Windows testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop now exposes a `/desktop/runtime` endpoint and the frontend connects directly to the live progress WebSocket with session support.
  * Browse UI now defaults to a user-friendly starting directory (typed value, first allowed dir, or `~`), and browse falls back to the user’s home when no path is provided.
* **Bug Fixes**
  * Improved crash logging and stderr-first startup errors.
  * Windows console output is handled more consistently when launched from terminals.
  * Browse/autocomplete no longer get blocked by allowlist rules (denylist still applies).
  * Desktop WebSocket origin checks and reconnect behavior were made more robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->