### PR TITLE
ci: bump Go to 1.26.5 to clear govulncheck GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/javinizer/javinizer-go
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Eyevinn/mp4ff v0.51.0


### PR DESCRIPTION
## Summary

The Vulnerability Scan CI job (`govulncheck v1.5.0`) has been failing on `main` with `GO-2026-5856` — a stdlib `crypto/tls` vulnerability (Encrypted Client Hello privacy leak) fixed in `go1.26.5`.

### Root cause

`go.mod` pins `go 1.26.4`, and the CI workflow (`.github/workflows/test.yml`) uses `go-version-file: go.mod` for Go setup. So the toolchain never picked up the `1.26.5` patch release containing the fix.

The affected call sites (flagged by govulncheck) are all pre-existing and unrelated to any recent change:
- `internal/desktop/server.go:119` — `desktop.StartServer` → `http.Server.Serve` → `tls.Conn.HandshakeContext`
- `internal/r18devdump/download.go:126` — `r18devdump.countingReader.Read` → `tls.Conn.Read`
- `internal/commandutil/batch_command.go:394` — `commandutil.UpdateEventHandler` → `tls.Conn.Write`
- `internal/update/upgrade.go:432` — `update.DownloadTo` → `http.Client.Do` → `tls.Dialer.DialContext`

### Fix

Bump the `go` directive in `go.mod` from `1.26.4` → `1.26.5`. The CI `go-version-file: go.mod` setup will then install `1.26.5`, which contains the fix.

### Validation

Verified locally with `go1.26.5` (auto-downloaded via `GOTOOLCHAIN=auto`):
- `govulncheck ./...` → **0 vulnerabilities found** (was: 1 stdlib vuln with 4 call traces)
- `go test -short ./...` → all pass
- `go vet ./...` → clean
- `go build ./...` → clean

This is a one-line change to `go.mod` (no code or dependency changes).