### PR TITLE
Fix browse box focus ring + allowed_directories persistence

### DIFF
--- a/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
+++ b/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
@@ -124,12 +124,12 @@
 		</ul>
 	{/if}
 
-	<form onsubmit={addDir} class="flex items-start gap-2">
+	<form onsubmit={addDir} class="flex items-center gap-2">
 		<PathInput
 			bind:value={newDir}
 			{placeholder}
 			{whitelistPaths}
-			class="flex-1"
+			class="h-9"
 			onnavigate={() => addDir()}
 		/>
 		<Button

--- a/web/frontend/src/lib/components/PathInput.svelte
+++ b/web/frontend/src/lib/components/PathInput.svelte
@@ -177,7 +177,7 @@
 			}, 120);
 		}}
 		{placeholder}
-		class="w-full px-3 py-1.5 pr-9 border rounded-md bg-background outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all font-mono text-sm {className}"
+		class="w-full px-3 py-1.5 pr-9 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all font-mono text-sm {className}"
 	/>
 	{#if autocompleteLoading}
 		<div class="absolute inset-y-0 right-3 flex items-center text-muted-foreground">

--- a/web/frontend/src/lib/components/PathInput.svelte
+++ b/web/frontend/src/lib/components/PathInput.svelte
@@ -177,7 +177,7 @@
 			}, 120);
 		}}
 		{placeholder}
-		class="w-full px-3 py-1.5 pr-9 border rounded-md bg-background focus:ring-2 focus:ring-primary focus:border-primary transition-all font-mono text-sm {className}"
+		class="w-full px-3 py-1.5 pr-9 border rounded-md bg-background outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all font-mono text-sm {className}"
 	/>
 	{#if autocompleteLoading}
 		<div class="absolute inset-y-0 right-3 flex items-center text-muted-foreground">

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
@@ -44,27 +44,47 @@
 		allow_unc: false,
 		allowed_unc_servers: [],
 	});
