### PR TITLE
Fix browse box outline + allowed_directories persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,7 +137,7 @@ ENV JAVINIZER_HOME=/javinizer \
     JAVINIZER_TEMP_DIR=/javinizer/temp \
     JAVINIZER_INIT_SERVER_HOST=0.0.0.0 \
     JAVINIZER_INIT_ALLOWED_DIRECTORIES=/media \
-    JAVINIZER_INIT_ALLOWED_ORIGINS="http://localhost:8080,http://localhost:5173,http://127.0.0.1:8080,http://127.0.0.1:5173" \
+    JAVINIZER_INIT_ALLOWED_ORIGINS="http://localhost:8765,http://localhost:5173,http://127.0.0.1:8765,http://127.0.0.1:5173" \
     JAVINIZER_IMAGE_DEFAULT_UID=${USER_ID} \
     JAVINIZER_IMAGE_DEFAULT_GID=${GROUP_ID} \
     CHROME_BIN=/usr/bin/chromium-browser \
@@ -147,11 +147,11 @@ ENV JAVINIZER_HOME=/javinizer \
     PATH="/usr/local/bin:${PATH}"
 
 # Expose API/web port
-EXPOSE 8080
+EXPOSE 8765
 
 # Health check endpoint
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD wget --no-verbose --tries=1 --method=GET -O /dev/null http://localhost:8080/health || exit 1
+    CMD wget --no-verbose --tries=1 --method=GET -O /dev/null http://localhost:8765/health || exit 1
 
 # Entrypoint script to initialize config
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ check-swagger:
 # Alias for backward compatibility
 docs: swagger
 	@echo "✅ Documentation up-to-date"
-	@echo "View at: http://localhost:8080/docs"
+	@echo "View at: http://localhost:8765/docs"
 
 # Generate mocks from interfaces using mockery v3
 # Pinned to v3.7.1 for reproducible output (regen drift otherwise).
@@ -631,8 +631,9 @@ docker-build-no-cache:
 # The setup CIDR is needed because the container sees the host as the Docker
 # bridge gateway (172.x), not 127.0.0.1, so the /auth/setup localhost guard
 # would reject the first-run setup screen without it.
-# Port on the host to publish the container's 8080. 8080 is too common (collides
-# with many dev tools); 8765 is distinctive. Override: make docker-run HOST_PORT=9090
+# Port on the host to publish the container's 8765. 8765 is distinctive
+# (8080 is too common and collides with many dev tools).
+# Override: make docker-run HOST_PORT=9090
 # Matches docker-compose.yml's HOST_PORT env var so `make` and `compose` agree.
 HOST_PORT ?= 8765
 # Host directory mounted at /media (input files, writable so organize works).
@@ -655,7 +656,7 @@ docker-run:
 	@if [ ! -d "$(ABS_MEDIA_DIR)" ]; then echo "warning: MEDIA_DIR '$(MEDIA_DIR)' does not exist or is not a directory — container will start but /media will be empty"; fi
 	docker run -d \
 		--name $(DOCKER_CONTAINER_NAME) \
-		-p "$(HOST_PORT):8080" \
+		-p "$(HOST_PORT):8765" \
 		-e JAVINIZER_SETUP_TRUSTED_CIDRS=172.16.0.0/12 \
 		-v "$(DATA_DIR):/javinizer" \
 		-v "$(ABS_MEDIA_DIR):/media" \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ chmod +x javinizer
 ./javinizer web
 ```
 
-Open **http://localhost:8080**, create your admin login on first startup, and start scraping.
+Open **http://localhost:8765**, create your admin login on first startup, and start scraping.
 
 - On macOS, swap the asset for `javinizer-darwin-universal`; on Windows, download `javinizer-windows-amd64.exe` and run `.\javinizer.exe web`.
 - Prefer [Docker](#docker), a [one-shot installer](#one-shot-install-linux--macos--windows), [Homebrew](#homebrew-macos--linux), a [binary](#prebuilt-binaries-manual-download), or [build from source](#build-from-source) for other setups.
@@ -58,7 +58,7 @@ curl -o ./data/config.yaml \
 docker run --rm \
   -e JAVINIZER_SETUP_TRUSTED_CIDRS=172.16.0.0/12 \
   --user "$(id -u):$(id -g)" \
-  -p 8080:8080 \
+  -p 8765:8765 \
   -v "$(pwd)/data:/javinizer" \
   -v "/path/to/your/media:/media" \
   ghcr.io/javinizer/javinizer-go:latest
@@ -256,7 +256,7 @@ Rename-Item javinizer-windows-amd64.exe javinizer.exe
 To run `javinizer` from anywhere, add its folder to your `PATH` (System Properties → Environment Variables → Path → New), or copy `javinizer.exe` into a folder that's already on your `PATH`.
 
 ```powershell
-# Start the web UI, then open http://localhost:8080
+# Start the web UI, then open http://localhost:8765
 .\javinizer.exe init
 .\javinizer.exe web
 ```
@@ -306,7 +306,7 @@ make build
 
 ```bash
 javinizer init          # creates a default config.yaml + database
-javinizer web           # starts the server at http://localhost:8080
+javinizer web           # starts the server at http://localhost:8765
 # Custom port/host:
 javinizer web --host 0.0.0.0 --port 8081
 ```
@@ -379,7 +379,7 @@ See the [CLI Reference](./docs/03-cli-reference.md) for every command and flag.
 
 ## Web UI
 
-Available in Docker and in the binary (embedded), at `http://localhost:8080`.
+Available in Docker and in the binary (embedded), at `http://localhost:8765`.
 
 | Page | What you do there |
 |---|---|
@@ -392,7 +392,7 @@ Available in Docker and in the binary (embedded), at `http://localhost:8080`.
 | **History** | View and roll back organization operations. |
 | **Settings** | Configure scrapers, output templates, and proxy settings. |
 
