### PR TITLE
fix(testkit): shut down WebSocket hub before DB close in CreateTestDeps

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1242,8 +1242,8 @@ jobs:
           body_len="$(printf '%s' "${body}" | jq -rR 'length')"
           if [ "${body_len}" -gt 500 ]; then
             body_preview="${body_excerpt}
-
-… *[read full release notes](${url})*"
+            
+            … *[read full release notes](${url})*"
           else
             body_preview="${body_excerpt}"
           fi

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.57.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/samber/lo v1.49.1 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/pressly/goose/v3 v3.27.0 h1:/D30gVTuQhu0WsNZYbJi4DMOsx1lNq+6SkLe+Wp59
 github.com/pressly/goose/v3 v3.27.0/go.mod h1:3ZBeCXqzkgIRvrEMDkYh1guvtoJTU5oMMuDdkutoM78=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.57.0 h1:AsSSrrMs4qI/hLrKlTH/TGQeTMY0ib1pAOX7vA3AdqE=
-github.com/quic-go/quic-go v0.57.0/go.mod h1:ly4QBAjHA2VhdnxhojRsCUOeJwKYg+taDlos92xb1+s=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/api/testkit/helpers.go
+++ b/internal/api/testkit/helpers.go
@@ -167,12 +167,6 @@ func CreateTestDeps(t *testing.T, cfg *config.Config, configFile string) *core.A
 		t.Fatalf("Failed to create test database: %v", err)
 	}
 
-	t.Cleanup(func() {
-		if err := db.Close(); err != nil {
-			t.Logf("Warning: failed to close test database: %v", err)
-		}
-	})
-
 	if err := db.RunMigrationsOnStartup(context.Background()); err != nil {
 		t.Fatalf("Failed to migrate test database: %v", err)
 	}
@@ -210,6 +204,23 @@ func CreateTestDeps(t *testing.T, cfg *config.Config, configFile string) *core.A
 
 	// Store the runtime so tests can retrieve it via GetTestRuntime
 	runtimeMap.Store(deps, rt)
+
+	// Register cleanup AFTER all goroutine-spawning setup so the WebSocket hub
+	// is shut down BEFORE the DB is closed. t.Cleanup is LIFO and t.TempDir()
+	// registered its auto-RemoveAll first (above), so this runs before the dir
+	// removal. Without the hub shutdown, the hub goroutine outlives db.Close(),
+	// races the temp-dir RemoveAll, and the resulting leftover poisons the
+	// shared parent temp dir for subsequent tests (cascade "directory not
+	// empty" / "process cannot access the file" flakes on Windows + Linux).
+	t.Cleanup(func() {
+		if rtState != nil {
+			rtState.Shutdown()
+		}
+		if err := db.Close(); err != nil {
+			t.Logf("Warning: failed to close test database: %v", err)
+		}
+		runtimeMap.Delete(deps)
+	})
 
 	return deps
 }

--- a/internal/api/testkit/helpers.go
+++ b/internal/api/testkit/helpers.go
@@ -167,6 +167,16 @@ func CreateTestDeps(t *testing.T, cfg *config.Config, configFile string) *core.A
 		t.Fatalf("Failed to create test database: %v", err)
 	}
 
+	// Register DB close immediately so it runs even if a later step fails
+	// (e.g. RunMigrationsOnStartup) and calls t.Fatalf before the runtime
+	// cleanup below is registered. LIFO ordering: this runs AFTER the runtime
+	// shutdown cleanup (registered later), so the hub is stopped first.
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Logf("Warning: failed to close test database: %v", err)
+		}
+	})
+
 	if err := db.RunMigrationsOnStartup(context.Background()); err != nil {
 		t.Fatalf("Failed to migrate test database: %v", err)
 	}
