### PR TITLE
fix(config): ship metadata.priority.* as inherited by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/scraper_issue.yml
+++ b/.github/ISSUE_TEMPLATE/scraper_issue.yml
@@ -17,7 +17,7 @@ body:
         - JavBus
         - JavDB
         - JavLibrary
-        - JavStash
+        - JAVStash
         - LibreDMM
         - MGSStage
         - R18Dev

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Docker deployments support environment-variable overrides. Defaults shown are fo
 | `TRANSLATION_PROVIDER` | `openai`, `deepl`, `google`, or `anthropic` |
 | `TRANSLATION_SOURCE_LANGUAGE` / `TRANSLATION_TARGET_LANGUAGE` | e.g. `ja` → `en` |
 | `OPENAI_API_KEY` / `DEEPL_API_KEY` / `GOOGLE_TRANSLATE_API_KEY` / `ANTHROPIC_API_KEY` | Provider keys |
-| `JAVSTASH_API_KEY` | JavStash GraphQL API key (get from javstash.org) |
+| `JAVSTASH_API_KEY` | JAVStash GraphQL API key (get from javstash.org) |
 
 ### Development
 

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -225,79 +225,30 @@ scrapers:
         base_url: "https://javstash.org/graphql"
         language: en # en | ja
 metadata:
+    # Per-field priorities default to inherit `scrapers.priority` (empty []).
+    # A non-empty list here locks the field to those scrapers exclusively with
+    # NO fallback to the global list — so it would ignore scrapers the user
+    # later enables (issue #105). Leave fields empty to inherit; set a list only
+    # to customize a specific field's scraper order.
     priority:
-        actress:
-            - dmm
-            - r18dev
-            - libredmm
-        original_title:
-            - dmm
-            - r18dev
-            - libredmm
-        cover_url:
-            - dmm
-            - r18dev
-            - libredmm
-        description:
-            - dmm
-            - r18dev
-            - libredmm
-        director:
-            - dmm
-            - r18dev
-            - libredmm
-        genre:
-            - dmm
-            - r18dev
-            - libredmm
-        id:
-            - dmm
-            - r18dev
-            - libredmm
-        content_id:
-            - dmm
-            - r18dev
-            - libredmm
-        label:
-            - dmm
-            - r18dev
-            - libredmm
-        maker:
-            - dmm
-            - r18dev
-            - libredmm
-        poster_url:
-            - r18dev
-            - libredmm
-            - dmm
-        rating:
-            - dmm
-            - r18dev
-            - libredmm
-        release_date:
-            - dmm
-            - r18dev
-            - libredmm
-        runtime:
-            - dmm
-            - r18dev
-            - libredmm
-        series:
-            - dmm
-            - r18dev
-            - libredmm
-        screenshot_url:
-            - dmm
-            - r18dev
-            - libredmm
-        title:
-            - dmm
-            - r18dev
-            - libredmm
-        trailer_url:
-            - dmm
-            - r18dev
-            - libredmm
+        actress: []
+        content_id: []
+        cover_url: []
+        description: []
+        director: []
+        genre: []
+        id: []
+        label: []
+        maker: []
+        original_title: []
+        poster_url: []
+        rating: []
+        release_date: []
+        runtime: []
+        screenshot_url: []
+        series: []
+        title: []
+        trailer_url: []
     # Actress image database (SQLite-backed)
     actress_database:
         enabled: true

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -1080,7 +1080,7 @@ These variables are specific to Docker deployments and container orchestration:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `JAVSTASH_API_KEY` | Optional* | - | Javstash scraper API key (required if using javstash scraper) |
+| `JAVSTASH_API_KEY` | Optional* | - | JAVStash scraper API key (required if using javstash scraper) |
 | `CHROME_BIN` | Optional | - | Path to Chrome/Chromium binary (auto-detected if empty) |
 | `CHROME_PATH` | Optional | - | Alternative path to Chrome/Chromium binary |
 
