### PR TITLE
fix(aggregator): boundary-aware word replacement for censored tokens

### DIFF
--- a/internal/aggregator/word_processor.go
+++ b/internal/aggregator/word_processor.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/javinizer/javinizer-go/internal/models"
 )
@@ -76,6 +78,20 @@ func NewWordProcessor(cfg *MetadataConfig, repo wordLookup) *wordProcessor {
 }
 
 // Apply replaces occurrences of known words in the input text.
+//
+// Two matching strategies, dispatched by whether the pattern contains the
+// censor character '*':
+//
+//   - Patterns WITH '*' (censored-word tokens, e.g. "F***"): matched as a whole
+//     token using replaceTokenBounded. The match must be bounded on both sides
+//     by string start/end or a char that is neither a letter nor '*'. This
+//     prevents a short censored token from matching as a substring inside a
+//     longer, unlisted censored token — e.g. "F***" no longer fires inside
+//     "F****d" (which would yield "Fuck*d"). Issue #106.
+//   - Patterns WITHOUT '*' (e.g. the "[Recommended For Smartphones] " prefix
+//     strip): matched as a plain substring via strings.ReplaceAll, preserving
+//     the original behavior for patterns that are genuinely meant to match
+//     as substrings.
 func (wp *wordProcessor) Apply(text string) string {
 	if wp == nil || wp.cfg == nil || !wp.cfg.WordReplacement.Enabled {
 		return text
@@ -95,12 +111,86 @@ func (wp *wordProcessor) Apply(text string) string {
 
 	result := text
 	for _, p := range sorted {
-		if strings.Contains(result, p.orig) {
+		if strings.ContainsRune(p.orig, '*') {
+			result = replaceTokenBounded(result, p.orig, p.repl)
+		} else if strings.Contains(result, p.orig) {
 			result = strings.ReplaceAll(result, p.orig, p.repl)
 		}
 	}
 
 	return result
+}
+
+// replaceTokenBounded replaces every non-overlapping occurrence of orig in text
+// with repl, but only when the match is bounded on both sides by string
+// start/end or a character that is neither a Unicode letter nor '*'. This is
+// the "whole censored token" rule: '*' is the censor character, so a run like
+// "F***" is a complete censored word only if the char after it is not a letter
+// (which would extend the word) and not '*' (which would mean it's actually a
+// longer censored token, e.g. "F****d").
+//
+// The boundary chars are INSPECTED but not consumed, so two censored tokens
+// separated by a single space ("F*** S***e") both match — the space serves as
+// the trailing boundary for the first and the leading boundary for the second.
+func replaceTokenBounded(text, orig, repl string) string {
+	if orig == "" {
+		return text
+	}
+	var b strings.Builder
+	b.Grow(len(text))
+	i := 0
+	for {
+		idx := strings.Index(text[i:], orig)
+		if idx < 0 {
+			b.WriteString(text[i:])
+			break
+		}
+		start := i + idx
+		end := start + len(orig)
+		if start > 0 && !isCensorBoundary(boundaryRuneBefore(text, start)) {
+			b.WriteString(text[i:end])
+			i = end
+			continue
+		}
+		if end < len(text) && !isCensorBoundary(boundaryRuneAfter(text, end)) {
+			b.WriteString(text[i:end])
+			i = end
+			continue
+		}
+		b.WriteString(text[i:start])
+		b.WriteString(repl)
+		i = end
+	}
+	return b.String()
+}
+
+// isCensorBoundary reports whether r may act as a boundary for a censored-word
+// token: any char that is NOT a Unicode letter and NOT '*'. Digits, spaces,
+// punctuation, and symbols all qualify; letters and '*' extend the token.
+func isCensorBoundary(r rune) bool {
+	return r != '*' && !unicode.IsLetter(r)
+}
+
+// boundaryRuneBefore decodes the full rune immediately preceding byte index
+// `start` in `text` (UTF-8 aware). Returns -1 if start is at the beginning.
+// Used so multibyte adjacent chars (e.g. Japanese) are classified by their
+// actual rune, not a single lead/continuation byte.
+func boundaryRuneBefore(text string, start int) rune {
+	if start <= 0 || start > len(text) {
+		return -1
+	}
+	r, _ := utf8.DecodeLastRuneInString(text[:start])
+	return r
+}
+
+// boundaryRuneAfter decodes the full rune starting at byte index `end` in
+// `text` (UTF-8 aware). Returns -1 if end is at the end of the string.
+func boundaryRuneAfter(text string, end int) rune {
+	if end < 0 || end >= len(text) {
+		return -1
+	}
+	r, _ := utf8.DecodeRuneInString(text[end:])
+	return r
 }
 
 // ApplyToMovie applies word replacements to all text fields of a Movie.

--- a/internal/aggregator/word_processor.go
+++ b/internal/aggregator/word_processor.go
@@ -133,7 +133,7 @@ func (wp *wordProcessor) Apply(text string) string {
 // separated by a single space ("F*** S***e") both match — the space serves as
 // the trailing boundary for the first and the leading boundary for the second.
 func replaceTokenBounded(text, orig, repl string) string {
-	if orig == "" {
+	if orig == "" || !strings.Contains(text, orig) {
 		return text
 	}
 	var b strings.Builder

--- a/internal/aggregator/word_processor_boundary_test.go
+++ b/internal/aggregator/word_processor_boundary_test.go
@@ -1,0 +1,154 @@
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestApplyWordReplacement_CensoredTokenNotMatchedAsSubstring is the regression
+// guard for issue #106: a short censored token (F***) must NOT be replaced when
+// it appears as a prefix of a longer, unlisted censored token (F****d).
+//
+// The default word-replacement list ships {F***: Fuck, F***e: Force,
+// F*****g: Forcing} but NOT F****d. Under the old strings.ReplaceAll matcher,
+// F*** matched as a substring at position 0 of F****d, producing "Fuck*d".
+// Boundary-aware matching treats F*** as a whole censored token (bounded by
+// non-letter, non-asterisk chars), so the trailing '*' of F****d blocks the
+// match and F****d is left unchanged.
+func TestApplyWordReplacement_CensoredTokenNotMatchedAsSubstring(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***":    "Fuck",
+		"F***e":   "Force",
+		"F*****g": "Forcing",
+	})
+
+	// F****d is NOT in the cache — F*** must not fire inside it.
+	assert.Equal(t, "F****d", wp.Apply("F****d"))
+}
+
+// TestApplyWordReplacement_CensoredTokenMatchesStandalone locks the positive
+// side of boundary-aware matching: a censored token that IS bounded (by string
+// start/end, whitespace, or punctuation) is still replaced. This guards against
+// the boundary check becoming too strict and dropping legitimate replacements.
+func TestApplyWordReplacement_CensoredTokenMatchesStandalone(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***":    "Fuck",
+		"F***e":   "Force",
+		"F*****g": "Forcing",
+	})
+
+	assert.Equal(t, "Fuck", wp.Apply("F***"))
+	assert.Equal(t, "Fuck movie", wp.Apply("F*** movie"))
+	assert.Equal(t, "movie Fuck", wp.Apply("movie F***"))
+	assert.Equal(t, "Fuck, title", wp.Apply("F***, title"))
+	assert.Equal(t, "(Fuck)", wp.Apply("(F***)"))
+
+	// Listed longer censored tokens still replace when standalone — guards
+	// against an over-strict boundary rejecting a token whose end lands on
+	// end-of-string, and locks the longest-first sort + boundary interaction
+	// for asterisk patterns.
+	assert.Equal(t, "Forcing", wp.Apply("F*****g"))
+	assert.Equal(t, "Force", wp.Apply("F***e"))
+}
+
+// TestApplyWordReplacement_CensoredTokenAdjacentTokens ensures the boundary
+// check (which inspects chars without consuming them) doesn't starve an
+// immediately-following token of its leading boundary. Two censored tokens
+// separated by a space must both replace.
+func TestApplyWordReplacement_CensoredTokenAdjacentTokens(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***":  "Fuck",
+		"S***e": "Slave",
+	})
+
+	assert.Equal(t, "Fuck Slave", wp.Apply("F*** S***e"))
+}
+
+// TestApplyWordReplacement_NonAsteriskPatternStillSubstring confirms that
+// patterns WITHOUT '*' (e.g. the "[Recommended For Smartphones] " prefix strip)
+// keep the old substring-matching behavior — they are genuinely meant to match
+// as substrings, not as bounded tokens.
+func TestApplyWordReplacement_NonAsteriskPatternStillSubstring(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"[Recommended For Smartphones] ": "",
+	})
+
+	assert.Equal(t, "Title", wp.Apply("[Recommended For Smartphones] Title"))
+}
+
+// TestApplyWordReplacements_CensoredTokenInTitle is the end-to-end regression
+// guard for issue #106: a movie title containing an unlisted censored token
+// (F****d, the r18dev-censored form of "Forced") must not be corrupted by the
+// shorter F*** entry in the default list into "Fuck*d". The title is passed
+// through applyToMovie exactly as the aggregator does during a scrape.
+func TestApplyWordReplacements_CensoredTokenInTitle(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***":    "Fuck",
+		"F***e":   "Force",
+		"F*****g": "Forcing",
+	})
+
+	movie := &models.Movie{
+		Title: "F****d Entry",
+	}
+	wp.applyToMovie(movie)
+
+	assert.Equal(t, "F****d Entry", movie.Title)
+}
+
+// TestApplyWordReplacement_MultibyteBoundary confirms the boundary check decodes
+// full UTF-8 runes (not single bytes) when classifying the char adjacent to a
+// censored token. This matters for r18dev titles, which can be Japanese.
+//
+// A censored token directly abutting a multibyte rune (Japanese katakana/kanji,
+// or full-width punctuation like 「」) must be classified by the actual rune:
+// a Japanese letter extends the word (blocks the match), while a Japanese
+// punctuation char is a boundary (allows the match). The old byte-level read
+// misclassified lead/continuation bytes and got these wrong.
+func TestApplyWordReplacement_MultibyteBoundary(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***": "Fuck",
+	})
+
+	// Censored token followed directly by a Japanese letter (no separator):
+	// ド is a letter and extends the word, so F*** must NOT fire.
+	assert.Equal(t, "F***ドラマ", wp.Apply("F***ドラマ"))
+	// With a separator it replaces.
+	assert.Equal(t, "Fuck ドラマ", wp.Apply("F*** ドラマ"))
+	// Japanese full-width brackets 「」 are punctuation (boundaries), so the
+	// token inside them replaces.
+	assert.Equal(t, "「Fuck」", wp.Apply("「F***」"))
+}