@@ -208,16 +218,14 @@ func CreateTestDeps(t *testing.T, cfg *config.Config, configFile string) *core.A
 	// Register cleanup AFTER all goroutine-spawning setup so the WebSocket hub
 	// is shut down BEFORE the DB is closed. t.Cleanup is LIFO and t.TempDir()
 	// registered its auto-RemoveAll first (above), so this runs before the dir
-	// removal. Without the hub shutdown, the hub goroutine outlives db.Close(),
-	// races the temp-dir RemoveAll, and the resulting leftover poisons the
-	// shared parent temp dir for subsequent tests (cascade "directory not
-	// empty" / "process cannot access the file" flakes on Windows + Linux).
+	// removal; the db.Close() cleanup registered above runs after this (LIFO),
+	// so the hub is stopped first. Without the hub shutdown, the hub goroutine
+	// outlives db.Close(), races the temp-dir RemoveAll, and the resulting
+	// leftover poisons the shared parent temp dir for subsequent tests (cascade
+	// "directory not empty" / "process cannot access the file" flakes).
 	t.Cleanup(func() {
 		if rtState != nil {
 			rtState.Shutdown()
-		}
-		if err := db.Close(); err != nil {
-			t.Logf("Warning: failed to close test database: %v", err)
 		}
 		runtimeMap.Delete(deps)
 	})


### PR DESCRIPTION
## What

Fixes the Windows + Linux TempDir-cleanup flake cascade that surfaced after PR #101 merged.

## Root cause

`CreateTestDeps` spawned a WebSocket hub goroutine via `rtState.ResetWebSocketHub()` but **never registered cleanup to stop it**. The hub goroutine outlived `db.Close()`, racing `t.TempDir()`'s auto-`RemoveAll`:

- **Windows:** the leftover held the SQLite `-wal`/`-shm` sidecar files → "The process cannot access the file because it is being used by another process."
- **Linux:** the leftover left the temp dir non-empty → "directory not empty."

Either way, the failed cleanup **poisoned the shared parent temp dir** for subsequent tests in the package, cascading into `TestProcessUpdateMode_*` and `TestProcessOrganizeJob_*` failures that weren't those tests' fault.

## Fix

Register the cleanup **after** all goroutine-spawning setup (so `rtState` is in scope), shutting down the hub before closing the DB. `t.Cleanup` is LIFO and `t.TempDir()` registered its auto-`RemoveAll` first, so this runs before the dir removal:

```go
t.Cleanup(func() {
    if rtState != nil {
        rtState.Shutdown()  // stops the hub goroutine
    }
    if err := db.Close(); err != nil { ... }
    runtimeMap.Delete(deps)  // don't resurrect a shut-down runtime
})
```

This addresses the actual root cause (unstopped background goroutine holding DB connections) rather than the surface symptom. My earlier #102 attempt (switching WAL→DELETE journal mode) just shifted the flake — it avoided the sidecar files but didn't stop the goroutine, so Linux started failing reliably instead.

## Verification

- `docker run ... go test -run 'TestProcessUpdateMode_*|TestProcessOrganizeJob_CopiesFileAndGeneratesNFO' -count=30 ./internal/api/batch/` (Linux/Alpine) → all pass (previously failed within ~3 iterations)
- `go test -race -run 'TestProcessUpdateMode|TestProcessOrganizeJob' -count=5 ./internal/api/batch/` → race-clean
- `go test -short ./internal/api/batch/ ./internal/api/testkit/ ./internal/api/core/` → all pass
- gofmt clean, go vet clean

## Why this is the right fix (vs. #102)

`CreateTestDeps` already had a `CleanupServerHub` helper (`internal/api/testkit/helpers.go:285`) that calls `rtState.Shutdown()` — but it required tests to call it manually, and the failing tests didn't. This PR makes the shutdown automatic as part of `CreateTestDeps`'s own cleanup, so no test can forget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment cleanup to shut down runtime state more reliably and prevent leftover state from affecting later tests.
  * Reduced the chance of stale test resources by ensuring temporary data and database connections are cleaned up in the proper order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->