@@ -1180,7 +1180,7 @@ The following settings will cause the application to fail on startup if misconfi
 |---------|------------------|---------------|
 | Config file parsing | Invalid YAML syntax | `Failed to load config: <error>` |
 | Config version | Newer version than supported | `config version X is newer than supported version Y; please update Javinizer` |
-| Javstash scraper | Enabled without API key | `javstash: api_key is required (set in config)` (or set the `JAVSTASH_API_KEY` env var) |
+| JAVStash scraper | Enabled without API key | `javstash: api_key is required (set in config)` (or set the `JAVSTASH_API_KEY` env var) |
 | Scrapers proxy | `enabled: true` without `default_profile` | `scrapers.proxy.default_profile is required when scrapers.proxy.enabled is true` |
 | Scrapers proxy | `default_profile` / per-scraper `profile` references an unknown profile | `scrapers.proxy.default_profile references unknown profile "X"` |
 

--- a/docs/03-cli-reference.md
+++ b/docs/03-cli-reference.md
@@ -776,7 +776,7 @@ Scrapers:
   - Caribbeancom: false
   - DLGetchu: false
   - FC2: false
-  - Javstash: false
+  - JAVStash: false
 
 Output:
   - Folder format: <ID> [<STUDIO>] - <TITLE> (<YEAR>)

--- a/internal/config/config.yaml.example
+++ b/internal/config/config.yaml.example
@@ -225,79 +225,30 @@ scrapers:
         base_url: "https://javstash.org/graphql"
         language: en # en | ja
 metadata:
+    # Per-field priorities default to inherit `scrapers.priority` (empty []).
+    # A non-empty list here locks the field to those scrapers exclusively with
+    # NO fallback to the global list — so it would ignore scrapers the user
+    # later enables (issue #105). Leave fields empty to inherit; set a list only
+    # to customize a specific field's scraper order.
     priority:
-        actress:
-            - dmm
-            - r18dev
-            - libredmm
-        original_title:
-            - dmm
-            - r18dev
-            - libredmm
-        cover_url:
-            - dmm
-            - r18dev
-            - libredmm
-        description:
-            - dmm
-            - r18dev
-            - libredmm
-        director:
-            - dmm
-            - r18dev
-            - libredmm
-        genre:
-            - dmm
-            - r18dev
-            - libredmm
-        id:
-            - dmm
-            - r18dev
-            - libredmm
-        content_id:
-            - dmm
-            - r18dev
-            - libredmm
-        label:
-            - dmm
-            - r18dev
-            - libredmm
-        maker:
-            - dmm
-            - r18dev
-            - libredmm
-        poster_url:
-            - r18dev
-            - libredmm
-            - dmm
-        rating:
-            - dmm
-            - r18dev
-            - libredmm
-        release_date:
-            - dmm
-            - r18dev
-            - libredmm
-        runtime:
-            - dmm
-            - r18dev
-            - libredmm
-        series:
-            - dmm
-            - r18dev
-            - libredmm
-        screenshot_url:
-            - dmm
-            - r18dev
-            - libredmm
-        title:
-            - dmm
-            - r18dev
-            - libredmm
-        trailer_url:
-            - dmm
-            - r18dev
-            - libredmm
+        actress: []
+        content_id: []
+        cover_url: []
+        description: []
+        director: []
+        genre: []
+        id: []
+        label: []
+        maker: []
+        original_title: []
+        poster_url: []
+        rating: []
+        release_date: []
+        runtime: []
+        screenshot_url: []
+        series: []
+        title: []
+        trailer_url: []
     # Actress image database (SQLite-backed)
     actress_database:
         enabled: true

