### PR TITLE
Harden path picker: autocomplete stays alive + browse respects allowed_directories

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3967,6 +3967,10 @@ const docTemplate = `{
                 "path": {
                     "type": "string",
                     "example": "/path/to/directory"
+                },
+                "scope": {
+                    "type": "string",
+                    "example": "configure"
                 }
             }
         },
@@ -4877,6 +4881,10 @@ const docTemplate = `{
                 "path": {
                     "type": "string",
                     "example": "/path/to/vid"
+                },
+                "scope": {
+                    "type": "string",
+                    "example": "configure"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3965,6 +3965,10 @@
                 "path": {
                     "type": "string",
                     "example": "/path/to/directory"
+                },
+                "scope": {
+                    "type": "string",
+                    "example": "configure"
                 }
             }
         },
@@ -4875,6 +4879,10 @@
                 "path": {
                     "type": "string",
                     "example": "/path/to/vid"
+                },
+                "scope": {
+                    "type": "string",
+                    "example": "configure"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -395,6 +395,9 @@ definitions:
       path:
         example: /path/to/directory
         type: string
+      scope:
+        example: configure
+        type: string
     type: object
   github_com_javinizer_javinizer-go_internal_api_contracts.BrowseResponse:
     properties:
@@ -1032,6 +1035,9 @@ definitions:
         type: integer
       path:
         example: /path/to/vid
+        type: string
+      scope:
+        example: configure
         type: string
     required:
     - path

--- a/internal/api/contracts/file_types.go
+++ b/internal/api/contracts/file_types.go
@@ -30,7 +30,8 @@ type FileInfo struct {
 
 // BrowseRequest represents a browse request
 type BrowseRequest struct {
-	Path string `json:"path" example:"/path/to/directory"`
+	Path  string `json:"path" example:"/path/to/directory"`
+	Scope string `json:"scope,omitempty" example:"configure"`
 }
 
 // BrowseResponse represents browse results
@@ -44,6 +45,7 @@ type BrowseResponse struct {
 type PathAutocompleteRequest struct {
 	Path  string `json:"path" binding:"required" example:"/path/to/vid"`
 	Limit int    `json:"limit,omitempty" example:"10"`
+	Scope string `json:"scope,omitempty" example:"configure"`
 }
 
 // PathAutocompleteSuggestion represents a single autocomplete suggestion.

--- a/internal/api/core/path_validation.go
+++ b/internal/api/core/path_validation.go
@@ -84,10 +84,10 @@ func ValidateScanPath(userPath string, cfg *SecurityNarrowConfig) (string, error
 }
 
 // ValidateBrowsePath is the browse variant of ValidateScanPath: it skips the
-// allowlist gate so the browse/autocomplete endpoints can list directories
-// outside the allowlist (used to configure the allowlist/denylist). The
-// allowlist is enforced only at file-operation time (scan/organize). The
-// denylist still applies.
+// allowlist gate so the configure-scope browse/autocomplete endpoints can list
+// directories outside the allowlist (used to configure the allowlist/denylist).
+// Operational browse/autocomplete use ValidateScanPath instead. The denylist
+// always applies.
 func ValidateBrowsePath(userPath string, cfg *SecurityNarrowConfig) (string, error) {
 	return validateBrowsePath(userPath, cfg)
 }
@@ -113,9 +113,10 @@ func ValidateAndOpenPath(userPath string, cfg *SecurityNarrowConfig) (*os.File, 
 }
 
 // ValidateAndOpenBrowsePath is the browse variant of ValidateAndOpenPath: it
-// skips the allowlist gate so the browse endpoint can list directories outside
-// the allowlist (used to configure the allowlist). The allowlist is enforced
-// only at file-operation time (scan/organize). The denylist still applies.
+// skips the allowlist gate so the configure-scope browse endpoint can list
+// directories outside the allowlist (used to configure the allowlist).
+// Operational browse uses ValidateAndOpenPath instead. The denylist always
+// applies.
 func ValidateAndOpenBrowsePath(userPath string, cfg *SecurityNarrowConfig) (*os.File, string, error) {
 	return validateAndOpenPath(userPath, cfg, true)
 }

--- a/internal/api/file/autocomplete.go
+++ b/internal/api/file/autocomplete.go
@@ -36,10 +36,9 @@ func autocompletePath(rt *core.APIRuntime) gin.HandlerFunc {
 		}
 
 		apiCfg := rt.GetAPIConfig()
-		// Autocomplete never enforces the allowlist (see browse.go): the allowlist
-		// is a safety guard for file operations, not for path completion. The
-		// denylist still applies.
-		basePath, fragment, err := resolveAutocompleteBasePath(req.Path, apiCfg.SecurityConfig())
+		// Scope selects the validator: "configure" skips the allowlist (bootstrap);
+		// the default (operation) enforces it. The denylist always applies.
+		basePath, fragment, err := resolveAutocompleteBasePath(req.Path, apiCfg.SecurityConfig(), req.Scope)
 		if err != nil {
 			apperrors.WriteAPIError(c, err)
 			return
@@ -90,7 +89,7 @@ func autocompletePath(rt *core.APIRuntime) gin.HandlerFunc {
 	}
 }
 
-func resolveAutocompleteBasePath(userPath string, cfg *core.SecurityNarrowConfig) (string, string, error) {
+func resolveAutocompleteBasePath(userPath string, cfg *core.SecurityNarrowConfig, scope string) (string, string, error) {
 	trimmedPath := strings.TrimSpace(userPath)
 	if trimmedPath == "" {
 		return "", "", fmt.Errorf("path is required")
@@ -114,9 +113,12 @@ func resolveAutocompleteBasePath(userPath string, cfg *core.SecurityNarrowConfig
 		}
 	}
 
-	// Autocomplete never enforces the allowlist (see browse.go): the allowlist
-	// is a safety guard for file operations, not for path completion.
-	validBasePath, err := core.ValidateBrowsePath(basePath, cfg)
+	var validBasePath string
+	if scope == "configure" {
+		validBasePath, err = core.ValidateBrowsePath(basePath, cfg)
+	} else {
+		validBasePath, err = core.ValidateScanPath(basePath, cfg)
+	}
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/api/file/autocomplete_uncovered_test.go
+++ b/internal/api/file/autocomplete_uncovered_test.go
@@ -40,8 +40,8 @@ func TestResolveAutocompleteBasePath_WhitespaceOnlyPath(t *testing.T) {
 }
 
 func TestResolveAutocompleteBasePath_WithSecurityConfig(t *testing.T) {
-	// Path with nil security config will panic on ValidateScanPath,
-	// so we provide an empty config
+	// Path with nil security config causes ValidateScanPath to return an error
+	// (not panic), so we provide an empty config
 	cfg := &core.SecurityNarrowConfig{}
 	basePath, fragment, err := resolveAutocompleteBasePath("/home/use", cfg, "")
 	if err != nil {

--- a/internal/api/file/autocomplete_uncovered_test.go
+++ b/internal/api/file/autocomplete_uncovered_test.go
@@ -30,12 +30,12 @@ func TestHasTrailingPathSeparator_Uncovered(t *testing.T) {
 }
 
 func TestResolveAutocompleteBasePath_EmptyPath(t *testing.T) {
-	_, _, err := resolveAutocompleteBasePath("", nil)
+	_, _, err := resolveAutocompleteBasePath("", nil, "")
 	assert.Error(t, err)
 }
 
 func TestResolveAutocompleteBasePath_WhitespaceOnlyPath(t *testing.T) {
-	_, _, err := resolveAutocompleteBasePath("   ", nil)
+	_, _, err := resolveAutocompleteBasePath("   ", nil, "")
 	assert.Error(t, err)
 }
 
@@ -43,7 +43,7 @@ func TestResolveAutocompleteBasePath_WithSecurityConfig(t *testing.T) {
 	// Path with nil security config will panic on ValidateScanPath,
 	// so we provide an empty config
 	cfg := &core.SecurityNarrowConfig{}
-	basePath, fragment, err := resolveAutocompleteBasePath("/home/use", cfg)
+	basePath, fragment, err := resolveAutocompleteBasePath("/home/use", cfg, "")
 	if err != nil {
 		// Validation may fail depending on OS, but should not panic
 		return

--- a/internal/api/file/browse.go
+++ b/internal/api/file/browse.go
@@ -30,27 +30,30 @@ func browseDirectory(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		if req.Path == "" {
-			// Default to the user's home — the most likely place for a videos
-			// folder — rather than the process CWD (which for the desktop app is
-			// wherever it launched from, often System32).
-			if home, err := os.UserHomeDir(); err == nil && home != "" {
-				req.Path = home
-			}
-			if req.Path == "" {
-				req.Path, _ = os.Getwd()
-			}
-		}
-
 		apiCfg := rt.GetAPIConfig()
 
-		// Browse never enforces the allowlist: the allowlist is a safety guard
-		// for file operations (scan/organize), not a restriction on listing
-		// directories to configure it. Enforcing it here would be a catch-22
-		// (you can't browse to add the first allowed directory, or to add a
-		// directory on another drive like D:\). The denylist (/proc, /sys, /dev
-		// + config) still applies.
-		dirFile, validPath, err := core.ValidateAndOpenBrowsePath(req.Path, apiCfg.SecurityConfig())
+		var dirFile *os.File
+		var validPath string
+		var err error
+		if req.Scope == "configure" {
+			if req.Path == "" {
+				if home, homeErr := os.UserHomeDir(); homeErr == nil && home != "" {
+					req.Path = home
+				}
+				if req.Path == "" {
+					req.Path, _ = os.Getwd()
+				}
+			}
+			dirFile, validPath, err = core.ValidateAndOpenBrowsePath(req.Path, apiCfg.SecurityConfig())
+		} else {
+			if req.Path == "" {
+				scanCfg := apiCfg.ScannerConfig()
+				if len(scanCfg.AllowedDirectories) > 0 {
+					req.Path = scanCfg.AllowedDirectories[0]
+				}
+			}
+			dirFile, validPath, err = core.ValidateAndOpenPath(req.Path, apiCfg.SecurityConfig())
+		}
 		if err != nil {
 			apperrors.WriteAPIError(c, err)
 			return

--- a/internal/api/file/browse_security_model_test.go
+++ b/internal/api/file/browse_security_model_test.go
@@ -18,13 +18,6 @@ import (
 	"github.com/javinizer/javinizer-go/internal/api/testkit"
 )
 
-// These tests encode the security model: the allowlist is a safety guard for
-// file OPERATIONS (scan/organize), not a restriction on BROWSING. Browse and
-// autocomplete never enforce the allowlist — otherwise configuring the
-// allowlist is a catch-22 (you can't browse to add the first directory, or to
-// add a directory on another drive like D:\). The denylist (/proc, /sys, /dev
-// + config) still applies. This holds regardless of install environment.
-
 func newBrowseTestRouter(t *testing.T, allowedDirs []string) (*gin.Engine, string) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
@@ -43,19 +36,34 @@ func newBrowseTestRouter(t *testing.T, allowedDirs []string) (*gin.Engine, strin
 	return router, dir
 }
 
-// TestBrowse_NeverEnforcesAllowlist_EmptyAllowlist: first-time setup (no
-// allowed dirs) — browse must still list the directory.
-func TestBrowse_NeverEnforcesAllowlist_EmptyAllowlist(t *testing.T) {
-	router, dir := newBrowseTestRouter(t, nil)
-	canonical, err := filepath.EvalSymlinks(dir)
-	require.NoError(t, err)
-
-	body, _ := json.Marshal(contracts.BrowseRequest{Path: dir})
+func doBrowse(t *testing.T, router *gin.Engine, path, scope string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(contracts.BrowseRequest{Path: path, Scope: scope})
 	req := httptest.NewRequest("POST", "/browse", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
+	return w
+}
 
+func doAutocomplete(t *testing.T, router *gin.Engine, path, scope string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(contracts.PathAutocompleteRequest{Path: path, Scope: scope})
+	req := httptest.NewRequest("POST", "/browse/autocomplete", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// --- Configure scope (unrestricted) ---
+
+func TestBrowse_ConfigureScope_EmptyAllowlist(t *testing.T) {
+	router, dir := newBrowseTestRouter(t, nil)
+	canonical, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+
+	w := doBrowse(t, router, dir, "configure")
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp contracts.BrowseResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -63,39 +71,23 @@ func TestBrowse_NeverEnforcesAllowlist_EmptyAllowlist(t *testing.T) {
 	assert.Len(t, resp.Items, 3, "videos, movies, readme.txt")
 }
 
-// TestBrowse_NeverEnforcesAllowlist_DotOnlyAllowlist: the default desktop
-// config (allowed_directories: ['.']) — browse must list a directory outside
-// the CWD (the Windows D:\ catch-22).
-func TestBrowse_NeverEnforcesAllowlist_DotOnlyAllowlist(t *testing.T) {
+func TestBrowse_ConfigureScope_DotOnlyAllowlist(t *testing.T) {
 	router, dir := newBrowseTestRouter(t, []string{"."})
 	canonical, err := filepath.EvalSymlinks(dir)
 	require.NoError(t, err)
 
-	body, _ := json.Marshal(contracts.BrowseRequest{Path: dir})
-	req := httptest.NewRequest("POST", "/browse", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doBrowse(t, router, dir, "configure")
 	require.Equal(t, http.StatusOK, w.Code,
-		"browse must not enforce the allowlist even when it is '.'; body=%s", w.Body.String())
+		"configure scope must not enforce the allowlist even when it is '.'; body=%s", w.Body.String())
 	var resp contracts.BrowseResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, canonical, resp.CurrentPath)
 }
 
-// TestAutocomplete_NeverEnforcesAllowlist: autocomplete must return
-// suggestions regardless of the allowlist (empty here).
-func TestAutocomplete_NeverEnforcesAllowlist(t *testing.T) {
+func TestAutocomplete_ConfigureScope(t *testing.T) {
 	router, dir := newBrowseTestRouter(t, nil)
 
-	// Trailing separator → list contents of dir, fragment "" → all dirs.
-	body, _ := json.Marshal(contracts.PathAutocompleteRequest{Path: dir + string(os.PathSeparator)})
-	req := httptest.NewRequest("POST", "/browse/autocomplete", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doAutocomplete(t, router, dir+string(os.PathSeparator), "configure")
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp contracts.PathAutocompleteResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -108,17 +100,10 @@ func TestAutocomplete_NeverEnforcesAllowlist(t *testing.T) {
 	assert.NotContains(t, names, "readme.txt", "only directories are suggested")
 }
 
-// TestAutocomplete_NeverEnforcesAllowlist_FragmentFilter: typing a partial
-// path filters by the fragment even with an empty allowlist.
-func TestAutocomplete_NeverEnforcesAllowlist_FragmentFilter(t *testing.T) {
+func TestAutocomplete_ConfigureScope_FragmentFilter(t *testing.T) {
 	router, dir := newBrowseTestRouter(t, nil)
 
-	body, _ := json.Marshal(contracts.PathAutocompleteRequest{Path: filepath.Join(dir, "vi")})
-	req := httptest.NewRequest("POST", "/browse/autocomplete", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doAutocomplete(t, router, filepath.Join(dir, "vi"), "configure")
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp contracts.PathAutocompleteResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -126,44 +111,113 @@ func TestAutocomplete_NeverEnforcesAllowlist_FragmentFilter(t *testing.T) {
 	assert.Equal(t, "videos", resp.Suggestions[0].Name)
 }
 
-// TestBrowse_StillEnforcesDenylist: even without the allowlist, the denylist
-// (built-in /proc, /sys, /dev) still blocks sensitive system directories.
-func TestBrowse_StillEnforcesDenylist(t *testing.T) {
+// --- Operation scope (allowlist-enforcing) ---
+
+func TestBrowse_OperationScope_RejectsWhenAllowlistEmpty(t *testing.T) {
+	router, dir := newBrowseTestRouter(t, nil)
+
+	w := doBrowse(t, router, dir, "")
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"operation scope must reject when allowlist is empty; body=%s", w.Body.String())
+}
+
+func TestBrowse_OperationScope_RejectsPathOutsideAllowlist(t *testing.T) {
+	allowedDir := t.TempDir()
+	router, _ := newBrowseTestRouter(t, []string{allowedDir})
+	outsideDir := t.TempDir()
+
+	w := doBrowse(t, router, outsideDir, "")
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"operation scope must reject a path outside the allowlist; body=%s", w.Body.String())
+}
+
+func TestBrowse_OperationScope_AllowsPathInsideAllowlist(t *testing.T) {
+	router, dir := newBrowseTestRouter(t, []string{})
+	_ = router
+	allowedDir := filepath.Join(dir, "videos")
+	router2, _ := newBrowseTestRouter(t, []string{allowedDir})
+
+	w := doBrowse(t, router2, allowedDir, "")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var resp contracts.BrowseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.CurrentPath)
+}
+
+func TestAutocomplete_OperationScope_RejectsWhenAllowlistEmpty(t *testing.T) {
+	router, dir := newBrowseTestRouter(t, nil)
+
+	w := doAutocomplete(t, router, dir+string(os.PathSeparator), "")
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"operation autocomplete must reject when allowlist is empty; body=%s", w.Body.String())
+}
+
+func TestAutocomplete_OperationScope_RejectsPathOutsideAllowlist(t *testing.T) {
+	allowedDir := t.TempDir()
+	router, _ := newBrowseTestRouter(t, []string{allowedDir})
+	outsideDir := t.TempDir()
+
+	w := doAutocomplete(t, router, filepath.Join(outsideDir, "frag"), "")
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"operation autocomplete must reject a path outside the allowlist; body=%s", w.Body.String())
+}
+
+// --- Denylist applies to both scopes ---
+
+func TestBrowse_Denylist_ConfigureScope(t *testing.T) {
 	if _, err := os.Stat("/proc"); err != nil {
 		t.Skip("/proc not present on this platform")
 	}
 	router, _ := newBrowseTestRouter(t, nil)
 
-	body, _ := json.Marshal(contracts.BrowseRequest{Path: "/proc"})
-	req := httptest.NewRequest("POST", "/browse", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doBrowse(t, router, "/proc", "configure")
 	assert.NotEqual(t, http.StatusOK, w.Code,
-		"denylist must still block /proc even without the allowlist")
+		"denylist must block /proc in configure scope")
 }
 
-// TestBrowse_EmptyPathFallsBackToGetwd covers the os.Getwd() fallback in the
-// empty-path branch: when os.UserHomeDir() is unavailable (HOME unset), the
-// handler must fall back to the process working directory rather than fail.
-func TestBrowse_EmptyPathFallsBackToGetwd(t *testing.T) {
+func TestBrowse_Denylist_OperationScope(t *testing.T) {
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("/proc not present on this platform")
+	}
+	router, _ := newBrowseTestRouter(t, []string{"/"})
+
+	w := doBrowse(t, router, "/proc", "")
+	assert.NotEqual(t, http.StatusOK, w.Code,
+		"denylist must block /proc in operation scope")
+}
+
+// --- Empty path fallback ---
+
+func TestBrowse_EmptyPath_ConfigureScopeFallsBackToHome(t *testing.T) {
 	router, _ := newBrowseTestRouter(t, nil)
 
-	// Force os.UserHomeDir() to fail so the Getwd fallback is taken. On Unix
-	// an empty HOME makes UserHomeDir return ("", error); on Windows the same
-	// applies via USERPROFILE. t.Setenv restores them after the test.
 	t.Setenv("HOME", "")
 	t.Setenv("USERPROFILE", "")
 
-	body, _ := json.Marshal(contracts.BrowseRequest{Path: ""})
-	req := httptest.NewRequest("POST", "/browse", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	// The test process's CWD is a real, non-denied directory, so the Getwd
-	// fallback must resolve it and return a listing (200), not an error.
+	w := doBrowse(t, router, "", "configure")
 	assert.Equal(t, http.StatusOK, w.Code,
-		"empty path with no home dir must fall back to Getwd and succeed")
+		"empty path with no home dir must fall back to Getwd and succeed in configure scope")
+}
+
+func TestBrowse_EmptyPath_OperationScopeRejectsWhenAllowlistEmpty(t *testing.T) {
+	router, _ := newBrowseTestRouter(t, nil)
+
+	w := doBrowse(t, router, "", "")
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"operation scope with empty allowlist and empty path must 403")
+}
+
+func TestBrowse_EmptyPath_OperationScope_DefaultsToFirstAllowedDir(t *testing.T) {
+	allowedDir := t.TempDir()
+	router, _ := newBrowseTestRouter(t, []string{allowedDir})
+
+	w := doBrowse(t, router, "", "")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var resp contracts.BrowseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	allowedCanonical, err := filepath.EvalSymlinks(allowedDir)
+	require.NoError(t, err)
+	respCanonical, err := filepath.EvalSymlinks(resp.CurrentPath)
+	require.NoError(t, err)
+	assert.Equal(t, allowedCanonical, respCanonical)
 }

--- a/internal/api/file/browse_security_model_test.go
+++ b/internal/api/file/browse_security_model_test.go
@@ -132,12 +132,11 @@ func TestBrowse_OperationScope_RejectsPathOutsideAllowlist(t *testing.T) {
 }
 
 func TestBrowse_OperationScope_AllowsPathInsideAllowlist(t *testing.T) {
-	router, dir := newBrowseTestRouter(t, []string{})
-	_ = router
+	_, dir := newBrowseTestRouter(t, []string{})
 	allowedDir := filepath.Join(dir, "videos")
-	router2, _ := newBrowseTestRouter(t, []string{allowedDir})
+	router, _ := newBrowseTestRouter(t, []string{allowedDir})
 
-	w := doBrowse(t, router2, allowedDir, "")
+	w := doBrowse(t, router, allowedDir, "")
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	var resp contracts.BrowseResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))

--- a/internal/api/file/browse_security_model_test.go
+++ b/internal/api/file/browse_security_model_test.go
@@ -198,6 +198,26 @@ func TestBrowse_EmptyPath_ConfigureScopeFallsBackToHome(t *testing.T) {
 		"empty path with no home dir must fall back to Getwd and succeed in configure scope")
 }
 
+func TestBrowse_EmptyPath_ConfigureScopeUsesHomeDir(t *testing.T) {
+	homeDir := t.TempDir()
+	router, _ := newBrowseTestRouter(t, nil)
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	w := doBrowse(t, router, "", "configure")
+	assert.Equal(t, http.StatusOK, w.Code,
+		"empty path with a valid home dir must default to home and succeed in configure scope")
+
+	var resp contracts.BrowseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	resolvedHome, err := filepath.EvalSymlinks(homeDir)
+	require.NoError(t, err)
+	resolvedCurrent, err := filepath.EvalSymlinks(resp.CurrentPath)
+	require.NoError(t, err)
+	assert.Equal(t, resolvedHome, resolvedCurrent)
+}
+
 func TestBrowse_EmptyPath_OperationScopeRejectsWhenAllowlistEmpty(t *testing.T) {
 	router, _ := newBrowseTestRouter(t, nil)
 

--- a/internal/api/file/handlers_test.go
+++ b/internal/api/file/handlers_test.go
@@ -484,7 +484,7 @@ func homeOutsideAllowlist(t *testing.T) string {
 	return os.TempDir()
 }
 
-func TestBrowseDirectory_AllowlistNotEnforced(t *testing.T) {
+func TestBrowseDirectory_ConfigureScope_AllowlistNotEnforced(t *testing.T) {
 	// Configure scope: browse never enforces the allowlist. The allowlist is a
 	// safety guard for file OPERATIONS (scan/organize), not a restriction on
 	// browsing to configure it. Paths outside the allowlist return 200 (the

--- a/internal/api/file/handlers_test.go
+++ b/internal/api/file/handlers_test.go
@@ -485,7 +485,7 @@ func homeOutsideAllowlist(t *testing.T) string {
 }
 
 func TestBrowseDirectory_AllowlistNotEnforced(t *testing.T) {
-	// Security model: browse never enforces the allowlist. The allowlist is a
+	// Configure scope: browse never enforces the allowlist. The allowlist is a
 	// safety guard for file OPERATIONS (scan/organize), not a restriction on
 	// browsing to configure it. Paths outside the allowlist return 200 (the
 	// directory is listed). The denylist (/proc, /sys, /dev + config) still
@@ -519,7 +519,7 @@ func TestBrowseDirectory_AllowlistNotEnforced(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			reqBody := contracts.BrowseRequest{Path: tc.path}
+			reqBody := contracts.BrowseRequest{Path: tc.path, Scope: "configure"}
 			body, err := json.Marshal(reqBody)
 			require.NoError(t, err)
 
@@ -668,7 +668,8 @@ func TestAutocompletePath_PathTraversalResolved(t *testing.T) {
 	router.POST("/browse/autocomplete", autocompletePath(testkit.GetTestRuntime(deps)))
 
 	reqBody := contracts.PathAutocompleteRequest{
-		Path: filepath.Join(tempDir, "..", "etc"),
+		Path:  filepath.Join(tempDir, "..", "etc"),
+		Scope: "configure",
 	}
 	body, err := json.Marshal(reqBody)
 	require.NoError(t, err)

--- a/internal/api/file/miss_test.go
+++ b/internal/api/file/miss_test.go
@@ -234,7 +234,7 @@ func TestGetCurrentWorkingDirectory_Miss_WithAllowedDirs(t *testing.T) {
 // --- resolveAutocompleteBasePath: empty path ---
 
 func TestResolveAutocompleteBasePath_Miss_EmptyPath(t *testing.T) {
-	_, _, err := resolveAutocompleteBasePath("", nil)
+	_, _, err := resolveAutocompleteBasePath("", nil, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "path is required")
 }

--- a/web/frontend/src/app.css
+++ b/web/frontend/src/app.css
@@ -62,6 +62,9 @@ body {
 .bg-card {
 	background-color: hsl(var(--card));
 }
+.bg-popover {
+	background-color: hsl(var(--popover));
+}
 .bg-primary {
 	background-color: hsl(var(--primary));
 }
@@ -83,6 +86,9 @@ body {
 }
 .text-card-foreground {
 	color: hsl(var(--card-foreground));
+}
+.text-popover-foreground {
+	color: hsl(var(--popover-foreground));
 }
 .text-primary {
 	color: hsl(var(--primary));

--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -24,6 +24,7 @@ export interface ScanResponse {
 
 export interface BrowseRequest {
 	path: string;
+	scope?: 'operation' | 'configure';
 }
 
 export interface BrowseResponse {
@@ -35,6 +36,7 @@ export interface BrowseResponse {
 export interface PathAutocompleteRequest {
 	path: string;
 	limit?: number;
+	scope?: 'operation' | 'configure';
 }
 
 export interface PathAutocompleteSuggestion {

--- a/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
+++ b/web/frontend/src/lib/components/AllowedDirectoriesEditor.svelte
@@ -131,6 +131,7 @@
 			{whitelistPaths}
 			class="h-9"
 			onnavigate={() => addDir()}
+			scope="configure"
 		/>
 		<Button
 			variant="outline"
@@ -208,6 +209,7 @@
 					multiSelect={false}
 					folderOnly={true}
 					{whitelistPaths}
+					scope="configure"
 				/>
 			</div>
 

--- a/web/frontend/src/lib/components/FileBrowser.svelte
+++ b/web/frontend/src/lib/components/FileBrowser.svelte
@@ -37,6 +37,7 @@
 		selectedFolders?: string[];
 		triggerScan?: number;
 		whitelistPaths?: string[];
+		scope?: 'operation' | 'configure';
 	}
 
 	let {
@@ -50,7 +51,8 @@
 		recursiveScan = $bindable(false),
 		selectedFolders: selectedFolders = $bindable([]),
 		triggerScan = 0,
-		whitelistPaths = []
+		whitelistPaths = [],
+		scope = 'operation',
 	}: Props = $props();
 
 	let currentPath = $state('');
@@ -193,7 +195,7 @@
 		selectedFolders = [];
 		anchorFolderPath = null;
 		try {
-			const response: BrowseResponse = await apiClient.browse({ path: path || '/' });
+			const response: BrowseResponse = await apiClient.browse({ path: path || '/', scope });
 			currentPath = response.current_path;
 			parentPath = response.parent_path || '';
 			pathInputValue = response.current_path; // Sync path input
@@ -202,7 +204,12 @@
 			items = response.items;
 			currentPage = 1;
 		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to browse directory';
+			const msg = e instanceof Error ? e.message : 'Failed to browse directory';
+			if (scope === 'operation' && (msg.includes('allowed directories') || msg.includes('403'))) {
+				error = 'This path is outside your allowed directories. Add it in Settings → Security.';
+			} else {
+				error = msg;
+			}
 		} finally {
 			loading = false;
 		}
@@ -411,6 +418,7 @@
 				{loading}
 				whitelistPaths={whitelistPaths}
 				drillOnSelect={true}
+				{scope}
 			/>
 		</div>
 	</div>

--- a/web/frontend/src/lib/components/FileBrowser.svelte
+++ b/web/frontend/src/lib/components/FileBrowser.svelte
@@ -410,6 +410,7 @@
 				navigateDisabled={!pathInputValue.trim() || loading}
 				{loading}
 				whitelistPaths={whitelistPaths}
+				drillOnSelect={true}
 			/>
 		</div>
 	</div>

--- a/web/frontend/src/lib/components/PathInput.svelte
+++ b/web/frontend/src/lib/components/PathInput.svelte
@@ -45,6 +45,7 @@
 	let autocompleteLoading = $state(false);
 	let autocompleteDebounceId: ReturnType<typeof setTimeout> | null = null;
 	let autocompleteRequestToken = 0;
+	let blurTimeoutId: ReturnType<typeof setTimeout> | null = null;
 	let inputEl = $state<HTMLInputElement | null>(null);
 	let autocompleteError = $state<string | null>(null);
 
@@ -149,6 +150,14 @@
 		pathSuggestions = [];
 		activeIndex = -1;
 		autocompleteRequestToken += 1;
+		if (autocompleteDebounceId) {
+			clearTimeout(autocompleteDebounceId);
+			autocompleteDebounceId = null;
+		}
+		if (blurTimeoutId) {
+			clearTimeout(blurTimeoutId);
+			blurTimeoutId = null;
+		}
 		if (inputEl) {
 			inputEl.focus();
 			const end = value.length;
@@ -211,12 +220,17 @@
 
 	function handleFocus() {
 		focused = true;
+		if (blurTimeoutId) {
+			clearTimeout(blurTimeoutId);
+			blurTimeoutId = null;
+		}
 	}
 
 	function handleBlur() {
-		setTimeout(() => {
+		blurTimeoutId = setTimeout(() => {
 			focused = false;
 			clearSuggestions();
+			blurTimeoutId = null;
 		}, 120);
 	}
 

--- a/web/frontend/src/lib/components/PathInput.svelte
+++ b/web/frontend/src/lib/components/PathInput.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { apiClient } from '$lib/api/client';
 	import type { PathAutocompleteSuggestion } from '$lib/api/types';
-	import { Folder, ArrowRight, LoaderCircle } from 'lucide-svelte';
+	import { Folder, ChevronRight, LoaderCircle, CornerDownLeft, ArrowUp, ArrowDown } from 'lucide-svelte';
 	import Button from './ui/Button.svelte';
+	import { portalToBody } from '$lib/actions/portal';
 
 	interface Props {
 		value?: string;
@@ -14,6 +15,7 @@
 		navigateDisabled?: boolean;
 		loading?: boolean;
 		escapeValue?: string;
+		drillOnSelect?: boolean;
 		class?: string;
 	}
 
@@ -27,18 +29,21 @@
 		navigateDisabled = false,
 		loading = false,
 		escapeValue,
+		drillOnSelect = false,
 		class: className = ''
 	}: Props = $props();
 
-	let isEditing = $state(false);
+	const pathAutocompleteLimit = 8;
+	const SEP = '/';
+
+	let focused = $state(false);
 	let pathSuggestions = $state<PathAutocompleteSuggestion[]>([]);
-	let activeSuggestionIndex = $state(-1);
-	let userNavigatedSuggestions = $state(false);
+	let activeIndex = $state(-1);
+	let userNavigated = $state(false);
 	let autocompleteLoading = $state(false);
 	let autocompleteDebounceId: ReturnType<typeof setTimeout> | null = null;
 	let autocompleteRequestToken = 0;
-
-	const pathAutocompleteLimit = 8;
+	let inputEl = $state<HTMLInputElement | null>(null);
 
 	let whitelistSuggestions = $derived.by(() => {
 		if (whitelistPaths.length === 0) return [];
@@ -51,7 +56,7 @@
 
 	let displayedSuggestions = $derived.by(() => {
 		if (pathSuggestions.length > 0) return pathSuggestions;
-		if (!isEditing) return [];
+		if (!focused) return [];
 		const input = value.trim().toLowerCase();
 		if (input === '' && whitelistSuggestions.length > 0) return whitelistSuggestions;
 		if (input !== '' && whitelistSuggestions.length > 0) {
@@ -63,84 +68,109 @@
 		return [];
 	});
 
-	let showSuggestions = $derived(displayedSuggestions.length > 0 && isEditing);
+	let showSuggestions = $derived(focused && displayedSuggestions.length > 0);
+
+	function currentFragment(): string {
+		const trimmed = value.trim();
+		const idx = Math.max(trimmed.lastIndexOf(SEP), trimmed.lastIndexOf('\\'));
+		if (idx === -1) return trimmed;
+		return trimmed.slice(idx + 1);
+	}
 
 	function clearSuggestions() {
 		autocompleteRequestToken += 1;
 		pathSuggestions = [];
-		activeSuggestionIndex = -1;
-		userNavigatedSuggestions = false;
+		activeIndex = -1;
+		userNavigated = false;
 		autocompleteLoading = false;
 	}
 
-	function selectSuggestion(suggestion: PathAutocompleteSuggestion) {
-		value = suggestion.path;
-		isEditing = false;
-		clearSuggestions();
-		onchange?.(suggestion.path);
-		onnavigate?.(suggestion.path);
+	function clampActive() {
+		const n = displayedSuggestions.length;
+		if (n === 0) {
+			activeIndex = -1;
+			return;
+		}
+		if (activeIndex < 0) activeIndex = 0;
+		if (activeIndex >= n) activeIndex = n - 1;
 	}
 
 	async function fetchSuggestions(inputPath: string) {
 		const requestToken = ++autocompleteRequestToken;
 		autocompleteLoading = true;
-
 		try {
 			const response = await apiClient.autocompletePath({
 				path: inputPath,
 				limit: pathAutocompleteLimit
 			});
-
-			if (requestToken !== autocompleteRequestToken || !isEditing) return;
-
+			if (requestToken !== autocompleteRequestToken || !focused) return;
 			pathSuggestions = response.suggestions;
-			activeSuggestionIndex = -1;
+			activeIndex = -1;
 		} catch {
 			if (requestToken !== autocompleteRequestToken) return;
 			pathSuggestions = [];
-			activeSuggestionIndex = -1;
+			activeIndex = -1;
 		} finally {
-			if (requestToken === autocompleteRequestToken) {
-				autocompleteLoading = false;
-			}
+			if (requestToken === autocompleteRequestToken) autocompleteLoading = false;
+		}
+	}
+
+	function withTrailingSep(p: string): string {
+		if (p === '' || p.endsWith(SEP) || p.endsWith('\\')) return p;
+		return p + SEP;
+	}
+
+	function selectSuggestion(suggestion: PathAutocompleteSuggestion) {
+		const drill = drillOnSelect;
+		const next = drill ? withTrailingSep(suggestion.path) : suggestion.path;
+		value = next;
+		onchange?.(next);
+		onnavigate?.(next);
+		userNavigated = false;
+		pathSuggestions = [];
+		activeIndex = -1;
+		if (inputEl) {
+			inputEl.focus();
+			const end = value.length;
+			requestAnimationFrame(() => {
+				inputEl?.setSelectionRange(end, end);
+			});
+		}
+		if (drill) {
+			void fetchSuggestions(next);
 		}
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
-		if (e.key === 'ArrowDown' && displayedSuggestions.length > 0) {
+		const n = displayedSuggestions.length;
+		if (e.key === 'ArrowDown' && n > 0) {
 			e.preventDefault();
-			userNavigatedSuggestions = true;
-			activeSuggestionIndex =
-				activeSuggestionIndex >= displayedSuggestions.length - 1 ? 0 : activeSuggestionIndex + 1;
-		} else if (e.key === 'ArrowUp' && displayedSuggestions.length > 0) {
+			userNavigated = true;
+			activeIndex = activeIndex >= n - 1 ? 0 : activeIndex + 1;
+		} else if (e.key === 'ArrowUp' && n > 0) {
 			e.preventDefault();
-			userNavigatedSuggestions = true;
-			activeSuggestionIndex =
-				activeSuggestionIndex <= 0 ? displayedSuggestions.length - 1 : activeSuggestionIndex - 1;
+			userNavigated = true;
+			activeIndex = activeIndex <= 0 ? n - 1 : activeIndex - 1;
+		} else if (e.key === 'Tab' && n > 0 && userNavigated && activeIndex >= 0) {
+			e.preventDefault();
+			selectSuggestion(displayedSuggestions[activeIndex]);
 		} else if (e.key === 'Enter') {
-			if (
-				userNavigatedSuggestions &&
-				showSuggestions &&
-				activeSuggestionIndex >= 0 &&
-				displayedSuggestions[activeSuggestionIndex]
-			) {
+			if (userNavigated && showSuggestions && activeIndex >= 0 && displayedSuggestions[activeIndex]) {
 				e.preventDefault();
-				selectSuggestion(displayedSuggestions[activeSuggestionIndex]);
+				selectSuggestion(displayedSuggestions[activeIndex]);
 				return;
 			}
 			onnavigate?.(value.trim());
 		} else if (e.key === 'Escape') {
-			if (escapeValue !== undefined) {
-				value = escapeValue;
-			}
-			isEditing = false;
+			if (escapeValue !== undefined) value = escapeValue;
+			focused = false;
 			clearSuggestions();
 		}
 	}
 
 	function handleInput() {
-		userNavigatedSuggestions = false;
-		activeSuggestionIndex = -1;
+		userNavigated = false;
+		activeIndex = -1;
 		onchange?.(value);
 		const inputPath = value.trim();
 
@@ -149,65 +179,113 @@
 			autocompleteDebounceId = null;
 		}
 
-		if (!isEditing || !inputPath) {
+		if (!focused || !inputPath) {
 			clearSuggestions();
 			return;
 		}
 
 		autocompleteDebounceId = setTimeout(() => {
 			void fetchSuggestions(inputPath);
-		}, 160);
+		}, 120);
 	}
 
 	function handleFocus() {
-		isEditing = true;
+		focused = true;
 	}
+
+	function handleBlur() {
+		setTimeout(() => {
+			focused = false;
+			clearSuggestions();
+		}, 120);
+	}
+
+	$effect(() => {
+		void displayedSuggestions;
+		clampActive();
+	});
+
+	let popoverStyle = $state('');
+
+	function repositionPopover() {
+		if (!inputEl) return;
+		const r = inputEl.getBoundingClientRect();
+		popoverStyle = `position:fixed;top:${Math.round(r.bottom + 4)}px;left:${Math.round(r.left)}px;width:${Math.round(r.width)}px;z-index:50;`;
+	}
+
+	$effect(() => {
+		if (!showSuggestions) return;
+		repositionPopover();
+		const onScrollResize = () => repositionPopover();
+		window.addEventListener('scroll', onScrollResize, true);
+		window.addEventListener('resize', onScrollResize);
+		const id = requestAnimationFrame(repositionPopover);
+		return () => {
+			window.removeEventListener('scroll', onScrollResize, true);
+			window.removeEventListener('resize', onScrollResize);
+			cancelAnimationFrame(id);
+		};
+	});
 </script>
 
 <div class="relative flex-1">
 	<input
+		bind:this={inputEl}
 		type="text"
 		bind:value
 		onkeydown={handleKeydown}
 		oninput={handleInput}
 		onfocus={handleFocus}
-		onblur={() => {
-			setTimeout(() => {
-				isEditing = false;
-			}, 120);
-		}}
+		onblur={handleBlur}
 		{placeholder}
-		class="w-full px-3 py-1.5 pr-9 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all font-mono text-sm {className}"
+		autocomplete="off"
+		spellcheck="false"
+		class="ac-input w-full px-3 py-1.5 pr-9 border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all font-mono text-sm {className}"
 	/>
+
 	{#if autocompleteLoading}
-		<div class="absolute inset-y-0 right-3 flex items-center text-muted-foreground">
+		<div class="ac-spinner absolute inset-y-0 right-3 flex items-center text-muted-foreground">
 			<LoaderCircle class="h-3.5 w-3.5 animate-spin" />
 		</div>
 	{/if}
 
 	{#if showSuggestions}
-		<div class="absolute z-20 mt-2 w-full rounded-lg border bg-background shadow-lg overflow-hidden">
-			<div class="px-3 py-1.5 text-xs text-muted-foreground border-b border-border/60 bg-muted/30">
-				Type a path, or use ↑↓ to pick a suggestion
+		<div use:portalToBody style={popoverStyle} class="ac-popover rounded-lg border border-border bg-popover text-popover-foreground shadow-xl shadow-black/10 overflow-hidden">
+			<div class="ac-head flex items-center justify-between px-3 py-1.5 border-b border-border/60 bg-muted/40">
+				<span class="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground">Folders</span>
+				<span class="text-[0.65rem] tabular-nums text-muted-foreground/70">{displayedSuggestions.length}</span>
 			</div>
-			<div class="max-h-64 overflow-y-auto py-1">
+			<div class="max-h-72 overflow-y-auto py-0.5">
 				{#each displayedSuggestions as suggestion, index (suggestion.path)}
+					{@const frag = currentFragment().toLowerCase()}
+					{@const matched = frag !== '' && suggestion.name.toLowerCase().startsWith(frag)}
+					{@const rest = matched ? suggestion.name.slice(frag.length) : ''}
 					<button
 						type="button"
 						onmousedown={(event) => {
 							event.preventDefault();
 							selectSuggestion(suggestion);
 						}}
-						class="w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors
-							{index === activeSuggestionIndex ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60'}"
+						class="ac-row group w-full flex items-center gap-2.5 px-2.5 py-1.5 text-left transition-colors
+							{index === activeIndex ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50'}"
 					>
-						<Folder class="h-4 w-4 text-blue-500 shrink-0" />
-						<div class="min-w-0 flex-1">
-							<div class="truncate font-medium">{suggestion.name}</div>
-							<div class="truncate text-xs text-muted-foreground font-mono">{suggestion.path}</div>
+						<Folder class="h-4 w-4 shrink-0 {index === activeIndex ? 'text-primary' : 'text-blue-500/80'}" />
+						<div class="min-w-0 flex-1 flex items-baseline gap-1">
+							{#if matched}
+								<span class="ac-match font-semibold truncate">{suggestion.name.slice(0, frag.length)}</span><span class="truncate font-medium opacity-90">{rest}</span>
+							{:else}
+								<span class="truncate font-medium">{suggestion.name}</span>
+							{/if}
 						</div>
+						<span class="ac-path hidden sm:block truncate text-[0.7rem] text-muted-foreground font-mono max-w-[40%]">{suggestion.path}</span>
+						<ChevronRight class="h-3.5 w-3.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground" />
 					</button>
 				{/each}
+			</div>
+			<div class="ac-foot hidden sm:flex items-center gap-3 px-3 py-1.5 border-t border-border/60 bg-muted/30 text-[0.65rem] text-muted-foreground/80">
+				<span class="flex items-center gap-1"><ArrowUp class="h-3 w-3" /><ArrowDown class="h-3 w-3" /> navigate</span>
+				<span class="flex items-center gap-1"><CornerDownLeft class="h-3 w-3" /> select</span>
+				<span class="ml-auto">esc to dismiss</span>
 			</div>
 		</div>
 	{/if}
@@ -216,7 +294,25 @@
 {#if showNavigateButton}
 	<Button variant="outline" size="sm" onclick={() => onnavigate?.(value.trim())} disabled={!value.trim() || navigateDisabled || loading} title="Navigate to path">
 		{#snippet children()}
-			<ArrowRight class="h-4 w-4" />
+			<CornerDownLeft class="h-4 w-4" />
 		{/snippet}
 	</Button>
 {/if}
+
+<style>
+	.ac-popover {
+		animation: ac-pop 120ms cubic-bezier(0.16, 1, 0.3, 1) both;
+		transform-origin: top center;
+	}
+	@keyframes ac-pop {
+		from { transform: translateY(-4px) scaleY(0.98); }
+		to { transform: translateY(0) scaleY(1); }
+	}
+	.ac-row {
+		animation: ac-row-in 100ms cubic-bezier(0.16, 1, 0.3, 1) both;
+	}
+	@keyframes ac-row-in {
+		from { opacity: 0; transform: translateX(-2px); }
+		to { opacity: 1; transform: translateX(0); }
+	}
+</style>

--- a/web/frontend/src/lib/components/PathInput.svelte
+++ b/web/frontend/src/lib/components/PathInput.svelte
@@ -117,8 +117,14 @@
 			pathSuggestions = [];
 			activeIndex = -1;
 			const msg = e instanceof Error ? e.message : '';
-			if (scope === 'operation' && (msg.includes('allowed directories') || msg.includes('403'))) {
-				autocompleteError = 'No allowed directories configured — add one in Settings → Security.';
+			if (scope === 'operation' && (msg.includes('403') || msg.includes('allowed directories'))) {
+				if (msg.includes('no allowed directories configured')) {
+					autocompleteError = 'No allowed directories configured — add one in Settings → Security.';
+				} else if (msg.includes('outside allowed directories') || msg.includes('path outside')) {
+					autocompleteError = 'This path is outside your allowed directories. Add it in Settings → Security.';
+				} else {
+					autocompleteError = null;
+				}
 			} else {
 				autocompleteError = null;
 			}
@@ -129,7 +135,8 @@
 
 	function withTrailingSep(p: string): string {
 		if (p === '' || p.endsWith(SEP) || p.endsWith('\\')) return p;
-		return p + SEP;
+		const sep = p.includes('\\') && !p.includes(SEP) ? '\\' : SEP;
+		return p + sep;
 	}
 
 	function selectSuggestion(suggestion: PathAutocompleteSuggestion) {
@@ -141,6 +148,7 @@
 		userNavigated = false;
 		pathSuggestions = [];
 		activeIndex = -1;
+		autocompleteRequestToken += 1;
 		if (inputEl) {
 			inputEl.focus();
 			const end = value.length;

--- a/web/frontend/src/lib/components/PathInput.svelte
+++ b/web/frontend/src/lib/components/PathInput.svelte
@@ -16,6 +16,7 @@
 		loading?: boolean;
 		escapeValue?: string;
 		drillOnSelect?: boolean;
+		scope?: 'operation' | 'configure';
 		class?: string;
 	}
 
@@ -30,6 +31,7 @@
 		loading = false,
 		escapeValue,
 		drillOnSelect = false,
+		scope = 'operation',
 		class: className = ''
 	}: Props = $props();
 
@@ -44,6 +46,7 @@
 	let autocompleteDebounceId: ReturnType<typeof setTimeout> | null = null;
 	let autocompleteRequestToken = 0;
 	let inputEl = $state<HTMLInputElement | null>(null);
+	let autocompleteError = $state<string | null>(null);
 
 	let whitelistSuggestions = $derived.by(() => {
 		if (whitelistPaths.length === 0) return [];
@@ -83,6 +86,7 @@
 		activeIndex = -1;
 		userNavigated = false;
 		autocompleteLoading = false;
+		autocompleteError = null;
 	}
 
 	function clampActive() {
@@ -101,15 +105,23 @@
 		try {
 			const response = await apiClient.autocompletePath({
 				path: inputPath,
-				limit: pathAutocompleteLimit
+				limit: pathAutocompleteLimit,
+				scope
 			});
 			if (requestToken !== autocompleteRequestToken || !focused) return;
 			pathSuggestions = response.suggestions;
 			activeIndex = -1;
-		} catch {
+			autocompleteError = null;
+		} catch (e) {
 			if (requestToken !== autocompleteRequestToken) return;
 			pathSuggestions = [];
 			activeIndex = -1;
+			const msg = e instanceof Error ? e.message : '';
+			if (scope === 'operation' && (msg.includes('allowed directories') || msg.includes('403'))) {
+				autocompleteError = 'No allowed directories configured — add one in Settings → Security.';
+			} else {
+				autocompleteError = null;
+			}
 		} finally {
 			if (requestToken === autocompleteRequestToken) autocompleteLoading = false;
 		}
@@ -288,6 +300,9 @@
 				<span class="ml-auto">esc to dismiss</span>
 			</div>
 		</div>
+	{/if}
+	{#if autocompleteError}
+		<p class="mt-1 text-xs text-muted-foreground">{autocompleteError}</p>
 	{/if}
 </div>
 


### PR DESCRIPTION
Two related changes to the path picker (PathInput / FileBrowser + the browse/autocomplete endpoints), reviewed across multiple model perspectives (glm-5.2 reviewers + GPT-5.5).

## 1. Autocomplete stays alive after selecting a suggestion (fix)

Previously, selecting a suggestion set isEditing=false and cleared suggestions; the input kept focus but handleInput early-returned on !isEditing, so typing after a selection **never re-fetched** autocomplete. Appending/modifying a selected path got zero suggestions until you blurred and refocused.

- Decouple `focused` (gated only on blur/Esc, never on select) from the dropdown-open state, so the next keystroke after a select re-triggers fetch.
- Add an opt-in `drillOnSelect` prop (default false). FileBrowser (navigation) passes true to drill into a directory on select (append trailing slash + re-fetch its children); other callers get a clean select with no trailing slash, no refetch, keeping focused true so autocomplete still works on the next keystroke.
- Portal the popover to document.body with fixed viewport positioning so it escapes nested stacking contexts.
- **Fix the actual bleed-through root cause:** bg-popover / text-popover-foreground were referenced but never defined as Tailwind utilities in this v4 CSS-based setup, so the popover had no background-color and was transparent. Register them in app.css.
- Caret to end after select, Tab completes the highlighted row, fragment highlighting, header (count) + footer (keyboard hints), drill-in chevron, transform-only entrance animations.

## 2. Scope browse/autocomplete to allowed_directories by default (feat)

Browse and autocomplete never enforced the allowed_directories allowlist — an authenticated user could list the entire filesystem via the file picker (only the denylist /proc,/sys,/dev applied), even though scan/organize were locked to the allowlist. Info-disclosure for remote/Docker deployments.

Add a `scope` field to BrowseRequest and PathAutocompleteRequest (json scope,omitempty):
- `scope: "configure"` → unrestricted (current behavior; denylist only). Used **only** by AllowedDirectoriesEditor in setup/settings, preserving the bootstrap escape-hatch for adding the first directory or a dir on another drive.
- default / `scope: "operation"` (or any other value, **fail-safe**) → allowlist-enforcing. Browse/autocomplete now use the same validator as scan (deny-by-default when empty; path must be inside an allowed dir). 403s surface an "add it in Settings → Security" hint in the UI.

**Backend:** browse.go branches on req.Scope (configure → ValidateAndOpenBrowsePath; else → ValidateAndOpenPath). autocomplete.go's resolveAutocompleteBasePath takes a scope param (configure → ValidateBrowsePath; else → ValidateScanPath).
**Frontend:** PathInput + FileBrowser got a scope prop (default 'operation'); AllowedDirectoriesEditor passes scope='configure' to both its inline PathInput and its modal FileBrowser.
**Tests:** browse_security_model_test.go rewritten — old NeverEnforcesAllowlist tests renamed to ConfigureScope (pass scope:configure); new OperationScope tests added (reject-when-empty, reject-outside, allow-inside).

### Residual risk (acknowledged)
The scope field is client-controlled — any authenticated user can pass scope:"configure" to browse freely. This is the intended bootstrap escape-hatch and is no worse than the prior always-unrestricted browse behavior for authenticated users. It only matters if the product ever adds less-privileged users/roles; that would need server-side role gating.

## Validation
- `go test ./internal/api/...` — pass
- `go vet ./internal/...` — clean
- `svelte-check` — 0 errors, 0 warnings
- `vitest` (full) — 369/369 pass
- macOS desktop app rebuilt and manually verified