+	// baseline tracks the last saved/loaded security state so `dirty` stays
+	// accurate even while the sync effect (below) mirrors draft edits into the
+	// shared config object. Populated by the rehydrate $effect on mount.
+	let baseline = $state<SecurityDraft>({
+		allowed_directories: [],
+		denied_directories: [],
+		allow_unc: false,
+		allowed_unc_servers: [],
+	});
 
 	$effect(() => {
 		const cfg = hydratedConfig ?? config;
 		if (cfg !== lastConfigRef) {
 			lastConfigRef = cfg;
-			draft = snapshot(cfg);
+			const snap = snapshot(cfg);
+			draft = snap;
+			baseline = snap;
 		}
+	});
+
+	// Mirror draft edits into the parent config object so the top-level
+	// "Save Changes" button (which PUTs the whole config) persists security
+	// edits too. Without this, only the narrow "Save Security" endpoint would
+	// see the draft, and a whole-config save would clobber the directories the
+	// user just added with the stale value still held in settings.config.
+	$effect(() => {
+		const sec = config?.api?.security;
+		if (!sec) return;
+		sec.allowed_directories = [...draft.allowed_directories];
+		sec.denied_directories = [...draft.denied_directories];
+		sec.allow_unc = draft.allow_unc;
+		sec.allowed_unc_servers = [...draft.allowed_unc_servers];
 	});
 
 	let newUncServer = $state('');
 
 	let dirty = $derived(
-		(() => {
-			const sec = (hydratedConfig ?? config)?.api?.security;
-			return (
-				!arrayEqual(draft.allowed_directories, sec?.allowed_directories ?? []) ||
-				!arrayEqual(draft.denied_directories, sec?.denied_directories ?? []) ||
-				draft.allow_unc !== (sec?.allow_unc ?? false) ||
-				!arrayEqual(draft.allowed_unc_servers, sec?.allowed_unc_servers ?? [])
-			);
-		})(),
+		!arrayEqual(draft.allowed_directories, baseline.allowed_directories) ||
+			!arrayEqual(draft.denied_directories, baseline.denied_directories) ||
+			draft.allow_unc !== baseline.allow_unc ||
+			!arrayEqual(draft.allowed_unc_servers, baseline.allowed_unc_servers),
 	);
 
 	function arrayEqual(a: string[], b: string[]): boolean {
@@ -93,12 +113,14 @@
 			return apiClient.updateSecurityConfig(req);
 		},
 		onSuccess: (data) => {
-			draft = {
+			const saved: SecurityDraft = {
 				allowed_directories: [...(data.security.allowed_directories ?? [])],
 				denied_directories: [...(data.security.denied_directories ?? [])],
 				allow_unc: data.security.allow_unc,
 				allowed_unc_servers: [...(data.security.allowed_unc_servers ?? [])],
 			};
+			draft = saved;
+			baseline = saved;
 			toastStore.success('Security settings saved and reloaded', 4000);
 			void queryClient.invalidateQueries({ queryKey: ['config'] }).then(async () => {
 				const fresh = await queryClient.fetchQuery<Config>({

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.svelte
@@ -60,7 +60,7 @@
 			lastConfigRef = cfg;
 			const snap = snapshot(cfg);
 			draft = snap;
-			baseline = snap;
+			baseline = snapshot(cfg);
 		}
 	});
 
@@ -120,7 +120,12 @@
 				allowed_unc_servers: [...(data.security.allowed_unc_servers ?? [])],
 			};
 			draft = saved;
-			baseline = saved;
+			baseline = {
+				allowed_directories: [...saved.allowed_directories],
+				denied_directories: [...saved.denied_directories],
+				allow_unc: saved.allow_unc,
+				allowed_unc_servers: [...saved.allowed_unc_servers],
+			};
 			toastStore.success('Security settings saved and reloaded', 4000);
 			void queryClient.invalidateQueries({ queryKey: ['config'] }).then(async () => {
 				const fresh = await queryClient.fetchQuery<Config>({

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
@@ -95,169 +95,169 @@ async function expandSection(container: HTMLElement): Promise<void> {
 	}
 }
 
-	describe('SecuritySettingsSection', () => {
-	it('renders the empty-state hint when no allowed directories are configured', async () => {
-		const { container } = renderSection(makeConfig());
-		await expandSection(container);
-		expect(container.textContent).toContain('No allowed directories configured');
-	});
-
-	it('lists configured allowed directories', async () => {
-		const { container } = renderSection(
-			makeConfig({ allowed_directories: ['/mnt/videos', '/mnt/media'] }),
-		);
-		await expandSection(container);
-		expect(container.textContent).toContain('/mnt/videos');
-		expect(container.textContent).toContain('/mnt/media');
-	});
-
-	it('marks the first allowed directory as the default scan path', async () => {
-		const { container } = renderSection(
-			makeConfig({ allowed_directories: ['/mnt/videos', '/mnt/media'] }),
-		);
-		await expandSection(container);
-		expect(container.textContent).toContain('Default');
-	});
-
-	it('adds an allowed directory from the path input', async () => {
-		const { container } = renderSection(makeConfig());
-		await expandSection(container);
-		const input = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
-		expect(input).toBeTruthy();
-		await fireEvent.input(input, { target: { value: '/new/dir' } });
-		const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
-		await fireEvent.click(addBtn);
-		expect(container.textContent).toContain('/new/dir');
-	});
-
-	it('disables the Save button until the draft is dirty', async () => {
-		const { container } = renderSection(
-			makeConfig({ allowed_directories: ['/existing'] }),
-		);
-		await expandSection(container);
-		const buttons = Array.from(container.querySelectorAll('button'));
-		const save = buttons.find((b) => b.textContent?.includes('Save Security')) as HTMLButtonElement;
-		expect(save).toBeTruthy();
-		expect(save.hasAttribute('disabled')).toBe(true);
-	});
-
-	it('enables Save and persists the security block via the dedicated endpoint', async () => {
-		const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
-		await expandSection(container);
-		const buttons = Array.from(container.querySelectorAll('button'));
-		let save = buttons.find((b) => b.textContent?.includes('Save Security')) as HTMLButtonElement;
-		expect(save).toBeTruthy();
-		expect(save.hasAttribute('disabled')).toBe(true);
-
-		const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
-		expect(removeBtn).toBeTruthy();
-		await fireEvent.click(removeBtn);
-
-		save = Array.from(container.querySelectorAll('button')).find(
-			(b) => b.textContent?.includes('Save Security'),
-		) as HTMLButtonElement;
-		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
-
-		mockUpdateSecurityConfig.mockResolvedValue({
-			security: {
-				allowed_directories: [],
-				denied_directories: [],
-				max_files_per_scan: 0,
-				scan_timeout_seconds: 0,
-				allowed_origins: [],
-				allow_unc: false,
-				allowed_unc_servers: [],
-				rate_limit: { requests_per_minute: 0 },
-				trusted_proxies: [],
-				force_secure_cookies: false,
-			},
-		});
-		const successSpy = vi.spyOn(toastStore, 'success');
-		await fireEvent.click(save);
-
-		await waitFor(() => expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1));
-		expect(mockUpdateSecurityConfig).toHaveBeenCalledWith(
-			expect.objectContaining({ allowed_directories: [] }),
-		);
-		await waitFor(() => expect(successSpy).toHaveBeenCalled());
-	});
-
-	it('toasts an error when the save fails', async () => {
-		mockUpdateSecurityConfig.mockRejectedValue(new Error('server refused'));
-		const errorSpy = vi.spyOn(toastStore, 'error');
-		const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
-		await expandSection(container);
-
-		const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
-		await fireEvent.click(removeBtn);
-
-		const save = Array.from(container.querySelectorAll('button')).find(
-			(b) => b.textContent?.includes('Save Security'),
-		) as HTMLButtonElement;
-		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
-		await fireEvent.click(save);
-
-		await waitFor(() => expect(errorSpy).toHaveBeenCalled());
-		expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1);
-	});
+describe('SecuritySettingsSection', () => {
+it('renders the empty-state hint when no allowed directories are configured', async () => {
+	const { container } = renderSection(makeConfig());
+	await expandSection(container);
+	expect(container.textContent).toContain('No allowed directories configured');
 });
 
-	it('rehydrates the draft from the fresh config query after a successful save', async () => {
-		mockUpdateSecurityConfig.mockResolvedValue({
-			security: {
-				allowed_directories: ['/persisted'],
-				denied_directories: [],
-				max_files_per_scan: 0,
-				scan_timeout_seconds: 0,
-				allowed_origins: [],
-				allow_unc: true,
-				allowed_unc_servers: ['\\\\srv\\share'],
-				rate_limit: { requests_per_minute: 0 },
-				trusted_proxies: [],
-				force_secure_cookies: false,
-			},
-		});
-		mockGetConfig.mockResolvedValue(
-			makeConfig({
-				allowed_directories: ['/persisted'],
-				allow_unc: true,
-				allowed_unc_servers: ['\\\\srv\\share'],
-			}) as unknown as SettingsConfig,
-		);
+it('lists configured allowed directories', async () => {
+	const { container } = renderSection(
+		makeConfig({ allowed_directories: ['/mnt/videos', '/mnt/media'] }),
+	);
+	await expandSection(container);
+	expect(container.textContent).toContain('/mnt/videos');
+	expect(container.textContent).toContain('/mnt/media');
+});
 
-		const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
-		await expandSection(container);
+it('marks the first allowed directory as the default scan path', async () => {
+	const { container } = renderSection(
+		makeConfig({ allowed_directories: ['/mnt/videos', '/mnt/media'] }),
+	);
+	await expandSection(container);
+	expect(container.textContent).toContain('Default');
+});
 
-		const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
-		await fireEvent.click(removeBtn);
+it('adds an allowed directory from the path input', async () => {
+	const { container } = renderSection(makeConfig());
+	await expandSection(container);
+	const input = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
+	expect(input).toBeTruthy();
+	await fireEvent.input(input, { target: { value: '/new/dir' } });
+	const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
+	await fireEvent.click(addBtn);
+	expect(container.textContent).toContain('/new/dir');
+});
 
-		const save = Array.from(container.querySelectorAll('button')).find(
-			(b) => b.textContent?.includes('Save Security'),
-		) as HTMLButtonElement;
-		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
-		await fireEvent.click(save);
+it('disables the Save button until the draft is dirty', async () => {
+	const { container } = renderSection(
+		makeConfig({ allowed_directories: ['/existing'] }),
+	);
+	await expandSection(container);
+	const buttons = Array.from(container.querySelectorAll('button'));
+	const save = buttons.find((b) => b.textContent?.includes('Save Security')) as HTMLButtonElement;
+	expect(save).toBeTruthy();
+	expect(save.hasAttribute('disabled')).toBe(true);
+});
 
-		await waitFor(() => expect(mockGetConfig).toHaveBeenCalledTimes(1));
-		await waitFor(() => expect(container.textContent).toContain('/persisted'));
-		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(true));
+it('enables Save and persists the security block via the dedicated endpoint', async () => {
+	const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
+	await expandSection(container);
+	const buttons = Array.from(container.querySelectorAll('button'));
+	let save = buttons.find((b) => b.textContent?.includes('Save Security')) as HTMLButtonElement;
+	expect(save).toBeTruthy();
+	expect(save.hasAttribute('disabled')).toBe(true);
+
+	const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
+	expect(removeBtn).toBeTruthy();
+	await fireEvent.click(removeBtn);
+
+	save = Array.from(container.querySelectorAll('button')).find(
+		(b) => b.textContent?.includes('Save Security'),
+	) as HTMLButtonElement;
+	await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
+
+	mockUpdateSecurityConfig.mockResolvedValue({
+		security: {
+			allowed_directories: [],
+			denied_directories: [],
+			max_files_per_scan: 0,
+			scan_timeout_seconds: 0,
+			allowed_origins: [],
+			allow_unc: false,
+			allowed_unc_servers: [],
+			rate_limit: { requests_per_minute: 0 },
+			trusted_proxies: [],
+			force_secure_cookies: false,
+		},
 	});
+	const successSpy = vi.spyOn(toastStore, 'success');
+	await fireEvent.click(save);
 
-	it('propagates draft edits into the shared config so the top-level Save Changes persists them', async () => {
-		// Regression: the section kept a local draft that was never written back
-		// to the parent config, so the whole-config PUT ("Save Changes" button)
-		// would clobber a just-added directory with the stale value. The sync
-		// effect must mirror draft edits into config.api.security.
-		const config = makeConfig({ allowed_directories: [] });
-		const { container } = renderSection(config);
-		await expandSection(container);
+	await waitFor(() => expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1));
+	expect(mockUpdateSecurityConfig).toHaveBeenCalledWith(
+		expect.objectContaining({ allowed_directories: [] }),
+	);
+	await waitFor(() => expect(successSpy).toHaveBeenCalled());
+});
 
-		const input = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
-		expect(input).toBeTruthy();
-		await fireEvent.input(input, { target: { value: '/mnt/videos' } });
-		const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
-		await fireEvent.click(addBtn);
+it('toasts an error when the save fails', async () => {
+	mockUpdateSecurityConfig.mockRejectedValue(new Error('server refused'));
+	const errorSpy = vi.spyOn(toastStore, 'error');
+	const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
+	await expandSection(container);
 
-		await waitFor(() =>
-			expect(config.api.security.allowed_directories).toEqual(['/mnt/videos']),
-		);
+	const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
+	await fireEvent.click(removeBtn);
+
+	const save = Array.from(container.querySelectorAll('button')).find(
+		(b) => b.textContent?.includes('Save Security'),
+	) as HTMLButtonElement;
+	await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
+	await fireEvent.click(save);
+
+	await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+	expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1);
+});
+});
+
+it('rehydrates the draft from the fresh config query after a successful save', async () => {
+	mockUpdateSecurityConfig.mockResolvedValue({
+		security: {
+			allowed_directories: ['/persisted'],
+			denied_directories: [],
+			max_files_per_scan: 0,
+			scan_timeout_seconds: 0,
+			allowed_origins: [],
+			allow_unc: true,
+			allowed_unc_servers: ['\\\\srv\\share'],
+			rate_limit: { requests_per_minute: 0 },
+			trusted_proxies: [],
+			force_secure_cookies: false,
+		},
 	});
+	mockGetConfig.mockResolvedValue(
+		makeConfig({
+			allowed_directories: ['/persisted'],
+			allow_unc: true,
+			allowed_unc_servers: ['\\\\srv\\share'],
+		}) as unknown as SettingsConfig,
+	);
+
+	const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
+	await expandSection(container);
+
+	const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
+	await fireEvent.click(removeBtn);
+
+	const save = Array.from(container.querySelectorAll('button')).find(
+		(b) => b.textContent?.includes('Save Security'),
+	) as HTMLButtonElement;
+	await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
+	await fireEvent.click(save);
+
+	await waitFor(() => expect(mockGetConfig).toHaveBeenCalledTimes(1));
+	await waitFor(() => expect(container.textContent).toContain('/persisted'));
+	await waitFor(() => expect(save.hasAttribute('disabled')).toBe(true));
+});
+
+it('propagates draft edits into the shared config so the top-level Save Changes persists them', async () => {
+	// Regression: the section kept a local draft that was never written back
+	// to the parent config, so the whole-config PUT ("Save Changes" button)
+	// would clobber a just-added directory with the stale value. The sync
+	// effect must mirror draft edits into config.api.security.
+	const config = makeConfig({ allowed_directories: [] });
+	const { container } = renderSection(config);
+	await expandSection(container);
+
+	const input = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
+	expect(input).toBeTruthy();
+	await fireEvent.input(input, { target: { value: '/mnt/videos' } });
+	const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
+	await fireEvent.click(addBtn);
+
+	await waitFor(() =>
+		expect(config.api.security.allowed_directories).toEqual(['/mnt/videos']),
+	);
+});

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
@@ -96,169 +96,169 @@ async function expandSection(container: HTMLElement): Promise<void> {
 }
 
 describe('SecuritySettingsSection', () => {
-it('renders the empty-state hint when no allowed directories are configured', async () => {
-	const { container } = renderSection(makeConfig());
-	await expandSection(container);
-	expect(container.textContent).toContain('No allowed directories configured');
-});
-
-it('lists configured allowed directories', async () => {
-	const { container } = renderSection(
-		makeConfig({ allowed_directories: ['/mnt/videos', '/mnt/media'] }),
-	);
-	await expandSection(container);
-	expect(container.textContent).toContain('/mnt/videos');
-	expect(container.textContent).toContain('/mnt/media');
-});
-
-it('marks the first allowed directory as the default scan path', async () => {
-	const { container } = renderSection(
-		makeConfig({ allowed_directories: ['/mnt/videos', '/mnt/media'] }),
-	);
-	await expandSection(container);
-	expect(container.textContent).toContain('Default');
-});
-
-it('adds an allowed directory from the path input', async () => {
-	const { container } = renderSection(makeConfig());
-	await expandSection(container);
-	const input = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
-	expect(input).toBeTruthy();
-	await fireEvent.input(input, { target: { value: '/new/dir' } });
-	const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
-	await fireEvent.click(addBtn);
-	expect(container.textContent).toContain('/new/dir');
-});
-
-it('disables the Save button until the draft is dirty', async () => {
-	const { container } = renderSection(
-		makeConfig({ allowed_directories: ['/existing'] }),
-	);
-	await expandSection(container);
-	const buttons = Array.from(container.querySelectorAll('button'));
-	const save = buttons.find((b) => b.textContent?.includes('Save Security')) as HTMLButtonElement;
-	expect(save).toBeTruthy();
-	expect(save.hasAttribute('disabled')).toBe(true);
-});
-
-it('enables Save and persists the security block via the dedicated endpoint', async () => {
-	const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
-	await expandSection(container);
-	const buttons = Array.from(container.querySelectorAll('button'));
-	let save = buttons.find((b) => b.textContent?.includes('Save Security')) as HTMLButtonElement;
-	expect(save).toBeTruthy();
-	expect(save.hasAttribute('disabled')).toBe(true);
-
-	const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
-	expect(removeBtn).toBeTruthy();
-	await fireEvent.click(removeBtn);
-
-	save = Array.from(container.querySelectorAll('button')).find(
-		(b) => b.textContent?.includes('Save Security'),
-	) as HTMLButtonElement;
-	await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
-
-	mockUpdateSecurityConfig.mockResolvedValue({
-		security: {
-			allowed_directories: [],
-			denied_directories: [],
-			max_files_per_scan: 0,
-			scan_timeout_seconds: 0,
-			allowed_origins: [],
-			allow_unc: false,
-			allowed_unc_servers: [],
-			rate_limit: { requests_per_minute: 0 },
-			trusted_proxies: [],
-			force_secure_cookies: false,
-		},
+	it('renders the empty-state hint when no allowed directories are configured', async () => {
+		const { container } = renderSection(makeConfig());
+		await expandSection(container);
+		expect(container.textContent).toContain('No allowed directories configured');
 	});
-	const successSpy = vi.spyOn(toastStore, 'success');
-	await fireEvent.click(save);
 
-	await waitFor(() => expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1));
-	expect(mockUpdateSecurityConfig).toHaveBeenCalledWith(
-		expect.objectContaining({ allowed_directories: [] }),
-	);
-	await waitFor(() => expect(successSpy).toHaveBeenCalled());
-});
-
-it('toasts an error when the save fails', async () => {
-	mockUpdateSecurityConfig.mockRejectedValue(new Error('server refused'));
-	const errorSpy = vi.spyOn(toastStore, 'error');
-	const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
-	await expandSection(container);
-
-	const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
-	await fireEvent.click(removeBtn);
-
-	const save = Array.from(container.querySelectorAll('button')).find(
-		(b) => b.textContent?.includes('Save Security'),
-	) as HTMLButtonElement;
-	await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
-	await fireEvent.click(save);
-
-	await waitFor(() => expect(errorSpy).toHaveBeenCalled());
-	expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1);
-});
-
-it('rehydrates the draft from the fresh config query after a successful save', async () => {
-	mockUpdateSecurityConfig.mockResolvedValue({
-		security: {
-			allowed_directories: ['/persisted'],
-			denied_directories: [],
-			max_files_per_scan: 0,
-			scan_timeout_seconds: 0,
-			allowed_origins: [],
-			allow_unc: true,
-			allowed_unc_servers: ['\\\\srv\\share'],
-			rate_limit: { requests_per_minute: 0 },
-			trusted_proxies: [],
-			force_secure_cookies: false,
-		},
+	it('lists configured allowed directories', async () => {
+		const { container } = renderSection(
+			makeConfig({ allowed_directories: ['/mnt/videos', '/mnt/media'] }),
+		);
+		await expandSection(container);
+		expect(container.textContent).toContain('/mnt/videos');
+		expect(container.textContent).toContain('/mnt/media');
 	});
-	mockGetConfig.mockResolvedValue(
-		makeConfig({
-			allowed_directories: ['/persisted'],
-			allow_unc: true,
-			allowed_unc_servers: ['\\\\srv\\share'],
-		}) as unknown as SettingsConfig,
-	);
 
-	const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
-	await expandSection(container);
+	it('marks the first allowed directory as the default scan path', async () => {
+		const { container } = renderSection(
+			makeConfig({ allowed_directories: ['/mnt/videos', '/mnt/media'] }),
+		);
+		await expandSection(container);
+		expect(container.textContent).toContain('Default');
+	});
 
-	const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
-	await fireEvent.click(removeBtn);
+	it('adds an allowed directory from the path input', async () => {
+		const { container } = renderSection(makeConfig());
+		await expandSection(container);
+		const input = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
+		expect(input).toBeTruthy();
+		await fireEvent.input(input, { target: { value: '/new/dir' } });
+		const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
+		await fireEvent.click(addBtn);
+		expect(container.textContent).toContain('/new/dir');
+	});
 
-	const save = Array.from(container.querySelectorAll('button')).find(
-		(b) => b.textContent?.includes('Save Security'),
-	) as HTMLButtonElement;
-	await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
-	await fireEvent.click(save);
+	it('disables the Save button until the draft is dirty', async () => {
+		const { container } = renderSection(
+			makeConfig({ allowed_directories: ['/existing'] }),
+		);
+		await expandSection(container);
+		const buttons = Array.from(container.querySelectorAll('button'));
+		const save = buttons.find((b) => b.textContent?.includes('Save Security')) as HTMLButtonElement;
+		expect(save).toBeTruthy();
+		expect(save.hasAttribute('disabled')).toBe(true);
+	});
 
-	await waitFor(() => expect(mockGetConfig).toHaveBeenCalledTimes(1));
-	await waitFor(() => expect(container.textContent).toContain('/persisted'));
-	await waitFor(() => expect(save.hasAttribute('disabled')).toBe(true));
-});
+	it('enables Save and persists the security block via the dedicated endpoint', async () => {
+		const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
+		await expandSection(container);
+		const buttons = Array.from(container.querySelectorAll('button'));
+		let save = buttons.find((b) => b.textContent?.includes('Save Security')) as HTMLButtonElement;
+		expect(save).toBeTruthy();
+		expect(save.hasAttribute('disabled')).toBe(true);
 
-it('propagates draft edits into the shared config so the top-level Save Changes persists them', async () => {
-	// Regression: the section kept a local draft that was never written back
-	// to the parent config, so the whole-config PUT ("Save Changes" button)
-	// would clobber a just-added directory with the stale value. The sync
-	// effect must mirror draft edits into config.api.security.
-	const config = makeConfig({ allowed_directories: [] });
-	const { container } = renderSection(config);
-	await expandSection(container);
+		const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
+		expect(removeBtn).toBeTruthy();
+		await fireEvent.click(removeBtn);
 
-	const input = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
-	expect(input).toBeTruthy();
-	await fireEvent.input(input, { target: { value: '/mnt/videos' } });
-	const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
-	await fireEvent.click(addBtn);
+		save = Array.from(container.querySelectorAll('button')).find(
+			(b) => b.textContent?.includes('Save Security'),
+		) as HTMLButtonElement;
+		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
 
-	await waitFor(() =>
-		expect(config.api.security.allowed_directories).toEqual(['/mnt/videos']),
-	);
-});
+		mockUpdateSecurityConfig.mockResolvedValue({
+			security: {
+				allowed_directories: [],
+				denied_directories: [],
+				max_files_per_scan: 0,
+				scan_timeout_seconds: 0,
+				allowed_origins: [],
+				allow_unc: false,
+				allowed_unc_servers: [],
+				rate_limit: { requests_per_minute: 0 },
+				trusted_proxies: [],
+				force_secure_cookies: false,
+			},
+		});
+		const successSpy = vi.spyOn(toastStore, 'success');
+		await fireEvent.click(save);
+
+		await waitFor(() => expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1));
+		expect(mockUpdateSecurityConfig).toHaveBeenCalledWith(
+			expect.objectContaining({ allowed_directories: [] }),
+		);
+		await waitFor(() => expect(successSpy).toHaveBeenCalled());
+	});
+
+	it('toasts an error when the save fails', async () => {
+		mockUpdateSecurityConfig.mockRejectedValue(new Error('server refused'));
+		const errorSpy = vi.spyOn(toastStore, 'error');
+		const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
+		await expandSection(container);
+
+		const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
+		await fireEvent.click(removeBtn);
+
+		const save = Array.from(container.querySelectorAll('button')).find(
+			(b) => b.textContent?.includes('Save Security'),
+		) as HTMLButtonElement;
+		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
+		await fireEvent.click(save);
+
+		await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+		expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1);
+	});
+
+	it('rehydrates the draft from the fresh config query after a successful save', async () => {
+		mockUpdateSecurityConfig.mockResolvedValue({
+			security: {
+				allowed_directories: ['/persisted'],
+				denied_directories: [],
+				max_files_per_scan: 0,
+				scan_timeout_seconds: 0,
+				allowed_origins: [],
+				allow_unc: true,
+				allowed_unc_servers: ['\\\\srv\\share'],
+				rate_limit: { requests_per_minute: 0 },
+				trusted_proxies: [],
+				force_secure_cookies: false,
+			},
+		});
+		mockGetConfig.mockResolvedValue(
+			makeConfig({
+				allowed_directories: ['/persisted'],
+				allow_unc: true,
+				allowed_unc_servers: ['\\\\srv\\share'],
+			}) as unknown as SettingsConfig,
+		);
+
+		const { container } = renderSection(makeConfig({ allowed_directories: ['/existing'] }));
+		await expandSection(container);
+
+		const removeBtn = container.querySelector('button[aria-label^="Remove allowed directory"]') as HTMLButtonElement;
+		await fireEvent.click(removeBtn);
+
+		const save = Array.from(container.querySelectorAll('button')).find(
+			(b) => b.textContent?.includes('Save Security'),
+		) as HTMLButtonElement;
+		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
+		await fireEvent.click(save);
+
+		await waitFor(() => expect(mockGetConfig).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(container.textContent).toContain('/persisted'));
+		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(true));
+	});
+
+	it('propagates draft edits into the shared config so the top-level Save Changes persists them', async () => {
+		// Regression: the section kept a local draft that was never written back
+		// to the parent config, so the whole-config PUT ("Save Changes" button)
+		// would clobber a just-added directory with the stale value. The sync
+		// effect must mirror draft edits into config.api.security.
+		const config = makeConfig({ allowed_directories: [] });
+		const { container } = renderSection(config);
+		await expandSection(container);
+
+		const input = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
+		expect(input).toBeTruthy();
+		await fireEvent.input(input, { target: { value: '/mnt/videos' } });
+		const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
+		await fireEvent.click(addBtn);
+
+		await waitFor(() =>
+			expect(config.api.security.allowed_directories).toEqual(['/mnt/videos']),
+		);
+	});
 
 });

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
@@ -95,7 +95,7 @@ async function expandSection(container: HTMLElement): Promise<void> {
 	}
 }
 
-describe('SecuritySettingsSection', () => {
+	describe('SecuritySettingsSection', () => {
 	it('renders the empty-state hint when no allowed directories are configured', async () => {
 		const { container } = renderSection(makeConfig());
 		await expandSection(container);
@@ -240,4 +240,24 @@ describe('SecuritySettingsSection', () => {
 		await waitFor(() => expect(mockGetConfig).toHaveBeenCalledTimes(1));
 		await waitFor(() => expect(container.textContent).toContain('/persisted'));
 		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(true));
+	});
+
+	it('propagates draft edits into the shared config so the top-level Save Changes persists them', async () => {
+		// Regression: the section kept a local draft that was never written back
+		// to the parent config, so the whole-config PUT ("Save Changes" button)
+		// would clobber a just-added directory with the stale value. The sync
+		// effect must mirror draft edits into config.api.security.
+		const config = makeConfig({ allowed_directories: [] });
+		const { container } = renderSection(config);
+		await expandSection(container);
+
+		const input = container.querySelector('input[placeholder*="Add a directory"]') as HTMLInputElement;
+		expect(input).toBeTruthy();
+		await fireEvent.input(input, { target: { value: '/mnt/videos' } });
+		const addBtn = container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement;
+		await fireEvent.click(addBtn);
+
+		await waitFor(() =>
+			expect(config.api.security.allowed_directories).toEqual(['/mnt/videos']),
+		);
 	});

--- a/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
+++ b/web/frontend/src/lib/components/settings/sections/SecuritySettingsSection.test.ts
@@ -200,7 +200,6 @@ it('toasts an error when the save fails', async () => {
 	await waitFor(() => expect(errorSpy).toHaveBeenCalled());
 	expect(mockUpdateSecurityConfig).toHaveBeenCalledTimes(1);
 });
-});
 
 it('rehydrates the draft from the fresh config query after a successful save', async () => {
 	mockUpdateSecurityConfig.mockResolvedValue({
@@ -260,4 +259,6 @@ it('propagates draft edits into the shared config so the top-level Save Changes 
 	await waitFor(() =>
 		expect(config.api.security.allowed_directories).toEqual(['/mnt/videos']),
 	);
+});
+
 });


### PR DESCRIPTION
## Summary

Two focused fixes for the settings/setup UI.

## Changes

### 1. Clean focus ring on directory browse input
The directory input in the setup wizard showed a clipped/inconsistent focus ring — the browser default outline was rendering alongside the Tailwind `focus:ring-2`. Added `outline-none` to `PathInput` (matching `FormTextInput`/`FormTemplateInput`) and aligned the input height (`h-9`) + row centering (`items-center`) in `AllowedDirectoriesEditor` so the input matches the adjacent `size="sm"` Browse/Add buttons instead of sitting top-aligned and shorter.

### 2. Persist `allowed_directories` on Save Changes
`SecuritySettingsSection` kept a local `draft` that was **never written back** to the shared `settings.config`. The top-level **Save Changes** button does a whole-config `PUT /api/v1/config` using `settings.config`, so it sent the *stale* `allowed_directories` and clobbered a just-added directory on reload.

Fix: a sync `$effect` mirrors `draft` → `config.api.security.*` so both Save Changes (whole-config) and Save Security (narrow endpoint) see the same values. Dirty detection switched to a saved/loaded `baseline` (the sync would otherwise make draft==config and disable the Save button). `onSuccess` resets the baseline to the persisted values. Regression test added asserting the draft propagates into the parent config.

## Verification
- `go build ./...` ✅
- `go test -short ./internal/api/... ./internal/config/...` ✅
- `svelte-check` ✅ 0/0
- `SecuritySettingsSection.test.ts` ✅ 9/9

## Test plan
- [ ] Setup wizard: focus ring on the directory browse box looks consistent with other inputs
- [ ] Settings → Security: add an allowed directory → **Save Changes** (top-level) → reload → directory persists
- [ ] Settings → Security: add an allowed directory → **Save Security** (section-level) → reload → persists