--- a/internal/config/example_metadata_priority_test.go
+++ b/internal/config/example_metadata_priority_test.go
@@ -1,0 +1,50 @@
+package config_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	config "github.com/javinizer/javinizer-go/internal/config"
+)
+
+// metadataFieldsShippedByConfig lists every per-field priority key that the
+// Web UI / aggregator consults. A fresh `javinizer init` config must ship each
+// of these as ABSENT or an empty [] so the field inherits `scrapers.priority`
+// (World A semantics) instead of locking into a stale hardcoded list.
+//
+// Regression guard for issue #105: the embedded config.yaml.example previously
+// shipped every field as [dmm, r18dev, libredmm], which (a) excluded scrapers
+// the user later enabled (e.g. mgstage) and (b) caused persist failures for
+// titles only found on those excluded scrapers ("content_id is required when
+// using ContentID as primary key").
+var metadataFieldsShippedByConfig = []string{
+	"id", "content_id", "title", "original_title", "description",
+	"release_date", "runtime", "actress", "genre", "director",
+	"maker", "label", "series", "rating", "cover_url",
+	"poster_url", "screenshot_url", "trailer_url",
+}
+
+// TestExampleConfigShipsInheritedFieldPriorities verifies the embedded example
+// config (what `javinizer init` writes verbatim) does NOT lock any per-field
+// metadata priority into a non-empty override. Every field must be ABSENT or
+// empty [] so it inherits `scrapers.priority` and automatically picks up
+// scrapers the user enables later.
+func TestExampleConfigShipsInheritedFieldPriorities(t *testing.T) {
+	examplePath := filepath.Join("..", "..", "configs", "config.yaml.example")
+
+	cfg, err := config.Load(examplePath)
+	if err != nil {
+		t.Fatalf("failed to load config.yaml.example: %v", err)
+	}
+
+	for _, field := range metadataFieldsShippedByConfig {
+		override := cfg.Metadata.Priority.PerFieldOverride(field)
+		if len(override) > 0 {
+			t.Errorf(
+				"metadata.priority.%s ships as %v — a non-empty per-field override locks the "+
+					"field out of inheriting scrapers.priority (issue #105). Ship [] or omit the key.",
+				field, override,
+			)
+		}
+	}
+}

--- a/internal/scraper/javstash/javstash.go
+++ b/internal/scraper/javstash/javstash.go
@@ -21,7 +21,7 @@ const (
 	defaultBaseURL = "https://javstash.org/graphql"
 )
 
