### PR TITLE
fix(testkit): switch test DB to DELETE journal mode to fix Windows flake

### DIFF
--- a/internal/api/testkit/helpers.go
+++ b/internal/api/testkit/helpers.go
@@ -159,7 +159,12 @@ func CreateTestDeps(t *testing.T, cfg *config.Config, configFile string) *core.A
 	dbPath := filepath.Join(tmpDir, "test.db")
 	dbCfg := &database.Config{
 		Type: "sqlite",
-		DSN:  dbPath + "?_journal_mode=WAL&_busy_timeout=10000",
+		// _journal_mode=DELETE (not WAL) avoids the -wal/-shm sidecar files
+		// that Windows holds open briefly after Close(), causing flaky
+		// t.TempDir() RemoveAll cleanup ("The process cannot access the file
+		// because it is being used by another process"). WAL's concurrency
+		// benefits are irrelevant for single-process test DBs.
+		DSN: dbPath + "?_journal_mode=DELETE&_busy_timeout=10000",
 	}
 
 	db, err := database.New(dbCfg)
@@ -167,6 +172,9 @@ func CreateTestDeps(t *testing.T, cfg *config.Config, configFile string) *core.A
 		t.Fatalf("Failed to create test database: %v", err)
 	}
 
+	// Close the DB before t.TempDir()'s auto-RemoveAll cleanup runs. LIFO
+	// ordering means this runs first, but be explicit: closing before the
+	// dir removal is what actually releases the SQLite file handle on Windows.
 	t.Cleanup(func() {
 		if err := db.Close(); err != nil {
 			t.Logf("Warning: failed to close test database: %v", err)


### PR DESCRIPTION
## What

`TestProcessOrganizeJob_CopiesFileAndGeneratesNFO` was flaking on Windows. `t.TempDir()` `RemoveAll` cleanup failed with:

```
TempDir RemoveAll cleanup: unlinkat C:\...\test.db: The process cannot access the file because it is being used by another process.
```

The same commit passed on the PR's own Windows run (job 85572688471) and failed on the main-merge run (job 85574802299) — classic flake signature, not a regression from #101.

## Root cause

`testkit.CreateTestDeps` opened the SQLite test DB with `_journal_mode=WAL`. WAL mode creates `-wal` and `-shm` sidecar files that Windows holds open briefly even after `db.Close()` returns, racing Go's auto-`RemoveAll` on the temp dir.

`db.Close()` is registered via `t.Cleanup` (LIFO, runs before the `t.TempDir()` `RemoveAll`), so the ordering is correct — but WAL's sidecar files defeat that on Windows.

## Fix

Switch the test DSN to `_journal_mode=DELETE`. This avoids the sidecar files entirely (single `.db` file, released cleanly on close). WAL's concurrency benefits are irrelevant for these single-process test DBs.

## Verification

- `go test -count=1 -run TestProcessOrganizeJob_CopiesFileAndGeneratesNFO ./internal/api/batch/` passes locally.
- Monitoring the rerun of the original failed Windows job to confirm the flake reproduces/re-passes.

## Scope

Single-file change to `internal/api/testkit/helpers.go` (the test helper used by the failing `internal/api/batch/` package). Other test helpers (`integration_test.go`, `testing_test.go`) still use WAL but weren't failing — leaving them alone to keep the change minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of temporary directory cleanup on Windows by avoiding lingering database sidecar files.
  * Reduced flaky failures related to closing local test databases before cleanup runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->