--- a/internal/aggregator/word_processor_boundary_test.go
+++ b/internal/aggregator/word_processor_boundary_test.go
@@ -64,6 +64,23 @@ func TestApplyWordReplacement_CensoredTokenMatchesStandalone(t *testing.T) {
 	assert.Equal(t, "Force", wp.Apply("F***e"))
 }
 
+// TestApplyWordReplacement_CensoredTokenNoMatchReturnsUnchanged confirms the
+// no-match fast path: when the censored pattern is absent from the text, the
+// text is returned unchanged (and without avoidable allocation via the builder).
+func TestApplyWordReplacement_CensoredTokenNoMatchReturnsUnchanged(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***": "Fuck",
+	})
+
+	assert.Equal(t, "nothing here", wp.Apply("nothing here"))
+	assert.Equal(t, "", wp.Apply(""))
+}
+
 // TestApplyWordReplacement_CensoredTokenAdjacentTokens ensures the boundary
 // check (which inspects chars without consuming them) doesn't starve an
 // immediately-following token of its leading boundary. Two censored tokens


### PR DESCRIPTION
## Summary

Fixes the word-replacement matcher corrupting unlisted censored tokens, reported in #106.

### The bug

`internal/aggregator/word_processor.go` `Apply()` used `strings.ReplaceAll` — a blind substring match. The default word-replacement list ships `{F***: Fuck}` (among others). When a title contained `F****d` (the r18dev-censored form of "Forced", which is **not** in the default list), `F***` matched as a substring at position 0 → produced `Fuck*d`.