-**API docs** are served alongside the UI: [Scalar UI](http://localhost:8080/docs) and [Swagger UI](http://localhost:8080/swagger/index.html). See the [API Reference](./docs/07-api-reference.md) for endpoint documentation.
+**API docs** are served alongside the UI: [Scalar UI](http://localhost:8765/docs) and [Swagger UI](http://localhost:8765/swagger/index.html). See the [API Reference](./docs/07-api-reference.md) for endpoint documentation.
 
 ### Web development
 
@@ -404,7 +404,7 @@ make build && javinizer web
 **Dev mode (hot reload):**
 ```bash
 javinizer web        # terminal 1: backend
-make web-dev         # terminal 2: frontend at http://localhost:5174 (proxies API to :8080)
+make web-dev         # terminal 2: frontend at http://localhost:5174 (proxies API to :8765)
 ```
 
 See `web/frontend/README.md` for more.
@@ -480,7 +480,7 @@ Docker deployments support environment-variable overrides. Defaults shown are fo
 docker run --rm \
   -e LOG_LEVEL=debug -e TZ=Asia/Tokyo \
   -e JAVINIZER_SETUP_TRUSTED_CIDRS=172.16.0.0/12 \
-  -p 9000:8080 \
+  -p 9000:8765 \
   -v "$(pwd)/data:/javinizer" -v "/media/jav:/media" \
   ghcr.io/javinizer/javinizer-go:latest
 ```

--- a/cmd/javinizer/commands/api/command.go
+++ b/cmd/javinizer/commands/api/command.go
@@ -31,7 +31,7 @@ import (
 // @license.name MIT
 // @license.url https://opensource.org/licenses/MIT
 
-// @host localhost:8080
+// @host localhost:8765
 // @BasePath /
 // @schemes http https
 

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -15,7 +15,7 @@ config_version: 3
 
 server:
     host: localhost
-    port: 8080
+    port: 8765
 api:
     security:
         # CORS allowed origins for API and WebSocket connections
@@ -23,9 +23,9 @@ api:
         # - Empty array [] means same-origin only
         # - Add frontend origins if using a separate web server (e.g., "http://localhost:5173" for Vite dev server)
         allowed_origins:
-            - http://localhost:8080
+            - http://localhost:8765
             - http://localhost:5173
-            - http://127.0.0.1:8080
+            - http://127.0.0.1:8765
             - http://127.0.0.1:5173
 
         # Allowed directories for API file operations (organize, preview, etc.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - .env
 
     ports:
-      - "${HOST_PORT:-8765}:8080"
+      - "${HOST_PORT:-8765}:8765"
 
     volumes:
       # Application state (config, database, logs, cache)
@@ -64,7 +64,7 @@ services:
       - JAVINIZER_SETUP_TRUSTED_CIDRS=${JAVINIZER_SETUP_TRUSTED_CIDRS:-172.16.0.0/12}
 
     healthcheck:
-      test: ["CMD", "wget", "--method=GET", "-O", "/dev/null", "-q", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "--method=GET", "-O", "/dev/null", "-q", "http://localhost:8765/health"]
       interval: 30s
       timeout: 3s
       retries: 3
@@ -82,7 +82,7 @@ services:
     env_file:
       - .env
     ports:
-      - "${HOST_PORT:-8765}:8080"
+      - "${HOST_PORT:-8765}:8765"
     volumes:
       - ./data:/javinizer
       - ${MEDIA_PATH:-/path/to/your/jav-library}:/media

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -37,7 +37,7 @@ Configure the REST API server:
 ```yaml
 server:
   host: localhost  # Bind address
-  port: 8080       # Listen port
+  port: 8765       # Listen port
 ```
 
 ### API Security Settings
@@ -113,7 +113,7 @@ scrapers:
     default_profile: "main"   # Profile used by default when proxy is enabled
     profiles:
       main:
-        url: ""           # Examples: "http://proxy.example.com:8080", "socks5://localhost:1080"
+        url: ""           # Examples: "http://proxy.example.com:8765", "socks5://localhost:1080"
         username: ""      # Optional authentication
         password: ""      # Optional authentication
       backup:
@@ -1038,7 +1038,7 @@ services:
   javinizer:
     image: ghcr.io/javinizer/javinizer-go:latest
     ports:
-      - "8080:8080"
+      - "8765:8765"
     volumes:
       - ./config:/config
       - /media/videos:/data/videos:ro
@@ -1061,7 +1061,7 @@ Environment variables override configuration file settings and are particularly 
 | `JAVINIZER_DATA_DIR` | Optional | - | Override data directory (reserved for future use) |
 | `LOG_LEVEL` | Optional | `info` | Override log level (`debug`, `info`, `warn`, `error`) |
 | `UMASK` | Optional | `002` | Override file creation mask (e.g., `002` for `rwxrwxr-x`) |
-| `PORT` | Optional | `8080` | Override API server port |
+| `PORT` | Optional | `8765` | Override API server port |
 
 ### Docker Deployment Variables
 
@@ -1072,7 +1072,7 @@ These variables are specific to Docker deployments and container orchestration:
 | `PUID` | Optional | `1000` | User ID for file ownership in container |
 | `PGID` | Optional | `1000` | Group ID for file ownership in container |
 | `TZ` | Optional | `UTC` | Container timezone (IANA format: `America/New_York`) |
-| `HOST_PORT` | Optional | `8080` | Host port to expose Javinizer web UI |
+| `HOST_PORT` | Optional | `8765` | Host port to expose Javinizer web UI |
 | `FLARESOLVERR_HOST_PORT` | Optional | `8191` | Host port to expose FlareSolverr API |
 | `MEDIA_PATH` | Recommended | - | Absolute path to media library on host system |
 
@@ -1152,7 +1152,7 @@ PUID=1000
 PGID=1000
 
 # Ports
-HOST_PORT=8080
+HOST_PORT=8765
 FLARESOLVERR_HOST_PORT=8191
 
 # Timezone
@@ -1212,7 +1212,7 @@ When no configuration file exists:
 2. **Database**: SQLite database created at `data/javinizer.db`
 3. **Logs**: Output to `stdout` and `data/logs/javinizer.log`
 4. **Scrapers**: All scrapers available with default settings
-5. **Server**: Binds to `localhost:8080`
+5. **Server**: Binds to `localhost:8765`
 6. **Security**: Empty allowed directories denies all API file access (secure by default). Configure `api.security.allowed_directories` to enable access.
 
 ### Minimal Configuration Required
@@ -1238,7 +1238,7 @@ Javinizer provides sensible defaults for all configuration options. These defaul
 ```yaml
 server:
   host: localhost
-  port: 8080
+  port: 8765
 
 api:
   security:
@@ -1251,9 +1251,9 @@ api:
     trusted_proxies: []
     force_secure_cookies: false
     allowed_origins:
-      - "http://localhost:8080"
+      - "http://localhost:8765"
       - "http://localhost:5173"
-      - "http://127.0.0.1:8080"
+      - "http://127.0.0.1:8765"
       - "http://127.0.0.1:5173"
 ```
 
@@ -1548,7 +1548,7 @@ Docker deployments use `.env` files for per-environment settings:
 ```bash
 LOG_LEVEL=debug
 JAVINIZER_DEV_MODE=true
-VITE_API_URL=http://localhost:8080
+VITE_API_URL=http://localhost:8765
 ```
 
 **Production (`.env.prod`):**

--- a/docs/03-cli-reference.md
+++ b/docs/03-cli-reference.md
@@ -759,7 +759,7 @@ javinizer info
 === Javinizer Configuration ===
 Config file: configs/config.yaml
 Database: data/javinizer.db (sqlite)
-Server: localhost:8080
+Server: localhost:8765
 
 Scrapers:
   Priority: [r18dev libredmm dmm javlibrary javdb javbus jav321 mgstage tokyohot aventertainment caribbeancom dlgetchu fc2 javstash]
@@ -1046,7 +1046,7 @@ javinizer web [flags]
 **Examples:**
 
 ```bash
-# Start with defaults (localhost:8080)
+# Start with defaults (localhost:8765)
 javinizer web
 
 # Custom host and port
@@ -1056,28 +1056,28 @@ javinizer web --host 0.0.0.0 --port 9000
 javinizer web --verbose
 ```
 
-Once running, the interactive Web UI is available at `http://localhost:8080/`. See the [API Reference](./07-api-reference.md) for the full list of REST endpoints, request/response schemas, and the Scalar/Swagger docs at `/docs` and `/swagger/index.html`.
+Once running, the interactive Web UI is available at `http://localhost:8765/`. See the [API Reference](./07-api-reference.md) for the full list of REST endpoints, request/response schemas, and the Scalar/Swagger docs at `/docs` and `/swagger/index.html`.
 
 **Quick example API usage:**
 
 ```bash
 # Health check
-curl http://localhost:8080/health
+curl http://localhost:8765/health
 
 # First-run setup (stores a session cookie for authenticated requests)
-curl -X POST http://localhost:8080/api/v1/auth/setup \
+curl -X POST http://localhost:8765/api/v1/auth/setup \
   -H "Content-Type: application/json" \
   -c cookies.txt \
   -d '{"username":"admin","password":"password123"}'
 
 # Scrape a movie
-curl -X POST http://localhost:8080/api/v1/scrape \
+curl -X POST http://localhost:8765/api/v1/scrape \
   -b cookies.txt \
   -H "Content-Type: application/json" \
   -d '{"id": "IPX-535"}'
 
 # Get a cached movie by JAV ID
-curl -b cookies.txt http://localhost:8080/api/v1/movies/IPX-535
+curl -b cookies.txt http://localhost:8765/api/v1/movies/IPX-535
 ```
 
 ---

--- a/docs/07-api-reference.md
+++ b/docs/07-api-reference.md
@@ -4,7 +4,7 @@ The Javinizer REST API provides programmatic access to all metadata scraping, fi
 
 ## Overview
 
-- **Base URL**: `http://localhost:8080/api/v1`
+- **Base URL**: `http://localhost:8765/api/v1`
 - **Content Type**: `application/json`
 - **Authentication**: Built-in single-user session authentication
 - **WebSocket**: Real-time progress updates at `/ws/progress`
@@ -15,7 +15,7 @@ The Javinizer REST API provides programmatic access to all metadata scraping, fi
 
 **Using Docker (recommended):**
 ```bash
-docker run --rm -p 8080:8080 \
+docker run --rm -p 8765:8765 \
   -v "$(pwd)/data:/javinizer" \
   -v "/path/to/media:/media" \
   ghcr.io/javinizer/javinizer-go:latest
@@ -30,14 +30,14 @@ javinizer web
 ```bash
 javinizer web --port 9000
 ```
-Or set `server.port` in `config.yaml` (default `8080`).
+Or set `server.port` in `config.yaml` (default `8765`).
 
 ### Interactive API Documentation
 
 The API server provides two interactive documentation interfaces:
 
-- **Scalar UI**: [http://localhost:8080/docs](http://localhost:8080/docs) - Modern, user-friendly API explorer
-- **Swagger UI**: [http://localhost:8080/swagger/index.html](http://localhost:8080/swagger/index.html) - Traditional OpenAPI spec viewer
+- **Scalar UI**: [http://localhost:8765/docs](http://localhost:8765/docs) - Modern, user-friendly API explorer
+- **Swagger UI**: [http://localhost:8765/swagger/index.html](http://localhost:8765/swagger/index.html) - Traditional OpenAPI spec viewer
 
 These interfaces provide:
 - Complete request/response schemas
@@ -50,13 +50,13 @@ These interfaces provide:
 On first startup, protected API routes return `503` until credentials are configured.
 
 1. Start server: `javinizer web`
-2. Open Web UI at `http://localhost:8080/`
+2. Open Web UI at `http://localhost:8765/`
 3. Create default username/password in the setup screen
 4. Session cookie is issued automatically after setup
 
 **CLI setup example (cookie jar):**
 ```bash
-curl -X POST http://localhost:8080/api/v1/auth/setup \
+curl -X POST http://localhost:8765/api/v1/auth/setup \
   -H "Content-Type: application/json" \
   -c cookies.txt \
   -d '{"username":"admin","password":"password123"}'
@@ -83,14 +83,14 @@ Scrape, retrieve, and manage movie metadata.
 
 **Example - Scrape movie:**
 ```bash
-curl -X POST http://localhost:8080/api/v1/scrape \
+curl -X POST http://localhost:8765/api/v1/scrape \
   -H "Content-Type: application/json" \
   -d '{"id": "IPX-535"}'
 ```
 
 **Example - List movies:**
 ```bash
-curl http://localhost:8080/api/v1/movies
+curl http://localhost:8765/api/v1/movies
 ```
 
 ### Actresses
@@ -112,19 +112,19 @@ Manage actress database with images and metadata.
 
 **Example - Search actresses:**
 ```bash
-curl "http://localhost:8080/api/v1/actresses/search?q=Sakura"
+curl "http://localhost:8765/api/v1/actresses/search?q=Sakura"
 ```
 
 **Example - Merge preview:**
 ```bash
-curl -X POST http://localhost:8080/api/v1/actresses/merge/preview \
+curl -X POST http://localhost:8765/api/v1/actresses/merge/preview \
   -H "Content-Type: application/json" \
   -d '{"target_id": 12, "source_id": 34}'
 ```
 
 **Example - Apply merge:**
 ```bash
-curl -X POST http://localhost:8080/api/v1/actresses/merge \
+curl -X POST http://localhost:8765/api/v1/actresses/merge \
   -H "Content-Type: application/json" \
   -d '{
     "target_id": 12,
@@ -143,14 +143,14 @@ curl -X POST http://localhost:8080/api/v1/actresses/merge \
 
 **Example - Export actresses:**
 ```bash
-curl -b cookies.txt http://localhost:8080/api/v1/actresses/export -o actresses.json
+curl -b cookies.txt http://localhost:8765/api/v1/actresses/export -o actresses.json
 ```
 
 `GET /api/v1/actresses/export` streams the entire actress table as a JSON array with `Content-Type: application/json`. Rows are emitted in chunks of 1000 so large libraries (100k+ actresses) do not need to fit in memory. The output is a plain JSON array of actress objects, suitable for backup or migration.
 
 **Example - Import actresses:**
 ```bash
-curl -X POST http://localhost:8080/api/v1/actresses/import \
+curl -X POST http://localhost:8765/api/v1/actresses/import \
   -H "Content-Type: application/json" \
   -d '{
     "actresses": [
@@ -196,20 +196,20 @@ Batch scraping workflow with job tracking and WebSocket progress updates.
 
 **Example - Start batch scrape:**
 ```bash
-curl -X POST http://localhost:8080/api/v1/batch/scrape \
+curl -X POST http://localhost:8765/api/v1/batch/scrape \
   -H "Content-Type: application/json" \
   -d '{"directory": "/media/unsorted"}'
 ```
 
 **Example - Get batch job status:**
 ```bash
-curl http://localhost:8080/api/v1/batch/abc-123-def
+curl http://localhost:8765/api/v1/batch/abc-123-def
 ```
 
 **`manual_inputs` (PR #68):** `POST /api/v1/batch/scrape` accepts a `manual_inputs` object keyed by file path. Each value is either a JAV ID (scrapes as that ID, bypassing the matcher) or a URL (scrapes with URL-compatible scrapers). This powers the web UI's Manual Scrape flow.
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/batch/scrape \
+curl -X POST http://localhost:8765/api/v1/batch/scrape \
   -H "Content-Type: application/json" \
   -d '{
     "files": ["/media/unsorted/vid1.mp4", "/media/unsorted/vid2.mp4"],
@@ -250,7 +250,7 @@ Browse filesystem, scan directories, and preview organization results.
 
 **Example - Scan directory:**
 ```bash
-curl -X POST http://localhost:8080/api/v1/scan \
+curl -X POST http://localhost:8765/api/v1/scan \
   -H "Content-Type: application/json" \
   -d '{"path": "/media"}'
 ```
@@ -278,18 +278,18 @@ Configuration, proxy testing, and scraper management.
 
 **Example - Get configuration:**
 ```bash
-curl -b cookies.txt http://localhost:8080/api/v1/config
+curl -b cookies.txt http://localhost:8765/api/v1/config
 ```
 
 **Example - Test proxy:**
 ```bash
-curl -X POST http://localhost:8080/api/v1/proxy/test \
+curl -X POST http://localhost:8765/api/v1/proxy/test \
   -H "Content-Type: application/json" \
   -d '{
     "mode": "direct",
     "proxy": {
       "enabled": true,
-      "url": "http://proxy.example.com:8080"
+      "url": "http://proxy.example.com:8765"
     }
   }'
 ```
@@ -307,7 +307,7 @@ Track and rollback file organization operations.
 
 **Example - List history:**
 ```bash
-curl http://localhost:8080/api/v1/history
+curl http://localhost:8765/api/v1/history
 ```
 
 ### Resources
@@ -322,7 +322,7 @@ Serve temporary and persistent image files.
 
 **Example - Get temp poster:**
 ```bash
-curl http://localhost:8080/api/v1/temp/posters/abc-123/IPX-535-poster.jpg -o poster.jpg
+curl http://localhost:8765/api/v1/temp/posters/abc-123/IPX-535-poster.jpg -o poster.jpg
 ```
 
 **Note:** Temp posters are preserved in `data/temp/posters/{jobID}/` when organization fails, allowing retry without re-scraping.
@@ -385,7 +385,7 @@ An authenticated session cookie is required.
 
 **Connect to WebSocket:**
 ```javascript
-const ws = new WebSocket('ws://localhost:8080/ws/progress');
+const ws = new WebSocket('ws://localhost:8765/ws/progress');
 
 ws.onmessage = (event) => {
   const update = JSON.parse(event.data);
@@ -479,8 +479,8 @@ Standard error format:
 
 For full request/response schemas, examples, and interactive testing, visit:
 
-- **Scalar UI**: [http://localhost:8080/docs](http://localhost:8080/docs) - Recommended for exploration
-- **Swagger UI**: [http://localhost:8080/swagger/index.html](http://localhost:8080/swagger/index.html) - Full OpenAPI spec
+- **Scalar UI**: [http://localhost:8765/docs](http://localhost:8765/docs) - Recommended for exploration
+- **Swagger UI**: [http://localhost:8765/swagger/index.html](http://localhost:8765/swagger/index.html) - Full OpenAPI spec
 
 These interfaces provide complete documentation including:
 - Request body schemas

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -277,7 +277,7 @@ Edit `./data/config.yaml` on the host:
 ```yaml
 server:
   host: "0.0.0.0"
-  port: 8080
+  port: 8765
 
 scrapers:
   priority: ["r18dev", "dmm"]
@@ -290,7 +290,7 @@ scrapers:
     default_profile: "main"
     profiles:
       main:
-        url: "http://proxy.example.com:8080"
+        url: "http://proxy.example.com:8765"
         # username: ""   # Optional authentication
         # password: ""   # Optional authentication
 
@@ -319,7 +319,7 @@ Or edit `docker-compose.yml` directly:
 
 ```yaml
 ports:
-  - "9090:8080"  # Access at http://localhost:9090
+  - "9090:8765"  # Access at http://localhost:9090
 ```
 
 ---
@@ -477,13 +477,13 @@ PUID=$(id -u) PGID=$(id -g) docker compose up -d
 
 ### Network Security
 
-The default configuration binds to `0.0.0.0:8080` (all interfaces). For production:
+The default configuration binds to `0.0.0.0:8765` (all interfaces). For production:
 
 1. **Use a reverse proxy** (nginx, Caddy) with HTTPS
 2. **Restrict binding** to localhost:
    ```yaml
    ports:
-     - "127.0.0.1:8080:8080"
+     - "127.0.0.1:8765:8765"
    ```
 3. **Complete first-run authentication setup** in Web UI (built-in single-user auth)
 
@@ -513,7 +513,7 @@ services:
     restart: unless-stopped
 
     ports:
-      - "127.0.0.1:8080:8080"  # Localhost only
+      - "127.0.0.1:8765:8765"  # Localhost only
 
     volumes:
       - ./data:/javinizer

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -7620,7 +7620,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
-	Host:             "localhost:8080",
+	Host:             "localhost:8765",
 	BasePath:         "/",
 	Schemes:          []string{"http", "https"},
 	Title:            "Javinizer API",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -18,7 +18,7 @@
         },
         "version": "1.0"
     },
-    "host": "localhost:8080",
+    "host": "localhost:8765",
     "basePath": "/",
     "paths": {
         "/api/v1/actresses": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2932,7 +2932,7 @@ definitions:
           hardcode the image ref or rebuild steps per environment.
         type: string
     type: object
-host: localhost:8080
+host: localhost:8765
 info:
   contact:
     name: API Support

--- a/internal/aggregator/word_processor.go
+++ b/internal/aggregator/word_processor.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/javinizer/javinizer-go/internal/models"
 )
@@ -76,6 +78,20 @@ func NewWordProcessor(cfg *MetadataConfig, repo wordLookup) *wordProcessor {
 }
 
 // Apply replaces occurrences of known words in the input text.
+//
+// Two matching strategies, dispatched by whether the pattern contains the
+// censor character '*':
+//
+//   - Patterns WITH '*' (censored-word tokens, e.g. "F***"): matched as a whole
+//     token using replaceTokenBounded. The match must be bounded on both sides
+//     by string start/end or a char that is neither a letter nor '*'. This
+//     prevents a short censored token from matching as a substring inside a
+//     longer, unlisted censored token — e.g. "F***" no longer fires inside
+//     "F****d" (which would yield "Fuck*d"). Issue #106.
+//   - Patterns WITHOUT '*' (e.g. the "[Recommended For Smartphones] " prefix
+//     strip): matched as a plain substring via strings.ReplaceAll, preserving
+//     the original behavior for patterns that are genuinely meant to match
+//     as substrings.
 func (wp *wordProcessor) Apply(text string) string {
 	if wp == nil || wp.cfg == nil || !wp.cfg.WordReplacement.Enabled {
 		return text
@@ -95,12 +111,86 @@ func (wp *wordProcessor) Apply(text string) string {
 
 	result := text
 	for _, p := range sorted {
-		if strings.Contains(result, p.orig) {
+		if strings.ContainsRune(p.orig, '*') {
+			result = replaceTokenBounded(result, p.orig, p.repl)
+		} else if strings.Contains(result, p.orig) {
 			result = strings.ReplaceAll(result, p.orig, p.repl)
 		}
 	}
 
 	return result
+}
+
+// replaceTokenBounded replaces every non-overlapping occurrence of orig in text
+// with repl, but only when the match is bounded on both sides by string
+// start/end or a character that is neither a Unicode letter nor '*'. This is
+// the "whole censored token" rule: '*' is the censor character, so a run like
+// "F***" is a complete censored word only if the char after it is not a letter
+// (which would extend the word) and not '*' (which would mean it's actually a
+// longer censored token, e.g. "F****d").
+//
+// The boundary chars are INSPECTED but not consumed, so two censored tokens
+// separated by a single space ("F*** S***e") both match — the space serves as
+// the trailing boundary for the first and the leading boundary for the second.
+func replaceTokenBounded(text, orig, repl string) string {
+	if orig == "" {
+		return text
+	}
+	var b strings.Builder
+	b.Grow(len(text))
+	i := 0
+	for {
+		idx := strings.Index(text[i:], orig)
+		if idx < 0 {
+			b.WriteString(text[i:])
+			break
+		}
+		start := i + idx
+		end := start + len(orig)
+		if start > 0 && !isCensorBoundary(boundaryRuneBefore(text, start)) {
+			b.WriteString(text[i:end])
+			i = end
+			continue
+		}
+		if end < len(text) && !isCensorBoundary(boundaryRuneAfter(text, end)) {
+			b.WriteString(text[i:end])
+			i = end
+			continue
+		}
+		b.WriteString(text[i:start])
+		b.WriteString(repl)
+		i = end
+	}
+	return b.String()
+}
+
+// isCensorBoundary reports whether r may act as a boundary for a censored-word
+// token: any char that is NOT a Unicode letter and NOT '*'. Digits, spaces,
+// punctuation, and symbols all qualify; letters and '*' extend the token.
+func isCensorBoundary(r rune) bool {
+	return r != '*' && !unicode.IsLetter(r)
+}
+
+// boundaryRuneBefore decodes the full rune immediately preceding byte index
+// `start` in `text` (UTF-8 aware). Returns -1 if start is at the beginning.
+// Used so multibyte adjacent chars (e.g. Japanese) are classified by their
+// actual rune, not a single lead/continuation byte.
+func boundaryRuneBefore(text string, start int) rune {
+	if start <= 0 || start > len(text) {
+		return -1
+	}
+	r, _ := utf8.DecodeLastRuneInString(text[:start])
+	return r
+}
+
+// boundaryRuneAfter decodes the full rune starting at byte index `end` in
+// `text` (UTF-8 aware). Returns -1 if end is at the end of the string.
+func boundaryRuneAfter(text string, end int) rune {
+	if end < 0 || end >= len(text) {
+		return -1
+	}
+	r, _ := utf8.DecodeRuneInString(text[end:])
+	return r
 }
 
 // ApplyToMovie applies word replacements to all text fields of a Movie.

--- a/internal/aggregator/word_processor.go
+++ b/internal/aggregator/word_processor.go
@@ -133,7 +133,7 @@ func (wp *wordProcessor) Apply(text string) string {
 // separated by a single space ("F*** S***e") both match — the space serves as
 // the trailing boundary for the first and the leading boundary for the second.
 func replaceTokenBounded(text, orig, repl string) string {
-	if orig == "" {
+	if orig == "" || !strings.Contains(text, orig) {
 		return text
 	}
 	var b strings.Builder

--- a/internal/aggregator/word_processor_boundary_test.go
+++ b/internal/aggregator/word_processor_boundary_test.go
@@ -1,0 +1,154 @@
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestApplyWordReplacement_CensoredTokenNotMatchedAsSubstring is the regression
+// guard for issue #106: a short censored token (F***) must NOT be replaced when
+// it appears as a prefix of a longer, unlisted censored token (F****d).
+//
+// The default word-replacement list ships {F***: Fuck, F***e: Force,
+// F*****g: Forcing} but NOT F****d. Under the old strings.ReplaceAll matcher,
+// F*** matched as a substring at position 0 of F****d, producing "Fuck*d".
+// Boundary-aware matching treats F*** as a whole censored token (bounded by
+// non-letter, non-asterisk chars), so the trailing '*' of F****d blocks the
+// match and F****d is left unchanged.
+func TestApplyWordReplacement_CensoredTokenNotMatchedAsSubstring(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***":    "Fuck",
+		"F***e":   "Force",
+		"F*****g": "Forcing",
+	})
+
+	// F****d is NOT in the cache — F*** must not fire inside it.
+	assert.Equal(t, "F****d", wp.Apply("F****d"))
+}
+
+// TestApplyWordReplacement_CensoredTokenMatchesStandalone locks the positive
+// side of boundary-aware matching: a censored token that IS bounded (by string
+// start/end, whitespace, or punctuation) is still replaced. This guards against
+// the boundary check becoming too strict and dropping legitimate replacements.
+func TestApplyWordReplacement_CensoredTokenMatchesStandalone(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***":    "Fuck",
+		"F***e":   "Force",
+		"F*****g": "Forcing",
+	})
+
+	assert.Equal(t, "Fuck", wp.Apply("F***"))
+	assert.Equal(t, "Fuck movie", wp.Apply("F*** movie"))
+	assert.Equal(t, "movie Fuck", wp.Apply("movie F***"))
+	assert.Equal(t, "Fuck, title", wp.Apply("F***, title"))
+	assert.Equal(t, "(Fuck)", wp.Apply("(F***)"))
+
+	// Listed longer censored tokens still replace when standalone — guards
+	// against an over-strict boundary rejecting a token whose end lands on
+	// end-of-string, and locks the longest-first sort + boundary interaction
+	// for asterisk patterns.
+	assert.Equal(t, "Forcing", wp.Apply("F*****g"))
+	assert.Equal(t, "Force", wp.Apply("F***e"))
+}
+
+// TestApplyWordReplacement_CensoredTokenAdjacentTokens ensures the boundary
+// check (which inspects chars without consuming them) doesn't starve an
+// immediately-following token of its leading boundary. Two censored tokens
+// separated by a space must both replace.
+func TestApplyWordReplacement_CensoredTokenAdjacentTokens(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***":  "Fuck",
+		"S***e": "Slave",
+	})
+
+	assert.Equal(t, "Fuck Slave", wp.Apply("F*** S***e"))
+}
+
+// TestApplyWordReplacement_NonAsteriskPatternStillSubstring confirms that
+// patterns WITHOUT '*' (e.g. the "[Recommended For Smartphones] " prefix strip)
+// keep the old substring-matching behavior — they are genuinely meant to match
+// as substrings, not as bounded tokens.
+func TestApplyWordReplacement_NonAsteriskPatternStillSubstring(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"[Recommended For Smartphones] ": "",
+	})
+
+	assert.Equal(t, "Title", wp.Apply("[Recommended For Smartphones] Title"))
+}
+
+// TestApplyWordReplacements_CensoredTokenInTitle is the end-to-end regression
+// guard for issue #106: a movie title containing an unlisted censored token
+// (F****d, the r18dev-censored form of "Forced") must not be corrupted by the
+// shorter F*** entry in the default list into "Fuck*d". The title is passed
+// through applyToMovie exactly as the aggregator does during a scrape.
+func TestApplyWordReplacements_CensoredTokenInTitle(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***":    "Fuck",
+		"F***e":   "Force",
+		"F*****g": "Forcing",
+	})
+
+	movie := &models.Movie{
+		Title: "F****d Entry",
+	}
+	wp.applyToMovie(movie)
+
+	assert.Equal(t, "F****d Entry", movie.Title)
+}
+
+// TestApplyWordReplacement_MultibyteBoundary confirms the boundary check decodes
+// full UTF-8 runes (not single bytes) when classifying the char adjacent to a
+// censored token. This matters for r18dev titles, which can be Japanese.
+//
+// A censored token directly abutting a multibyte rune (Japanese katakana/kanji,
+// or full-width punctuation like 「」) must be classified by the actual rune:
+// a Japanese letter extends the word (blocks the match), while a Japanese
+// punctuation char is a boundary (allows the match). The old byte-level read
+// misclassified lead/continuation bytes and got these wrong.
+func TestApplyWordReplacement_MultibyteBoundary(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***": "Fuck",
+	})
+
+	// Censored token followed directly by a Japanese letter (no separator):
+	// ド is a letter and extends the word, so F*** must NOT fire.
+	assert.Equal(t, "F***ドラマ", wp.Apply("F***ドラマ"))
+	// With a separator it replaces.
+	assert.Equal(t, "Fuck ドラマ", wp.Apply("F*** ドラマ"))
+	// Japanese full-width brackets 「」 are punctuation (boundaries), so the
+	// token inside them replaces.
+	assert.Equal(t, "「Fuck」", wp.Apply("「F***」"))
+}

--- a/internal/aggregator/word_processor_boundary_test.go
+++ b/internal/aggregator/word_processor_boundary_test.go
@@ -64,6 +64,23 @@ func TestApplyWordReplacement_CensoredTokenMatchesStandalone(t *testing.T) {
 	assert.Equal(t, "Force", wp.Apply("F***e"))
 }
 
+// TestApplyWordReplacement_CensoredTokenNoMatchReturnsUnchanged confirms the
+// no-match fast path: when the censored pattern is absent from the text, the
+// text is returned unchanged (and without avoidable allocation via the builder).
+func TestApplyWordReplacement_CensoredTokenNoMatchReturnsUnchanged(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"F***": "Fuck",
+	})
+
+	assert.Equal(t, "nothing here", wp.Apply("nothing here"))
+	assert.Equal(t, "", wp.Apply(""))
+}
+
 // TestApplyWordReplacement_CensoredTokenAdjacentTokens ensures the boundary
 // check (which inspects chars without consuming them) doesn't starve an
 // immediately-following token of its leading boundary. Two censored tokens

--- a/internal/api/server/routes.go
+++ b/internal/api/server/routes.go
@@ -86,7 +86,7 @@ func registerCORSMiddleware(router *gin.Engine, rt *core.APIRuntime) {
 		}
 
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-		allowedHeaders := []string{"Content-Type", "Authorization", "Accept", "Origin", "X-Requested-With"}
+		allowedHeaders := []string{"Content-Type", "Authorization", "Accept", "Origin", "X-Requested-With", "X-Session-ID"}
 		c.Writer.Header().Set("Access-Control-Allow-Headers", strings.Join(allowedHeaders, ", "))
 
 		if c.Request.Method == "OPTIONS" {

--- a/internal/config/config.yaml.example
+++ b/internal/config/config.yaml.example
@@ -15,7 +15,7 @@ config_version: 3
 
 server:
     host: localhost
-    port: 8080
+    port: 8765
 api:
     security:
         # CORS allowed origins for API and WebSocket connections
@@ -23,9 +23,9 @@ api:
         # - Empty array [] means same-origin only
         # - Add frontend origins if using a separate web server (e.g., "http://localhost:5173" for Vite dev server)
         allowed_origins:
-            - http://localhost:8080
+            - http://localhost:8765
             - http://localhost:5173
-            - http://127.0.0.1:8080
+            - http://127.0.0.1:8765
             - http://127.0.0.1:5173
 
         # Allowed directories for API file operations (organize, preview, etc.)

--- a/internal/config/config_migration_test.go
+++ b/internal/config/config_migration_test.go
@@ -33,7 +33,7 @@ scrapers:
 	require.NoError(t, err)
 
 	assert.Equal(t, CurrentConfigVersion, cfg.ConfigVersion)
-	assert.Equal(t, 8080, cfg.Server.Port)                                            // Reset to default port
+	assert.Equal(t, 8765, cfg.Server.Port)                                            // Reset to default port
 	assert.Equal(t, DefaultConfig(nil, nil).Scrapers.Priority, cfg.Scrapers.Priority) // Reset to default priorities
 
 	saved, err := os.ReadFile(cfgPath)

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -28,7 +28,7 @@ func getFirstScraperPriorityStatic() string {
 func defaultServerConfig() ServerConfig {
 	return ServerConfig{
 		Host: "localhost",
-		Port: 8080,
+		Port: 8765,
 	}
 }
 
@@ -41,9 +41,9 @@ func defaultAPIConfig() APIConfig {
 			MaxFilesPerScan:    10000,
 			ScanTimeoutSeconds: 30,
 			AllowedOrigins: []string{
-				"http://localhost:8080",
+				"http://localhost:8765",
 				"http://localhost:5173",
-				"http://127.0.0.1:8080",
+				"http://127.0.0.1:8765",
 				"http://127.0.0.1:5173",
 			},
 			RateLimit: RateLimitConfig{

--- a/web/frontend/playwright.frontend.config.ts
+++ b/web/frontend/playwright.frontend.config.ts
@@ -17,7 +17,7 @@
  * shared +layout onMount calls) so no real backend is required.
  *
  * webServer spawns Vite (no backend). The regular vite.config.ts is fine:
- * its /api proxy to :8080 is never reached because page.route intercepts
+ * its /api proxy to :8765 is never reached because page.route intercepts
  * /api requests in the browser before Vite's proxy sees them.
  *
  * Run with:

--- a/web/frontend/src/lib/api/client.ts
+++ b/web/frontend/src/lib/api/client.ts
@@ -89,6 +89,9 @@ class APIClient {
 	getPreviewImageURL(imageURL: string) {
 		return this.system.getPreviewImageURL(imageURL);
 	}
+	withSessionParam(url: string) {
+		return this.system.withSessionParam(url);
+	}
 	async getCurrentWorkingDirectory() {
 		return this.system.getCurrentWorkingDirectory();
 	}

--- a/web/frontend/src/lib/api/clients/common.test.ts
+++ b/web/frontend/src/lib/api/clients/common.test.ts
@@ -8,8 +8,8 @@ describe('getAPIBaseURL', () => {
 
 	it('returns VITE_API_URL in dev mode when the env is set', () => {
 		vi.stubEnv('DEV', true);
-		vi.stubEnv('VITE_API_URL', 'http://localhost:8080');
-		expect(getAPIBaseURL()).toBe('http://localhost:8080');
+		vi.stubEnv('VITE_API_URL', 'http://localhost:8765');
+		expect(getAPIBaseURL()).toBe('http://localhost:8765');
 	});
 
 	it('returns empty string (same-origin) in production even when VITE_API_URL is baked into the bundle', () => {
@@ -17,10 +17,10 @@ describe('getAPIBaseURL', () => {
 		// the API client to a fixed host:port that won't match the server's
 		// actual bind address. The desktop binary's `web` subcommand reads the
 		// portable config's random port (e.g. 58915), but the baked-in env
-		// says :8080 → "Failed to fetch". Gating on import.meta.env.DEV
+		// says :8765 → "Failed to fetch". Gating on import.meta.env.DEV
 		// ensures production builds use same-origin relative URLs.
 		vi.stubEnv('DEV', false);
-		vi.stubEnv('VITE_API_URL', 'http://localhost:8080');
+		vi.stubEnv('VITE_API_URL', 'http://localhost:8765');
 		expect(getAPIBaseURL()).toBe('');
 	});
 

--- a/web/frontend/src/lib/api/clients/common.ts
+++ b/web/frontend/src/lib/api/clients/common.ts
@@ -105,9 +105,9 @@ export class BaseClient {
 // In the desktop app (Wails webview) the SPA loads from wails://wails.localhost
 // and must use same-origin relative URLs so requests route through the embedded
 // reverse proxy to the API server on its random localhost port. A dev .env may
-// bake VITE_API_URL=http://localhost:8080 into the bundle; that would make the
+// bake VITE_API_URL=http://localhost:8765 into the bundle; that would make the
 // SPA fetch cross-origin (and to the wrong port — the desktop binary's config
-// binds a random high port, not 8080), which WKWebView blocks with
+// binds a random high port, not 8765), which WKWebView blocks with
 // "Load failed". Force same-origin in the desktop context regardless of the
 // baked-in env value.
 //
@@ -115,7 +115,7 @@ export class BaseClient {
 // with VITE_API_URL baked in would otherwise pin the API client to a fixed
 // host:port that won't match the server's actual bind address — e.g. running
 // the desktop binary's `web` subcommand (which reads the portable config's
-// random port) against a bundle baked with :8080 produces "Failed to fetch".
+// random port) against a bundle baked with :8765 produces "Failed to fetch".
 export function getAPIBaseURL(): string {
 	if (isDesktopApp()) return '';
 	if (import.meta.env.DEV && import.meta.env.VITE_API_URL) {

--- a/web/frontend/src/lib/api/clients/common.ts
+++ b/web/frontend/src/lib/api/clients/common.ts
@@ -167,9 +167,21 @@ export class SystemClient extends BaseClient {
 
 	getPreviewImageURL(imageURL: string): string {
 		const url = `${this.baseURL}/api/v1/temp/image?url=${encodeURIComponent(imageURL)}`;
+		return this.withSessionParam(url);
+	}
+
+	// withSessionParam appends ?session= to /api/v1/ URLs for the desktop app,
+	// where WKWebView does not persist the session cookie against the direct
+	// backend origin and <img>/WebSocket can't set the X-Session-ID header. In
+	// the browser (dev proxy or same-origin prod), the session cookie
+	// authenticates these requests natively, so this is a no-op there.
+	withSessionParam(url: string): string {
 		if (!isDesktopApp()) return url;
+		if (!url.includes('/api/v1/')) return url;
 		const session = BaseClient.getSessionID();
-		return session ? `${url}&session=${encodeURIComponent(session)}` : url;
+		if (!session) return url;
+		const sep = url.includes('?') ? '&' : '?';
+		return `${url}${sep}session=${encodeURIComponent(session)}`;
 	}
 
 	async getCurrentWorkingDirectory(): Promise<{ path: string }> {

--- a/web/frontend/src/lib/api/types.test.ts
+++ b/web/frontend/src/lib/api/types.test.ts
@@ -125,7 +125,7 @@ describe('types.ts has no unnecessary any', () => {
 	});
 
 	it('new config sub-interfaces exist and are properly typed', () => {
-		const server: ServerConfig = { host: 'localhost', port: 8080 };
+		const server: ServerConfig = { host: 'localhost', port: 8765 };
 		const profile: ProxyProfile = { url: 'http://proxy:8080', username: 'user', password: 'pass' };
 		const proxy: ProxyConfig = { enabled: true, profile: 'main', profiles: { main: profile } };
 		const fs: FlareSolverrConfig = {

--- a/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
+++ b/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
@@ -124,12 +124,12 @@
 		</ul>
 	{/if}
 
-	<form onsubmit={addDir} class="flex items-start gap-2">
+	<form onsubmit={addDir} class="flex items-center gap-2">
 		<PathInput
 			bind:value={newDir}
 			{placeholder}
 			{whitelistPaths}
-			class="flex-1"
+			class="h-9"
 			onnavigate={() => addDir()}
 		/>
 		<Button

--- a/web/frontend/src/lib/components/PathInput.svelte
+++ b/web/frontend/src/lib/components/PathInput.svelte
@@ -177,7 +177,7 @@
 			}, 120);
 		}}
 		{placeholder}
-		class="w-full px-3 py-1.5 pr-9 border rounded-md bg-background focus:ring-2 focus:ring-primary focus:border-primary transition-all font-mono text-sm {className}"
+		class="w-full px-3 py-1.5 pr-9 border rounded-md bg-background outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all font-mono text-sm {className}"
 	/>
 	{#if autocompleteLoading}
 		<div class="absolute inset-y-0 right-3 flex items-center text-muted-foreground">

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
@@ -44,27 +44,47 @@
 		allow_unc: false,
 		allowed_unc_servers: [],
 	});
+	// baseline tracks the last saved/loaded security state so `dirty` stays
+	// accurate even while the sync effect (below) mirrors draft edits into the
+	// shared config object. Populated by the rehydrate $effect on mount.
+	let baseline = $state<SecurityDraft>({
+		allowed_directories: [],
+		denied_directories: [],
+		allow_unc: false,
+		allowed_unc_servers: [],
+	});
 
 	$effect(() => {
 		const cfg = hydratedConfig ?? config;
 		if (cfg !== lastConfigRef) {
 			lastConfigRef = cfg;
-			draft = snapshot(cfg);
+			const snap = snapshot(cfg);
+			draft = snap;
+			baseline = snap;
 		}
+	});
+
+	// Mirror draft edits into the parent config object so the top-level
+	// "Save Changes" button (which PUTs the whole config) persists security
+	// edits too. Without this, only the narrow "Save Security" endpoint would
+	// see the draft, and a whole-config save would clobber the directories the
+	// user just added with the stale value still held in settings.config.
+	$effect(() => {
+		const sec = config?.api?.security;
+		if (!sec) return;
+		sec.allowed_directories = [...draft.allowed_directories];
+		sec.denied_directories = [...draft.denied_directories];
+		sec.allow_unc = draft.allow_unc;
+		sec.allowed_unc_servers = [...draft.allowed_unc_servers];
 	});
 
 	let newUncServer = $state('');
 
 	let dirty = $derived(
-		(() => {
-			const sec = (hydratedConfig ?? config)?.api?.security;
-			return (
-				!arrayEqual(draft.allowed_directories, sec?.allowed_directories ?? []) ||
-				!arrayEqual(draft.denied_directories, sec?.denied_directories ?? []) ||
-				draft.allow_unc !== (sec?.allow_unc ?? false) ||
-				!arrayEqual(draft.allowed_unc_servers, sec?.allowed_unc_servers ?? [])
-			);
-		})(),
+		!arrayEqual(draft.allowed_directories, baseline.allowed_directories) ||
+			!arrayEqual(draft.denied_directories, baseline.denied_directories) ||
+			draft.allow_unc !== baseline.allow_unc ||
+			!arrayEqual(draft.allowed_unc_servers, baseline.allowed_unc_servers),
 	);
 
 	function arrayEqual(a: string[], b: string[]): boolean {
@@ -93,12 +113,14 @@
 			return apiClient.updateSecurityConfig(req);
 		},
 		onSuccess: (data) => {
-			draft = {
+			const saved: SecurityDraft = {
 				allowed_directories: [...(data.security.allowed_directories ?? [])],
 				denied_directories: [...(data.security.denied_directories ?? [])],
 				allow_unc: data.security.allow_unc,
 				allowed_unc_servers: [...(data.security.allowed_unc_servers ?? [])],
 			};
+			draft = saved;
+			baseline = saved;
 			toastStore.success('Security settings saved and reloaded', 4000);
 			void queryClient.invalidateQueries({ queryKey: ['config'] }).then(async () => {
 				const fresh = await queryClient.fetchQuery<Config>({

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
@@ -39,7 +39,7 @@ if (!Element.prototype.animate) {
 
 function makeConfig(overrides: Partial<SettingsConfig['api']['security']> = {}): SettingsConfig {
 	return {
-		server: { host: '0.0.0.0', port: 8080 },
+		server: { host: '0.0.0.0', port: 8765 },
 		api: {
 			security: {
 				allowed_directories: [],

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
@@ -95,7 +95,7 @@ async function expandSection(container: HTMLElement): Promise<void> {
 	}
 }
 
-describe('SecuritySettingsSection', () => {
+	describe('SecuritySettingsSection', () => {
 	it('renders the empty-state hint when no allowed directories are configured', async () => {
 		const { container } = renderSection(makeConfig());
 		await expandSection(container);
@@ -240,4 +240,24 @@ describe('SecuritySettingsSection', () => {
 		await waitFor(() => expect(mockGetConfig).toHaveBeenCalledTimes(1));
 		await waitFor(() => expect(container.textContent).toContain('/persisted'));
 		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(true));
+	});
+
+	it('propagates draft edits into the shared config so the top-level Save Changes persists them', async () => {
+		// Regression: the section kept a local draft that was never written back
+		// to the parent config, so the whole-config PUT ("Save Changes" button)
+		// would clobber a just-added directory with the stale value. The sync
+		// effect must mirror draft edits into config.api.security.
+		const config = makeConfig({ allowed_directories: [] });
+		const { container } = renderSection(config);
+		await expandSection(container);
+
+		const input = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
+		expect(input).toBeTruthy();
+		await fireEvent.input(input, { target: { value: '/mnt/videos' } });
+		const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
+		await fireEvent.click(addBtn);
+
+		await waitFor(() =>
+			expect(config.api.security.allowed_directories).toEqual(['/mnt/videos']),
+		);
 	});

--- a/web/frontend/src/lib/components/settings/sections/ServerSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/ServerSettingsSection.svelte
@@ -129,7 +129,7 @@
 			</div>
 			<div>
 				<label class="block text-sm font-medium mb-2" for="server-port">Port</label>
-				<input id="server-port" type="number" bind:value={config.server.port} class={inputClass} placeholder="8080" />
+				<input id="server-port" type="number" bind:value={config.server.port} class={inputClass} placeholder="8765" />
 			</div>
 		</div>
 		<div>

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -1,0 +1,628 @@
+<script lang="ts">
+	import { onMount, tick } from 'svelte';
+	import { cubicOut, quintOut } from 'svelte/easing';
+	import { scale } from 'svelte/transition';
+	import { apiClient } from '$lib/api/client';
+	import { BaseClient } from '$lib/api/clients/common';
+	import { toastStore } from '$lib/stores/toast';
+	import { getThemeStore } from '$lib/stores/theme.svelte';
+	import { websocketStore } from '$lib/stores/websocket';
+	import Button from '$lib/components/ui/Button.svelte';
+	import StepCredentials from './StepCredentials.svelte';
+	import StepDirectories from './StepDirectories.svelte';
+	import StepScrapers from './StepScrapers.svelte';
+	import type { Scraper } from '$lib/api/types';
+	import {
+		ArrowLeft,
+		ArrowRight,
+		Check,
+		FolderCheck,
+		Loader2,
+		ShieldCheck,
+		Sparkles,
+	} from 'lucide-svelte';
+
+	interface Props {
+		onComplete: () => void;
+	}
+
+	let { onComplete }: Props = $props();
+
+	type StepId = 'credentials' | 'directories' | 'scrapers';
+
+	const steps: { id: StepId; index: number; label: string; hint: string; icon: typeof ShieldCheck }[] = [
+		{ id: 'credentials', index: 0, label: 'Admin Account', hint: 'Secure your server', icon: ShieldCheck },
+		{ id: 'directories', index: 1, label: 'Library Folders', hint: 'Where your media lives', icon: FolderCheck },
+		{ id: 'scrapers', index: 2, label: 'Scrapers', hint: 'Metadata sources', icon: Sparkles },
+	];
+
+	let stepIndex = $state(0);
+	let submitting = $state(false);
+	let error = $state<string | null>(null);
+
+	let credentials = $state({ username: '', password: '', confirm: '' });
+
+	let dirs = $state<string[]>([]);
+
+	let availableScrapers = $state<Scraper[]>([]);
+	let selectedScrapers = $state<string[]>([]);
+	let scrapersLoading = $state(false);
+
+	let stageEl = $state<HTMLElement | null>(null);
+	let stageHeight = $state<number | null>(null);
+	let heightReady = $state(false);
+
+	const TRANSITION_MS = 360;
+
+	$effect(() => {
+		const el = stageEl;
+		if (!el) return;
+		const measure = () => {
+			stageHeight = el.offsetHeight;
+			heightReady = true;
+		};
+		void measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(el);
+		return () => ro.disconnect();
+	});
+
+	let currentStep = $derived(steps[stepIndex]);
+	let isLastStep = $derived(stepIndex === steps.length - 1);
+
+	function gotoStep(index: number) {
+		if (index < 0 || index >= steps.length) return;
+		stepIndex = index;
+		error = null;
+	}
+
+	function syncWebSocketAuth() {
+		websocketStore.connect();
+	}
+
+	async function fetchScrapers() {
+		if (availableScrapers.length > 0 || scrapersLoading) return;
+		scrapersLoading = true;
+		try {
+			availableScrapers = await apiClient.getScrapers();
+			selectedScrapers = availableScrapers.filter((s) => s.enabled).map((s) => s.name);
+		} catch {
+			toastStore.error('Could not load available scrapers', 4000);
+		} finally {
+			scrapersLoading = false;
+		}
+	}
+
+	// Step 1: create the admin account (required to obtain a session for the
+	// protected scraper/config endpoints). This is the only commit before the
+	// final Finish — credentials are irreversible, so Back is hidden afterwards.
+	async function handleCredentialsNext() {
+		error = null;
+		if (credentials.password !== credentials.confirm) {
+			error = 'Passwords do not match';
+			return;
+		}
+		submitting = true;
+		try {
+			const result = await apiClient.setupAuth({
+				username: credentials.username,
+				password: credentials.password,
+			});
+			credentials.password = '';
+			credentials.confirm = '';
+			if (result?.session_id) BaseClient.setSessionID(result.session_id);
+			syncWebSocketAuth();
+			gotoStep(1);
+			toastStore.success('Admin account created', 3000);
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to create admin account';
+		} finally {
+			submitting = false;
+		}
+	}
+
+	// Step 2: directories are staged locally; nothing is committed until Finish
+	// so the transition to the scrapers step is instant.
+	function handleDirectoriesNext() {
+		error = null;
+		gotoStep(2);
+	}
+
+	function handleDirectoriesSkip() {
+		error = null;
+		gotoStep(2);
+	}
+
+	// Final step: commit the staged directories and scraper selection together.
+	async function handleScrapersFinish() {
+		error = null;
+		submitting = true;
+		try {
+			const fresh = await apiClient.getConfig();
+			const sec = fresh?.api?.security;
+			await apiClient.updateSecurityConfig({
+				allowed_directories: dirs,
+				denied_directories: [...(sec?.denied_directories ?? [])],
+				allow_unc: sec?.allow_unc ?? false,
+				allowed_unc_servers: [...(sec?.allowed_unc_servers ?? [])],
+			});
+
+			const config = await apiClient.getConfig();
+			const sc = (config.scrapers ?? {}) as Record<string, unknown>;
+			sc.priority = [...selectedScrapers];
+			for (const scraper of availableScrapers) {
+				if (!sc[scraper.name]) sc[scraper.name] = {};
+				(sc[scraper.name] as Record<string, unknown>).enabled = selectedScrapers.includes(scraper.name);
+			}
+			config.scrapers = sc as typeof config.scrapers;
+			await apiClient.request('/api/v1/config', {
+				method: 'PUT',
+				body: JSON.stringify(config),
+			});
+			toastStore.success('Setup complete. Welcome to Javinizer.', 4000);
+			onComplete();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to save setup configuration';
+		} finally {
+			submitting = false;
+		}
+	}
+
+	function handleBack() {
+		if (stepIndex === 2) gotoStep(1);
+	}
+
+	function handleNext() {
+		if (stepIndex === 0) void handleCredentialsNext();
+		else if (stepIndex === 1) void handleDirectoriesNext();
+		else void handleScrapersFinish();
+	}
+
+	let canProceed = $derived.by(() => {
+		if (submitting) return false;
+		if (stepIndex === 0) {
+			return (
+				credentials.username.trim().length > 0 &&
+				credentials.password.length >= 8 &&
+				credentials.confirm.length >= 8
+			);
+		}
+		return true;
+	});
+
+	let nextLabel = $derived(
+		submitting
+			? stepIndex === 0
+				? 'Creating…'
+				: isLastStep
+					? 'Finishing…'
+					: 'Saving…'
+			: isLastStep
+				? 'Finish Setup'
+				: 'Continue',
+	);
+
+	onMount(() => {
+		getThemeStore().initTheme();
+	});
+
+	// Lazily fetch the scraper list when the user reaches the scrapers step.
+	// Requires an authenticated session (created in step 1), so it can only
+	// run once the credentials step is complete.
+	$effect(() => {
+		if (stepIndex === 2) void fetchScrapers();
+	});
+</script>
+
+<svelte:head>
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+	<link
+		href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,500;12..96,600;12..96,700&display=swap"
+		rel="stylesheet"
+	/>
+</svelte:head>
+
+<div class="wizard-shell">
+	<!-- Brand / stepper rail -->
+	<aside class="brand-rail" aria-hidden="true">
+		<div class="brand-glow brand-glow-a"></div>
+		<div class="brand-glow brand-glow-b"></div>
+		<div class="brand-grid"></div>
+
+		<div class="brand-inner">
+			<div class="brand-mark" in:scale|local={{ start: 0.8, duration: 420, easing: quintOut }}>
+				<svg viewBox="0 0 512 512" width="34" height="34" aria-hidden="true">
+					<rect width="512" height="512" rx="112" fill="currentColor" />
+					<path d="M330 150v198c0 54-37 88-92 88-44 0-74-19-92-58l52-26c9 19 23 29 41 29 22 0 36-16 36-42V150h55z" fill="#ffffff" />
+				</svg>
+			</div>
+			<div class="brand-word">Javinizer</div>
+
+			<nav class="stepper" aria-label="Setup progress">
+				<div class="stepper-track" aria-hidden="true">
+					<div
+						class="stepper-track-fill"
+						style="height: {Math.max(0, (stepIndex / (steps.length - 1)) * 100)}%"
+					></div>
+				</div>
+				{#each steps as step, i (step.id)}
+					<div class="stepper-row" class:active={stepIndex === i} class:done={stepIndex > i}>
+						<div class="stepper-node">
+							{#if stepIndex > i}
+								<Check class="stepper-check" />
+							{:else}
+								<span class="stepper-num">{i + 1}</span>
+							{/if}
+						</div>
+						<div class="stepper-text">
+							<div class="stepper-label">{step.label}</div>
+							<div class="stepper-hint">{step.hint}</div>
+						</div>
+					</div>
+				{/each}
+			</nav>
+
+			<div class="brand-foot">
+				<div class="brand-foot-row"><span class="brand-dot"></span> Step {stepIndex + 1} of {steps.length}</div>
+			</div>
+		</div>
+	</aside>
+
+	<!-- Content -->
+	<main class="content-pane">
+		<div class="content-frame">
+			<div class="content-stage"
+				style="height: {stageHeight !== null ? `${stageHeight}px` : 'auto'}; transition: {heightReady ? `height ${TRANSITION_MS}ms cubic-out` : 'none'};">
+				{#key stepIndex}
+					<div
+						class="content-card stage-card"
+						bind:this={stageEl}
+						in:scale|local={{ start: 1.03, duration: TRANSITION_MS, easing: cubicOut }}
+						out:scale|local={{ start: 0.985, duration: TRANSITION_MS, easing: cubicOut }}
+					>
+						{#if stepIndex === 0}
+							<StepCredentials bind:credentials {error} {submitting} />
+						{:else if stepIndex === 1}
+							<StepDirectories bind:dirs {error} {submitting} onSkip={handleDirectoriesSkip} />
+						{:else}
+							<StepScrapers
+								bind:selected={selectedScrapers}
+								scrapers={availableScrapers}
+								loading={scrapersLoading}
+								{error}
+								{submitting}
+							/>
+						{/if}
+					</div>
+				{/key}
+			</div>
+
+			<div class="content-nav">
+				{#if stepIndex === 2}
+					<Button variant="ghost" onclick={handleBack} disabled={submitting}>
+						{#snippet children()}
+							<ArrowLeft class="h-4 w-4" />
+							Back
+						{/snippet}
+					</Button>
+				{:else}
+					<div></div>
+				{/if}
+
+				<div class="nav-right">
+					{#if stepIndex === 1}
+						<Button variant="ghost" onclick={handleDirectoriesSkip} disabled={submitting}>
+							{#snippet children()}Skip for now{/snippet}
+						</Button>
+					{/if}
+					<Button onclick={handleNext} disabled={!canProceed}>
+						{#snippet children()}
+							{#if submitting}
+								<Loader2 class="h-4 w-4 animate-spin" />
+							{:else if isLastStep}
+								<Check class="h-4 w-4" />
+							{:else}
+								<ArrowRight class="h-4 w-4" />
+							{/if}
+							{nextLabel}
+						{/snippet}
+					</Button>
+				</div>
+			</div>
+		</div>
+	</main>
+</div>
+
+<style>
+	.wizard-shell {
+		display: grid;
+		grid-template-columns: minmax(280px, 1fr) minmax(0, 2fr);
+		min-height: 100vh;
+		width: 100%;
+	}
+
+	/* ---- Brand rail ---- */
+	.brand-rail {
+		position: relative;
+		overflow: hidden;
+		background: radial-gradient(120% 100% at 0% 0%, hsl(224 76% 12%) 0%, hsl(222 84% 6%) 55%, hsl(222 84% 4%) 100%);
+		color: hsl(210 40% 98%);
+		padding: 2.75rem 2.25rem;
+		display: flex;
+		flex-direction: column;
+		isolation: isolate;
+	}
+
+	.brand-glow {
+		position: absolute;
+		border-radius: 9999px;
+		filter: blur(72px);
+		opacity: 0.55;
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	.brand-glow-a {
+		width: 320px;
+		height: 320px;
+		background: hsl(217 91% 60% / 0.5);
+		top: -80px;
+		right: -90px;
+	}
+
+	.brand-glow-b {
+		width: 260px;
+		height: 260px;
+		background: hsl(265 85% 62% / 0.32);
+		bottom: -70px;
+		left: -60px;
+	}
+
+	.brand-grid {
+		position: absolute;
+		inset: 0;
+		background-image: radial-gradient(hsl(210 40% 98% / 0.07) 1px, transparent 1px);
+		background-size: 22px 22px;
+		mask-image: radial-gradient(120% 90% at 30% 20%, black 0%, transparent 78%);
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	.brand-inner {
+		position: relative;
+		z-index: 1;
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+	}
+
+	.brand-mark {
+		color: hsl(217 91% 60%);
+		display: inline-flex;
+		filter: drop-shadow(0 6px 18px hsl(217 91% 60% / 0.45));
+	}
+
+	.brand-word {
+		font-family: 'Bricolage Grotesque', ui-sans-serif, system-ui, sans-serif;
+		font-weight: 700;
+		font-size: 1.85rem;
+		letter-spacing: -0.02em;
+		margin-top: 1rem;
+		background: linear-gradient(180deg, hsl(210 40% 98%), hsl(210 40% 82%));
+		-webkit-background-clip: text;
+		background-clip: text;
+		color: transparent;
+	}
+
+	.stepper {
+		position: relative;
+		margin-top: 3rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1.4rem;
+	}
+
+	.stepper-track {
+		position: absolute;
+		left: 17px;
+		top: 8px;
+		bottom: 8px;
+		width: 2px;
+		background: hsl(210 40% 98% / 0.12);
+		border-radius: 9999px;
+		overflow: hidden;
+	}
+
+	.stepper-track-fill {
+		width: 100%;
+		background: linear-gradient(180deg, hsl(217 91% 65%), hsl(265 85% 62%));
+		border-radius: 9999px;
+		transition: height 360ms cubic-out;
+	}
+
+	.stepper-row {
+		position: relative;
+		display: flex;
+		align-items: flex-start;
+		gap: 0.85rem;
+		opacity: 0.5;
+		transition: opacity 220ms cubic-out;
+	}
+
+	.stepper-row.active {
+		opacity: 1;
+	}
+
+	.stepper-row.done {
+		opacity: 0.78;
+	}
+
+	.stepper-node {
+		flex-shrink: 0;
+		width: 36px;
+		height: 36px;
+		border-radius: 9999px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: hsl(217 84% 10%);
+		border: 1.5px solid hsl(210 40% 98% / 0.18);
+		font-weight: 600;
+		font-size: 0.85rem;
+		transition: all 240ms cubic-out;
+		z-index: 1;
+	}
+
+	.stepper-row.active .stepper-node {
+		background: linear-gradient(140deg, hsl(217 91% 62%), hsl(265 85% 60%));
+		border-color: transparent;
+		box-shadow: 0 0 0 4px hsl(217 91% 60% / 0.18), 0 8px 20px hsl(217 91% 55% / 0.4);
+		transform: scale(1.06);
+	}
+
+	.stepper-row.done .stepper-node {
+		background: hsl(217 84% 18%);
+		border-color: hsl(217 91% 60% / 0.5);
+		color: hsl(217 91% 75%);
+	}
+
+	:global(.stepper-check) {
+		width: 16px;
+		height: 16px;
+	}
+
+	.stepper-num {
+		color: hsl(210 40% 88%);
+	}
+
+	.stepper-row.active .stepper-num {
+		color: hsl(210 40% 98%);
+	}
+
+	.stepper-text {
+		padding-top: 0.35rem;
+	}
+
+	.stepper-label {
+		font-size: 0.95rem;
+		font-weight: 600;
+		letter-spacing: -0.01em;
+	}
+
+	.stepper-hint {
+		font-size: 0.78rem;
+		color: hsl(210 40% 72%);
+		margin-top: 0.1rem;
+	}
+
+	.brand-foot {
+		margin-top: auto;
+		padding-top: 2rem;
+	}
+
+	.brand-foot-row {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		color: hsl(210 40% 70%);
+	}
+
+	.brand-dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 9999px;
+		background: hsl(217 91% 65%);
+		box-shadow: 0 0 12px hsl(217 91% 65%);
+	}
+
+	/* ---- Content pane ---- */
+	.content-pane {
+		display: flex;
+		align-items: stretch;
+		justify-content: center;
+		padding: 2rem 1.5rem;
+		background: hsl(var(--background));
+	}
+
+	.content-frame {
+		width: 100%;
+		max-width: 640px;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		gap: 1.5rem;
+		padding: 1.5rem 0;
+	}
+
+	.content-stage {
+		position: relative;
+		width: 100%;
+	}
+
+	.content-card {
+		background: hsl(var(--card));
+		border: 1px solid hsl(var(--border));
+		border-radius: calc(var(--radius) + 6px);
+		padding: 2.25rem;
+		box-shadow:
+			0 1px 2px hsl(222 84% 4% / 0.04),
+			0 24px 60px -28px hsl(222 84% 4% / 0.25);
+	}
+
+	.stage-card {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		transform-origin: center top;
+		will-change: transform, opacity;
+	}
+
+	.content-nav {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		position: relative;
+		z-index: 2;
+	}
+
+	.nav-right {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-left: auto;
+	}
+
+	@media (max-width: 900px) {
+		.wizard-shell {
+			grid-template-columns: 1fr;
+		}
+
+		.brand-rail {
+			padding: 2rem 1.5rem 1.5rem;
+		}
+
+		.brand-glow-a {
+			width: 220px;
+			height: 220px;
+		}
+
+		.stepper {
+			margin-top: 1.75rem;
+			gap: 1rem;
+		}
+
+		.content-pane {
+			padding: 1.25rem 1rem;
+		}
+
+		.content-card {
+			padding: 1.5rem;
+		}
+	}
+</style>

--- a/web/frontend/src/lib/components/setup/StepCredentials.svelte
+++ b/web/frontend/src/lib/components/setup/StepCredentials.svelte
@@ -1,0 +1,309 @@
+<script lang="ts">
+	import { ShieldCheck, KeyRound, User, Eye, EyeOff } from 'lucide-svelte';
+
+	interface Credentials {
+		username: string;
+		password: string;
+		confirm: string;
+	}
+
+	let {
+		credentials = $bindable(),
+		error = null as string | null,
+		submitting = false,
+	}: {
+		credentials: Credentials;
+		error?: string | null;
+		submitting?: boolean;
+	} = $props();
+
+	let showPassword = $state(false);
+	let showConfirm = $state(false);
+
+	let passwordStrength = $derived.by(() => {
+		const p = credentials.password;
+		if (p.length === 0) return { score: 0, label: '', pct: 0 };
+		let score = 0;
+		if (p.length >= 8) score++;
+		if (p.length >= 12) score++;
+		if (/[A-Z]/.test(p) && /[a-z]/.test(p)) score++;
+		if (/\d/.test(p) && /[^A-Za-z0-9]/.test(p)) score++;
+		const labels = ['', 'Weak', 'Fair', 'Good', 'Strong'];
+		return { score, label: labels[score], pct: (score / 4) * 100 };
+	});
+
+	let match = $derived(
+		credentials.confirm.length === 0 || credentials.password === credentials.confirm,
+	);
+</script>
+
+<div class="step-head">
+	<div class="step-badge"><ShieldCheck class="h-5 w-5" /></div>
+	<h1 class="step-title">Create your admin account</h1>
+	<p class="step-sub">
+		This becomes the master login for this Javinizer server. You can add more users later.
+	</p>
+</div>
+
+<form class="step-body" onsubmit={(e) => e.preventDefault()}>
+	{#if error}
+		<div class="alert" role="alert">{error}</div>
+	{/if}
+
+	<label class="field">
+		<span class="field-label">Username</span>
+		<div class="field-control">
+			<User class="field-icon" />
+			<input
+				class="field-input pl-9"
+				type="text"
+				required
+				autocomplete="username"
+				placeholder="admin"
+				bind:value={credentials.username}
+				disabled={submitting}
+			/>
+		</div>
+	</label>
+
+	<label class="field">
+		<span class="field-label">Password</span>
+		<div class="field-control">
+			<KeyRound class="field-icon" />
+			<input
+				class="field-input pl-9 pr-9"
+				type={showPassword ? 'text' : 'password'}
+				required
+				minlength="8"
+				autocomplete="new-password"
+				placeholder="At least 8 characters"
+				bind:value={credentials.password}
+				disabled={submitting}
+			/>
+			<button
+				type="button"
+				class="field-eye"
+				onclick={() => (showPassword = !showPassword)}
+				tabindex="-1"
+				aria-label={showPassword ? 'Hide password' : 'Show password'}
+			>
+				{#if showPassword}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+			</button>
+		</div>
+		{#if credentials.password.length > 0}
+			<div class="strength">
+				<div class="strength-bar"><span class="strength-fill" data-score={passwordStrength.score} style="width: {passwordStrength.pct}%"></span></div>
+				<span class="strength-label" data-score={passwordStrength.score}>{passwordStrength.label}</span>
+			</div>
+		{/if}
+	</label>
+
+	<label class="field">
+		<span class="field-label">Confirm password</span>
+		<div class="field-control">
+			<KeyRound class="field-icon" />
+			<input
+				class="field-input pl-9 pr-9"
+				type={showConfirm ? 'text' : 'password'}
+				required
+				minlength="8"
+				autocomplete="new-password"
+				placeholder="Re-enter password"
+				bind:value={credentials.confirm}
+				disabled={submitting}
+			/>
+			<button
+				type="button"
+				class="field-eye"
+				onclick={() => (showConfirm = !showConfirm)}
+				tabindex="-1"
+				aria-label={showConfirm ? 'Hide password' : 'Show password'}
+			>
+				{#if showConfirm}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+			</button>
+		</div>
+		{#if credentials.confirm.length > 0 && !match}
+			<span class="field-hint field-hint-error">Passwords do not match</span>
+		{/if}
+	</label>
+</form>
+
+<style>
+	.step-head {
+		margin-bottom: 1.5rem;
+	}
+
+	.step-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 44px;
+		height: 44px;
+		border-radius: 12px;
+		background: hsl(var(--primary) / 0.12);
+		color: hsl(var(--primary));
+		margin-bottom: 0.85rem;
+	}
+
+	.step-title {
+		font-size: 1.6rem;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		line-height: 1.15;
+	}
+
+	.step-sub {
+		margin-top: 0.4rem;
+		color: hsl(var(--muted-foreground));
+		font-size: 0.92rem;
+		line-height: 1.5;
+	}
+
+	.step-body {
+		display: flex;
+		flex-direction: column;
+		gap: 1.1rem;
+	}
+
+	.alert {
+		border: 1px solid hsl(var(--destructive) / 0.4);
+		background: hsl(var(--destructive) / 0.1);
+		color: hsl(var(--destructive));
+		padding: 0.55rem 0.75rem;
+		border-radius: 0.5rem;
+		font-size: 0.85rem;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.field-label {
+		font-size: 0.82rem;
+		font-weight: 600;
+	}
+
+	.field-control {
+		position: relative;
+		display: flex;
+		align-items: center;
+	}
+
+	:global(.field-icon) {
+		position: absolute;
+		left: 0.7rem;
+		width: 16px;
+		height: 16px;
+		color: hsl(var(--muted-foreground));
+		pointer-events: none;
+	}
+
+	.field-input {
+		width: 100%;
+		border: 1px solid hsl(var(--border));
+		background: hsl(var(--background));
+		border-radius: 0.5rem;
+		padding: 0.6rem 0.75rem;
+		font-size: 0.92rem;
+		outline: none;
+		transition: border-color 160ms, box-shadow 160ms;
+	}
+
+	.field-input:focus {
+		border-color: hsl(var(--primary));
+		box-shadow: 0 0 0 3px hsl(var(--primary) / 0.18);
+	}
+
+	.field-input:disabled {
+		opacity: 0.6;
+	}
+
+	.field-input.pl-9 {
+		padding-left: 2.5rem;
+	}
+
+	.field-input.pr-9 {
+		padding-right: 2.5rem;
+	}
+
+	.field-eye {
+		position: absolute;
+		right: 0.5rem;
+		display: inline-flex;
+		padding: 0.3rem;
+		border-radius: 0.375rem;
+		color: hsl(var(--muted-foreground));
+		background: transparent;
+		border: none;
+		cursor: pointer;
+	}
+
+	.field-eye:hover {
+		color: hsl(var(--foreground));
+	}
+
+	.field-hint {
+		font-size: 0.78rem;
+	}
+
+	.field-hint-error {
+		color: hsl(var(--destructive));
+	}
+
+	.strength {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+	}
+
+	.strength-bar {
+		flex: 1;
+		height: 5px;
+		border-radius: 9999px;
+		background: hsl(var(--muted));
+		overflow: hidden;
+	}
+
+	.strength-fill {
+		display: block;
+		height: 100%;
+		border-radius: 9999px;
+		transition: width 240ms cubic-out, background 240ms;
+		background: hsl(var(--destructive));
+	}
+
+	.strength-fill[data-score='2'] {
+		background: hsl(38 92% 50%);
+	}
+
+	.strength-fill[data-score='3'] {
+		background: hsl(142 71% 45%);
+	}
+
+	.strength-fill[data-score='4'] {
+		background: hsl(152 76% 40%);
+	}
+
+	.strength-label {
+		font-size: 0.72rem;
+		font-weight: 600;
+		min-width: 3rem;
+		text-align: right;
+		color: hsl(var(--muted-foreground));
+	}
+
+	.strength-label[data-score='1'] {
+		color: hsl(var(--destructive));
+	}
+
+	.strength-label[data-score='2'] {
+		color: hsl(38 92% 45%);
+	}
+
+	.strength-label[data-score='3'],
+	.strength-label[data-score='4'] {
+		color: hsl(142 71% 40%);
+	}
+</style>

--- a/web/frontend/src/lib/components/setup/StepDirectories.svelte
+++ b/web/frontend/src/lib/components/setup/StepDirectories.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { FolderCheck } from 'lucide-svelte';
+	import AllowedDirectoriesEditor from '$lib/components/AllowedDirectoriesEditor.svelte';
+
+	let {
+		dirs = $bindable(),
+		error = null as string | null,
+		submitting = false,
+		onSkip,
+	}: {
+		dirs: string[];
+		error?: string | null;
+		submitting?: boolean;
+		onSkip?: () => void;
+	} = $props();
+</script>
+
+<div class="step-head">
+	<div class="step-badge"><FolderCheck class="h-5 w-5" /></div>
+	<h1 class="step-title">Point Javinizer at your library</h1>
+	<p class="step-sub">
+		Add the folders that hold your video files. Javinizer can only read and write inside these
+		locations — add as many as you need.
+	</p>
+</div>
+
+{#if error}
+	<div class="alert" role="alert">{error}</div>
+{/if}
+
+<div class="editor-wrap" class:disabled={submitting}>
+	<AllowedDirectoriesEditor
+		bind:directories={dirs}
+		whitelistPaths={dirs}
+		emptyHint="No directories added yet. Add one below to enable scanning, or skip and add later."
+	/>
+</div>
+
+<style>
+	.step-head {
+		margin-bottom: 1.5rem;
+	}
+
+	.step-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 44px;
+		height: 44px;
+		border-radius: 12px;
+		background: hsl(var(--primary) / 0.12);
+		color: hsl(var(--primary));
+		margin-bottom: 0.85rem;
+	}
+
+	.step-title {
+		font-size: 1.6rem;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		line-height: 1.15;
+	}
+
+	.step-sub {
+		margin-top: 0.4rem;
+		color: hsl(var(--muted-foreground));
+		font-size: 0.92rem;
+		line-height: 1.5;
+	}
+
+	.alert {
+		border: 1px solid hsl(var(--destructive) / 0.4);
+		background: hsl(var(--destructive) / 0.1);
+		color: hsl(var(--destructive));
+		padding: 0.55rem 0.75rem;
+		border-radius: 0.5rem;
+		font-size: 0.85rem;
+		margin-bottom: 1rem;
+	}
+
+	.editor-wrap.disabled {
+		opacity: 0.6;
+		pointer-events: none;
+	}
+</style>

--- a/web/frontend/src/lib/components/setup/StepScrapers.svelte
+++ b/web/frontend/src/lib/components/setup/StepScrapers.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+	import { Sparkles, Loader2 } from 'lucide-svelte';
+	import ScraperSelector from '$lib/components/ScraperSelector.svelte';
+	import type { Scraper } from '$lib/api/types';
+
+	let {
+		selected = $bindable(),
+		scrapers = [] as Scraper[],
+		loading = false,
+		error = null as string | null,
+		submitting = false,
+	}: {
+		selected: string[];
+		scrapers: Scraper[];
+		loading?: boolean;
+		error?: string | null;
+		submitting?: boolean;
+	} = $props();
+
+	let wizardScrapers = $derived(scrapers.map((s) => ({ ...s, enabled: true })));
+	let hasScrapers = $derived(scrapers.length > 0);
+	let selectedCount = $derived(selected.length);
+</script>
+
+<div class="step-head">
+	<div class="step-badge"><Sparkles class="h-5 w-5" /></div>
+	<h1 class="step-title">Choose your metadata sources</h1>
+	<p class="step-sub">
+		Pick the scrapers Javinizer will query for metadata and arrange them by priority — higher means a
+		source wins when fields conflict. You can fine-tune each scraper's options later in Settings.
+	</p>
+</div>
+
+{#if error}
+	<div class="alert" role="alert">{error}</div>
+{/if}
+
+{#if loading}
+	<div class="state">
+		<Loader2 class="h-5 w-5 animate-spin" />
+		<span>Loading scrapers…</span>
+	</div>
+{:else if !hasScrapers}
+	<div class="state">
+		<p>No scrapers reported by the API.</p>
+		<p class="state-hint">You can configure scrapers later in Settings → Scrapers.</p>
+	</div>
+{:else}
+	<div class="selector-wrap" class:disabled={submitting}>
+		<ScraperSelector scrapers={wizardScrapers} bind:selected={selected} disabled={submitting} />
+	</div>
+
+	<div class="summary">
+		<span class="summary-dot" data-on={selectedCount > 0}></span>
+		{#if selectedCount === 0}
+			<span>No scrapers selected — scraping will be unavailable until you enable some.</span>
+		{:else}
+			<span><strong>{selectedCount}</strong> scraper{selectedCount > 1 ? 's' : ''} selected, ordered by priority.</span>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.step-head {
+		margin-bottom: 1.5rem;
+	}
+
+	.step-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 44px;
+		height: 44px;
+		border-radius: 12px;
+		background: hsl(var(--primary) / 0.12);
+		color: hsl(var(--primary));
+		margin-bottom: 0.85rem;
+	}
+
+	.step-title {
+		font-size: 1.6rem;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		line-height: 1.15;
+	}
+
+	.step-sub {
+		margin-top: 0.4rem;
+		color: hsl(var(--muted-foreground));
+		font-size: 0.92rem;
+		line-height: 1.5;
+	}
+
+	.alert {
+		border: 1px solid hsl(var(--destructive) / 0.4);
+		background: hsl(var(--destructive) / 0.1);
+		color: hsl(var(--destructive));
+		padding: 0.55rem 0.75rem;
+		border-radius: 0.5rem;
+		font-size: 0.85rem;
+		margin-bottom: 1rem;
+	}
+
+	.state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 2.5rem 1rem;
+		text-align: center;
+		color: hsl(var(--muted-foreground));
+		font-size: 0.9rem;
+	}
+
+	.state-hint {
+		font-size: 0.8rem;
+	}
+
+	.selector-wrap.disabled {
+		opacity: 0.6;
+		pointer-events: none;
+	}
+
+	.summary {
+		margin-top: 1rem;
+		display: flex;
+		align-items: center;
+		gap: 0.55rem;
+		padding: 0.6rem 0.8rem;
+		border-radius: 0.5rem;
+		background: hsl(var(--muted) / 0.5);
+		font-size: 0.82rem;
+		color: hsl(var(--muted-foreground));
+	}
+
+	.summary strong {
+		color: hsl(var(--foreground));
+	}
+
+	.summary-dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 9999px;
+		background: hsl(var(--muted-foreground) / 0.5);
+	}
+
+	.summary-dot[data-on='true'] {
+		background: hsl(142 71% 45%);
+		box-shadow: 0 0 8px hsl(142 71% 45% / 0.6);
+	}
+</style>

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -9,16 +9,13 @@
 	import DialogContainer from '$lib/components/ui/DialogContainer.svelte';
 	import BackgroundJobIndicator from '$lib/components/BackgroundJobIndicator.svelte';
 	import ProgressModal from '$lib/components/ProgressModal.svelte';
-	import AllowedDirectoriesEditor from '$lib/components/AllowedDirectoriesEditor.svelte';
-	import Button from '$lib/components/ui/Button.svelte';
 	import { apiClient } from '$lib/api/client';
 	import { BaseClient } from '$lib/api/clients/common';
 	import { websocketStore } from '$lib/stores/websocket';
-	import { toastStore } from '$lib/stores/toast';
 	import { getBackgroundJobState, reopenModal, dismiss, closeModal } from '$lib/stores/background-job.svelte';
 	import { getQueryClient } from '$lib/query/client';
 	import { getThemeStore } from '$lib/stores/theme.svelte';
-	import { Save, FolderCheck, ArrowRight } from 'lucide-svelte';
+	import SetupWizard from '$lib/components/setup/SetupWizard.svelte';
 	import '../app.css';
 
 	let { children } = $props();
@@ -33,20 +30,9 @@
 	let authAuthenticated = $state(false);
 	let authUsername = $state('');
 	let authError = $state<string | null>(null);
-	let setupUsername = $state('');
-	let setupPassword = $state('');
-	let setupPasswordConfirm = $state('');
 	let loginUsername = $state('');
 	let loginPassword = $state('');
 	let loginRememberMe = $state(true);
-	let setupNeedsDirs = $state(false);
-	let setupDirs = $state<string[]>([]);
-	let setupDirsSubmitting = $state(false);
-	let setupSecurityDefaults = $state({
-		denied_directories: [] as string[],
-		allow_unc: false,
-		allowed_unc_servers: [] as string[],
-	});
 
 	function syncWebSocketAuthState() {
 		if (authAuthenticated) {
@@ -77,86 +63,6 @@
 			authLoading = false;
 			syncWebSocketAuthState();
 		}
-	}
-
-	async function handleSetupSubmit(event: SubmitEvent) {
-		event.preventDefault();
-		authError = null;
-
-		if (setupPassword !== setupPasswordConfirm) {
-			authError = 'Passwords do not match';
-			return;
-		}
-
-		authSubmitting = true;
-		try {
-			const setupResult = await apiClient.setupAuth({
-				username: setupUsername,
-				password: setupPassword
-			});
-			setupPassword = '';
-			setupPasswordConfirm = '';
-			if (setupResult?.session_id) { BaseClient.setSessionID(setupResult.session_id); }
-			loginPassword = '';
-			await refreshAuthStatus();
-			if (authAuthenticated) {
-				setupNeedsDirs = true;
-				try {
-					const fresh = await apiClient.getConfig();
-					const sec = fresh?.api?.security;
-					setupSecurityDefaults = {
-						denied_directories: [...(sec?.denied_directories ?? [])],
-						allow_unc: sec?.allow_unc ?? false,
-						allowed_unc_servers: [...(sec?.allowed_unc_servers ?? [])],
-					};
-					setupDirs = [...(sec?.allowed_directories ?? [])];
-				} catch (error) {
-					setupSecurityDefaults = {
-						denied_directories: [],
-						allow_unc: false,
-						allowed_unc_servers: [],
-					};
-					setupDirs = [];
-					authError = error instanceof Error
-						? `Failed to load current security settings: ${error.message}. You can still save allowed directories below.`
-						: 'Failed to load current security settings. You can still save allowed directories below.';
-				}
-			}
-		} catch (error) {
-			authError = error instanceof Error ? error.message : 'Failed to initialize authentication';
-		} finally {
-			authSubmitting = false;
-		}
-	}
-
-	async function handleSetupDirsSubmit(event: SubmitEvent) {
-		event.preventDefault();
-		authError = null;
-		setupDirsSubmitting = true;
-		try {
-			await apiClient.updateSecurityConfig({
-				allowed_directories: setupDirs,
-				denied_directories: setupSecurityDefaults.denied_directories,
-				allow_unc: setupSecurityDefaults.allow_unc,
-				allowed_unc_servers: setupSecurityDefaults.allowed_unc_servers,
-			});
-			setupNeedsDirs = false;
-			if (setupDirs.length > 0) {
-				toastStore.success('Allowed directories saved. Ready to scan.', 4000);
-			} else {
-				toastStore.info('You can add allowed directories later in Settings → Security.', 5000);
-			}
-		} catch (error) {
-			authError = error instanceof Error ? error.message : 'Failed to save allowed directories';
-		} finally {
-			setupDirsSubmitting = false;
-		}
-	}
-
-	function handleSetupDirsSkip() {
-		setupNeedsDirs = false;
-		setupDirs = [];
-		toastStore.info('You can add allowed directories later in Settings → Security.', 5000);
 	}
 
 	async function handleLoginSubmit(event: SubmitEvent) {
@@ -241,23 +147,15 @@
 			</button>
 		</div>
 	</div>
+{:else if !authInitialized}
+	<SetupWizard onComplete={() => { authInitialized = true; authAuthenticated = true; syncWebSocketAuthState(); }} />
 {:else if !authAuthenticated}
 	<div class="min-h-screen bg-background flex items-center justify-center px-4 py-10">
 		<div class="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm space-y-4">
 			<div class="space-y-1">
-				<h1 class="text-2xl font-bold">
-					{#if authInitialized}
-						Login Required
-					{:else}
-						First-Time Setup
-					{/if}
-				</h1>
+				<h1 class="text-2xl font-bold">Login Required</h1>
 				<p class="text-sm text-muted-foreground">
-					{#if authInitialized}
-						Sign in with your configured username and password.
-					{:else}
-						Create the default username and password for this server.
-					{/if}
+					Sign in with your configured username and password.
 				</p>
 			</div>
 
@@ -267,146 +165,50 @@
 				</div>
 			{/if}
 
-			{#if authInitialized}
-				<form class="space-y-3" onsubmit={handleLoginSubmit}>
-					<div class="space-y-1">
-						<label class="text-sm font-medium" for="login-username">Username</label>
-						<input
-							id="login-username"
-							class="w-full rounded-md border bg-background px-3 py-2 text-sm"
-							type="text"
-							required
-							autocomplete="username"
-							bind:value={loginUsername}
-						/>
-					</div>
-					<div class="space-y-1">
-						<label class="text-sm font-medium" for="login-password">Password</label>
-						<input
-							id="login-password"
-							class="w-full rounded-md border bg-background px-3 py-2 text-sm"
-							type="password"
-							required
-							autocomplete="current-password"
-							bind:value={loginPassword}
-						/>
-					</div>
-					<label class="flex items-start gap-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-sm">
-						<input
-							type="checkbox"
-							class="mt-0.5 rounded"
-							bind:checked={loginRememberMe}
-						/>
-						<span class="space-y-0.5">
-							<span class="block font-medium text-foreground">Remember me</span>
-							<span class="block text-xs text-muted-foreground">
-								Keep this browser signed in across browser and server restarts for the normal session lifetime.
-							</span>
+			<form class="space-y-3" onsubmit={handleLoginSubmit}>
+				<div class="space-y-1">
+					<label class="text-sm font-medium" for="login-username">Username</label>
+					<input
+						id="login-username"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm"
+						type="text"
+						required
+						autocomplete="username"
+						bind:value={loginUsername}
+					/>
+				</div>
+				<div class="space-y-1">
+					<label class="text-sm font-medium" for="login-password">Password</label>
+					<input
+						id="login-password"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm"
+						type="password"
+						required
+						autocomplete="current-password"
+						bind:value={loginPassword}
+					/>
+				</div>
+				<label class="flex items-start gap-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-sm">
+					<input
+						type="checkbox"
+						class="mt-0.5 rounded"
+						bind:checked={loginRememberMe}
+					/>
+					<span class="space-y-0.5">
+						<span class="block font-medium text-foreground">Remember me</span>
+						<span class="block text-xs text-muted-foreground">
+							Keep this browser signed in across browser and server restarts for the normal session lifetime.
 						</span>
-					</label>
-					<button
-						type="submit"
-						disabled={authSubmitting}
-						class="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
-					>
-						{authSubmitting ? 'Signing in...' : 'Sign In'}
-					</button>
-				</form>
-			{:else}
-				<form class="space-y-3" onsubmit={handleSetupSubmit}>
-					<div class="space-y-1">
-						<label class="text-sm font-medium" for="setup-username">Username</label>
-						<input
-							id="setup-username"
-							class="w-full rounded-md border bg-background px-3 py-2 text-sm"
-							type="text"
-							required
-							autocomplete="username"
-							bind:value={setupUsername}
-						/>
-					</div>
-					<div class="space-y-1">
-						<label class="text-sm font-medium" for="setup-password">Password</label>
-						<input
-							id="setup-password"
-							class="w-full rounded-md border bg-background px-3 py-2 text-sm"
-							type="password"
-							required
-							minlength="8"
-							autocomplete="new-password"
-							bind:value={setupPassword}
-						/>
-					</div>
-					<div class="space-y-1">
-						<label class="text-sm font-medium" for="setup-password-confirm">Confirm Password</label>
-						<input
-							id="setup-password-confirm"
-							class="w-full rounded-md border bg-background px-3 py-2 text-sm"
-							type="password"
-							required
-							minlength="8"
-							autocomplete="new-password"
-							bind:value={setupPasswordConfirm}
-						/>
-					</div>
-					<button
-						type="submit"
-						disabled={authSubmitting}
-						class="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
-					>
-						{authSubmitting ? 'Saving...' : 'Create Credentials'}
-					</button>
-				</form>
-			{/if}
-		</div>
-	</div>
-{:else if setupNeedsDirs}
-	<div class="min-h-screen bg-background flex items-center justify-center px-4 py-10">
-		<div class="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm space-y-4">
-			<div class="space-y-2">
-				<div class="flex items-center gap-3">
-					<div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
-						<FolderCheck class="h-5 w-5" />
-					</div>
-					<h1 class="text-2xl font-bold leading-tight">Add Allowed Directories</h1>
-				</div>
-				<p class="text-sm text-muted-foreground">
-					Add the folders you want to scan for videos; you can change this later in Settings → Security.
-				</p>
-				<p class="text-xs text-muted-foreground">
-					With no allowed directories configured, all file operations are blocked.
-				</p>
-			</div>
-
-			{#if authError}
-				<div class="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-					{authError}
-				</div>
-			{/if}
-
-			<AllowedDirectoriesEditor
-				bind:directories={setupDirs}
-				whitelistPaths={setupDirs}
-				emptyHint="No directories added yet. Add one below to enable scanning, or skip and add later."
-			/>
-
-			<form class="space-y-2" onsubmit={handleSetupDirsSubmit}>
-				<Button type="submit" disabled={setupDirsSubmitting} class="w-full">
-					{#snippet children()}
-						<FolderCheck class="h-4 w-4 mr-2" />
-						{setupDirsSubmitting ? 'Saving...' : 'Save & Continue'}
-					{/snippet}
-				</Button>
+					</span>
+				</label>
+				<button
+					type="submit"
+					disabled={authSubmitting}
+					class="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
+				>
+					{authSubmitting ? 'Signing in...' : 'Sign In'}
+				</button>
 			</form>
-			<button
-				type="button"
-				disabled={setupDirsSubmitting}
-				onclick={handleSetupDirsSkip}
-				class="w-full inline-flex items-center justify-center gap-1 rounded-md px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground disabled:opacity-60"
-			>
-				Skip for now
-				<ArrowRight class="h-3.5 w-3.5" />
-			</button>
 		</div>
 	</div>
 {:else}

--- a/web/frontend/src/routes/+page.svelte
+++ b/web/frontend/src/routes/+page.svelte
@@ -334,7 +334,7 @@
 
 	async function openDocs() {
 		if (browser) {
-			window.open(`${location.protocol}//${location.hostname}:8080/docs`, '_blank', 'noopener,noreferrer');
+			window.open(`${location.protocol}//${location.hostname}:8765/docs`, '_blank', 'noopener,noreferrer');
 			return;
 		}
 		await goto('/docs');

--- a/web/frontend/src/routes/jobs/+page.svelte
+++ b/web/frontend/src/routes/jobs/+page.svelte
@@ -243,7 +243,7 @@
 		const results = Object.values(job.results || {});
 		for (const r of results) {
 			if (r.movie?.cropped_poster_url) {
-				return r.movie.cropped_poster_url;
+				return apiClient.withSessionParam(r.movie.cropped_poster_url);
 			}
 			if (r.movie?.poster_url) {
 				return apiClient.getPreviewImageURL(r.movie.poster_url);

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -11,6 +11,8 @@ vi.mock('$lib/api/client', () => ({
 		logoutAuth: vi.fn(),
 		getConfig: vi.fn(),
 		updateSecurityConfig: vi.fn(),
+		getScrapers: vi.fn(),
+		request: vi.fn(),
 	},
 }));
 
@@ -63,34 +65,56 @@ function authenticatedStatus() {
 	>;
 }
 
-function freshConfig(allowed: string[] = []) {
+function freshConfig(allowed: string[] = [], overrides: Record<string, unknown> = {}) {
 	return {
+		scrapers: { priority: [] },
 		api: {
 			security: {
 				allowed_directories: allowed,
 				denied_directories: [],
 				allow_unc: false,
 				allowed_unc_servers: [],
+				...overrides,
 			},
 		},
 	} as unknown as Awaited<ReturnType<typeof apiClient.getConfig>>;
 }
 
-function securityResponse(allowed: string[] = [], overrides: Record<string, unknown> = {}) {
-	return {
-		security: {
-			allowed_directories: allowed,
-			denied_directories: [],
-			allow_unc: false,
-			allowed_unc_servers: [],
-			...overrides,
-		},
-	} as unknown as Awaited<ReturnType<typeof apiClient.updateSecurityConfig>>;
+function scrapersResponse() {
+	return [
+		{ name: 'r18', display_title: 'R18', enabled: true, options: {} },
+		{ name: 'javlibrary', display_title: 'JavLibrary', enabled: true, options: {} },
+	] as unknown as Awaited<ReturnType<typeof apiClient.getScrapers>>;
+}
+
+function findButton(container: HTMLElement, text: string): HTMLButtonElement {
+	return Array.from(container.querySelectorAll('button')).find((b) =>
+		b.textContent?.includes(text),
+	) as HTMLButtonElement;
+}
+
+async function fillCredentials(container: HTMLElement) {
+	const username = container.querySelector('input[placeholder="admin"]') as HTMLInputElement;
+	const password = container.querySelector(
+		'input[placeholder="At least 8 characters"]',
+	) as HTMLInputElement;
+	const confirm = container.querySelector(
+		'input[placeholder="Re-enter password"]',
+	) as HTMLInputElement;
+	await fireEvent.input(username, { target: { value: 'admin' } });
+	await fireEvent.input(password, { target: { value: 'password123' } });
+	await fireEvent.input(confirm, { target: { value: 'password123' } });
+	return { username, password, confirm };
 }
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	apiClient.getAuthStatus.mockReset();
 	apiClient.getAuthStatus.mockResolvedValue(uninitializedStatus());
+	apiClient.getScrapers.mockResolvedValue(scrapersResponse());
+	apiClient.getConfig.mockResolvedValue(freshConfig());
+	apiClient.updateSecurityConfig.mockResolvedValue({ security: { allowed_directories: [] } } as unknown as Awaited<ReturnType<typeof apiClient.updateSecurityConfig>>);
+	apiClient.request.mockResolvedValue({ message: 'ok' });
 	toastStore.clear();
 	vi.spyOn(toastStore, 'success');
 	vi.spyOn(toastStore, 'info');
@@ -100,175 +124,57 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-describe('first-run setup allowed directories step', () => {
-	it('shows the credentials form before auth is initialized', async () => {
-		const { container, getByText } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
-		expect(container.textContent).toContain('Create the default username and password');
-		expect(getByText('Create Credentials')).toBeTruthy();
+describe('first-run setup wizard', () => {
+	it('shows the credentials step before auth is initialized', async () => {
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		expect(container.textContent).toContain('Admin Account');
+		expect(findButton(container, 'Continue')).toBeTruthy();
 	});
 
-	it('transitions to the allowed directories step after credentials are created', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
+	it('creates the admin account and advances to the directories step', async () => {
 		apiClient.setupAuth.mockResolvedValue(
 			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
 		);
-		apiClient.getConfig.mockResolvedValue(freshConfig());
-		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse());
 
 		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
 
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
+		await fireEvent.click(findButton(container, 'Continue'));
 
-		const form = username.closest('form') as HTMLFormElement;
-		await fireEvent.submit(form);
-
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
-		expect(container.textContent).toContain('you can change this later in Settings');
-		expect(apiClient.getConfig).toHaveBeenCalledTimes(1);
+		await waitFor(() => expect(apiClient.setupAuth).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		// directories/scrapers are staged — no config/security calls yet at step 1
+		expect(apiClient.getConfig).not.toHaveBeenCalled();
 		expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled();
 	});
 
-	it('persists allowed directories via the security endpoint on submit', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
+	it('hides the Back button on the directories step (credentials are committed)', async () => {
 		apiClient.setupAuth.mockResolvedValue(
 			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
 		);
-		apiClient.getConfig.mockResolvedValue(freshConfig());
-		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse(['/mnt/videos']));
 
 		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
 
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
-		await fireEvent.submit(username.closest('form') as HTMLFormElement);
-
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
-
-		const dirInput = container.querySelector(
-			'input[placeholder*="Add a directory"]',
-		) as HTMLInputElement;
-		expect(dirInput).toBeTruthy();
-		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
-		const addBtn = container.querySelector(
-			'button[title="Add allowed directory"]',
-		) as HTMLButtonElement;
-		await fireEvent.click(addBtn);
-		await tick();
-
-		const save = Array.from(container.querySelectorAll('button')).find((b) =>
-			b.textContent?.includes('Save & Continue'),
-		) as HTMLButtonElement;
-		expect(save).toBeTruthy();
-		await fireEvent.click(save);
-
-		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
-		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
-			expect.objectContaining({
-				allowed_directories: ['/mnt/videos'],
-				denied_directories: [],
-				allow_unc: false,
-				allowed_unc_servers: [],
-			}),
-		);
-		await waitFor(() => expect(vi.mocked(toastStore.success)).toHaveBeenCalled());
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		expect(findButton(container, 'Back')).toBeUndefined();
 	});
 
-	it('commits a typed directory on Enter without clicking the add button', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
+	it('stages directories and advances to the scrapers step without committing', async () => {
 		apiClient.setupAuth.mockResolvedValue(
 			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
 		);
-		apiClient.getConfig.mockResolvedValue(freshConfig());
-		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse(['/mnt/videos']));
 
 		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
 
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
-		await fireEvent.submit(username.closest('form') as HTMLFormElement);
-
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
-
-		const dirInput = container.querySelector(
-			'input[placeholder*="Add a directory"]',
-		) as HTMLInputElement;
-		expect(dirInput).toBeTruthy();
-		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
-		await fireEvent.keyDown(dirInput, { key: 'Enter' });
-		await tick();
-
-		const save = Array.from(container.querySelectorAll('button')).find((b) =>
-			b.textContent?.includes('Save & Continue'),
-		) as HTMLButtonElement;
-		await fireEvent.click(save);
-
-		await waitFor(() =>
-			expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
-				expect.objectContaining({ allowed_directories: ['/mnt/videos'] }),
-			),
-		);
-	});
-
-	it('sends all four security fields including current defaults', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
-		apiClient.setupAuth.mockResolvedValue(
-			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
-		);
-		apiClient.getConfig.mockResolvedValue({
-			api: {
-				security: {
-					allowed_directories: [],
-					denied_directories: ['/sensitive'],
-					allow_unc: true,
-					allowed_unc_servers: ['\\\\srv\\share'],
-				},
-			},
-		} as unknown as Awaited<ReturnType<typeof apiClient.getConfig>>);
-		apiClient.updateSecurityConfig.mockResolvedValue(
-			securityResponse(['/mnt/videos'], {
-				denied_directories: ['/sensitive'],
-				allow_unc: true,
-				allowed_unc_servers: ['\\\\srv\\share'],
-			}),
-		);
-
-		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
-
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
-		await fireEvent.submit(username.closest('form') as HTMLFormElement);
-
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
 
 		const dirInput = container.querySelector(
 			'input[placeholder*="Add a directory"]',
@@ -279,10 +185,51 @@ describe('first-run setup allowed directories step', () => {
 		);
 		await tick();
 
-		const save = Array.from(container.querySelectorAll('button')).find((b) =>
-			b.textContent?.includes('Save & Continue'),
-		) as HTMLButtonElement;
-		await fireEvent.click(save);
+		await fireEvent.click(findButton(container, 'Continue'));
+
+		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
+		// staged — nothing committed yet
+		expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled();
+	});
+
+	it('commits staged directories and scraper selection together on Finish', async () => {
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
+		apiClient.getConfig.mockResolvedValue({
+			scrapers: { priority: [] },
+			api: {
+				security: {
+					allowed_directories: [],
+					denied_directories: ['/sensitive'],
+					allow_unc: true,
+					allowed_unc_servers: ['\\\\srv\\share'],
+				},
+			},
+		} as unknown as Awaited<ReturnType<typeof apiClient.getConfig>>);
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
+
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+
+		const dirInput = container.querySelector(
+			'input[placeholder*="Add a directory"]',
+		) as HTMLInputElement;
+		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
+		await fireEvent.click(
+			container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement,
+		);
+		await tick();
+
+		await fireEvent.click(findButton(container, 'Continue'));
+
+		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
+		await waitFor(() => expect(apiClient.getScrapers).toHaveBeenCalledTimes(1));
+
+		await fireEvent.click(findButton(container, 'Finish Setup'));
 
 		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
 		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
@@ -293,70 +240,84 @@ describe('first-run setup allowed directories step', () => {
 				allowed_unc_servers: ['\\\\srv\\share'],
 			}),
 		);
+		await waitFor(() => expect(apiClient.request).toHaveBeenCalledTimes(1));
+		expect(apiClient.request).toHaveBeenCalledWith(
+			'/api/v1/config',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+		const calls = (apiClient.request as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+		const payload = JSON.parse((calls[0][1] as { body: string }).body);
+		expect(payload.scrapers.priority).toEqual(['r18', 'javlibrary']);
+		expect(payload.scrapers.r18.enabled).toBe(true);
+		expect(payload.scrapers.javlibrary.enabled).toBe(true);
+		await waitFor(() => expect(vi.mocked(toastStore.success)).toHaveBeenCalled());
 	});
 
-	it('skips the step without calling the security endpoint and toasts guidance', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
+	it('commits a typed directory on Enter before finishing', async () => {
 		apiClient.setupAuth.mockResolvedValue(
 			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
 		);
-		apiClient.getConfig.mockResolvedValue(freshConfig());
 
 		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
 
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
-		await fireEvent.submit(username.closest('form') as HTMLFormElement);
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
 
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
+		const dirInput = container.querySelector(
+			'input[placeholder*="Add a directory"]',
+		) as HTMLInputElement;
+		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
+		await fireEvent.keyDown(dirInput, { key: 'Enter' });
+		await tick();
 
-		const skipBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-			b.textContent?.includes('Skip for now'),
-		) as HTMLButtonElement;
-		expect(skipBtn).toBeTruthy();
-		await fireEvent.click(skipBtn);
+		await fireEvent.click(findButton(container, 'Continue'));
+		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
+		await fireEvent.click(findButton(container, 'Finish Setup'));
 
-		await waitFor(() =>
-			expect(vi.mocked(toastStore.info)).toHaveBeenCalledWith(
-				expect.stringContaining('Settings → Security'),
-				expect.any(Number),
-			),
+		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
+		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
+			expect.objectContaining({ allowed_directories: ['/mnt/videos'] }),
 		);
-		await waitFor(() => expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled());
-		expect(vi.mocked(toastStore.info)).toHaveBeenCalled();
 	});
 
-	it('surfaces a visible error when config loading fails but keeps the dirs gate stable', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
+	it('skips the directories step and still advances to scrapers', async () => {
 		apiClient.setupAuth.mockResolvedValue(
 			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
 		);
-		apiClient.getConfig.mockRejectedValue(new Error('network down'));
 
 		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
 
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
-		await fireEvent.submit(username.closest('form') as HTMLFormElement);
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
 
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
-		expect(container.textContent).toContain('Failed to load current security settings');
-		expect(container.textContent).toContain('network down');
-		expect(apiClient.getConfig).toHaveBeenCalledTimes(1);
+		await fireEvent.click(findButton(container, 'Skip for now'));
+
+		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
 		expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled();
+	});
+
+	it('shows a Back button on the scrapers step that returns to directories', async () => {
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
+
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		await fireEvent.click(findButton(container, 'Continue'));
+
+		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
+		const back = findButton(container, 'Back');
+		expect(back).toBeTruthy();
+		await fireEvent.click(back);
+
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
 	});
 });

--- a/web/frontend/tests/frontend/desktop-upgrade.spec.ts
+++ b/web/frontend/tests/frontend/desktop-upgrade.spec.ts
@@ -123,7 +123,7 @@ test.describe('Desktop upgrade CTA + notification (install_environment=desktop)'
 			r.fulfill({
 				status: 200,
 				json: {
-					server: { host: 'localhost', port: 8080 },
+					server: { host: 'localhost', port: 8765 },
 					system: {
 						version_check_enabled: true,
 						version_check_interval_hours: 24,

--- a/web/frontend/vite.config.ts
+++ b/web/frontend/vite.config.ts
@@ -12,27 +12,27 @@ export default defineConfig({
 		proxy: {
 			// Proxy API requests to Go backend during development
 			'/api': {
-				target: 'http://localhost:8080',
+				target: 'http://localhost:8765',
 				changeOrigin: true,
 			},
 			// Proxy WebSocket connections to Go backend during development.
 			// changeOrigin is FALSE for /ws (unlike /api + /health): the backend's
 			// WS upgrader validates Origin via isSameOrigin (scheme+host+port of
 			// the Origin header vs the request Host). With changeOrigin:true the
-			// Host is rewritten to the backend port (8080) while the browser Origin
+			// Host is rewritten to the backend port (8765) while the browser Origin
 			// stays on the Vite port (5173) → port mismatch → 403, so the browser
 			// could never open /ws/progress in dev. changeOrigin:false preserves the
 			// browser's original Host so Origin and Host match → same-origin allowed.
 			// Cookie auth is unaffected (the session cookie is scoped to the Vite
 			// origin the browser already holds it for).
 			'/ws': {
-				target: 'http://localhost:8080',
+				target: 'http://localhost:8765',
 				ws: true,
 				changeOrigin: false,
 			},
 			// Proxy health check
 			'/health': {
-				target: 'http://localhost:8080',
+				target: 'http://localhost:8765',
 				changeOrigin: true,
 			},
 		},

--- a/web/frontend/vite.fullstack.config.ts
+++ b/web/frontend/vite.fullstack.config.ts
@@ -2,15 +2,15 @@
  * Vite config for full-stack E2E tests.
  *
  * Identical to vite.config.ts (the production dev config) except it points
- * the /api + /ws + /health proxy at port 18080 instead of 8080 — the port
+ * the /api + /ws + /health proxy at port 18080 instead of 8765 — the port
  * cmd/javinizer-e2e binds by default. Keeps the e2e backend isolated from
- * any developer's running `javinizer web` dev instance on 8080.
+ * any developer's running `javinizer web` dev instance on 8765.
  *
  * It also overrides VITE_API_URL / VITE_WS_URL to empty so the frontend
  * issues relative requests (e2emock flow) instead of absolute ones. The
- * repo's .env hardcodes VITE_API_URL=http://localhost:8080 for normal dev,
+ * repo's .env hardcodes VITE_API_URL=http://localhost:8765 for normal dev,
  * which would bypass this config's proxy and point the browser straight at
- * :8080 (where no e2e backend listens). Empty values make getAPIBaseURL()
+ * :8765 (where no e2e backend listens). Empty values make getAPIBaseURL()
  * return '' so every /api + /ws request is relative → forwarded by the
  * proxy below to the e2e backend on 18080.
  */
@@ -24,7 +24,7 @@ export default defineConfig({
 	// Override the .env-provided absolute API/WS URLs so the frontend uses
 	// relative paths and the proxy below routes them to the e2e backend.
 	// `import.meta.env.VITE_*` is statically replaced at build/dev time, so
-	// an empty string here wins over .env's http://localhost:8080.
+	// an empty string here wins over .env's http://localhost:8765.
 	// JSON.stringify emits a valid JS string literal (bare '' is rejected by
 	// esbuild as an invalid define value).
 	define: {


### PR DESCRIPTION
## Summary

Started as two focused fixes (browse box outline + `allowed_directories` persistence) and grew to include the supporting port-switch and auth fixes needed to actually test them in dev/desktop. Five commits, each independently revertable.

## What changed

### 1. Browse box focus ring (`165fff7a`)
The directory input in the setup wizard showed a clipped/inconsistent focus ring — the browser default outline was rendering alongside the Tailwind `focus:ring-2`. Added `outline-none` to `PathInput` (matching `FormTextInput`/`FormTemplateInput`) and aligned the input height (`h-9`) + row centering (`items-center`) in `AllowedDirectoriesEditor` so the input matches the adjacent `size="sm"` Browse/Add buttons instead of sitting top-aligned and shorter.

### 2. `allowed_directories` not persisting (`33167e81`)
`SecuritySettingsSection` kept a local `draft` that was **never written back** to the shared `settings.config`. The top-level **Save Changes** button does a whole-config `PUT /api/v1/config` using `settings.config`, so it sent the *stale* `allowed_directories` and clobbered a just-added directory on reload.

Fix: a sync `$effect` mirrors `draft` → `config.api.security.*` so both Save Changes (whole-config) and Save Security (narrow endpoint) see the same values. Dirty detection switched to a saved/loaded `baseline` (the sync would otherwise make draft==config and disable the Save button). `onSuccess` resets the baseline to the persisted values. Regression test added asserting the draft propagates into the parent config.

### 3. CORS: allow `X-Session-ID` in preflight (`3d0b4caa`)
The frontend sends a custom `X-Session-ID` header on every authenticated request, but the CORS middleware only whitelisted `Content-Type, Authorization, Accept, Origin, X-Requested-With`. Any cross-origin request failed preflight with \"Request header field x-session-id is not allowed\". Added `X-Session-ID` to `Access-Control-Allow-Headers`. Swagger regenerated.

### 4. Default server port 8080 → 8765 (`a63a32a4`)
8080 collides with common dev tools (hit exactly this during testing — a `Dory` process was occupying 8080). Switched the default across `defaults.go` (Port + allowed origins), embedded `config.yaml.example`, `configs/config.yaml.example`, swagger `@host`, Dockerfile (`EXPOSE` + healthcheck + allowed origins), docker-compose.yml, Makefile, Vite proxy + `.env`, `ServerSettingsSection` placeholder, docs, and tests asserting the default port.

**Existing users' `config.yaml` is NOT rewritten** — their server keeps its configured port; only fresh installs get 8765.

### 5. Authenticate `<img>` via session cookie (dev proxy) (`35baecf1`)
The dev `.env` set `VITE_API_URL=http://localhost:8765`, making all API calls cross-origin (5174→8765). With `credentials:'same-origin'` + `SameSite=Lax` cookies, the session cookie never flowed cross-origin, so `<img>` tags to protected `/api/v1/temp/posters` / `/api/v1/temp/image` endpoints arrived unauthenticated (401).

**Proper fix:** emptied `VITE_API_URL` so the browser uses relative URLs through the Vite proxy (same-origin) — the session cookie set on login now authenticates both `fetch()` and `<img>` natively.

The `?session=` query-param fallback is kept **desktop-only** (`isDesktopApp()` guard). WKWebView + Wails' custom `wails://` scheme genuinely cannot persist cookies — confirmed via research as an upstream WebKit limitation (Wails issue [#3908](https://github.com/wailsapp/wails/issues/3908), labeled `blocked`; [#2590](https://github.com/wailsapp/wails/issues/2590); [SO 56658753](https://stackoverflow.com/questions/56658753)). localStorage + `?session=` is the maintainer-recommended workaround, which is what this project already does.

## Verification

- `go build ./...` ✅
- `go test -short ./...` ✅ all pass
- `make build` / `make web-build` ✅ clean
- `make build-app-darwin` ✅ — `bin/Javinizer.app` (universal) built and smoke-tested
- `svelte-check` ✅ 0 errors / 0 warnings
- Frontend tests ✅ 361/361 pass (the 8 `ResizeObserver` test errors are pre-existing, fixed separately on `fix/setup-wizard-resizeobserver-test-polyfill`)

## Test plan

- [ ] Setup wizard: focus ring on the directory browse box looks consistent with other inputs
- [ ] Settings → Security: add an allowed directory → click **Save Changes** (top-level) → reload page → directory persists
- [ ] Settings → Security: add an allowed directory → click **Save Security** (section-level) → reload → persists
- [ ] Dev (`make web-dev` + `make run-api-dev`): posters load on jobs + review pages (no 401 on `/api/v1/temp/posters`)
- [ ] Desktop app: posters load via the `?session=` fallback path
- [ ] Fresh install: server binds 8765; existing `config.yaml` keeps its configured port

## Notes

- The `ResizeObserver` test polyfill lives on a separate branch (`fix/setup-wizard-resizeobserver-test-polyfill`) to keep this PR focused; it can be reviewed/merged independently.
- Commits are intentionally split by concern so reviewers can step through each change; each is independently revertable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided first-time setup wizard for creating an admin account, choosing library folders, and selecting metadata sources.

* **Bug Fixes**
  * Updated the app and documentation to use the new default web/API port `8765`.
  * Improved security settings handling so saved access rules and network options stay in sync more reliably.
  * Fixed session-aware image URLs in the web app so preview content loads correctly in more cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->