-// scraper implements the JavStash scraper.
+// scraper implements the JAVStash scraper.
 type scraper struct {
 	client      *resty.Client
 	enabled     bool
@@ -88,7 +88,7 @@ type urlEntry struct {
 	URL string `json:"url"`
 }
 
-// newScraper creates a new JavStash scraper.
+// newScraper creates a new JAVStash scraper.
 func newScraper(settings *models.ScraperSettings, globalProxy *models.ProxyConfig, globalFlareSolverr models.FlareSolverrConfig) *scraper {
 	apiKey := strings.TrimSpace(settings.APIKey)
 
@@ -117,7 +117,7 @@ func newScraper(settings *models.ScraperSettings, globalProxy *models.ProxyConfi
 	}
 
 	if settings.RateLimit > 0 {
-		logging.Infof("Javstash: Rate limiting enabled with %dms delay between requests", settings.RateLimit)
+		logging.Infof("JAVStash: Rate limiting enabled with %dms delay between requests", settings.RateLimit)
 	}
 
 	return s
@@ -161,11 +161,11 @@ func (s *scraper) ExtractIDFromURL(urlStr string) (string, error) {
 			return parts[i], nil
 		}
 	}
-	return "", fmt.Errorf("failed to extract ID from JavStash URL")
+	return "", fmt.Errorf("failed to extract ID from JAVStash URL")
 }
 
 func (s *scraper) ScrapeURL(ctx context.Context, rawURL string) (*models.ScraperResult, error) {
-	return nil, models.NewScraperNotFoundError("Javstash", "JavStash is a GraphQL-based API and does not support direct URL scraping. Use ID-based search instead.")
+	return nil, models.NewScraperNotFoundError("JAVStash", "JAVStash is a GraphQL-based API and does not support direct URL scraping. Use ID-based search instead.")
 }
 
 func (s *scraper) ResolveDownloadProxyForHost(host string) (*models.ProxyConfig, *models.ProxyConfig, bool) {
@@ -234,12 +234,12 @@ func (s *scraper) Search(ctx context.Context, id string) (*models.ScraperResult,
 	}
 
 	if resp.StatusCode() == http.StatusUnauthorized {
-		return nil, models.NewScraperNotFoundError("Javstash", "invalid API key")
+		return nil, models.NewScraperNotFoundError("JAVStash", "invalid API key")
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		return nil, models.NewScraperStatusError("Javstash", resp.StatusCode(),
-			fmt.Sprintf("Javstash returned status %d", resp.StatusCode()))
+		return nil, models.NewScraperStatusError("JAVStash", resp.StatusCode(),
+			fmt.Sprintf("JAVStash returned status %d", resp.StatusCode()))
 	}
 
 	var graphQLResp graphQLResponse
@@ -249,13 +249,13 @@ func (s *scraper) Search(ctx context.Context, id string) (*models.ScraperResult,
 
 	if len(graphQLResp.Errors) > 0 {
 		if strings.Contains(graphQLResp.Errors[0].Message, "Not authorized") {
-			return nil, models.NewScraperNotFoundError("Javstash", "API key required for search")
+			return nil, models.NewScraperNotFoundError("JAVStash", "API key required for search")
 		}
 		return nil, fmt.Errorf("javstash: GraphQL error: %s", graphQLResp.Errors[0].Message)
 	}
 
 	if len(graphQLResp.Data.SearchScene) == 0 {
-		return nil, models.NewScraperNotFoundError("Javstash", fmt.Sprintf("no results for %s", id))
+		return nil, models.NewScraperNotFoundError("JAVStash", fmt.Sprintf("no results for %s", id))
 	}
 
 	return s.parseScene(&graphQLResp.Data.SearchScene[0], searchTerm)

--- a/internal/scraper/javstash/miss_test.go
+++ b/internal/scraper/javstash/miss_test.go
@@ -269,7 +269,7 @@ func TestScraper_GetURL_WhitespaceOnly(t *testing.T) {
 func TestScraper_ResolveDownloadProxyForHost(t *testing.T) {
 	s := &scraper{rateLimiter: ratelimit.NewLimiter(0)}
 	_, _, ok := s.ResolveDownloadProxyForHost("any-host.com")
-	assert.False(t, ok, "JavStash should not claim any hosts")
+	assert.False(t, ok, "JAVStash should not claim any hosts")
 }
 
 // --- Config method ---

--- a/internal/scraper/javstash/module.go
+++ b/internal/scraper/javstash/module.go
@@ -5,16 +5,16 @@ import (
 	"github.com/javinizer/javinizer-go/internal/scraperutil"
 )
 
-// Register registers the Javstash scraper with the given registrar.
+// Register registers the JAVStash scraper with the given registrar.
 func Register(reg scraperutil.ScraperRegistrar) {
 	reg.Register(scraperutil.ScraperRegistration{
 		Name:        "javstash",
-		Description: "Javstash",
+		Description: "JAVStash",
 		Options: []models.ScraperOption{
 			{
 				Key:         "api_key",
 				Label:       "API Key",
-				Description: "API key for Javstash.org authentication",
+				Description: "API key for JAVStash.org authentication",
 				Type:        "password",
 				Default:     "",
 			},

--- a/web/frontend/src/lib/components/priority/FieldRow.svelte
+++ b/web/frontend/src/lib/components/priority/FieldRow.svelte
@@ -2,6 +2,7 @@
 	import { SquarePen, RotateCcw } from 'lucide-svelte';
 	import Button from '../ui/Button.svelte';
 	import type { FieldStatus } from './priority';
+	import { formatScraperName } from './scraperNames';
 
 	interface Props {
 		fieldName: string;
@@ -15,22 +16,6 @@
 
 	let { fieldName, fieldLabel, priority, globalPriority, status, onEdit, onReset }: Props =
 		$props();
-
-	// Helper to format scraper names
-	function formatScraperName(name: string): string {
-		if (name === 'dmm') return 'DMM/Fanza';
-		if (name === 'libredmm') return 'LibreDMM (Fanza, MGStage, SOD, FC2)';
-		if (name === 'r18dev') return 'R18.dev';
-		if (name === 'javlibrary') return 'JavLibrary';
-		if (name === 'javdb') return 'JavDB';
-		if (name === 'javbus') return 'JavBus';
-		if (name === 'jav321') return 'Jav321';
-		if (name === 'tokyohot') return 'Tokyo-Hot';
-		if (name === 'aventertainment') return 'AV Entertainment';
-		if (name === 'dlgetchu') return 'DLGetchu';
-		if (name === 'caribbeancom') return 'Caribbeancom';
-		return name.charAt(0).toUpperCase() + name.slice(1);
-	}
 
 	// Per-status visual language.
 	// inherited (green): no override, uses the global priority list.

--- a/web/frontend/src/lib/components/priority/FieldRow.test.ts
+++ b/web/frontend/src/lib/components/priority/FieldRow.test.ts
@@ -75,6 +75,17 @@ describe('FieldRow', () => {
 		expect(custom.container.textContent).toContain('Tokyo-Hot');
 	});
 
+	// Regression guard for issue #105: mgstage (and fc2/javstash) fell through
+	// the scraper-name table and rendered as the raw config key. A field whose
+	// priority resolves to mgstage must show the proper "MGStage" label.
+	it('renders the MGStage label for the mgstage config key', () => {
+		const { container } = render(FieldRow, {
+			props: make_props({ status: 'custom', priority: ['mgstage'] }),
+		});
+		expect(container.textContent).toContain('MGStage');
+		expect(container.textContent).not.toContain('mgstage');
+	});
+
 	it('renders the inherited global chain as a defensive fallback for a custom + empty (legacy []) field', () => {
 		// A present-empty [] is LEGACY and folds to inherit on read — so this
 		// custom+empty branch should rarely fire; when it does, the row falls

--- a/web/frontend/src/lib/components/priority/MetadataPriority.svelte
+++ b/web/frontend/src/lib/components/priority/MetadataPriority.svelte
@@ -18,6 +18,7 @@
 		buildFieldPriorityOverride,
 		SKIP_SENTINEL
 	} from './priority';
+	import { formatScraperName } from './scraperNames';
 
 	interface Props {
 		config: SettingsConfig;
@@ -138,24 +139,10 @@
 		{ key: 'trailer_url', label: 'Trailer', category: 'Media', description: 'Preview video URL' }
 	];
 
-	function formatScraperName(name: string): string {
-		if (name === 'dmm') return 'DMM/Fanza';
-		if (name === 'libredmm') return 'LibreDMM (Fanza, MGStage, SOD, FC2)';
-		if (name === 'r18dev') return 'R18.dev';
-		if (name === 'javlibrary') return 'JavLibrary';
-		if (name === 'javdb') return 'JavDB';
-		if (name === 'javbus') return 'JavBus';
-		if (name === 'jav321') return 'Jav321';
-		if (name === 'tokyohot') return 'Tokyo-Hot';
-		if (name === 'aventertainment') return 'AV Entertainment';
-		if (name === 'dlgetchu') return 'DLGetchu';
-		if (name === 'caribbeancom') return 'Caribbeancom';
-		return name;
-	}
-
 	// Field priority / override helpers live in ./priority.ts (pure, unit-tested).
 	// They take `config` as their first argument and encode the two field
 	// states: "inherited" (green) and "custom" (orange).
+	// formatScraperName lives in ./scraperNames.ts (shared with FieldRow).
 
 	// Get list of enabled scrapers
 	function getEnabledScrapers(): string[] {

--- a/web/frontend/src/lib/components/priority/scraperNames.test.ts
+++ b/web/frontend/src/lib/components/priority/scraperNames.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { formatScraperName } from './scraperNames';
+
+describe('formatScraperName', () => {
+	it('maps known scraper keys to their display labels', () => {
+		expect(formatScraperName('dmm')).toBe('DMM/Fanza');
+		expect(formatScraperName('libredmm')).toBe('LibreDMM (Fanza, MGStage, SOD, FC2)');
+		expect(formatScraperName('r18dev')).toBe('R18.dev');
+		expect(formatScraperName('javlibrary')).toBe('JavLibrary');
+		expect(formatScraperName('javdb')).toBe('JavDB');
+		expect(formatScraperName('javbus')).toBe('JavBus');
+		expect(formatScraperName('jav321')).toBe('Jav321');
+		expect(formatScraperName('tokyohot')).toBe('Tokyo-Hot');
+		expect(formatScraperName('aventertainment')).toBe('AV Entertainment');
+		expect(formatScraperName('dlgetchu')).toBe('DLGetchu');
+		expect(formatScraperName('caribbeancom')).toBe('Caribbeancom');
+	});
+
+	// Regression guard for issue #105: mgstage, fc2, and javstage fell through
+	// to the raw key (or a naive capitalize) because the mapping table omitted
+	// them. They must render as proper labels everywhere the function is used.
+	it('maps previously-missing scraper keys instead of returning the raw key', () => {
+		expect(formatScraperName('mgstage')).toBe('MGStage');
+		expect(formatScraperName('fc2')).toBe('FC2');
+		expect(formatScraperName('javstash')).toBe('JAVStash');
+	});
+
+	it('falls back to the raw key for unknown scrapers', () => {
+		expect(formatScraperName('unknownscraper')).toBe('unknownscraper');
+	});
+});

--- a/web/frontend/src/lib/components/priority/scraperNames.ts
+++ b/web/frontend/src/lib/components/priority/scraperNames.ts
@@ -1,0 +1,42 @@
+/**
+ * Display labels for scraper config keys.
+ *
+ * Used by the Metadata Priority UI (MetadataPriority.svelte + FieldRow.svelte)
+ * so a scraper chip renders "MGStage" rather than the raw `mgstage` config key.
+ * Kept in one place so the table can't drift between the two call sites
+ * (issue #105: `mgstage`/`fc2`/`javstash` were missing and rendered verbatim).
+ */
+export function formatScraperName(name: string): string {
+	switch (name) {
+		case 'dmm':
+			return 'DMM/Fanza';
+		case 'libredmm':
+			return 'LibreDMM (Fanza, MGStage, SOD, FC2)';
+		case 'r18dev':
+			return 'R18.dev';
+		case 'javlibrary':
+			return 'JavLibrary';
+		case 'javdb':
+			return 'JavDB';
+		case 'javbus':
+			return 'JavBus';
+		case 'jav321':
+			return 'Jav321';
+		case 'tokyohot':
+			return 'Tokyo-Hot';
+		case 'aventertainment':
+			return 'AV Entertainment';
+		case 'dlgetchu':
+			return 'DLGetchu';
+		case 'caribbeancom':
+			return 'Caribbeancom';
+		case 'mgstage':
+			return 'MGStage';
+		case 'fc2':
+			return 'FC2';
+		case 'javstash':
+			return 'JAVStash';
+		default:
+			return name;
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two related bugs in the Web UI Settings reported in #105, plus normalizes the JAVStash scraper display name.

### 1. `metadata.priority.*` fields never inherited `scrapers.priority`

The embedded `internal/config/config.yaml.example` (what \`javinizer init\` writes verbatim via \`createFromEmbedded\`) shipped every per-field \`metadata.priority.*\` as a hardcoded \`[dmm, r18dev, libredmm]\`. Under the documented "World A" semantics (\`web/frontend/src/lib/components/priority/priority.ts\` → \`getFieldPriority\`), only an **absent** or **empty \`[]\`** key inherits \`scrapers.priority\`. Because the generated config wrote a concrete non-empty list for every field, every field was locked into "Custom" override mode from the start.

Consequences:
- Enabling/reordering scrapers in **Scraper Settings** (e.g. adding MGStage) updated \`scrapers.priority\` but never propagated to the per-field lists — \`mgstage\` was never added, and \`libredmm\` (not even enabled) persisted.
- The backend's exclusive-override behavior (\`internal/aggregator/aggregate.go\`, \`AggregateWithPriority\` / \`aggregateWithPriority\`) means a non-empty per-field list wins with **no fallback**. A title only found via \`mgstage\` had its \`id\`/\`content_id\` resolve to \`""\`, and \`MovieUpserter.resolveContentID\` (\`internal/database/movie_upserter.go\`) failed with \`content_id is required when using ContentID as primary key\`.

**Fix:** Empty all per-field \`metadata.priority.*\` to \`[]\` in the embedded example config (matching \`DefaultConfig()\`'s \`Priority: nil\`, so fields inherit `scrapers.priority` and automatically pick up scrapers the user enables. Synced to `configs/config.yaml.example` via `make config-sync`.

> Note: existing users who already ran `javinizer init` with the old config keep their stale per-field overrides until they empty those keys or set them to `[]`. `CurrentConfigVersion` is unchanged; no auto-migration is added (acceptable for the shipped-default scope of #105). Worth a release note.

### 2. `mgstage`/`fc2`/`javstash` rendered as raw config keys

`formatScraperName()` was duplicated in `MetadataPriority.svelte` and `FieldRow.svelte`, both omitting `mgstage`/`fc2`/`javstash` mappings, so the raw keys rendered in the UI.

**Fix:** Extracted a shared `web/frontend/src/lib/components/priority/scraperNames.ts` and wired both `.svelte` files to import it. Added the missing mappings (`mgstage`→MGStage, `fc2`→FC2, `javstash`→JAVStash). Unknown keys fall back to the raw name.

### 3. Normalize JAVStash display name

The backend `Description:` (`internal/scraper/javstash/module.go`) served `Javstash` as the canonical `display_title` via `GET /api/v1/scrapers`, while the issue requested `JAVStash`. Normalized every display-name string literal to `JAVStash` across the backend scraper errors, module description, docs, README, and issue template. Lowercase identifiers (scraper key, `Name()`, URLs `javstash.org`, env var `JAVSTASH_API_KEY`, error-prefix `javstash:`, package names) are intentionally left untouched. `CHANGELOG.md` left as historical.

## Tests

TDD red-green-refactor:
- **RED→GREEN (Go):** `internal/config/example_metadata_priority_test.go` — loads `config.yaml.example` and asserts every per-field override is empty/absent via the public `PerFieldOverride` accessor. Failed against the old hardcoded lists; passes after emptying.
- **RED→GREEN (frontend):** `scraperNames.test.ts` — locks `mgstage`→MGStage, `fc2`→FC2, `javstash`→JAVStash, the existing mappings, and the raw-key fallback.
- **REFACTOR:** both `.svelte` files import the shared `formatScraperName`; existing component tests stay green.
- Added an integration regression case in `FieldRow.test.ts` asserting `mgstage` renders as `MGStage` and the raw key does **not** appear.

End-to-end inheritance and the aggregator path (`[]` → inherit global) are already covered by pre-existing tests (`priority_exclusivity_test.go`, `priority_empty_override_test.go`), so no new tests were needed there.

## Validation

- `go build ./...` — clean
- `go vet ./internal/config/ ./internal/aggregator/ ./internal/scraper/javstash/` — clean
- `go test -short ./internal/config/ ./internal/aggregator/` — PASS
- `go test ./internal/scraper/javstash/ ./internal/config/ ./internal/api/system/` — PASS
- `cd web/frontend && npx vitest run src/lib/components/priority/` — 4 files / 47 tests PASS
- `cd web/frontend && npx svelte-check --threshold error` — 0 errors, 0 warnings
- `scripts/validate-config-sync.sh` — passed (example ↔ DefaultConfig synchronized)

Closes #105
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scraper naming and labeling throughout the app so names now display with consistent, user-friendly capitalization.
  * The metadata priority screen now shows clearer scraper names in shared formatting.

* **Bug Fixes**
  * Updated default metadata priority examples to inherit global scraper ordering unless a field is explicitly locked.
  * Refined scraper-related messages and error text for clearer feedback during search and URL handling.

* **Documentation**
  * Aligned configuration, CLI, and setup docs with the updated scraper naming and priority behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->