Reproduced directly against the real default-list entries:
```
F****d -> "Fuck*d"  (expected: F****d unchanged)
```

This isn't isolated to `F***` — a scan found **21 prefix-collision pairs** in the default list. They're currently benign only because both the short and long forms happen to be listed. Any source text containing a censored form that **isn't** enumerated gets corrupted, so no data-only change closes the class.

### The fix

Dispatched matching in `Apply()` by whether the pattern contains the censor character `*`:

- **Patterns with `*` (censored-word tokens):** matched via a new `replaceTokenBounded` helper. A match only fires when bounded on both sides by string start/end or a char that is **neither a Unicode letter nor `*`**. So `F***` in `F****d` is blocked (trailing `*` extends the censored token), while `F***` standalone / `F***,` / `F*** movie` all still replace.
- **Patterns without `*` (e.g. `[Recommended For Smartphones] ` prefix strip):** keep `strings.ReplaceAll` (genuine substring intent).

The `*`-presence is a clean, semantically-grounded discriminator: `*` is the censor character, so a `*`-pattern is a censored word that must match as a discrete token; a non-`*` pattern is a literal substring strip.

### UTF-8 correctness (addressed during review)

Boundary chars are decoded with `utf8.DecodeLastRuneInString` / `utf8.DecodeRuneInString` (via `boundaryRuneBefore`/`boundaryRuneAfter`), not single-byte reads — so multibyte adjacent chars are classified by their actual rune. This matters for r18dev titles, which can be Japanese:
- `F***ドラマ` stays unchanged (ド is a letter, extends the word)
- `F*** ドラマ` → `Fuck ドラマ` (separator)
- `「F***」` → `「Fuck」` (full-width brackets are punctuation boundaries)

