### PR TITLE
fix(docker): make docker-run work + redesign update popover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,10 +38,10 @@ PGID=1000
 # Port Configuration
 # ------------------------------------------------------------------------------
 # Host port to expose the Javinizer web UI and API.
-# Change this if port 8080 is already in use on your system.
+# Change this if port 8765 is already in use on your system.
 #
-# Default: 8080
-HOST_PORT=8080
+# Default: 8765
+HOST_PORT=8765
 
 # ------------------------------------------------------------------------------
 # FlareSolverr Port Configuration
@@ -138,4 +138,4 @@ JAVINIZER_SETUP_TRUSTED_CIDRS=172.16.0.0/12
 #
 # Uncomment to enable:
 # JAVINIZER_DEV_MODE=true
-# VITE_API_URL=http://localhost:8080
+# VITE_API_URL=http://localhost:8765

--- a/Dockerfile
+++ b/Dockerfile
@@ -157,4 +157,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # Run API server (will be passed to entrypoint)
-CMD ["javinizer", "api"]
+CMD ["javinizer", "web"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -156,5 +156,5 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
 # Entrypoint script to initialize config
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# Run API server (will be passed to entrypoint)
+# Run web server (will be passed to entrypoint)
 CMD ["javinizer", "web"]

--- a/Makefile
+++ b/Makefile
@@ -655,10 +655,10 @@ docker-run:
 	@if [ ! -d "$(ABS_MEDIA_DIR)" ]; then echo "warning: MEDIA_DIR '$(MEDIA_DIR)' does not exist or is not a directory — container will start but /media will be empty"; fi
 	docker run -d \
 		--name $(DOCKER_CONTAINER_NAME) \
-		-p $(HOST_PORT):8080 \
+		-p "$(HOST_PORT):8080" \
 		-e JAVINIZER_SETUP_TRUSTED_CIDRS=172.16.0.0/12 \
-		-v $(DATA_DIR):/javinizer \
-		-v $(ABS_MEDIA_DIR):/media \
+		-v "$(DATA_DIR):/javinizer" \
+		-v "$(ABS_MEDIA_DIR):/media" \
 		$(DOCKER_FULL_IMAGE)
 	@echo "Container started! Access at http://localhost:$(HOST_PORT)"
 	@echo "Logs: docker logs -f $(DOCKER_CONTAINER_NAME)"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: build-cli-linux build-cli-darwin build-cli-windows build-cli-all
 .PHONY: build-app-darwin build-app-windows build-app-linux build-app-all
 .PHONY: act-list act-test act-build act-lint act-docker act-cli-release act-ci act-dry act-help
-.PHONY: docker-build docker-build-no-cache docker-run docker-stop docker-clean docker-push docker-test docker-logs docker-help
+.PHONY: docker-build docker-build-no-cache docker-run docker-stop docker-restart docker-clean docker-push docker-test docker-logs docker-help
 .PHONY: docker-compose-up docker-compose-down docker-compose-restart docker-compose-logs docker-compose-build
 
 # Default target - show help
@@ -624,16 +624,43 @@ docker-build-no-cache:
 	@echo "Docker image built successfully!"
 	@docker images $(DOCKER_IMAGE)
 
+# Run Docker container (detached mode).
+# Mirrors docker-compose.yml's canonical env (host port, trusted CIDRs for
+# /auth/setup from the Docker bridge gateway, data + media mounts). Override via:
+#   make docker-run HOST_PORT=9090 MEDIA_DIR=./test-videos
+# The setup CIDR is needed because the container sees the host as the Docker
+# bridge gateway (172.x), not 127.0.0.1, so the /auth/setup localhost guard
+# would reject the first-run setup screen without it.
+# Port on the host to publish the container's 8080. 8080 is too common (collides
+# with many dev tools); 8765 is distinctive. Override: make docker-run HOST_PORT=9090
+# Matches docker-compose.yml's HOST_PORT env var so `make` and `compose` agree.
+HOST_PORT ?= 8765
+# Host directory mounted at /media (input files, writable so organize works).
+# Override: make docker-run MEDIA_DIR=./test-videos
+MEDIA_DIR ?= $(PWD)/media
+# Host directory for persistent app state (db, config, logs, temp). Defaults
+# to ./data, matching docker-compose.yml's ./data:/javinizer volume convention.
+# Already covered by .gitignore's /data/ entry. Does NOT collide with the
+# `javinizer` binary (the binary is a file at the repo root; data/ is a dir).
+# Override: make docker-run DATA_DIR=./my-data
+DATA_DIR ?= $(PWD)/data
+
 # Run Docker container (detached mode)
 docker-run:
-	@echo "Starting Docker container $(DOCKER_CONTAINER_NAME)..."
+	@echo "Starting Docker container $(DOCKER_CONTAINER_NAME) on port $(HOST_PORT)..."
+	-docker stop $(DOCKER_CONTAINER_NAME) 2>/dev/null || true
+	-docker rm $(DOCKER_CONTAINER_NAME) 2>/dev/null || true
+	@mkdir -p $(DATA_DIR)
+	$(eval ABS_MEDIA_DIR := $(abspath $(MEDIA_DIR)))
+	@if [ ! -d "$(ABS_MEDIA_DIR)" ]; then echo "warning: MEDIA_DIR '$(MEDIA_DIR)' does not exist or is not a directory — container will start but /media will be empty"; fi
 	docker run -d \
 		--name $(DOCKER_CONTAINER_NAME) \
-		-p 8080:8080 \
-		-v $(PWD)/javinizer:/javinizer \
-		-v $(PWD)/data:/data \
+		-p $(HOST_PORT):8080 \
+		-e JAVINIZER_SETUP_TRUSTED_CIDRS=172.16.0.0/12 \
+		-v $(DATA_DIR):/javinizer \
+		-v $(ABS_MEDIA_DIR):/media \
 		$(DOCKER_FULL_IMAGE)
-	@echo "Container started! Access at http://localhost:8080"
+	@echo "Container started! Access at http://localhost:$(HOST_PORT)"
 	@echo "Logs: docker logs -f $(DOCKER_CONTAINER_NAME)"
 
 # Stop and remove Docker container
@@ -642,6 +669,9 @@ docker-stop:
 	-docker stop $(DOCKER_CONTAINER_NAME)
 	-docker rm $(DOCKER_CONTAINER_NAME)
 	@echo "Container stopped and removed"
+
+# Restart Docker container (stop + run)
+docker-restart: docker-stop docker-run
 
 # View container logs
 docker-logs:
@@ -678,7 +708,7 @@ docker-push:
 docker-compose-up:
 	@echo "Starting services with docker-compose..."
 	docker-compose up -d
-	@echo "Services started! Access at http://localhost:8080"
+	@echo "Services started! Access at http://localhost:$(HOST_PORT)"
 
 # Stop services
 docker-compose-down:
@@ -708,7 +738,8 @@ docker-help:
 	@echo "  make docker-build-no-cache     - Build without cache (clean build)"
 	@echo ""
 	@echo "Run:"
-	@echo "  make docker-run                - Run container (detached, port 8080)"
+	@echo "  make docker-run                - Run container (detached, host port 8765)"
+	@echo "  make docker-run HOST_PORT=9090 MEDIA_DIR=./test-videos  - Custom port + media mount"
 	@echo "  make docker-stop               - Stop and remove container"
 	@echo "  make docker-logs               - View container logs"
 	@echo "  make docker-test               - Validate Docker image version metadata"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - .env
 
     ports:
-      - "${HOST_PORT:-8080}:8080"
+      - "${HOST_PORT:-8765}:8080"
 
     volumes:
       # Application state (config, database, logs, cache)
@@ -82,7 +82,7 @@ services:
     env_file:
       - .env
     ports:
-      - "${HOST_PORT:-8080}:8080"
+      - "${HOST_PORT:-8765}:8080"
     volumes:
       - ./data:/javinizer
       - ${MEDIA_PATH:-/path/to/your/jav-library}:/media
@@ -90,7 +90,7 @@ services:
       - ./web/frontend:/app/web/frontend
     environment:
       - JAVINIZER_DEV_MODE=${JAVINIZER_DEV_MODE:-true}
-      - VITE_API_URL=${VITE_API_URL:-http://localhost:8080}
+      - VITE_API_URL=${VITE_API_URL:-http://localhost:${HOST_PORT:-8765}}
       - JAVINIZER_HOME=/javinizer
       - JAVINIZER_CONFIG=/javinizer/config.yaml
       - JAVINIZER_DB=/javinizer/javinizer.db

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -233,7 +233,7 @@ cp .env.example .env
 docker compose up -d
 
 # 4. Access the web UI
-open http://localhost:8080
+open http://localhost:8765
 ```
 
 Essential `.env` values:
@@ -242,7 +242,7 @@ Essential `.env` values:
 |----------|---------|
 | `MEDIA_PATH` | Absolute host path to your JAV library (mounted at `/media` in the container) |
 | `PUID` / `PGID` | Match your host user (`id -u` / `id -g`) to avoid volume permission issues |
-| `HOST_PORT` | Host port for the web UI/API (default `8080`) |
+| `HOST_PORT` | Host port for the web UI/API (default `8765`) |
 | `TZ` | Container timezone, e.g. `America/New_York` (default `UTC`) |
 
 State (config, database, logs) persists in the `./data` volume; your media library is mounted read-write at `/media` for organize operations. To build the image locally instead of pulling, uncomment the `build:` block in `docker-compose.yml` (and comment out `image:`).
@@ -323,7 +323,7 @@ Start the API/Web server:
 javinizer web
 ```
 
-Then open [http://localhost:8080](http://localhost:8080) and create your default username/password.
+Then open [http://localhost:8765](http://localhost:8765) and create your default username/password.
 
 Notes:
 - Credentials are stored in `auth.credentials.json` next to your `config.yaml`.
@@ -603,9 +603,9 @@ Now that you have the basics working, explore these topics:
 
 ## Common Setup Issues
 
-### Port 8080 Already in Use
+### Port 8765 Already in Use
 
-**Problem**: Default API server port (8080) conflicts with another service.
+**Problem**: Default API server port (8765) conflicts with another service.
 
 **Solution**:
 ```bash

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -41,7 +41,7 @@ cp .env.example .env
 docker compose up -d
 
 # 4. Access the web UI
-open http://localhost:8080
+open http://localhost:8765
 ```
 
 To build the image locally instead of pulling the pre-built one, see [Building the Image](#building-the-image).
@@ -140,8 +140,8 @@ Javinizer uses a `.env` file to configure Docker Compose variables. This makes i
    # Required: Set your JAV library path
    MEDIA_PATH=/Users/you/JAV
 
-   # Optional: Change port if 8080 is in use
-   HOST_PORT=8080
+   # Optional: Change port if 8765 is in use
+   HOST_PORT=8765
 
    # Optional: Set your timezone
    TZ=America/New_York
@@ -161,7 +161,7 @@ Javinizer uses a `.env` file to configure Docker Compose variables. This makes i
 | `USER_ID` | Legacy alias for `PUID` | 1000 | Optional |
 | `GROUP_ID` | Legacy alias for `PGID` | 1000 | Optional |
 | `MEDIA_PATH` | Path to your JAV library on host | `/path/to/your/jav-library` | Yes |
-| `HOST_PORT` | Port to expose on host | 8080 | No |
+| `HOST_PORT` | Port to expose on host | 8765 | No |
 | `TZ` | Timezone (IANA format) | UTC | No |
 | `UMASK` | File creation mask (e.g. `002`, `022`); overrides `config.yaml` | `002` | No |
 | `LOG_LEVEL` | Log verbosity (`debug`, `info`, `warn`, `error`); overrides `config.yaml` | `info` | No |
@@ -349,7 +349,7 @@ docker compose logs
 ```
 
 Common issues:
-- **Port 8080 in use**: Set `HOST_PORT=9090` in `.env` file
+- **Port 8765 in use**: Set `HOST_PORT=9090` in `.env` file
 - **Permission denied**: Ensure the `./data` directory is writable and check `PUID`/`PGID` (or legacy `USER_ID`/`GROUP_ID`) in `.env`
 - **Volume mount failed**: Check that `MEDIA_PATH` in `.env` points to an existing directory
 
@@ -357,7 +357,7 @@ Common issues:
 
 The health check endpoint is `/health`. Test manually:
 ```bash
-curl http://localhost:8080/health
+curl http://localhost:8765/health
 ```
 
 ### Database Locked
@@ -697,7 +697,7 @@ If a deployment encounters issues, you can revert to a previous version:
    docker compose exec javinizer javinizer --version
    
    # Verify web UI is accessible
-   curl http://localhost:8080/health
+   curl http://localhost:8765/health
    ```
 
 ### Standalone Binary Rollback
@@ -805,7 +805,7 @@ Monitoring capabilities may be added in future releases. Track progress on GitHu
 
 - [Configuration Guide](./02-configuration.md) - Detailed configuration options
 - [CLI Usage](./03-cli-reference.md) - Command-line interface reference
-- [API Documentation](http://localhost:8080/docs) - REST API reference (when running)
+- [API Documentation](http://localhost:8765/docs) - REST API reference (when running)
 
 ---
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -71,9 +71,9 @@ prepare_internal_path() {
             echo "WARNING: chown -R on ${target_path} partially failed (some files may retain prior ownership)"
         fi
     elif ! awk -v path="${target_path}" '$2 == path { found=1; exit } END { exit found ? 0 : 1 }' /proc/mounts; then
-        chown -R "${target_uid}:${target_gid}" "${target_path}"
+        chown -R "${target_uid}:${target_gid}" "${target_path}" 2>/dev/null || true
     else
-        chown "${target_uid}:${target_gid}" "${target_path}"
+        chown "${target_uid}:${target_gid}" "${target_path}" 2>/dev/null || true
     fi
 }
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -71,9 +71,13 @@ prepare_internal_path() {
             echo "WARNING: chown -R on ${target_path} partially failed (some files may retain prior ownership)"
         fi
     elif ! awk -v path="${target_path}" '$2 == path { found=1; exit } END { exit found ? 0 : 1 }' /proc/mounts; then
-        chown -R "${target_uid}:${target_gid}" "${target_path}" 2>/dev/null || true
+        if ! chown -R "${target_uid}:${target_gid}" "${target_path}" 2>/dev/null; then
+            echo "WARNING: chown -R on ${target_path} failed (mount may be read-only)"
+        fi
     else
-        chown "${target_uid}:${target_gid}" "${target_path}" 2>/dev/null || true
+        if ! chown "${target_uid}:${target_gid}" "${target_path}" 2>/dev/null; then
+            echo "WARNING: chown on ${target_path} failed (mount may be read-only)"
+        fi
     fi
 }
 

--- a/web/frontend/src/lib/components/UpdateIndicator.svelte
+++ b/web/frontend/src/lib/components/UpdateIndicator.svelte
@@ -97,8 +97,9 @@
 			if (copyResetTimer) clearTimeout(copyResetTimer);
 			copyResetTimer = setTimeout(() => (copiedInstructions = false), 1500);
 		} catch {
-			// clipboard unavailable (non-secure context) — silently no-op; the
-			// user can still select the command text manually.
+			// clipboard unavailable (non-secure context) — surface it so the user
+			// knows to select the command text manually instead.
+			toastStore.error('Could not copy to clipboard — select the command text manually');
 		}
 	}
 

--- a/web/frontend/src/lib/components/UpdateIndicator.svelte
+++ b/web/frontend/src/lib/components/UpdateIndicator.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { cubicOut } from 'svelte/easing';
 	import { fly } from 'svelte/transition';
+	import { onDestroy } from 'svelte';
 	import { createMutation, useQueryClient } from '@tanstack/svelte-query';
-	import { ArrowUpCircle, RefreshCw, ChevronDown, Container, Monitor, Terminal } from 'lucide-svelte';
+	import { ArrowUpCircle, RefreshCw, ChevronDown, Container, Monitor, Terminal, Copy, Check } from 'lucide-svelte';
 	import { createVersionStatusQuery } from '$lib/query/queries';
 	import { apiClient } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast';
@@ -78,6 +79,29 @@
 
 	const checking = $derived(checkMutation.isPending);
 
+	// Copy-to-clipboard for the upgrade instructions: docker/CLI users get a
+	// multi-line command they can paste into a terminal. Shows a check-mark
+	// confirmation for ~1.5s then reverts to the copy icon.
+	let copiedInstructions = $state(false);
+	let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+	onDestroy(() => {
+		if (copyResetTimer) clearTimeout(copyResetTimer);
+	});
+	async function handleCopyInstructions(event: MouseEvent) {
+		event.stopPropagation();
+		const text = status?.upgrade_instructions;
+		if (!text) return;
+		try {
+			await navigator.clipboard.writeText(text);
+			copiedInstructions = true;
+			if (copyResetTimer) clearTimeout(copyResetTimer);
+			copyResetTimer = setTimeout(() => (copiedInstructions = false), 1500);
+		} catch {
+			// clipboard unavailable (non-secure context) — silently no-op; the
+			// user can still select the command text manually.
+		}
+	}
+
 	// Environment label + icon for the "running in" badge. The backend classifies
 	// docker/desktop/cli so the notification can tell a Docker user to `docker pull`
 	// (an in-app self-upgrade is impossible for a read-only image) instead of
@@ -119,7 +143,7 @@
 
 		{#if popoverOpen}
 			<div
-				class="absolute right-0 top-full mt-1 w-72 rounded-lg border bg-card p-3 shadow-lg z-50"
+				class="absolute right-0 top-full mt-1 w-80 rounded-lg border bg-card p-3 shadow-lg z-50"
 				in:fly={{ y: -4, duration: 120, easing: cubicOut }}
 				role="dialog"
 				aria-label="Update details"
@@ -134,45 +158,71 @@
 								Update available
 							{/if}
 						</p>
-						<p class="mt-1 text-xs text-muted-foreground break-all">
-							<span class="font-medium text-foreground">{status?.latest}</span>
-							<span class="mx-1">·</span>
-							current <span class="font-medium text-foreground">{status?.current}</span>
+						<p class="mt-1 text-xs text-muted-foreground">
+							<span class="font-mono text-foreground/80">{status?.current}</span>
+							<span class="mx-1.5 text-muted-foreground/60">→</span>
+							<span class="font-mono font-medium text-primary">{status?.latest}</span>
 						</p>
-						{#if status?.prerelease}
-							<span
-								class="inline-block mt-2 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/15 text-amber-700 dark:text-amber-300"
-							>
-								prerelease
-							</span>
-						{/if}
-						{#if status?.install_environment}
-							{@const Badge = envBadge.icon}
-							<span
-								class="inline-flex items-center gap-1 mt-2 px-1.5 py-0.5 rounded text-[10px] font-medium {envBadge.tone}"
-								title={envBadge.label}
-							>
-								<Badge class="h-3 w-3" />
-							{envBadge.label}
-							</span>
+						{#if status?.prerelease || status?.install_environment}
+							<div class="mt-2 flex flex-wrap items-center gap-1.5">
+								{#if status?.prerelease}
+									<span
+										class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/15 text-amber-700 dark:text-amber-300"
+									>
+										prerelease
+									</span>
+								{/if}
+								{#if status?.install_environment}
+									{@const Badge = envBadge.icon}
+									<span
+										class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium {envBadge.tone}"
+										title={envBadge.label}
+									>
+										<Badge class="h-3 w-3" />
+										{envBadge.label}
+									</span>
+								{/if}
+							</div>
 						{/if}
 					</div>
 				</div>
 
-				{#if status?.upgrade_instructions && status?.install_environment !== 'desktop'}
-					<!-- Backend-provided, environment-specific guidance: docker users see
-					`docker pull`, CLI users see `javinizer upgrade`. Rendered verbatim
-					(pre-wrap) so the indented commands stay readable. Desktop is
-					excluded here: the "Update & restart" button below IS the
-					self-upgrade, so a text block restating "click the button" (plus a
-					long GitHub-download fallback) is redundant and noisy. The API
-					still returns desktop guidance for the CLI `javinizer upgrade`
-					handoff path (internal/update/upgrade.go), which has no button to
-					defer to. -->
-					<pre
-						class="mt-2 px-2 py-1.5 rounded text-[11px] leading-relaxed whitespace-pre-wrap break-all bg-muted text-muted-foreground border border-border"
-					>{status.upgrade_instructions}</pre
+				{#if status?.upgrade_instructions && status?.install_environment !== 'desktop' && status?.install_environment !== 'docker'}
+					<!-- Backend-provided, environment-specific guidance: CLI users see
+					`javinizer upgrade`. Rendered verbatim (pre-wrap) so the indented
+					commands stay readable. Desktop is excluded here: the "Update &
+					restart" button below IS the self-upgrade, so a text block restating
+					"click the button" (plus a long GitHub-download fallback) is
+					redundant and noisy. Docker is excluded too: a user who ran
+					`docker run` already knows to `docker pull` — the "View release"
+					button covers the changelog. The API still returns guidance for
+					the CLI `javinizer upgrade` handoff path
+					(internal/update/upgrade.go), which has no button to defer to. -->
+					<div
+						class="mt-2 rounded-md bg-muted/60 border border-border overflow-hidden max-w-full"
 					>
+						<div class="flex items-center justify-between px-2 py-1 border-b border-border bg-muted">
+							<span class="font-mono text-[10px] text-muted-foreground select-none">sh</span>
+							<button
+								type="button"
+								onclick={handleCopyInstructions}
+								title="Copy command"
+								class="inline-flex items-center gap-1 px-1 py-0.5 rounded text-[10px] text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+							>
+								{#if copiedInstructions}
+									<Check class="h-3 w-3 text-emerald-500" />
+									<span class="text-emerald-500">Copied</span>
+								{:else}
+									<Copy class="h-3 w-3" />
+									<span>Copy</span>
+								{/if}
+							</button>
+						</div>
+						<pre
+							class="block w-full max-w-full px-2.5 py-1.5 text-[11px] leading-relaxed font-mono whitespace-pre overflow-x-auto text-muted-foreground"
+						>{status.upgrade_instructions}</pre
+						>
+					</div>
 				{/if}
 
 				<div class="mt-3 flex items-center gap-2">

--- a/web/frontend/src/lib/components/UpdateIndicator.test.ts
+++ b/web/frontend/src/lib/components/UpdateIndicator.test.ts
@@ -140,7 +140,11 @@ describe('UpdateIndicator', () => {
 		});
 	});
 
-	it('shows docker pull guidance when running in Docker', async () => {
+	it('hides the upgrade-instructions command block for Docker users (they know to docker pull)', async () => {
+		// Product decision: a Docker user who ran `docker run` already knows to
+		// `docker pull` — the command block is noise. The "View release" button
+		// covers the changelog. The environment badge still labels the install
+		// type so the user knows why no self-upgrade button is offered.
 		const { container } = renderWithClient(
 			makeStatus({
 				install_environment: 'docker',
@@ -158,11 +162,11 @@ describe('UpdateIndicator', () => {
 		await fireEvent.click(button!);
 
 		await waitFor(() => {
-			// Environment badge labels the install type so the user knows why the
-			// guidance differs from a normal self-upgrade.
+			// Environment badge still labels the install type.
 			expect(container.textContent).toContain('Running in Docker');
-			// The backend-provided instructions surface the copy-pasteable command.
-			expect(container.textContent).toContain('docker pull ghcr.io/javinizer/javinizer-go');
+			// The command block must NOT render for Docker users.
+			expect(container.textContent).not.toContain('docker pull ghcr.io/javinizer/javinizer-go');
+			expect(container.textContent).not.toContain('Pull the latest image');
 		});
 	});
 


### PR DESCRIPTION
## What

Two unrelated fixes batched in one PR (both surfaced while testing the poster-preview fixes from #101 on Docker).

### Docker — `make docker-run` was broken end-to-end

1. **Dockerfile CMD `api` → `web`** — the `api` subcommand was renamed to `web` in v1.1.0, but the Dockerfile was never updated. The container started and immediately exited with `unknown command "api"`.
2. **`docker-run` target rewrite** — the old target mounted `./javinizer` (the built binary) over `/javinizer`, hardcoded port 8080, mounted media read-only (broke organize), and didn't pass `JAVINIZER_SETUP_TRUSTED_CIDRS` (first-run setup was impossible from the host browser). Rewritten with:
   - `HOST_PORT ?= 8765` (less collision-prone than 8080; matches docker-compose.yml)
   - `MEDIA_DIR` mounted writable (organize needs writes)
   - `DATA_DIR ?= ./data` (aligns with docker-compose + is gitignored)
   - `JAVINIZER_SETUP_TRUSTED_CIDRS=172.16.0.0/12` baked in
   - `abspath` resolution for relative MEDIA_DIR + missing-dir warning
   - auto stop+rm existing container
3. **docker-entrypoint.sh** — `chown` in `prepare_internal_path` made non-fatal so read-only `/media` mounts don't crash the container (the writable-probe warning handles the actual permission check that follows).
4. **docker-compose.yml + .env.example + docs** — host-port default 8080→8765; dev profile `VITE_API_URL` tracks `HOST_PORT` so the dev profile isn't broken by the port change.

### UpdateIndicator popover redesign

- **Version line:** `latest · current` → `current → latest` with `font-mono` + arrow + primary color on the target version (clear direction of travel).
- **Badges:** prerelease + environment badges grouped into one flex row.
- **Command block:** restyled as a terminal snippet with a header bar (`sh` label + Copy button). `navigator.clipboard.writeText` with 1.5s check-mark confirmation; `onDestroy` cleans up the timer.
- **Docker users no longer see the command block** — a user who ran `docker run` already knows to `docker pull`; the "View release" button covers the changelog.
- **Popover widened** `w-72`→`w-80`; `<pre>` uses `whitespace-pre` + `overflow-x-auto` (no more `break-all` shattering commands mid-character).

## Verification

- `make docker-build` + `make docker-run MEDIA_DIR=./test-videos` → container starts, healthy, media mounted writable, auth setup works via trusted CIDR
- `curl localhost:8765/health` → 200
- `make docker-run HOST_PORT=9091` override works
- `cd web/frontend && npx svelte-check` → 0 errors / 0 warnings
- `cd web/frontend && npx vitest run src/lib/components/UpdateIndicator.test.ts` → 12/12 passing (the docker-instructions test was flipped from asserting shown → hidden)
- Remaining `8080` references in docs/.env.example are all container-internal port bindings (correct; only host-port refs were changed)

## Review

Reviewed via a parent-orchestrated review loop (3 fresh-context reviewers in round 1; 1 fix worker applying 5 synthesized fixes in round 2). No blockers. Fixes addressed: `docker-data/` gitignore collision, stale 8080 refs in .env/docs, `docker-compose-up` echo, dev profile `VITE_API_URL` mismatch, `copyResetTimer` onDestroy cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copyable upgrade instructions in the update popover for eligible installs.
  * Improved Docker startup and restart workflows, including configurable host port and persistent data/media paths.

* **Bug Fixes**
  * Made container startup more resilient when ownership changes encounter filesystem restrictions.

* **Documentation**
  * Updated setup, deployment, and troubleshooting guides to use the new default port **8765** and revised access URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->