The boundary chars are *inspected, not consumed*, so adjacent tokens (`F*** S***e`) both match.

### Why not a data fix / regex

- **Data fix** (`F***`→`F**k`, as the issue author suggested): would still produce `F**k*d` — doesn't fix substring matching and doesn't generalize across the other 20 collision pairs.
- **Regex with `\b` word boundaries:** censored tokens mix word-chars (`F`) with non-word-chars (`*`), so Go's `\b` (word/non-word transition) mis-fires. RE2 also lacks lookbehind, and a captured-boundaries regex hits an overlap problem for adjacent single-space-separated tokens. The hand-rolled `strings.Index` scan is the clean correct implementation.

## Tests

TDD red-green-refactor (`internal/aggregator/word_processor_boundary_test.go`):
1. **RED→GREEN:** `F****d` stays `F****d` (the exact bug) — failed as `Fuck*d` before, passes now.
2. **Regression guard:** `F***` still matches standalone, with trailing space, and with punctuation `,`/`(`.
3. **Listed longer tokens still replace:** `F*****g`→`Forcing`, `F***e`→`Force` (guards against an over-strict boundary rejecting end-of-string tokens; locks the longest-first sort + boundary interaction).
4. **Adjacent tokens:** `F*** S***e` → `Fuck Slave` (boundary char not consumed).
5. **Non-`*` patterns:** `[Recommended For Smartphones] ` prefix strip still works via substring.
6. **Multibyte boundary:** `F***ドラマ`, `F*** ドラマ`, `「F***」` — locks UTF-8-aware boundary decode.
7. **End-to-end:** `applyToMovie` on a title `F****d Entry` leaves it unchanged.

## Validation

- `go vet ./internal/aggregator/` — clean
- `go test ./internal/aggregator/` — all pass
- `go test -race ./internal/aggregator/` — PASS (race detector required for this package per AGENTS.md)
- `go build ./...` — clean

Closes #106