### PR TITLE
feat(web): rebuild first-run setup as a 3-step wizard

### DIFF
--- a/internal/api/file/handlers_test.go
+++ b/internal/api/file/handlers_test.go
@@ -1064,3 +1064,18 @@ func TestIsHomeDirectory_HomeDirUnresolvable(t *testing.T) {
 
 	assert.True(t, isHomeDirectory("/any/path"), "should return true (fail-closed) when home dir can't be resolved")
 }
+
+func TestIsHomeDirectory_SymlinkAlias(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		t.Skip("could not resolve home dir")
+	}
+
+	linkDir := t.TempDir()
+	homeLink := filepath.Join(linkDir, "home_link")
+	require.NoError(t, os.Symlink(home, homeLink))
+	t.Cleanup(func() { _ = os.Remove(homeLink) })
+
+	assert.True(t, isHomeDirectory(homeLink),
+		"symlink to home dir should be detected as home after canonicalization")
+}

--- a/internal/api/file/handlers_test.go
+++ b/internal/api/file/handlers_test.go
@@ -340,6 +340,34 @@ func TestGetCurrentWorkingDirectory(t *testing.T) {
 		// Should return first allowed directory
 		assert.Equal(t, "/media", response["path"])
 	})
+
+	t.Run("returns empty path when working directory is root", func(t *testing.T) {
+		// The desktop app launched from Finder/Explorer runs with CWD="/" (or
+		// a Windows drive root). Such a path is useless as a library default, so
+		// the endpoint returns an empty string rather than pre-filling "/".
+		origGetwd := osGetwd
+		t.Cleanup(func() { osGetwd = origGetwd })
+
+		osGetwd = func() (string, error) { return "/", nil }
+
+		cfg := config.DefaultConfig(nil, nil)
+		cfg.API.Security.AllowedDirectories = []string{}
+
+		deps := newTestDepsFromConfig(cfg)
+		router := gin.New()
+		router.GET("/cwd", getCurrentWorkingDirectory(testkit.GetTestRuntime(deps)))
+
+		req := httptest.NewRequest("GET", "/cwd", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, 200, w.Code)
+
+		var response map[string]string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.Equal(t, "", response["path"])
+	})
 }
 
 func TestBrowseDirectory(t *testing.T) {

--- a/internal/api/file/handlers_test.go
+++ b/internal/api/file/handlers_test.go
@@ -1018,3 +1018,49 @@ func TestIsRootPath(t *testing.T) {
 	assert.False(t, isRootPath(""), "Empty string should not be a root path")
 	assert.False(t, isRootPath("."), "Relative dot should not be a root path")
 }
+
+func TestIsHomeDirectory(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	if home != "" {
+		assert.True(t, isHomeDirectory(home), "user's home dir should be detected as home")
+	}
+	assert.False(t, isHomeDirectory("/tmp"), "/tmp should not be home")
+	assert.False(t, isHomeDirectory("/"), "root should not be home")
+	assert.False(t, isHomeDirectory(""), "empty should not be home")
+}
+
+func TestGetCurrentWorkingDirectory_HomeCWDReturnsEmpty(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		t.Skip("could not resolve home dir")
+	}
+
+	origGetwd := osGetwd
+	t.Cleanup(func() { osGetwd = origGetwd })
+	osGetwd = func() (string, error) { return home, nil }
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.API.Security.AllowedDirectories = []string{}
+
+	deps := newTestDepsFromConfig(cfg)
+	router := gin.New()
+	router.GET("/cwd", getCurrentWorkingDirectory(testkit.GetTestRuntime(deps)))
+
+	req := httptest.NewRequest("GET", "/cwd", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "", response["path"], "home dir as CWD should return empty (not safe to prefill)")
+}
+
+func TestIsHomeDirectory_HomeDirUnresolvable(t *testing.T) {
+	origHomeDir := osUserHomeDir
+	t.Cleanup(func() { osUserHomeDir = origHomeDir })
+	osUserHomeDir = func() (string, error) { return "", errors.New("home: unresolvable") }
+
+	assert.False(t, isHomeDirectory("/any/path"), "should return false when home dir can't be resolved")
+}

--- a/internal/api/file/handlers_test.go
+++ b/internal/api/file/handlers_test.go
@@ -1062,5 +1062,5 @@ func TestIsHomeDirectory_HomeDirUnresolvable(t *testing.T) {
 	t.Cleanup(func() { osUserHomeDir = origHomeDir })
 	osUserHomeDir = func() (string, error) { return "", errors.New("home: unresolvable") }
 
-	assert.False(t, isHomeDirectory("/any/path"), "should return false when home dir can't be resolved")
+	assert.True(t, isHomeDirectory("/any/path"), "should return true (fail-closed) when home dir can't be resolved")
 }

--- a/internal/api/file/handlers_test.go
+++ b/internal/api/file/handlers_test.go
@@ -3,6 +3,8 @@ package file
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -367,6 +369,27 @@ func TestGetCurrentWorkingDirectory(t *testing.T) {
 		var response map[string]string
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 		assert.Equal(t, "", response["path"])
+	})
+
+	t.Run("returns 500 when working directory cannot be resolved", func(t *testing.T) {
+		origGetwd := osGetwd
+		t.Cleanup(func() { osGetwd = origGetwd })
+
+		osGetwd = func() (string, error) { return "", errors.New("getwd: no such directory") }
+
+		cfg := config.DefaultConfig(nil, nil)
+		cfg.API.Security.AllowedDirectories = []string{}
+
+		deps := newTestDepsFromConfig(cfg)
+		router := gin.New()
+		router.GET("/cwd", getCurrentWorkingDirectory(testkit.GetTestRuntime(deps)))
+
+		req := httptest.NewRequest("GET", "/cwd", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
 	})
 }
 

--- a/internal/api/file/handlers_test.go
+++ b/internal/api/file/handlers_test.go
@@ -1008,3 +1008,13 @@ func TestScanDirectory_FilterFlag(t *testing.T) {
 		assert.Equal(t, 2, response.Count, "Lowercase filter should match uppercase directories/files")
 	})
 }
+
+func TestIsRootPath(t *testing.T) {
+	assert.True(t, isRootPath("/"), "Unix root should be a root path")
+	assert.True(t, isRootPath("C:\\"), "Windows drive root C:\\ should be a root path")
+	assert.True(t, isRootPath("C:/"), "Windows drive root C:/ should be a root path")
+	assert.True(t, isRootPath("D:\\"), "Windows drive root D:\\ should be a root path")
+	assert.False(t, isRootPath("/home"), "Non-root path should not be a root path")
+	assert.False(t, isRootPath(""), "Empty string should not be a root path")
+	assert.False(t, isRootPath("."), "Relative dot should not be a root path")
+}

--- a/internal/api/file/scan.go
+++ b/internal/api/file/scan.go
@@ -167,7 +167,15 @@ func isRootPath(path string) bool {
 func isHomeDirectory(path string) bool {
 	home, err := osUserHomeDir()
 	if err != nil || home == "" {
-		return false
+		return true
 	}
-	return path == home
+	resolvedHome, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		resolvedHome = home
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		resolvedPath = path
+	}
+	return resolvedPath == resolvedHome
 }

--- a/internal/api/file/scan.go
+++ b/internal/api/file/scan.go
@@ -3,6 +3,7 @@ package file
 import (
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/gin-gonic/gin"
 	"github.com/javinizer/javinizer-go/internal/api/apperrors"
@@ -10,6 +11,12 @@ import (
 	"github.com/javinizer/javinizer-go/internal/workflow"
 
 	contracts "github.com/javinizer/javinizer-go/internal/api/contracts"
+)
+
+// osGetwd is a seam over os.Getwd so the root-CWD branch in defaultPath can
+// be exercised without actually chdir-ing the test process into "/".
+var (
+	osGetwd = os.Getwd
 )
 
 // scanDirectory godoc
@@ -105,22 +112,48 @@ func scanDirectory(rt *core.APIRuntime) gin.HandlerFunc {
 
 func getCurrentWorkingDirectory(rt *core.APIRuntime) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var defaultPath string
-
-		apiCfg := rt.GetAPIConfig()
-		scanCfg := apiCfg.ScannerConfig()
-
-		if len(scanCfg.AllowedDirectories) > 0 {
-			defaultPath = scanCfg.AllowedDirectories[0]
-		} else {
-			cwd, err := os.Getwd()
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: err.Error()})
-				return
-			}
-			defaultPath = cwd
+		path, err := defaultPath(rt)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: err.Error()})
+			return
 		}
-
-		c.JSON(http.StatusOK, gin.H{"path": defaultPath})
+		c.JSON(http.StatusOK, gin.H{"path": path})
 	}
+}
+
+// defaultPath resolves a sensible absolute default path for the UI to
+// pre-fill browse/scan inputs with. It prefers the first configured allowed
+// directory; otherwise it uses the process working directory. When the CWD
+// is root-like ("/" or a Windows drive root) — as it is for the desktop app
+// launched from Finder/Explorer — it returns an empty string so the UI does
+// not pre-fill a useless "/".
+func defaultPath(rt *core.APIRuntime) (string, error) {
+	apiCfg := rt.GetAPIConfig()
+	scanCfg := apiCfg.ScannerConfig()
+
+	if len(scanCfg.AllowedDirectories) > 0 {
+		return scanCfg.AllowedDirectories[0], nil
+	}
+
+	cwd, err := osGetwd()
+	if err != nil {
+		return "", err
+	}
+	if isRootPath(cwd) {
+		return "", nil
+	}
+	return cwd, nil
+}
+
+// isRootPath reports whether path is a filesystem root ("/" on Unix, "C:\"
+// style drive roots on Windows). Such paths are useless as a library default.
+func isRootPath(path string) bool {
+	if path == "/" || path == string(filepath.Separator) {
+		return true
+	}
+	// Windows drive root, e.g. "C:\"
+	if len(path) == 3 && path[1] == ':' && (path[2] == '\\' || path[2] == '/') {
+		return true
+	}
+	return false
 }

--- a/internal/api/file/scan.go
+++ b/internal/api/file/scan.go
@@ -16,7 +16,8 @@ import (
 // osGetwd is a seam over os.Getwd so the root-CWD branch in defaultPath can
 // be exercised without actually chdir-ing the test process into "/".
 var (
-	osGetwd = os.Getwd
+	osGetwd       = os.Getwd
+	osUserHomeDir = os.UserHomeDir
 )
 
 // scanDirectory godoc
@@ -142,6 +143,9 @@ func defaultPath(rt *core.APIRuntime) (string, error) {
 	if isRootPath(cwd) {
 		return "", nil
 	}
+	if isHomeDirectory(cwd) {
+		return "", nil
+	}
 	return cwd, nil
 }
 
@@ -151,9 +155,19 @@ func isRootPath(path string) bool {
 	if path == "/" || path == string(filepath.Separator) {
 		return true
 	}
-	// Windows drive root, e.g. "C:\"
 	if len(path) == 3 && path[1] == ':' && (path[2] == '\\' || path[2] == '/') {
 		return true
 	}
 	return false
+}
+
+// isHomeDirectory reports whether path equals the user's home directory.
+// Prefilling the home directory grants file-operation scope over the entire
+// profile, so it is treated as unusable (same fail-closed behavior as root).
+func isHomeDirectory(path string) bool {
+	home, err := osUserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	return path == home
 }

--- a/web/frontend/src/lib/components/ScraperSelector.svelte
+++ b/web/frontend/src/lib/components/ScraperSelector.svelte
@@ -6,10 +6,11 @@
 	import { GripVertical, ChevronUp, ChevronDown, X } from 'lucide-svelte';
 	import { fade, fly } from 'svelte/transition';
 
-	let { scrapers = [], selected = $bindable([]), disabled = false }: {
+	let { scrapers = [], selected = $bindable([]), disabled = false, showAll = false }: {
 		scrapers?: Scraper[];
 		selected?: string[];
 		disabled?: boolean;
+		showAll?: boolean;
 	} = $props();
 
 	let draggedIndex = $state<number | null>(null);
@@ -29,7 +30,7 @@
 
 	// Get unselected enabled scrapers
 	const unselectedScrapers = $derived(
-		scrapers.filter((s) => s.enabled && !selected.includes(s.name))
+		scrapers.filter((s) => (showAll || s.enabled) && !selected.includes(s.name))
 	);
 
 	function addScraper(name: string) {
@@ -65,7 +66,7 @@
 	}
 
 	function selectAll() {
-		selected = scrapers.filter((s) => s.enabled).map((s) => s.name);
+		selected = scrapers.filter((s) => showAll || s.enabled).map((s) => s.name);
 	}
 
 	function selectNone() {

--- a/web/frontend/src/lib/components/ScraperSelector.svelte
+++ b/web/frontend/src/lib/components/ScraperSelector.svelte
@@ -28,7 +28,7 @@
 			.filter((s): s is Scraper => s !== undefined)
 	);
 
-	// Get unselected enabled scrapers
+	// Get unselected scrapers (includes disabled when showAll is true)
 	const unselectedScrapers = $derived(
 		scrapers.filter((s) => (showAll || s.enabled) && !selected.includes(s.name))
 	);

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -193,18 +193,17 @@
 				allowed_unc_servers: [...(sec?.allowed_unc_servers ?? [])],
 			});
 
-			const config = await apiClient.getConfig();
-			const sc = (config.scrapers ?? {}) as Record<string, unknown>;
+			const sc = (fresh.scrapers ?? {}) as Record<string, unknown>;
 			if (availableScrapers.length > 0) {
 				sc.priority = [...selectedScrapers];
 				for (const scraper of availableScrapers) {
 					if (!sc[scraper.name]) sc[scraper.name] = {};
 					(sc[scraper.name] as Record<string, unknown>).enabled = selectedScrapers.includes(scraper.name);
 				}
-				config.scrapers = sc as typeof config.scrapers;
+				fresh.scrapers = sc as typeof fresh.scrapers;
 				await apiClient.request('/api/v1/config', {
 					method: 'PUT',
-					body: JSON.stringify(config),
+					body: JSON.stringify(fresh),
 				});
 			}
 			toastStore.success('Setup complete. Welcome to Javinizer.', 4000);

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -17,10 +17,7 @@
 		ArrowLeft,
 		ArrowRight,
 		Check,
-		FolderCheck,
 		Loader2,
-		ShieldCheck,
-		Sparkles,
 	} from 'lucide-svelte';
 
 	interface Props {
@@ -31,10 +28,10 @@
 
 	type StepId = 'credentials' | 'directories' | 'scrapers';
 
-	const steps: { id: StepId; index: number; label: string; hint: string; icon: typeof ShieldCheck }[] = [
-		{ id: 'credentials', index: 0, label: 'Admin Account', hint: 'Secure your server', icon: ShieldCheck },
-		{ id: 'directories', index: 1, label: 'Library Folders', hint: 'Where your media lives', icon: FolderCheck },
-		{ id: 'scrapers', index: 2, label: 'Scrapers', hint: 'Metadata sources', icon: Sparkles },
+	const steps: { id: StepId; label: string; hint: string }[] = [
+		{ id: 'credentials', label: 'Admin Account', hint: 'Secure your server' },
+		{ id: 'directories', label: 'Library Folders', hint: 'Where your media lives' },
+		{ id: 'scrapers', label: 'Scrapers', hint: 'Metadata sources' },
 	];
 
 	let stepIndex = $state(0);
@@ -81,7 +78,6 @@
 		return () => ro.disconnect();
 	});
 
-	let currentStep = $derived(steps[stepIndex]);
 	let isLastStep = $derived(stepIndex === steps.length - 1);
 
 	function gotoStep(index: number) {
@@ -254,7 +250,9 @@
 					: 'Saving…'
 			: isLastStep
 				? 'Finish Setup'
-				: 'Continue',
+				: stepIndex === 0
+					? 'Create admin account'
+					: 'Continue',
 	);
 
 	onMount(() => {
@@ -301,7 +299,7 @@
 					></div>
 				</div>
 				{#each steps as step, i (step.id)}
-					<div class="stepper-row" class:active={stepIndex === i} class:done={stepIndex > i}>
+					<div class="stepper-row" class:active={stepIndex === i} class:done={stepIndex > i} aria-current={stepIndex === i ? 'step' : undefined}>
 						<div class="stepper-node">
 							{#if stepIndex > i}
 								<Check class="stepper-check" />
@@ -342,7 +340,7 @@
 								registeredAt={registeredAt}
 							/>
 						{:else if stepIndex === 0}
-							<StepCredentials bind:credentials {error} {submitting} />
+							<StepCredentials bind:credentials {error} {submitting} onSubmit={handleNext} />
 						{:else if stepIndex === 1}
 							<StepDirectories bind:dirs {error} {submitting} />
 						{:else}

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -73,6 +73,9 @@
 			heightReady = true;
 		};
 		void measure();
+		if (typeof ResizeObserver === 'undefined') {
+			return;
+		}
 		const ro = new ResizeObserver(measure);
 		ro.observe(el);
 		return () => ro.disconnect();

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -193,6 +193,9 @@
 				allowed_unc_servers: [...(sec?.allowed_unc_servers ?? [])],
 			});
 
+			if (fresh.api?.security) {
+				fresh.api.security.allowed_directories = dirs;
+			}
 			const sc = (fresh.scrapers ?? {}) as Record<string, unknown>;
 			if (availableScrapers.length > 0) {
 				sc.priority = [...selectedScrapers];

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -1,0 +1,628 @@
+<script lang="ts">
+	import { onMount, tick } from 'svelte';
+	import { cubicOut, quintOut } from 'svelte/easing';
+	import { scale } from 'svelte/transition';
+	import { apiClient } from '$lib/api/client';
+	import { BaseClient } from '$lib/api/clients/common';
+	import { toastStore } from '$lib/stores/toast';
+	import { getThemeStore } from '$lib/stores/theme.svelte';
+	import { websocketStore } from '$lib/stores/websocket';
+	import Button from '$lib/components/ui/Button.svelte';
+	import StepCredentials from './StepCredentials.svelte';
+	import StepDirectories from './StepDirectories.svelte';
+	import StepScrapers from './StepScrapers.svelte';
+	import type { Scraper } from '$lib/api/types';
+	import {
+		ArrowLeft,
+		ArrowRight,
+		Check,
+		FolderCheck,
+		Loader2,
+		ShieldCheck,
+		Sparkles,
+	} from 'lucide-svelte';
+
+	interface Props {
+		onComplete: () => void;
+	}
+
+	let { onComplete }: Props = $props();
+
+	type StepId = 'credentials' | 'directories' | 'scrapers';
+
+	const steps: { id: StepId; index: number; label: string; hint: string; icon: typeof ShieldCheck }[] = [
+		{ id: 'credentials', index: 0, label: 'Admin Account', hint: 'Secure your server', icon: ShieldCheck },
+		{ id: 'directories', index: 1, label: 'Library Folders', hint: 'Where your media lives', icon: FolderCheck },
+		{ id: 'scrapers', index: 2, label: 'Scrapers', hint: 'Metadata sources', icon: Sparkles },
+	];
+
+	let stepIndex = $state(0);
+	let submitting = $state(false);
+	let error = $state<string | null>(null);
+
+	let credentials = $state({ username: '', password: '', confirm: '' });
+
+	let dirs = $state<string[]>([]);
+
+	let availableScrapers = $state<Scraper[]>([]);
+	let selectedScrapers = $state<string[]>([]);
+	let scrapersLoading = $state(false);
+
+	let stageEl = $state<HTMLElement | null>(null);
+	let stageHeight = $state<number | null>(null);
+	let heightReady = $state(false);
+
+	const TRANSITION_MS = 360;
+
+	$effect(() => {
+		const el = stageEl;
+		if (!el) return;
+		const measure = () => {
+			stageHeight = el.offsetHeight;
+			heightReady = true;
+		};
+		void measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(el);
+		return () => ro.disconnect();
+	});
+
+	let currentStep = $derived(steps[stepIndex]);
+	let isLastStep = $derived(stepIndex === steps.length - 1);
+
+	function gotoStep(index: number) {
+		if (index < 0 || index >= steps.length) return;
+		stepIndex = index;
+		error = null;
+	}
+
+	function syncWebSocketAuth() {
+		websocketStore.connect();
+	}
+
+	async function fetchScrapers() {
+		if (availableScrapers.length > 0 || scrapersLoading) return;
+		scrapersLoading = true;
+		try {
+			availableScrapers = await apiClient.getScrapers();
+			selectedScrapers = availableScrapers.filter((s) => s.enabled).map((s) => s.name);
+		} catch {
+			toastStore.error('Could not load available scrapers', 4000);
+		} finally {
+			scrapersLoading = false;
+		}
+	}
+
+	// Step 1: create the admin account (required to obtain a session for the
+	// protected scraper/config endpoints). This is the only commit before the
+	// final Finish — credentials are irreversible, so Back is hidden afterwards.
+	async function handleCredentialsNext() {
+		error = null;
+		if (credentials.password !== credentials.confirm) {
+			error = 'Passwords do not match';
+			return;
+		}
+		submitting = true;
+		try {
+			const result = await apiClient.setupAuth({
+				username: credentials.username,
+				password: credentials.password,
+			});
+			credentials.password = '';
+			credentials.confirm = '';
+			if (result?.session_id) BaseClient.setSessionID(result.session_id);
+			syncWebSocketAuth();
+			gotoStep(1);
+			toastStore.success('Admin account created', 3000);
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to create admin account';
+		} finally {
+			submitting = false;
+		}
+	}
+
+	// Step 2: directories are staged locally; nothing is committed until Finish
+	// so the transition to the scrapers step is instant.
+	function handleDirectoriesNext() {
+		error = null;
+		gotoStep(2);
+	}
+
+	function handleDirectoriesSkip() {
+		error = null;
+		gotoStep(2);
+	}
+
+	// Final step: commit the staged directories and scraper selection together.
+	async function handleScrapersFinish() {
+		error = null;
+		submitting = true;
+		try {
+			const fresh = await apiClient.getConfig();
+			const sec = fresh?.api?.security;
+			await apiClient.updateSecurityConfig({
+				allowed_directories: dirs,
+				denied_directories: [...(sec?.denied_directories ?? [])],
+				allow_unc: sec?.allow_unc ?? false,
+				allowed_unc_servers: [...(sec?.allowed_unc_servers ?? [])],
+			});
+
+			const config = await apiClient.getConfig();
+			const sc = (config.scrapers ?? {}) as Record<string, unknown>;
+			sc.priority = [...selectedScrapers];
+			for (const scraper of availableScrapers) {
+				if (!sc[scraper.name]) sc[scraper.name] = {};
+				(sc[scraper.name] as Record<string, unknown>).enabled = selectedScrapers.includes(scraper.name);
+			}
+			config.scrapers = sc as typeof config.scrapers;
+			await apiClient.request('/api/v1/config', {
+				method: 'PUT',
+				body: JSON.stringify(config),
+			});
+			toastStore.success('Setup complete. Welcome to Javinizer.', 4000);
+			onComplete();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to save setup configuration';
+		} finally {
+			submitting = false;
+		}
+	}
+
+	function handleBack() {
+		if (stepIndex === 2) gotoStep(1);
+	}
+
+	function handleNext() {
+		if (stepIndex === 0) void handleCredentialsNext();
+		else if (stepIndex === 1) void handleDirectoriesNext();
+		else void handleScrapersFinish();
+	}
+
+	let canProceed = $derived.by(() => {
+		if (submitting) return false;
+		if (stepIndex === 0) {
+			return (
+				credentials.username.trim().length > 0 &&
+				credentials.password.length >= 8 &&
+				credentials.confirm.length >= 8
+			);
+		}
+		return true;
+	});
+
+	let nextLabel = $derived(
+		submitting
+			? stepIndex === 0
+				? 'Creating…'
+				: isLastStep
+					? 'Finishing…'
+					: 'Saving…'
+			: isLastStep
+				? 'Finish Setup'
+				: 'Continue',
+	);
+
+	onMount(() => {
+		getThemeStore().initTheme();
+	});
+
+	// Lazily fetch the scraper list when the user reaches the scrapers step.
+	// Requires an authenticated session (created in step 1), so it can only
+	// run once the credentials step is complete.
+	$effect(() => {
+		if (stepIndex === 2) void fetchScrapers();
+	});
+</script>
+
+<svelte:head>
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+	<link
+		href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,500;12..96,600;12..96,700&display=swap"
+		rel="stylesheet"
+	/>
+</svelte:head>
+
+<div class="wizard-shell">
+	<!-- Brand / stepper rail -->
+	<aside class="brand-rail" aria-hidden="true">
+		<div class="brand-glow brand-glow-a"></div>
+		<div class="brand-glow brand-glow-b"></div>
+		<div class="brand-grid"></div>
+
+		<div class="brand-inner">
+			<div class="brand-mark" in:scale|local={{ start: 0.8, duration: 420, easing: quintOut }}>
+				<svg viewBox="0 0 512 512" width="34" height="34" aria-hidden="true">
+					<rect width="512" height="512" rx="112" fill="currentColor" />
+					<path d="M330 150v198c0 54-37 88-92 88-44 0-74-19-92-58l52-26c9 19 23 29 41 29 22 0 36-16 36-42V150h55z" fill="#ffffff" />
+				</svg>
+			</div>
+			<div class="brand-word">Javinizer</div>
+
+			<nav class="stepper" aria-label="Setup progress">
+				<div class="stepper-track" aria-hidden="true">
+					<div
+						class="stepper-track-fill"
+						style="height: {Math.max(0, (stepIndex / (steps.length - 1)) * 100)}%"
+					></div>
+				</div>
+				{#each steps as step, i (step.id)}
+					<div class="stepper-row" class:active={stepIndex === i} class:done={stepIndex > i}>
+						<div class="stepper-node">
+							{#if stepIndex > i}
+								<Check class="stepper-check" />
+							{:else}
+								<span class="stepper-num">{i + 1}</span>
+							{/if}
+						</div>
+						<div class="stepper-text">
+							<div class="stepper-label">{step.label}</div>
+							<div class="stepper-hint">{step.hint}</div>
+						</div>
+					</div>
+				{/each}
+			</nav>
+
+			<div class="brand-foot">
+				<div class="brand-foot-row"><span class="brand-dot"></span> Step {stepIndex + 1} of {steps.length}</div>
+			</div>
+		</div>
+	</aside>
+
+	<!-- Content -->
+	<main class="content-pane">
+		<div class="content-frame">
+			<div class="content-stage"
+				style="height: {stageHeight !== null ? `${stageHeight}px` : 'auto'}; transition: {heightReady ? `height ${TRANSITION_MS}ms cubic-out` : 'none'};">
+				{#key stepIndex}
+					<div
+						class="content-card stage-card"
+						bind:this={stageEl}
+						in:scale|local={{ start: 1.03, duration: TRANSITION_MS, easing: cubicOut }}
+						out:scale|local={{ start: 0.985, duration: TRANSITION_MS, easing: cubicOut }}
+					>
+						{#if stepIndex === 0}
+							<StepCredentials bind:credentials {error} {submitting} />
+						{:else if stepIndex === 1}
+							<StepDirectories bind:dirs {error} {submitting} onSkip={handleDirectoriesSkip} />
+						{:else}
+							<StepScrapers
+								bind:selected={selectedScrapers}
+								scrapers={availableScrapers}
+								loading={scrapersLoading}
+								{error}
+								{submitting}
+							/>
+						{/if}
+					</div>
+				{/key}
+			</div>
+
+			<div class="content-nav">
+				{#if stepIndex === 2}
+					<Button variant="ghost" onclick={handleBack} disabled={submitting}>
+						{#snippet children()}
+							<ArrowLeft class="h-4 w-4" />
+							Back
+						{/snippet}
+					</Button>
+				{:else}
+					<div></div>
+				{/if}
+
+				<div class="nav-right">
+					{#if stepIndex === 1}
+						<Button variant="ghost" onclick={handleDirectoriesSkip} disabled={submitting}>
+							{#snippet children()}Skip for now{/snippet}
+						</Button>
+					{/if}
+					<Button onclick={handleNext} disabled={!canProceed}>
+						{#snippet children()}
+							{#if submitting}
+								<Loader2 class="h-4 w-4 animate-spin" />
+							{:else if isLastStep}
+								<Check class="h-4 w-4" />
+							{:else}
+								<ArrowRight class="h-4 w-4" />
+							{/if}
+							{nextLabel}
+						{/snippet}
+					</Button>
+				</div>
+			</div>
+		</div>
+	</main>
+</div>
+
+<style>
+	.wizard-shell {
+		display: grid;
+		grid-template-columns: minmax(280px, 1fr) minmax(0, 2fr);
+		min-height: 100vh;
+		width: 100%;
+	}
+
+	/* ---- Brand rail ---- */
+	.brand-rail {
+		position: relative;
+		overflow: hidden;
+		background: radial-gradient(120% 100% at 0% 0%, hsl(224 76% 12%) 0%, hsl(222 84% 6%) 55%, hsl(222 84% 4%) 100%);
+		color: hsl(210 40% 98%);
+		padding: 2.75rem 2.25rem;
+		display: flex;
+		flex-direction: column;
+		isolation: isolate;
+	}
+
+	.brand-glow {
+		position: absolute;
+		border-radius: 9999px;
+		filter: blur(72px);
+		opacity: 0.55;
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	.brand-glow-a {
+		width: 320px;
+		height: 320px;
+		background: hsl(217 91% 60% / 0.5);
+		top: -80px;
+		right: -90px;
+	}
+
+	.brand-glow-b {
+		width: 260px;
+		height: 260px;
+		background: hsl(265 85% 62% / 0.32);
+		bottom: -70px;
+		left: -60px;
+	}
+
+	.brand-grid {
+		position: absolute;
+		inset: 0;
+		background-image: radial-gradient(hsl(210 40% 98% / 0.07) 1px, transparent 1px);
+		background-size: 22px 22px;
+		mask-image: radial-gradient(120% 90% at 30% 20%, black 0%, transparent 78%);
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	.brand-inner {
+		position: relative;
+		z-index: 1;
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+	}
+
+	.brand-mark {
+		color: hsl(217 91% 60%);
+		display: inline-flex;
+		filter: drop-shadow(0 6px 18px hsl(217 91% 60% / 0.45));
+	}
+
+	.brand-word {
+		font-family: 'Bricolage Grotesque', ui-sans-serif, system-ui, sans-serif;
+		font-weight: 700;
+		font-size: 1.85rem;
+		letter-spacing: -0.02em;
+		margin-top: 1rem;
+		background: linear-gradient(180deg, hsl(210 40% 98%), hsl(210 40% 82%));
+		-webkit-background-clip: text;
+		background-clip: text;
+		color: transparent;
+	}
+
+	.stepper {
+		position: relative;
+		margin-top: 3rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1.4rem;
+	}
+
+	.stepper-track {
+		position: absolute;
+		left: 17px;
+		top: 8px;
+		bottom: 8px;
+		width: 2px;
+		background: hsl(210 40% 98% / 0.12);
+		border-radius: 9999px;
+		overflow: hidden;
+	}
+
+	.stepper-track-fill {
+		width: 100%;
+		background: linear-gradient(180deg, hsl(217 91% 65%), hsl(265 85% 62%));
+		border-radius: 9999px;
+		transition: height 360ms cubic-out;
+	}
+
+	.stepper-row {
+		position: relative;
+		display: flex;
+		align-items: flex-start;
+		gap: 0.85rem;
+		opacity: 0.5;
+		transition: opacity 220ms cubic-out;
+	}
+
+	.stepper-row.active {
+		opacity: 1;
+	}
+
+	.stepper-row.done {
+		opacity: 0.78;
+	}
+
+	.stepper-node {
+		flex-shrink: 0;
+		width: 36px;
+		height: 36px;
+		border-radius: 9999px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: hsl(217 84% 10%);
+		border: 1.5px solid hsl(210 40% 98% / 0.18);
+		font-weight: 600;
+		font-size: 0.85rem;
+		transition: all 240ms cubic-out;
+		z-index: 1;
+	}
+
+	.stepper-row.active .stepper-node {
+		background: linear-gradient(140deg, hsl(217 91% 62%), hsl(265 85% 60%));
+		border-color: transparent;
+		box-shadow: 0 0 0 4px hsl(217 91% 60% / 0.18), 0 8px 20px hsl(217 91% 55% / 0.4);
+		transform: scale(1.06);
+	}
+
+	.stepper-row.done .stepper-node {
+		background: hsl(217 84% 18%);
+		border-color: hsl(217 91% 60% / 0.5);
+		color: hsl(217 91% 75%);
+	}
+
+	:global(.stepper-check) {
+		width: 16px;
+		height: 16px;
+	}
+
+	.stepper-num {
+		color: hsl(210 40% 88%);
+	}
+
+	.stepper-row.active .stepper-num {
+		color: hsl(210 40% 98%);
+	}
+
+	.stepper-text {
+		padding-top: 0.35rem;
+	}
+
+	.stepper-label {
+		font-size: 0.95rem;
+		font-weight: 600;
+		letter-spacing: -0.01em;
+	}
+
+	.stepper-hint {
+		font-size: 0.78rem;
+		color: hsl(210 40% 72%);
+		margin-top: 0.1rem;
+	}
+
+	.brand-foot {
+		margin-top: auto;
+		padding-top: 2rem;
+	}
+
+	.brand-foot-row {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		color: hsl(210 40% 70%);
+	}
+
+	.brand-dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 9999px;
+		background: hsl(217 91% 65%);
+		box-shadow: 0 0 12px hsl(217 91% 65%);
+	}
+
+	/* ---- Content pane ---- */
+	.content-pane {
+		display: flex;
+		align-items: stretch;
+		justify-content: center;
+		padding: 2rem 1.5rem;
+		background: hsl(var(--background));
+	}
+
+	.content-frame {
+		width: 100%;
+		max-width: 640px;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		gap: 1.5rem;
+		padding: 1.5rem 0;
+	}
+
+	.content-stage {
+		position: relative;
+		width: 100%;
+	}
+
+	.content-card {
+		background: hsl(var(--card));
+		border: 1px solid hsl(var(--border));
+		border-radius: calc(var(--radius) + 6px);
+		padding: 2.25rem;
+		box-shadow:
+			0 1px 2px hsl(222 84% 4% / 0.04),
+			0 24px 60px -28px hsl(222 84% 4% / 0.25);
+	}
+
+	.stage-card {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		transform-origin: center top;
+		will-change: transform, opacity;
+	}
+
+	.content-nav {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		position: relative;
+		z-index: 2;
+	}
+
+	.nav-right {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-left: auto;
+	}
+
+	@media (max-width: 900px) {
+		.wizard-shell {
+			grid-template-columns: 1fr;
+		}
+
+		.brand-rail {
+			padding: 2rem 1.5rem 1.5rem;
+		}
+
+		.brand-glow-a {
+			width: 220px;
+			height: 220px;
+		}
+
+		.stepper {
+			margin-top: 1.75rem;
+			gap: 1rem;
+		}
+
+		.content-pane {
+			padding: 1.25rem 1rem;
+		}
+
+		.content-card {
+			padding: 1.5rem;
+		}
+	}
+</style>

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -239,6 +239,7 @@
 				credentials.confirm.length >= 8
 			);
 		}
+		if (isLastStep && scrapersLoading) return false;
 		return true;
 	});
 

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, tick } from 'svelte';
+	import { onMount } from 'svelte';
 	import { cubicOut, quintOut } from 'svelte/easing';
 	import { scale } from 'svelte/transition';
 	import { apiClient } from '$lib/api/client';
@@ -98,6 +98,7 @@
 			availableScrapers = await apiClient.getScrapers();
 			selectedScrapers = availableScrapers.filter((s) => s.enabled).map((s) => s.name);
 		} catch {
+			error = 'Could not load available scrapers. You can configure them later in Settings → Scrapers.';
 			toastStore.error('Could not load available scrapers', 4000);
 		} finally {
 			scrapersLoading = false;
@@ -171,6 +172,7 @@
 
 	function handleDirectoriesSkip() {
 		error = null;
+		dirs = [];
 		gotoStep(2);
 	}
 
@@ -265,14 +267,7 @@
 	});
 </script>
 
-<svelte:head>
-	<link rel="preconnect" href="https://fonts.googleapis.com" />
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link
-		href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,500;12..96,600;12..96,700&display=swap"
-		rel="stylesheet"
-	/>
-</svelte:head>
+
 
 <div class="wizard-shell">
 	<!-- Brand / stepper rail -->
@@ -324,7 +319,7 @@
 	<main class="content-pane">
 		<div class="content-frame">
 			<div class="content-stage"
-				style="height: {stageHeight !== null ? `${stageHeight}px` : 'auto'}; transition: {heightReady ? `height ${TRANSITION_MS}ms cubic-out` : 'none'};">
+				style="height: {stageHeight !== null ? `${stageHeight}px` : 'auto'}; transition: {heightReady ? `height ${TRANSITION_MS}ms cubic-bezier(0.33, 1, 0.68, 1)` : 'none'};">
 				{#key `${stepIndex}-${credentialsRegistered}`}
 					<div
 						class="content-card stage-card"
@@ -341,7 +336,7 @@
 						{:else if stepIndex === 0}
 							<StepCredentials bind:credentials {error} {submitting} />
 						{:else if stepIndex === 1}
-							<StepDirectories bind:dirs {error} {submitting} onSkip={handleDirectoriesSkip} />
+							<StepDirectories bind:dirs {error} {submitting} />
 						{:else}
 							<StepScrapers
 								bind:selected={selectedScrapers}
@@ -463,7 +458,7 @@
 	}
 
 	.brand-word {
-		font-family: 'Bricolage Grotesque', ui-sans-serif, system-ui, sans-serif;
+		font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
 		font-weight: 700;
 		font-size: 1.85rem;
 		letter-spacing: -0.02em;
@@ -497,7 +492,7 @@
 		width: 100%;
 		background: linear-gradient(180deg, hsl(217 91% 65%), hsl(265 85% 62%));
 		border-radius: 9999px;
-		transition: height 360ms cubic-out;
+		transition: height 360ms cubic-bezier(0.33, 1, 0.68, 1);
 	}
 
 	.stepper-row {
@@ -506,7 +501,7 @@
 		align-items: flex-start;
 		gap: 0.85rem;
 		opacity: 0.5;
-		transition: opacity 220ms cubic-out;
+		transition: opacity 220ms cubic-bezier(0.33, 1, 0.68, 1);
 	}
 
 	.stepper-row.active {
@@ -529,7 +524,7 @@
 		border: 1.5px solid hsl(210 40% 98% / 0.18);
 		font-weight: 600;
 		font-size: 0.85rem;
-		transition: all 240ms cubic-out;
+		transition: all 240ms cubic-bezier(0.33, 1, 0.68, 1);
 		z-index: 1;
 	}
 

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -274,7 +274,7 @@
 
 <div class="wizard-shell">
 	<!-- Brand / stepper rail -->
-	<aside class="brand-rail" aria-hidden="true">
+	<aside class="brand-rail">
 		<div class="brand-glow brand-glow-a"></div>
 		<div class="brand-glow brand-glow-b"></div>
 		<div class="brand-grid"></div>

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -120,7 +120,7 @@
 		dirsPrefilled = true;
 		try {
 			const { path } = await apiClient.getCurrentWorkingDirectory();
-			if (path && dirs.length === 0) dirs = [path];
+			if (path && dirs.length === 0 && stepIndex <= 1) dirs = [path];
 		} catch {
 			// Non-fatal: the user can still type/browse a directory manually.
 		}

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -55,6 +55,7 @@
 	let availableScrapers = $state<Scraper[]>([]);
 	let selectedScrapers = $state<string[]>([]);
 	let scrapersLoading = $state(false);
+	let scrapersFetched = $state(false);
 
 	let stageEl = $state<HTMLElement | null>(null);
 	let stageHeight = $state<number | null>(null);
@@ -91,7 +92,7 @@
 	}
 
 	async function fetchScrapers() {
-		if (availableScrapers.length > 0 || scrapersLoading) return;
+		if (scrapersFetched || scrapersLoading) return;
 		scrapersLoading = true;
 		try {
 			availableScrapers = await apiClient.getScrapers();
@@ -101,6 +102,7 @@
 			toastStore.error('Could not load available scrapers', 4000);
 		} finally {
 			scrapersLoading = false;
+			scrapersFetched = true;
 		}
 	}
 

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -195,16 +195,18 @@
 
 			const config = await apiClient.getConfig();
 			const sc = (config.scrapers ?? {}) as Record<string, unknown>;
-			sc.priority = [...selectedScrapers];
-			for (const scraper of availableScrapers) {
-				if (!sc[scraper.name]) sc[scraper.name] = {};
-				(sc[scraper.name] as Record<string, unknown>).enabled = selectedScrapers.includes(scraper.name);
+			if (availableScrapers.length > 0) {
+				sc.priority = [...selectedScrapers];
+				for (const scraper of availableScrapers) {
+					if (!sc[scraper.name]) sc[scraper.name] = {};
+					(sc[scraper.name] as Record<string, unknown>).enabled = selectedScrapers.includes(scraper.name);
+				}
+				config.scrapers = sc as typeof config.scrapers;
+				await apiClient.request('/api/v1/config', {
+					method: 'PUT',
+					body: JSON.stringify(config),
+				});
 			}
-			config.scrapers = sc as typeof config.scrapers;
-			await apiClient.request('/api/v1/config', {
-				method: 'PUT',
-				body: JSON.stringify(config),
-			});
 			toastStore.success('Setup complete. Welcome to Javinizer.', 4000);
 			onComplete();
 		} catch (e) {

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -9,6 +9,7 @@
 	import { websocketStore } from '$lib/stores/websocket';
 	import Button from '$lib/components/ui/Button.svelte';
 	import StepCredentials from './StepCredentials.svelte';
+	import StepCredentialsSuccess from './StepCredentialsSuccess.svelte';
 	import StepDirectories from './StepDirectories.svelte';
 	import StepScrapers from './StepScrapers.svelte';
 	import type { Scraper } from '$lib/api/types';
@@ -41,6 +42,16 @@
 	let error = $state<string | null>(null);
 
 	let credentials = $state({ username: '', password: '', confirm: '' });
+
+	// Credentials confirmation interstitial. After the admin account is created
+	// we pause on an explicit acknowledgement screen instead of auto-advancing,
+	// so the user is clearly notified their credentials were registered.
+	let credentialsRegistered = $state(false);
+	let registeredUsername = $state('');
+	let registeredAt = $state(new Date());
+	let sessionActive = $state(false);
+
+	let inCredentialsSuccess = $derived(stepIndex === 0 && credentialsRegistered);
 
 	let dirs = $state<string[]>([]);
 
@@ -93,9 +104,30 @@
 		}
 	}
 
+	// Pre-fill the directories list with a sensible absolute default path so
+	// the user lands on the library step with something to work from instead
+	// of an empty list. /api/v1/cwd returns the first allowed directory if any
+	// are configured, otherwise the process working directory — or, when that
+	// is a root path (desktop app launched from Finder/Explorer, where CWD is
+	// "/" or the bundle dir), an empty string. Only pre-fill once.
+	let dirsPrefilled = $state(false);
+	async function prefillDefaultDir() {
+		if (dirsPrefilled || dirs.length > 0) return;
+		dirsPrefilled = true;
+		try {
+			const { path } = await apiClient.getCurrentWorkingDirectory();
+			if (path && dirs.length === 0) dirs = [path];
+		} catch {
+			// Non-fatal: the user can still type/browse a directory manually.
+		}
+	}
+
 	// Step 1: create the admin account (required to obtain a session for the
 	// protected scraper/config endpoints). This is the only commit before the
 	// final Finish — credentials are irreversible, so Back is hidden afterwards.
+	// Instead of auto-advancing, we reveal a confirmation interstitial so the
+	// user is explicitly notified their credentials were registered; they then
+	// press Continue to proceed to the library folders step.
 	async function handleCredentialsNext() {
 		error = null;
 		if (credentials.password !== credentials.confirm) {
@@ -108,17 +140,26 @@
 				username: credentials.username,
 				password: credentials.password,
 			});
+			registeredUsername = credentials.username;
+			registeredAt = new Date();
+			sessionActive = Boolean(result?.session_id);
 			credentials.password = '';
 			credentials.confirm = '';
 			if (result?.session_id) BaseClient.setSessionID(result.session_id);
 			syncWebSocketAuth();
-			gotoStep(1);
-			toastStore.success('Admin account created', 3000);
+			credentialsRegistered = true;
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Failed to create admin account';
 		} finally {
 			submitting = false;
 		}
+	}
+
+	// Advance from the credentials confirmation interstitial to the directories
+	// step. Only reachable after the account has been successfully registered.
+	function handleCredentialsContinue() {
+		gotoStep(1);
+		toastStore.success('Admin account created', 3000);
 	}
 
 	// Step 2: directories are staged locally; nothing is committed until Finish
@@ -173,12 +214,14 @@
 	}
 
 	function handleNext() {
-		if (stepIndex === 0) void handleCredentialsNext();
+		if (inCredentialsSuccess) void handleCredentialsContinue();
+		else if (stepIndex === 0) void handleCredentialsNext();
 		else if (stepIndex === 1) void handleDirectoriesNext();
 		else void handleScrapersFinish();
 	}
 
 	let canProceed = $derived.by(() => {
+		if (inCredentialsSuccess) return true;
 		if (submitting) return false;
 		if (stepIndex === 0) {
 			return (
@@ -191,7 +234,9 @@
 	});
 
 	let nextLabel = $derived(
-		submitting
+		inCredentialsSuccess
+			? 'Continue to library setup'
+			: submitting
 			? stepIndex === 0
 				? 'Creating…'
 				: isLastStep
@@ -211,6 +256,12 @@
 	// run once the credentials step is complete.
 	$effect(() => {
 		if (stepIndex === 2) void fetchScrapers();
+	});
+
+	// Pre-fill the directories step with a sensible default absolute path as
+	// soon as an authenticated session exists (created in step 1).
+	$effect(() => {
+		if (credentialsRegistered) void prefillDefaultDir();
 	});
 </script>
 
@@ -274,14 +325,20 @@
 		<div class="content-frame">
 			<div class="content-stage"
 				style="height: {stageHeight !== null ? `${stageHeight}px` : 'auto'}; transition: {heightReady ? `height ${TRANSITION_MS}ms cubic-out` : 'none'};">
-				{#key stepIndex}
+				{#key `${stepIndex}-${credentialsRegistered}`}
 					<div
 						class="content-card stage-card"
 						bind:this={stageEl}
 						in:scale|local={{ start: 1.03, duration: TRANSITION_MS, easing: cubicOut }}
 						out:scale|local={{ start: 0.985, duration: TRANSITION_MS, easing: cubicOut }}
 					>
-						{#if stepIndex === 0}
+						{#if stepIndex === 0 && credentialsRegistered}
+							<StepCredentialsSuccess
+								username={registeredUsername}
+								{sessionActive}
+								registeredAt={registeredAt}
+							/>
+						{:else if stepIndex === 0}
 							<StepCredentials bind:credentials {error} {submitting} />
 						{:else if stepIndex === 1}
 							<StepDirectories bind:dirs {error} {submitting} onSkip={handleDirectoriesSkip} />
@@ -320,6 +377,8 @@
 						{#snippet children()}
 							{#if submitting}
 								<Loader2 class="h-4 w-4 animate-spin" />
+							{:else if inCredentialsSuccess}
+								<ArrowRight class="h-4 w-4" />
 							{:else if isLastStep}
 								<Check class="h-4 w-4" />
 							{:else}

--- a/web/frontend/src/lib/components/setup/StepCredentials.svelte
+++ b/web/frontend/src/lib/components/setup/StepCredentials.svelte
@@ -47,7 +47,7 @@
 	</p>
 </div>
 
-<form class="step-body" onsubmit={(e) => { e.preventDefault(); onSubmit?.(); }}>
+<form id="credentials-form" class="step-body" onsubmit={(e) => { e.preventDefault(); onSubmit?.(); }}>
 	{#if error}
 		<div class="alert" role="alert">{error}</div>
 	{/if}
@@ -131,6 +131,8 @@
 		{/if}
 	</label>
 </form>
+
+<button type="submit" form="credentials-form" class="sr-only" aria-hidden="true" tabindex="-1"></button>
 
 <style>
 	.step-head {

--- a/web/frontend/src/lib/components/setup/StepCredentials.svelte
+++ b/web/frontend/src/lib/components/setup/StepCredentials.svelte
@@ -84,7 +84,7 @@
 				type="button"
 				class="field-eye"
 				onclick={() => (showPassword = !showPassword)}
-				tabindex="-1"
+				tabindex="0"
 				aria-label={showPassword ? 'Hide password' : 'Show password'}
 			>
 				{#if showPassword}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
@@ -116,7 +116,7 @@
 				type="button"
 				class="field-eye"
 				onclick={() => (showConfirm = !showConfirm)}
-				tabindex="-1"
+				tabindex="0"
 				aria-label={showConfirm ? 'Hide password' : 'Show password'}
 			>
 				{#if showConfirm}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
@@ -270,7 +270,7 @@
 		display: block;
 		height: 100%;
 		border-radius: 9999px;
-		transition: width 240ms cubic-out, background 240ms;
+		transition: width 240ms cubic-bezier(0.33, 1, 0.68, 1), background 240ms;
 		background: hsl(var(--destructive));
 	}
 

--- a/web/frontend/src/lib/components/setup/StepCredentials.svelte
+++ b/web/frontend/src/lib/components/setup/StepCredentials.svelte
@@ -85,6 +85,7 @@
 				class="field-eye"
 				onclick={() => (showPassword = !showPassword)}
 				tabindex="0"
+				disabled={submitting}
 				aria-label={showPassword ? 'Hide password' : 'Show password'}
 			>
 				{#if showPassword}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
@@ -117,6 +118,7 @@
 				class="field-eye"
 				onclick={() => (showConfirm = !showConfirm)}
 				tabindex="0"
+				disabled={submitting}
 				aria-label={showConfirm ? 'Hide password' : 'Show password'}
 			>
 				{#if showConfirm}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}

--- a/web/frontend/src/lib/components/setup/StepCredentials.svelte
+++ b/web/frontend/src/lib/components/setup/StepCredentials.svelte
@@ -11,10 +11,12 @@
 		credentials = $bindable(),
 		error = null as string | null,
 		submitting = false,
+		onSubmit,
 	}: {
 		credentials: Credentials;
 		error?: string | null;
 		submitting?: boolean;
+		onSubmit?: () => void;
 	} = $props();
 
 	let showPassword = $state(false);
@@ -45,7 +47,7 @@
 	</p>
 </div>
 
-<form class="step-body" onsubmit={(e) => e.preventDefault()}>
+<form class="step-body" onsubmit={(e) => { e.preventDefault(); onSubmit?.(); }}>
 	{#if error}
 		<div class="alert" role="alert">{error}</div>
 	{/if}

--- a/web/frontend/src/lib/components/setup/StepCredentials.svelte
+++ b/web/frontend/src/lib/components/setup/StepCredentials.svelte
@@ -1,0 +1,309 @@
+<script lang="ts">
+	import { ShieldCheck, KeyRound, User, Eye, EyeOff } from 'lucide-svelte';
+
+	interface Credentials {
+		username: string;
+		password: string;
+		confirm: string;
+	}
+
+	let {
+		credentials = $bindable(),
+		error = null as string | null,
+		submitting = false,
+	}: {
+		credentials: Credentials;
+		error?: string | null;
+		submitting?: boolean;
+	} = $props();
+
+	let showPassword = $state(false);
+	let showConfirm = $state(false);
+
+	let passwordStrength = $derived.by(() => {
+		const p = credentials.password;
+		if (p.length === 0) return { score: 0, label: '', pct: 0 };
+		let score = 0;
+		if (p.length >= 8) score++;
+		if (p.length >= 12) score++;
+		if (/[A-Z]/.test(p) && /[a-z]/.test(p)) score++;
+		if (/\d/.test(p) && /[^A-Za-z0-9]/.test(p)) score++;
+		const labels = ['', 'Weak', 'Fair', 'Good', 'Strong'];
+		return { score, label: labels[score], pct: (score / 4) * 100 };
+	});
+
+	let match = $derived(
+		credentials.confirm.length === 0 || credentials.password === credentials.confirm,
+	);
+</script>
+
+<div class="step-head">
+	<div class="step-badge"><ShieldCheck class="h-5 w-5" /></div>
+	<h1 class="step-title">Create your admin account</h1>
+	<p class="step-sub">
+		This becomes the master login for this Javinizer server. You can add more users later.
+	</p>
+</div>
+
+<form class="step-body" onsubmit={(e) => e.preventDefault()}>
+	{#if error}
+		<div class="alert" role="alert">{error}</div>
+	{/if}
+
+	<label class="field">
+		<span class="field-label">Username</span>
+		<div class="field-control">
+			<User class="field-icon" />
+			<input
+				class="field-input pl-9"
+				type="text"
+				required
+				autocomplete="username"
+				placeholder="admin"
+				bind:value={credentials.username}
+				disabled={submitting}
+			/>
+		</div>
+	</label>
+
+	<label class="field">
+		<span class="field-label">Password</span>
+		<div class="field-control">
+			<KeyRound class="field-icon" />
+			<input
+				class="field-input pl-9 pr-9"
+				type={showPassword ? 'text' : 'password'}
+				required
+				minlength="8"
+				autocomplete="new-password"
+				placeholder="At least 8 characters"
+				bind:value={credentials.password}
+				disabled={submitting}
+			/>
+			<button
+				type="button"
+				class="field-eye"
+				onclick={() => (showPassword = !showPassword)}
+				tabindex="-1"
+				aria-label={showPassword ? 'Hide password' : 'Show password'}
+			>
+				{#if showPassword}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+			</button>
+		</div>
+		{#if credentials.password.length > 0}
+			<div class="strength">
+				<div class="strength-bar"><span class="strength-fill" data-score={passwordStrength.score} style="width: {passwordStrength.pct}%"></span></div>
+				<span class="strength-label" data-score={passwordStrength.score}>{passwordStrength.label}</span>
+			</div>
+		{/if}
+	</label>
+
+	<label class="field">
+		<span class="field-label">Confirm password</span>
+		<div class="field-control">
+			<KeyRound class="field-icon" />
+			<input
+				class="field-input pl-9 pr-9"
+				type={showConfirm ? 'text' : 'password'}
+				required
+				minlength="8"
+				autocomplete="new-password"
+				placeholder="Re-enter password"
+				bind:value={credentials.confirm}
+				disabled={submitting}
+			/>
+			<button
+				type="button"
+				class="field-eye"
+				onclick={() => (showConfirm = !showConfirm)}
+				tabindex="-1"
+				aria-label={showConfirm ? 'Hide password' : 'Show password'}
+			>
+				{#if showConfirm}<EyeOff class="h-4 w-4" />{:else}<Eye class="h-4 w-4" />{/if}
+			</button>
+		</div>
+		{#if credentials.confirm.length > 0 && !match}
+			<span class="field-hint field-hint-error">Passwords do not match</span>
+		{/if}
+	</label>
+</form>
+
+<style>
+	.step-head {
+		margin-bottom: 1.5rem;
+	}
+
+	.step-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 44px;
+		height: 44px;
+		border-radius: 12px;
+		background: hsl(var(--primary) / 0.12);
+		color: hsl(var(--primary));
+		margin-bottom: 0.85rem;
+	}
+
+	.step-title {
+		font-size: 1.6rem;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		line-height: 1.15;
+	}
+
+	.step-sub {
+		margin-top: 0.4rem;
+		color: hsl(var(--muted-foreground));
+		font-size: 0.92rem;
+		line-height: 1.5;
+	}
+
+	.step-body {
+		display: flex;
+		flex-direction: column;
+		gap: 1.1rem;
+	}
+
+	.alert {
+		border: 1px solid hsl(var(--destructive) / 0.4);
+		background: hsl(var(--destructive) / 0.1);
+		color: hsl(var(--destructive));
+		padding: 0.55rem 0.75rem;
+		border-radius: 0.5rem;
+		font-size: 0.85rem;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.field-label {
+		font-size: 0.82rem;
+		font-weight: 600;
+	}
+
+	.field-control {
+		position: relative;
+		display: flex;
+		align-items: center;
+	}
+
+	:global(.field-icon) {
+		position: absolute;
+		left: 0.7rem;
+		width: 16px;
+		height: 16px;
+		color: hsl(var(--muted-foreground));
+		pointer-events: none;
+	}
+
+	.field-input {
+		width: 100%;
+		border: 1px solid hsl(var(--border));
+		background: hsl(var(--background));
+		border-radius: 0.5rem;
+		padding: 0.6rem 0.75rem;
+		font-size: 0.92rem;
+		outline: none;
+		transition: border-color 160ms, box-shadow 160ms;
+	}
+
+	.field-input:focus {
+		border-color: hsl(var(--primary));
+		box-shadow: 0 0 0 3px hsl(var(--primary) / 0.18);
+	}
+
+	.field-input:disabled {
+		opacity: 0.6;
+	}
+
+	.field-input.pl-9 {
+		padding-left: 2.5rem;
+	}
+
+	.field-input.pr-9 {
+		padding-right: 2.5rem;
+	}
+
+	.field-eye {
+		position: absolute;
+		right: 0.5rem;
+		display: inline-flex;
+		padding: 0.3rem;
+		border-radius: 0.375rem;
+		color: hsl(var(--muted-foreground));
+		background: transparent;
+		border: none;
+		cursor: pointer;
+	}
+
+	.field-eye:hover {
+		color: hsl(var(--foreground));
+	}
+
+	.field-hint {
+		font-size: 0.78rem;
+	}
+
+	.field-hint-error {
+		color: hsl(var(--destructive));
+	}
+
+	.strength {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+	}
+
+	.strength-bar {
+		flex: 1;
+		height: 5px;
+		border-radius: 9999px;
+		background: hsl(var(--muted));
+		overflow: hidden;
+	}
+
+	.strength-fill {
+		display: block;
+		height: 100%;
+		border-radius: 9999px;
+		transition: width 240ms cubic-out, background 240ms;
+		background: hsl(var(--destructive));
+	}
+
+	.strength-fill[data-score='2'] {
+		background: hsl(38 92% 50%);
+	}
+
+	.strength-fill[data-score='3'] {
+		background: hsl(142 71% 45%);
+	}
+
+	.strength-fill[data-score='4'] {
+		background: hsl(152 76% 40%);
+	}
+
+	.strength-label {
+		font-size: 0.72rem;
+		font-weight: 600;
+		min-width: 3rem;
+		text-align: right;
+		color: hsl(var(--muted-foreground));
+	}
+
+	.strength-label[data-score='1'] {
+		color: hsl(var(--destructive));
+	}
+
+	.strength-label[data-score='2'] {
+		color: hsl(38 92% 45%);
+	}
+
+	.strength-label[data-score='3'],
+	.strength-label[data-score='4'] {
+		color: hsl(142 71% 40%);
+	}
+</style>

--- a/web/frontend/src/lib/components/setup/StepCredentialsSuccess.svelte
+++ b/web/frontend/src/lib/components/setup/StepCredentialsSuccess.svelte
@@ -1,0 +1,399 @@
+<script lang="ts">
+	import { fly, scale } from 'svelte/transition';
+	import { cubicOut, quintOut } from 'svelte/easing';
+	import { ShieldCheck, Fingerprint } from 'lucide-svelte';
+
+	interface Props {
+		username: string;
+		sessionActive: boolean;
+		registeredAt: Date;
+	}
+
+	let { username, sessionActive, registeredAt }: Props = $props();
+
+	let time = $derived(
+		registeredAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+	);
+	let date = $derived(
+		registeredAt
+			.toLocaleDateString([], { year: 'numeric', month: 'short', day: '2-digit' })
+			.toUpperCase(),
+	);
+</script>
+
+<svelte:head>
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+	<link
+		href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap"
+		rel="stylesheet"
+	/>
+</svelte:head>
+
+<div class="success">
+	<!-- Emblem -->
+	<div class="emblem" in:scale={{ start: 0.6, duration: 520, easing: quintOut }}>
+		<div class="emblem-burst"></div>
+		<svg class="emblem-ring" viewBox="0 0 120 120" aria-hidden="true">
+			<circle
+				class="ring-track"
+				cx="60"
+				cy="60"
+				r="52"
+				fill="none"
+				stroke-width="3"
+			/>
+			<circle
+				class="ring-fill"
+				cx="60"
+				cy="60"
+				r="52"
+				fill="none"
+				stroke-width="3"
+				stroke-linecap="round"
+				pathLength="100"
+			/>
+			<path
+				class="ring-check"
+				d="M42 61 L54 73 L80 47"
+				fill="none"
+				stroke-width="4.5"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				pathLength="100"
+			/>
+		</svg>
+		<div class="emblem-core">
+			<ShieldCheck class="emblem-icon" />
+		</div>
+	</div>
+
+	<!-- Heading -->
+	<div class="head" in:fly={{ y: 14, duration: 460, delay: 280, easing: cubicOut }}>
+		<span class="kicker">Account Registered</span>
+		<h1 class="title">Your admin account is secured</h1>
+		<p class="sub">
+			Credentials have been registered and your session is now active. Keep these
+			details safe — you'll use them to sign in to Javinizer.
+		</p>
+	</div>
+
+	<!-- Credential receipt -->
+	<dl class="receipt" in:fly={{ y: 18, duration: 480, delay: 420, easing: cubicOut }}>
+		<div class="receipt-top">
+			<span class="receipt-stamp">
+				<Fingerprint class="h-3.5 w-3.5" />
+				Javinizer · Credential Receipt
+			</span>
+			<span class="receipt-no">№ {username.slice(0, 4).toUpperCase().padEnd(4, '0')}-{registeredAt.getTime().toString().slice(-4)}</span>
+		</div>
+
+		<div class="receipt-rows">
+			<div class="receipt-row">
+				<dt>Username</dt>
+				<dd class="mono">{username}</dd>
+			</div>
+			<div class="receipt-row">
+				<dt>Password</dt>
+				<dd class="mono masked" aria-label="password hidden">
+					<span class="masked-bullets">
+						{#each [...Array(8).keys()] as i (i)}<span class="dot" style="animation-delay: {600 + i * 60}ms"></span>{/each}
+					</span>
+				</dd>
+			</div>
+			<div class="receipt-row">
+				<dt>Registered</dt>
+				<dd class="mono">{date} · {time}</dd>
+			</div>
+			<div class="receipt-row">
+				<dt>Session</dt>
+				<dd class="session">
+					<span class="session-dot" class:active={sessionActive}></span>
+					{sessionActive ? 'Active' : 'Pending'}
+				</dd>
+			</div>
+		</div>
+
+		<div class="receipt-perf"></div>
+		<div class="receipt-foot">
+			<span>Receipt issued locally · no data leaves this server</span>
+		</div>
+	</dl>
+</div>
+
+<style>
+	.success {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		gap: 1.35rem;
+		padding: 0.5rem 0 0.25rem;
+	}
+
+	/* ---- Emblem ---- */
+	.emblem {
+		position: relative;
+		width: 104px;
+		height: 104px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.emblem-burst {
+		position: absolute;
+		inset: -22px;
+		border-radius: 9999px;
+		background:
+			radial-gradient(circle at 50% 50%, hsl(152 76% 42% / 0.32) 0%, transparent 62%),
+			conic-gradient(from 0deg, hsl(152 76% 45% / 0.18), transparent 25%, hsl(217 91% 60% / 0.16), transparent 60%, hsl(152 76% 45% / 0.18));
+		filter: blur(6px);
+		animation: burst 900ms cubic-out both;
+	}
+
+	@keyframes burst {
+		from { opacity: 0; transform: scale(0.5); }
+		to { opacity: 1; transform: scale(1); }
+	}
+
+	.emblem-ring {
+		position: absolute;
+		width: 104px;
+		height: 104px;
+		overflow: visible;
+	}
+
+	.ring-track {
+		stroke: hsl(var(--border));
+	}
+
+	.ring-fill {
+		stroke: hsl(152 71% 45%);
+		stroke-dasharray: 100;
+		stroke-dashoffset: 100;
+		transform: rotate(-90deg);
+		transform-origin: 60px 60px;
+		animation: draw-ring 760ms cubic-bezier(0.65, 0, 0.35, 1) 120ms forwards;
+		filter: drop-shadow(0 0 6px hsl(152 71% 50% / 0.45));
+	}
+
+	@keyframes draw-ring {
+		to { stroke-dashoffset: 0; }
+	}
+
+	.ring-check {
+		stroke: hsl(152 71% 42%);
+		stroke-dasharray: 100;
+		stroke-dashoffset: 100;
+		animation: draw-check 360ms cubic-out 720ms forwards;
+		filter: drop-shadow(0 1px 2px hsl(152 71% 45% / 0.4));
+	}
+
+	@keyframes draw-check {
+		to { stroke-dashoffset: 0; }
+	}
+
+	.emblem-core {
+		position: relative;
+		width: 56px;
+		height: 56px;
+		border-radius: 9999px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: hsl(152 71% 96%);
+		border: 1px solid hsl(152 71% 80%);
+		box-shadow: inset 0 0 0 3px hsl(0 0% 100% / 0.6);
+		animation: core-in 420ms cubic-out 560ms both;
+	}
+
+	@keyframes core-in {
+		from { opacity: 0; transform: scale(0.4); }
+		to { opacity: 1; transform: scale(1); }
+	}
+
+	:global(.emblem-icon) {
+		width: 26px;
+		height: 26px;
+		color: hsl(152 71% 38%);
+	}
+
+	/* ---- Heading ---- */
+	.head {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.35rem;
+	}
+
+	.kicker {
+		font-family: 'Space Mono', ui-monospace, monospace;
+		font-size: 0.68rem;
+		font-weight: 700;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: hsl(152 71% 40%);
+	}
+
+	.title {
+		font-family: 'Bricolage Grotesque', ui-sans-serif, system-ui, sans-serif;
+		font-size: 1.7rem;
+		font-weight: 700;
+		letter-spacing: -0.025em;
+		line-height: 1.12;
+	}
+
+	.sub {
+		max-width: 30rem;
+		font-size: 0.9rem;
+		line-height: 1.55;
+		color: hsl(var(--muted-foreground));
+	}
+
+	/* ---- Receipt ---- */
+	.receipt {
+		width: 100%;
+		max-width: 26rem;
+		margin-top: 0.4rem;
+		background: hsl(var(--card));
+		border: 1.5px dashed hsl(var(--border));
+		border-radius: 14px;
+		padding: 1.1rem 1.25rem 0;
+		position: relative;
+		box-shadow: 0 18px 40px -24px hsl(222 84% 4% / 0.3);
+	}
+
+	.receipt-top {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding-bottom: 0.85rem;
+		border-bottom: 1px dashed hsl(var(--border));
+	}
+
+	.receipt-stamp {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		font-family: 'Space Mono', ui-monospace, monospace;
+		font-size: 0.66rem;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: hsl(var(--muted-foreground));
+	}
+
+	.receipt-no {
+		font-family: 'Space Mono', ui-monospace, monospace;
+		font-size: 0.62rem;
+		color: hsl(var(--muted-foreground));
+		opacity: 0.8;
+	}
+
+	.receipt-rows {
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+		padding: 0.95rem 0 1.1rem;
+	}
+
+	.receipt-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.receipt-row dt {
+		font-size: 0.72rem;
+		font-weight: 600;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: hsl(var(--muted-foreground));
+	}
+
+	.receipt-row dd {
+		font-size: 0.88rem;
+		font-weight: 600;
+		color: hsl(var(--foreground));
+	}
+
+	.mono {
+		font-family: 'Space Mono', ui-monospace, monospace;
+		font-weight: 700;
+		letter-spacing: -0.01em;
+	}
+
+	.masked-bullets {
+		display: inline-flex;
+		gap: 0.4rem;
+		align-items: center;
+	}
+
+	.dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 9999px;
+		background: hsl(var(--foreground));
+		opacity: 1;
+		animation: dot-in 220ms cubic-out both;
+	}
+
+	@keyframes dot-in {
+		from { opacity: 0; transform: translateY(3px); }
+		to { opacity: 1; transform: translateY(0); }
+	}
+
+	.session {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		color: hsl(var(--muted-foreground));
+		font-family: 'Space Mono', ui-monospace, monospace;
+		font-size: 0.78rem;
+		font-weight: 700;
+	}
+
+	.session-dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 9999px;
+		background: hsl(var(--muted-foreground));
+		opacity: 0.5;
+	}
+
+	.session-dot.active {
+		background: hsl(152 71% 45%);
+		opacity: 1;
+		box-shadow: 0 0 0 3px hsl(152 71% 45% / 0.18);
+		animation: pulse 1.8s ease-in-out infinite;
+	}
+
+	@keyframes pulse {
+		0%, 100% { box-shadow: 0 0 0 3px hsl(152 71% 45% / 0.18); }
+		50% { box-shadow: 0 0 0 5px hsl(152 71% 45% / 0.08); }
+	}
+
+	.receipt-perf {
+		height: 10px;
+		margin: 0 -1.25rem;
+		background:
+			radial-gradient(circle at 5px -2px, transparent 5px, hsl(var(--card)) 5.5px) repeat-x,
+			hsl(var(--card));
+		background-size: 10px 10px;
+		mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+	}
+
+	.receipt-foot {
+		padding: 0.6rem 0 0.9rem;
+		font-family: 'Space Mono', ui-monospace, monospace;
+		font-size: 0.6rem;
+		letter-spacing: 0.05em;
+		color: hsl(var(--muted-foreground));
+		opacity: 0.75;
+		text-align: center;
+	}
+
+</style>

--- a/web/frontend/src/lib/components/setup/StepCredentialsSuccess.svelte
+++ b/web/frontend/src/lib/components/setup/StepCredentialsSuccess.svelte
@@ -21,14 +21,7 @@
 	);
 </script>
 
-<svelte:head>
-	<link rel="preconnect" href="https://fonts.googleapis.com" />
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link
-		href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap"
-		rel="stylesheet"
-	/>
-</svelte:head>
+
 
 <div class="success">
 	<!-- Emblem -->
@@ -149,7 +142,7 @@
 			radial-gradient(circle at 50% 50%, hsl(152 76% 42% / 0.32) 0%, transparent 62%),
 			conic-gradient(from 0deg, hsl(152 76% 45% / 0.18), transparent 25%, hsl(217 91% 60% / 0.16), transparent 60%, hsl(152 76% 45% / 0.18));
 		filter: blur(6px);
-		animation: burst 900ms cubic-out both;
+		animation: burst 900ms cubic-bezier(0.33, 1, 0.68, 1) both;
 	}
 
 	@keyframes burst {
@@ -186,7 +179,7 @@
 		stroke: hsl(152 71% 42%);
 		stroke-dasharray: 100;
 		stroke-dashoffset: 100;
-		animation: draw-check 360ms cubic-out 720ms forwards;
+		animation: draw-check 360ms cubic-bezier(0.33, 1, 0.68, 1) 720ms forwards;
 		filter: drop-shadow(0 1px 2px hsl(152 71% 45% / 0.4));
 	}
 
@@ -205,7 +198,7 @@
 		background: hsl(152 71% 96%);
 		border: 1px solid hsl(152 71% 80%);
 		box-shadow: inset 0 0 0 3px hsl(0 0% 100% / 0.6);
-		animation: core-in 420ms cubic-out 560ms both;
+		animation: core-in 420ms cubic-bezier(0.33, 1, 0.68, 1) 560ms both;
 	}
 
 	@keyframes core-in {
@@ -228,7 +221,7 @@
 	}
 
 	.kicker {
-		font-family: 'Space Mono', ui-monospace, monospace;
+		font-family: ui-monospace, 'SF Mono', 'Cascadia Code', 'Menlo', monospace;
 		font-size: 0.68rem;
 		font-weight: 700;
 		letter-spacing: 0.22em;
@@ -237,7 +230,7 @@
 	}
 
 	.title {
-		font-family: 'Bricolage Grotesque', ui-sans-serif, system-ui, sans-serif;
+		font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
 		font-size: 1.7rem;
 		font-weight: 700;
 		letter-spacing: -0.025em;
@@ -277,7 +270,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.35rem;
-		font-family: 'Space Mono', ui-monospace, monospace;
+		font-family: ui-monospace, 'SF Mono', 'Cascadia Code', 'Menlo', monospace;
 		font-size: 0.66rem;
 		font-weight: 700;
 		letter-spacing: 0.1em;
@@ -286,7 +279,7 @@
 	}
 
 	.receipt-no {
-		font-family: 'Space Mono', ui-monospace, monospace;
+		font-family: ui-monospace, 'SF Mono', 'Cascadia Code', 'Menlo', monospace;
 		font-size: 0.62rem;
 		color: hsl(var(--muted-foreground));
 		opacity: 0.8;
@@ -321,7 +314,7 @@
 	}
 
 	.mono {
-		font-family: 'Space Mono', ui-monospace, monospace;
+		font-family: ui-monospace, 'SF Mono', 'Cascadia Code', 'Menlo', monospace;
 		font-weight: 700;
 		letter-spacing: -0.01em;
 	}
@@ -338,7 +331,7 @@
 		border-radius: 9999px;
 		background: hsl(var(--foreground));
 		opacity: 1;
-		animation: dot-in 220ms cubic-out both;
+		animation: dot-in 220ms cubic-bezier(0.33, 1, 0.68, 1) both;
 	}
 
 	@keyframes dot-in {
@@ -351,7 +344,7 @@
 		align-items: center;
 		gap: 0.4rem;
 		color: hsl(var(--muted-foreground));
-		font-family: 'Space Mono', ui-monospace, monospace;
+		font-family: ui-monospace, 'SF Mono', 'Cascadia Code', 'Menlo', monospace;
 		font-size: 0.78rem;
 		font-weight: 700;
 	}
@@ -388,7 +381,7 @@
 
 	.receipt-foot {
 		padding: 0.6rem 0 0.9rem;
-		font-family: 'Space Mono', ui-monospace, monospace;
+		font-family: ui-monospace, 'SF Mono', 'Cascadia Code', 'Menlo', monospace;
 		font-size: 0.6rem;
 		letter-spacing: 0.05em;
 		color: hsl(var(--muted-foreground));

--- a/web/frontend/src/lib/components/setup/StepDirectories.svelte
+++ b/web/frontend/src/lib/components/setup/StepDirectories.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { FolderCheck } from 'lucide-svelte';
+	import AllowedDirectoriesEditor from '$lib/components/AllowedDirectoriesEditor.svelte';
+
+	let {
+		dirs = $bindable(),
+		error = null as string | null,
+		submitting = false,
+		onSkip,
+	}: {
+		dirs: string[];
+		error?: string | null;
+		submitting?: boolean;
+		onSkip?: () => void;
+	} = $props();
+</script>
+
+<div class="step-head">
+	<div class="step-badge"><FolderCheck class="h-5 w-5" /></div>
+	<h1 class="step-title">Point Javinizer at your library</h1>
+	<p class="step-sub">
+		Add the folders that hold your video files. Javinizer can only read and write inside these
+		locations — add as many as you need.
+	</p>
+</div>
+
+{#if error}
+	<div class="alert" role="alert">{error}</div>
+{/if}
+
+<div class="editor-wrap" class:disabled={submitting}>
+	<AllowedDirectoriesEditor
+		bind:directories={dirs}
+		whitelistPaths={dirs}
+		emptyHint="No directories added yet. Add one below to enable scanning, or skip and add later."
+	/>
+</div>
+
+<style>
+	.step-head {
+		margin-bottom: 1.5rem;
+	}
+
+	.step-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 44px;
+		height: 44px;
+		border-radius: 12px;
+		background: hsl(var(--primary) / 0.12);
+		color: hsl(var(--primary));
+		margin-bottom: 0.85rem;
+	}
+
+	.step-title {
+		font-size: 1.6rem;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		line-height: 1.15;
+	}
+
+	.step-sub {
+		margin-top: 0.4rem;
+		color: hsl(var(--muted-foreground));
+		font-size: 0.92rem;
+		line-height: 1.5;
+	}
+
+	.alert {
+		border: 1px solid hsl(var(--destructive) / 0.4);
+		background: hsl(var(--destructive) / 0.1);
+		color: hsl(var(--destructive));
+		padding: 0.55rem 0.75rem;
+		border-radius: 0.5rem;
+		font-size: 0.85rem;
+		margin-bottom: 1rem;
+	}
+
+	.editor-wrap.disabled {
+		opacity: 0.6;
+		pointer-events: none;
+	}
+</style>

--- a/web/frontend/src/lib/components/setup/StepDirectories.svelte
+++ b/web/frontend/src/lib/components/setup/StepDirectories.svelte
@@ -6,12 +6,10 @@
 		dirs = $bindable(),
 		error = null as string | null,
 		submitting = false,
-		onSkip,
 	}: {
 		dirs: string[];
 		error?: string | null;
 		submitting?: boolean;
-		onSkip?: () => void;
 	} = $props();
 </script>
 

--- a/web/frontend/src/lib/components/setup/StepScrapers.svelte
+++ b/web/frontend/src/lib/components/setup/StepScrapers.svelte
@@ -17,7 +17,6 @@
 		submitting?: boolean;
 	} = $props();
 
-	let wizardScrapers = $derived(scrapers.map((s) => ({ ...s, enabled: true })));
 	let hasScrapers = $derived(scrapers.length > 0);
 	let selectedCount = $derived(selected.length);
 </script>
@@ -47,7 +46,7 @@
 	</div>
 {:else}
 	<div class="selector-wrap" class:disabled={submitting}>
-		<ScraperSelector scrapers={wizardScrapers} bind:selected={selected} disabled={submitting} />
+		<ScraperSelector scrapers={scrapers} bind:selected={selected} disabled={submitting} showAll={true} />
 	</div>
 
 	<div class="summary">

--- a/web/frontend/src/lib/components/setup/StepScrapers.svelte
+++ b/web/frontend/src/lib/components/setup/StepScrapers.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+	import { Sparkles, Loader2 } from 'lucide-svelte';
+	import ScraperSelector from '$lib/components/ScraperSelector.svelte';
+	import type { Scraper } from '$lib/api/types';
+
+	let {
+		selected = $bindable(),
+		scrapers = [] as Scraper[],
+		loading = false,
+		error = null as string | null,
+		submitting = false,
+	}: {
+		selected: string[];
+		scrapers: Scraper[];
+		loading?: boolean;
+		error?: string | null;
+		submitting?: boolean;
+	} = $props();
+
+	let wizardScrapers = $derived(scrapers.map((s) => ({ ...s, enabled: true })));
+	let hasScrapers = $derived(scrapers.length > 0);
+	let selectedCount = $derived(selected.length);
+</script>
+
+<div class="step-head">
+	<div class="step-badge"><Sparkles class="h-5 w-5" /></div>
+	<h1 class="step-title">Choose your metadata sources</h1>
+	<p class="step-sub">
+		Pick the scrapers Javinizer will query for metadata and arrange them by priority — higher means a
+		source wins when fields conflict. You can fine-tune each scraper's options later in Settings.
+	</p>
+</div>
+
+{#if error}
+	<div class="alert" role="alert">{error}</div>
+{/if}
+
+{#if loading}
+	<div class="state">
+		<Loader2 class="h-5 w-5 animate-spin" />
+		<span>Loading scrapers…</span>
+	</div>
+{:else if !hasScrapers}
+	<div class="state">
+		<p>No scrapers reported by the API.</p>
+		<p class="state-hint">You can configure scrapers later in Settings → Scrapers.</p>
+	</div>
+{:else}
+	<div class="selector-wrap" class:disabled={submitting}>
+		<ScraperSelector scrapers={wizardScrapers} bind:selected={selected} disabled={submitting} />
+	</div>
+
+	<div class="summary">
+		<span class="summary-dot" data-on={selectedCount > 0}></span>
+		{#if selectedCount === 0}
+			<span>No scrapers selected — scraping will be unavailable until you enable some.</span>
+		{:else}
+			<span><strong>{selectedCount}</strong> scraper{selectedCount > 1 ? 's' : ''} selected, ordered by priority.</span>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.step-head {
+		margin-bottom: 1.5rem;
+	}
+
+	.step-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 44px;
+		height: 44px;
+		border-radius: 12px;
+		background: hsl(var(--primary) / 0.12);
+		color: hsl(var(--primary));
+		margin-bottom: 0.85rem;
+	}
+
+	.step-title {
+		font-size: 1.6rem;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		line-height: 1.15;
+	}
+
+	.step-sub {
+		margin-top: 0.4rem;
+		color: hsl(var(--muted-foreground));
+		font-size: 0.92rem;
+		line-height: 1.5;
+	}
+
+	.alert {
+		border: 1px solid hsl(var(--destructive) / 0.4);
+		background: hsl(var(--destructive) / 0.1);
+		color: hsl(var(--destructive));
+		padding: 0.55rem 0.75rem;
+		border-radius: 0.5rem;
+		font-size: 0.85rem;
+		margin-bottom: 1rem;
+	}
+
+	.state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 2.5rem 1rem;
+		text-align: center;
+		color: hsl(var(--muted-foreground));
+		font-size: 0.9rem;
+	}
+
+	.state-hint {
+		font-size: 0.8rem;
+	}
+
+	.selector-wrap.disabled {
+		opacity: 0.6;
+		pointer-events: none;
+	}
+
+	.summary {
+		margin-top: 1rem;
+		display: flex;
+		align-items: center;
+		gap: 0.55rem;
+		padding: 0.6rem 0.8rem;
+		border-radius: 0.5rem;
+		background: hsl(var(--muted) / 0.5);
+		font-size: 0.82rem;
+		color: hsl(var(--muted-foreground));
+	}
+
+	.summary strong {
+		color: hsl(var(--foreground));
+	}
+
+	.summary-dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 9999px;
+		background: hsl(var(--muted-foreground) / 0.5);
+	}
+
+	.summary-dot[data-on='true'] {
+		background: hsl(142 71% 45%);
+		box-shadow: 0 0 8px hsl(142 71% 45% / 0.6);
+	}
+</style>

--- a/web/frontend/src/lib/utils/storage.ts
+++ b/web/frontend/src/lib/utils/storage.ts
@@ -9,11 +9,15 @@ export function clearClientStorage(): void {
 
 	try {
 		const cookies = document.cookie.split(';');
+		const hostname = location.hostname;
 		for (const raw of cookies) {
 			const name = raw.split('=')[0]?.trim();
 			if (!name) continue;
 			document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; max-age=0`;
-			document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=${location.hostname}; max-age=0`;
+			if (hostname) {
+				document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=${hostname}; max-age=0`;
+				document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=.${hostname}; max-age=0`;
+			}
 		}
 	} catch {
 		// ignore cookie access errors

--- a/web/frontend/src/lib/utils/storage.ts
+++ b/web/frontend/src/lib/utils/storage.ts
@@ -1,0 +1,20 @@
+export function clearClientStorage(): void {
+	if (typeof window === 'undefined') return;
+
+	try {
+		localStorage.clear();
+	} catch {
+		// localStorage may be unavailable in private mode or sandboxed frames
+	}
+
+	try {
+		const cookies = document.cookie.split(';');
+		for (const raw of cookies) {
+			const name = raw.split('=')[0]?.trim();
+			if (!name) continue;
+			document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; max-age=0`;
+		}
+	} catch {
+		// ignore cookie access errors
+	}
+}

--- a/web/frontend/src/lib/utils/storage.ts
+++ b/web/frontend/src/lib/utils/storage.ts
@@ -13,6 +13,7 @@ export function clearClientStorage(): void {
 			const name = raw.split('=')[0]?.trim();
 			if (!name) continue;
 			document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; max-age=0`;
+			document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=${location.hostname}; max-age=0`;
 		}
 	} catch {
 		// ignore cookie access errors

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -9,16 +9,13 @@
 	import DialogContainer from '$lib/components/ui/DialogContainer.svelte';
 	import BackgroundJobIndicator from '$lib/components/BackgroundJobIndicator.svelte';
 	import ProgressModal from '$lib/components/ProgressModal.svelte';
-	import AllowedDirectoriesEditor from '$lib/components/AllowedDirectoriesEditor.svelte';
-	import Button from '$lib/components/ui/Button.svelte';
 	import { apiClient } from '$lib/api/client';
 	import { BaseClient } from '$lib/api/clients/common';
 	import { websocketStore } from '$lib/stores/websocket';
-	import { toastStore } from '$lib/stores/toast';
 	import { getBackgroundJobState, reopenModal, dismiss, closeModal } from '$lib/stores/background-job.svelte';
 	import { getQueryClient } from '$lib/query/client';
 	import { getThemeStore } from '$lib/stores/theme.svelte';
-	import { Save, FolderCheck, ArrowRight } from 'lucide-svelte';
+	import SetupWizard from '$lib/components/setup/SetupWizard.svelte';
 	import '../app.css';
 
 	let { children } = $props();
@@ -33,20 +30,9 @@
 	let authAuthenticated = $state(false);
 	let authUsername = $state('');
 	let authError = $state<string | null>(null);
-	let setupUsername = $state('');
-	let setupPassword = $state('');
-	let setupPasswordConfirm = $state('');
 	let loginUsername = $state('');
 	let loginPassword = $state('');
 	let loginRememberMe = $state(true);
-	let setupNeedsDirs = $state(false);
-	let setupDirs = $state<string[]>([]);
-	let setupDirsSubmitting = $state(false);
-	let setupSecurityDefaults = $state({
-		denied_directories: [] as string[],
-		allow_unc: false,
-		allowed_unc_servers: [] as string[],
-	});
 
 	function syncWebSocketAuthState() {
 		if (authAuthenticated) {
@@ -77,86 +63,6 @@
 			authLoading = false;
 			syncWebSocketAuthState();
 		}
-	}
-
-	async function handleSetupSubmit(event: SubmitEvent) {
-		event.preventDefault();
-		authError = null;
-
-		if (setupPassword !== setupPasswordConfirm) {
-			authError = 'Passwords do not match';
-			return;
-		}
-
-		authSubmitting = true;
-		try {
-			const setupResult = await apiClient.setupAuth({
-				username: setupUsername,
-				password: setupPassword
-			});
-			setupPassword = '';
-			setupPasswordConfirm = '';
-			if (setupResult?.session_id) { BaseClient.setSessionID(setupResult.session_id); }
-			loginPassword = '';
-			await refreshAuthStatus();
-			if (authAuthenticated) {
-				setupNeedsDirs = true;
-				try {
-					const fresh = await apiClient.getConfig();
-					const sec = fresh?.api?.security;
-					setupSecurityDefaults = {
-						denied_directories: [...(sec?.denied_directories ?? [])],
-						allow_unc: sec?.allow_unc ?? false,
-						allowed_unc_servers: [...(sec?.allowed_unc_servers ?? [])],
-					};
-					setupDirs = [...(sec?.allowed_directories ?? [])];
-				} catch (error) {
-					setupSecurityDefaults = {
-						denied_directories: [],
-						allow_unc: false,
-						allowed_unc_servers: [],
-					};
-					setupDirs = [];
-					authError = error instanceof Error
-						? `Failed to load current security settings: ${error.message}. You can still save allowed directories below.`
-						: 'Failed to load current security settings. You can still save allowed directories below.';
-				}
-			}
-		} catch (error) {
-			authError = error instanceof Error ? error.message : 'Failed to initialize authentication';
-		} finally {
-			authSubmitting = false;
-		}
-	}
-
-	async function handleSetupDirsSubmit(event: SubmitEvent) {
-		event.preventDefault();
-		authError = null;
-		setupDirsSubmitting = true;
-		try {
-			await apiClient.updateSecurityConfig({
-				allowed_directories: setupDirs,
-				denied_directories: setupSecurityDefaults.denied_directories,
-				allow_unc: setupSecurityDefaults.allow_unc,
-				allowed_unc_servers: setupSecurityDefaults.allowed_unc_servers,
-			});
-			setupNeedsDirs = false;
-			if (setupDirs.length > 0) {
-				toastStore.success('Allowed directories saved. Ready to scan.', 4000);
-			} else {
-				toastStore.info('You can add allowed directories later in Settings → Security.', 5000);
-			}
-		} catch (error) {
-			authError = error instanceof Error ? error.message : 'Failed to save allowed directories';
-		} finally {
-			setupDirsSubmitting = false;
-		}
-	}
-
-	function handleSetupDirsSkip() {
-		setupNeedsDirs = false;
-		setupDirs = [];
-		toastStore.info('You can add allowed directories later in Settings → Security.', 5000);
 	}
 
 	async function handleLoginSubmit(event: SubmitEvent) {
@@ -241,23 +147,15 @@
 			</button>
 		</div>
 	</div>
+{:else if !authInitialized}
+	<SetupWizard onComplete={() => { authInitialized = true; authAuthenticated = true; syncWebSocketAuthState(); }} />
 {:else if !authAuthenticated}
 	<div class="min-h-screen bg-background flex items-center justify-center px-4 py-10">
 		<div class="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm space-y-4">
 			<div class="space-y-1">
-				<h1 class="text-2xl font-bold">
-					{#if authInitialized}
-						Login Required
-					{:else}
-						First-Time Setup
-					{/if}
-				</h1>
+				<h1 class="text-2xl font-bold">Login Required</h1>
 				<p class="text-sm text-muted-foreground">
-					{#if authInitialized}
-						Sign in with your configured username and password.
-					{:else}
-						Create the default username and password for this server.
-					{/if}
+					Sign in with your configured username and password.
 				</p>
 			</div>
 
@@ -267,146 +165,50 @@
 				</div>
 			{/if}
 
-			{#if authInitialized}
-				<form class="space-y-3" onsubmit={handleLoginSubmit}>
-					<div class="space-y-1">
-						<label class="text-sm font-medium" for="login-username">Username</label>
-						<input
-							id="login-username"
-							class="w-full rounded-md border bg-background px-3 py-2 text-sm"
-							type="text"
-							required
-							autocomplete="username"
-							bind:value={loginUsername}
-						/>
-					</div>
-					<div class="space-y-1">
-						<label class="text-sm font-medium" for="login-password">Password</label>
-						<input
-							id="login-password"
-							class="w-full rounded-md border bg-background px-3 py-2 text-sm"
-							type="password"
-							required
-							autocomplete="current-password"
-							bind:value={loginPassword}
-						/>
-					</div>
-					<label class="flex items-start gap-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-sm">
-						<input
-							type="checkbox"
-							class="mt-0.5 rounded"
-							bind:checked={loginRememberMe}
-						/>
-						<span class="space-y-0.5">
-							<span class="block font-medium text-foreground">Remember me</span>
-							<span class="block text-xs text-muted-foreground">
-								Keep this browser signed in across browser and server restarts for the normal session lifetime.
-							</span>
+			<form class="space-y-3" onsubmit={handleLoginSubmit}>
+				<div class="space-y-1">
+					<label class="text-sm font-medium" for="login-username">Username</label>
+					<input
+						id="login-username"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm"
+						type="text"
+						required
+						autocomplete="username"
+						bind:value={loginUsername}
+					/>
+				</div>
+				<div class="space-y-1">
+					<label class="text-sm font-medium" for="login-password">Password</label>
+					<input
+						id="login-password"
+						class="w-full rounded-md border bg-background px-3 py-2 text-sm"
+						type="password"
+						required
+						autocomplete="current-password"
+						bind:value={loginPassword}
+					/>
+				</div>
+				<label class="flex items-start gap-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-sm">
+					<input
+						type="checkbox"
+						class="mt-0.5 rounded"
+						bind:checked={loginRememberMe}
+					/>
+					<span class="space-y-0.5">
+						<span class="block font-medium text-foreground">Remember me</span>
+						<span class="block text-xs text-muted-foreground">
+							Keep this browser signed in across browser and server restarts for the normal session lifetime.
 						</span>
-					</label>
-					<button
-						type="submit"
-						disabled={authSubmitting}
-						class="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
-					>
-						{authSubmitting ? 'Signing in...' : 'Sign In'}
-					</button>
-				</form>
-			{:else}
-				<form class="space-y-3" onsubmit={handleSetupSubmit}>
-					<div class="space-y-1">
-						<label class="text-sm font-medium" for="setup-username">Username</label>
-						<input
-							id="setup-username"
-							class="w-full rounded-md border bg-background px-3 py-2 text-sm"
-							type="text"
-							required
-							autocomplete="username"
-							bind:value={setupUsername}
-						/>
-					</div>
-					<div class="space-y-1">
-						<label class="text-sm font-medium" for="setup-password">Password</label>
-						<input
-							id="setup-password"
-							class="w-full rounded-md border bg-background px-3 py-2 text-sm"
-							type="password"
-							required
-							minlength="8"
-							autocomplete="new-password"
-							bind:value={setupPassword}
-						/>
-					</div>
-					<div class="space-y-1">
-						<label class="text-sm font-medium" for="setup-password-confirm">Confirm Password</label>
-						<input
-							id="setup-password-confirm"
-							class="w-full rounded-md border bg-background px-3 py-2 text-sm"
-							type="password"
-							required
-							minlength="8"
-							autocomplete="new-password"
-							bind:value={setupPasswordConfirm}
-						/>
-					</div>
-					<button
-						type="submit"
-						disabled={authSubmitting}
-						class="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
-					>
-						{authSubmitting ? 'Saving...' : 'Create Credentials'}
-					</button>
-				</form>
-			{/if}
-		</div>
-	</div>
-{:else if setupNeedsDirs}
-	<div class="min-h-screen bg-background flex items-center justify-center px-4 py-10">
-		<div class="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm space-y-4">
-			<div class="space-y-2">
-				<div class="flex items-center gap-3">
-					<div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
-						<FolderCheck class="h-5 w-5" />
-					</div>
-					<h1 class="text-2xl font-bold leading-tight">Add Allowed Directories</h1>
-				</div>
-				<p class="text-sm text-muted-foreground">
-					Add the folders you want to scan for videos; you can change this later in Settings → Security.
-				</p>
-				<p class="text-xs text-muted-foreground">
-					With no allowed directories configured, all file operations are blocked.
-				</p>
-			</div>
-
-			{#if authError}
-				<div class="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-					{authError}
-				</div>
-			{/if}
-
-			<AllowedDirectoriesEditor
-				bind:directories={setupDirs}
-				whitelistPaths={setupDirs}
-				emptyHint="No directories added yet. Add one below to enable scanning, or skip and add later."
-			/>
-
-			<form class="space-y-2" onsubmit={handleSetupDirsSubmit}>
-				<Button type="submit" disabled={setupDirsSubmitting} class="w-full">
-					{#snippet children()}
-						<FolderCheck class="h-4 w-4 mr-2" />
-						{setupDirsSubmitting ? 'Saving...' : 'Save & Continue'}
-					{/snippet}
-				</Button>
+					</span>
+				</label>
+				<button
+					type="submit"
+					disabled={authSubmitting}
+					class="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
+				>
+					{authSubmitting ? 'Signing in...' : 'Sign In'}
+				</button>
 			</form>
-			<button
-				type="button"
-				disabled={setupDirsSubmitting}
-				onclick={handleSetupDirsSkip}
-				class="w-full inline-flex items-center justify-center gap-1 rounded-md px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground disabled:opacity-60"
-			>
-				Skip for now
-				<ArrowRight class="h-3.5 w-3.5" />
-			</button>
 		</div>
 	</div>
 {:else}

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -155,7 +155,7 @@
 		</div>
 	</div>
 {:else if !authInitialized}
-	<SetupWizard onComplete={() => { void refreshAuthStatus(); syncWebSocketAuthState(); }} />
+	<SetupWizard onComplete={() => { void refreshAuthStatus(); }} />
 {:else if !authAuthenticated}
 	<div class="min-h-screen bg-background flex items-center justify-center px-4 py-10">
 		<div class="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm space-y-4">

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -154,7 +154,7 @@
 		</div>
 	</div>
 {:else if !authInitialized}
-	<SetupWizard onComplete={() => { authInitialized = true; authAuthenticated = true; syncWebSocketAuthState(); }} />
+	<SetupWizard onComplete={() => { void refreshAuthStatus(); syncWebSocketAuthState(); }} />
 {:else if !authAuthenticated}
 	<div class="min-h-screen bg-background flex items-center justify-center px-4 py-10">
 		<div class="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm space-y-4">

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -16,6 +16,7 @@
 	import { getQueryClient } from '$lib/query/client';
 	import { getThemeStore } from '$lib/stores/theme.svelte';
 	import SetupWizard from '$lib/components/setup/SetupWizard.svelte';
+	import { clearClientStorage } from '$lib/utils/storage';
 	import '../app.css';
 
 	let { children } = $props();
@@ -33,6 +34,7 @@
 	let loginUsername = $state('');
 	let loginPassword = $state('');
 	let loginRememberMe = $state(true);
+	let clientStorageCleared = false;
 
 	function syncWebSocketAuthState() {
 		if (authAuthenticated) {
@@ -49,6 +51,10 @@
 			const status = await apiClient.getAuthStatus();
 			authUnavailable = false;
 			authInitialized = status.initialized;
+			if (!status.initialized && !clientStorageCleared) {
+				clearClientStorage();
+				clientStorageCleared = true;
+			}
 			authAuthenticated = status.authenticated;
 			authUsername = status.username ?? '';
 			if (!loginUsername && authUsername) {

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -53,6 +53,7 @@
 			authInitialized = status.initialized;
 			if (!status.initialized && !clientStorageCleared) {
 				clearClientStorage();
+				BaseClient.setSessionID(null);
 				clientStorageCleared = true;
 			}
 			authAuthenticated = status.authenticated;

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -120,11 +120,11 @@ async function fillCredentials(container: HTMLElement) {
 
 // Register the admin account and dismiss the credentials-confirmation
 // interstitial, landing on the directories step. Registration is now a
-// two-click flow: Continue (creates the account) → Continue to library setup
+// two-click flow: Create admin account → Continue to library setup
 // (acknowledges and advances).
 async function proceedToDirectories(container: HTMLElement) {
 	await fillCredentials(container);
-	await fireEvent.click(findButton(container, 'Continue')!);
+	await fireEvent.click(findButton(container, 'Create admin account')!);
 	await waitFor(() => expect(apiClient.setupAuth).toHaveBeenCalledTimes(1));
 	await waitFor(() =>
 		expect(container.textContent).toContain('Your admin account is secured'),
@@ -158,7 +158,7 @@ describe('first-run setup wizard', () => {
 		const { container } = render(Layout);
 		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
 		expect(container.textContent).toContain('Admin Account');
-		expect(findButton(container, 'Continue')).toBeTruthy();
+		expect(findButton(container, 'Create admin account')).toBeTruthy();
 	});
 
 	it('creates the admin account and advances to the directories step', async () => {

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -12,6 +12,7 @@ vi.mock('$lib/api/client', () => ({
 		getConfig: vi.fn(),
 		updateSecurityConfig: vi.fn(),
 		getScrapers: vi.fn(),
+		getCurrentWorkingDirectory: vi.fn(),
 		request: vi.fn(),
 	},
 }));
@@ -51,6 +52,16 @@ if (!Element.prototype.animate) {
 		queueMicrotask(() => anim.onfinish?.());
 		return anim as unknown as Animation;
 	};
+}
+
+// jsdom has no ResizeObserver; the wizard's stage-height measurement effect
+// uses one, so polyfill it to avoid uncaught exceptions during render.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+	globalThis.ResizeObserver = class {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	} as unknown as typeof ResizeObserver;
 }
 
 function uninitializedStatus() {
@@ -107,12 +118,29 @@ async function fillCredentials(container: HTMLElement) {
 	return { username, password, confirm };
 }
 
+// Register the admin account and dismiss the credentials-confirmation
+// interstitial, landing on the directories step. Registration is now a
+// two-click flow: Continue (creates the account) → Continue to library setup
+// (acknowledges and advances).
+async function proceedToDirectories(container: HTMLElement) {
+	await fillCredentials(container);
+	await fireEvent.click(findButton(container, 'Continue'));
+	await waitFor(() => expect(apiClient.setupAuth).toHaveBeenCalledTimes(1));
+	await waitFor(() =>
+		expect(container.textContent).toContain('Your admin account is secured'),
+	);
+	await fireEvent.click(findButton(container, 'Continue to library setup'));
+	await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+}
+
 beforeEach(() => {
 	vi.clearAllMocks();
+	localStorage.clear();
 	apiClient.getAuthStatus.mockReset();
 	apiClient.getAuthStatus.mockResolvedValue(uninitializedStatus());
 	apiClient.getScrapers.mockResolvedValue(scrapersResponse());
 	apiClient.getConfig.mockResolvedValue(freshConfig());
+	apiClient.getCurrentWorkingDirectory.mockResolvedValue({ path: '' });
 	apiClient.updateSecurityConfig.mockResolvedValue({ security: { allowed_directories: [] } } as unknown as Awaited<ReturnType<typeof apiClient.updateSecurityConfig>>);
 	apiClient.request.mockResolvedValue({ message: 'ok' });
 	toastStore.clear();
@@ -122,6 +150,7 @@ beforeEach(() => {
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	localStorage.clear();
 });
 
 describe('first-run setup wizard', () => {
@@ -139,12 +168,7 @@ describe('first-run setup wizard', () => {
 
 		const { container } = render(Layout);
 		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
-		await fillCredentials(container);
-
-		await fireEvent.click(findButton(container, 'Continue'));
-
-		await waitFor(() => expect(apiClient.setupAuth).toHaveBeenCalledTimes(1));
-		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		await proceedToDirectories(container);
 		// directories/scrapers are staged — no config/security calls yet at step 1
 		expect(apiClient.getConfig).not.toHaveBeenCalled();
 		expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled();
@@ -157,10 +181,7 @@ describe('first-run setup wizard', () => {
 
 		const { container } = render(Layout);
 		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
-		await fillCredentials(container);
-		await fireEvent.click(findButton(container, 'Continue'));
-
-		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		await proceedToDirectories(container);
 		expect(findButton(container, 'Back')).toBeUndefined();
 	});
 
@@ -171,10 +192,7 @@ describe('first-run setup wizard', () => {
 
 		const { container } = render(Layout);
 		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
-		await fillCredentials(container);
-		await fireEvent.click(findButton(container, 'Continue'));
-
-		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		await proceedToDirectories(container);
 
 		const dirInput = container.querySelector(
 			'input[placeholder*="Add a directory"]',
@@ -210,10 +228,7 @@ describe('first-run setup wizard', () => {
 
 		const { container } = render(Layout);
 		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
-		await fillCredentials(container);
-		await fireEvent.click(findButton(container, 'Continue'));
-
-		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		await proceedToDirectories(container);
 
 		const dirInput = container.querySelector(
 			'input[placeholder*="Add a directory"]',
@@ -260,10 +275,7 @@ describe('first-run setup wizard', () => {
 
 		const { container } = render(Layout);
 		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
-		await fillCredentials(container);
-		await fireEvent.click(findButton(container, 'Continue'));
-
-		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		await proceedToDirectories(container);
 
 		const dirInput = container.querySelector(
 			'input[placeholder*="Add a directory"]',
@@ -289,10 +301,7 @@ describe('first-run setup wizard', () => {
 
 		const { container } = render(Layout);
 		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
-		await fillCredentials(container);
-		await fireEvent.click(findButton(container, 'Continue'));
-
-		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		await proceedToDirectories(container);
 
 		await fireEvent.click(findButton(container, 'Skip for now'));
 
@@ -307,10 +316,7 @@ describe('first-run setup wizard', () => {
 
 		const { container } = render(Layout);
 		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
-		await fillCredentials(container);
-		await fireEvent.click(findButton(container, 'Continue'));
-
-		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		await proceedToDirectories(container);
 		await fireEvent.click(findButton(container, 'Continue'));
 
 		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
@@ -319,5 +325,86 @@ describe('first-run setup wizard', () => {
 		await fireEvent.click(back);
 
 		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+	});
+
+	it('pre-fills the directories list with a sensible default path after registration', async () => {
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
+		apiClient.getCurrentWorkingDirectory.mockResolvedValue({ path: '/home/test/Videos' });
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await proceedToDirectories(container);
+
+		await waitFor(() =>
+			expect(container.textContent).toContain('/home/test/Videos'),
+		);
+		// The pre-filled path is staged as the default (first) allowed directory.
+		expect(apiClient.getCurrentWorkingDirectory).toHaveBeenCalledTimes(1);
+	});
+
+	it('commits the pre-filled default directory on Finish', async () => {
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
+		apiClient.getCurrentWorkingDirectory.mockResolvedValue({ path: '/home/test/Videos' });
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await proceedToDirectories(container);
+		await waitFor(() =>
+			expect(container.textContent).toContain('/home/test/Videos'),
+		);
+
+		await fireEvent.click(findButton(container, 'Continue'));
+		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
+		await waitFor(() => expect(apiClient.getScrapers).toHaveBeenCalledTimes(1));
+		await fireEvent.click(findButton(container, 'Finish Setup'));
+
+		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
+		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
+			expect.objectContaining({ allowed_directories: ['/home/test/Videos'] }),
+		);
+	});
+
+	it('leaves the directories list empty when /cwd returns an empty path', async () => {
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
+		apiClient.getCurrentWorkingDirectory.mockResolvedValue({ path: '' });
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await proceedToDirectories(container);
+
+		await waitFor(() => expect(apiClient.getCurrentWorkingDirectory).toHaveBeenCalledTimes(1));
+		expect(container.textContent).toContain('No directories added yet');
+		expect(container.textContent).not.toContain('/home');
+	});
+
+	it('clears all localStorage and cookies when the wizard is shown (first-run)', async () => {
+		localStorage.setItem('javinizer_test_stale', 'stale');
+		localStorage.setItem('javinizer_input_path', '/old/path');
+		localStorage.setItem('javinizer_session', 'old-session-id');
+		expect(localStorage.getItem('javinizer_test_stale')).toBe('stale');
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+
+		expect(localStorage.getItem('javinizer_test_stale')).toBeNull();
+		expect(localStorage.getItem('javinizer_input_path')).toBeNull();
+		expect(localStorage.getItem('javinizer_session')).toBeNull();
+		expect(localStorage.length).toBe(0);
+	});
+
+	it('does not clear localStorage when the app is already initialized', async () => {
+		apiClient.getAuthStatus.mockResolvedValue({ initialized: true, authenticated: false, username: null } as unknown as Awaited<ReturnType<typeof apiClient.getAuthStatus>>);
+		localStorage.setItem('javinizer_test_keep', 'keep');
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Login Required'));
+
+		expect(localStorage.getItem('javinizer_test_keep')).toBe('keep');
 	});
 });

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -412,3 +412,21 @@ describe('first-run setup wizard', () => {
 		expect(localStorage.getItem('javinizer_test_keep')).toBe('keep');
 	});
 });
+
+	it('creates the admin account when submitting the credentials form', async () => {
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+
+		const form = container.querySelector('#credentials-form') as HTMLFormElement;
+		await fireEvent.submit(form);
+
+		await waitFor(() => expect(apiClient.setupAuth).toHaveBeenCalledTimes(1));
+		await waitFor(() =>
+			expect(container.textContent).toContain('Your admin account is secured'),
+		);
+	});

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -11,6 +11,8 @@ vi.mock('$lib/api/client', () => ({
 		logoutAuth: vi.fn(),
 		getConfig: vi.fn(),
 		updateSecurityConfig: vi.fn(),
+		getScrapers: vi.fn(),
+		request: vi.fn(),
 	},
 }));
 
@@ -63,34 +65,56 @@ function authenticatedStatus() {
 	>;
 }
 
-function freshConfig(allowed: string[] = []) {
+function freshConfig(allowed: string[] = [], overrides: Record<string, unknown> = {}) {
 	return {
+		scrapers: { priority: [] },
 		api: {
 			security: {
 				allowed_directories: allowed,
 				denied_directories: [],
 				allow_unc: false,
 				allowed_unc_servers: [],
+				...overrides,
 			},
 		},
 	} as unknown as Awaited<ReturnType<typeof apiClient.getConfig>>;
 }
 
-function securityResponse(allowed: string[] = [], overrides: Record<string, unknown> = {}) {
-	return {
-		security: {
-			allowed_directories: allowed,
-			denied_directories: [],
-			allow_unc: false,
-			allowed_unc_servers: [],
-			...overrides,
-		},
-	} as unknown as Awaited<ReturnType<typeof apiClient.updateSecurityConfig>>;
+function scrapersResponse() {
+	return [
+		{ name: 'r18', display_title: 'R18', enabled: true, options: {} },
+		{ name: 'javlibrary', display_title: 'JavLibrary', enabled: true, options: {} },
+	] as unknown as Awaited<ReturnType<typeof apiClient.getScrapers>>;
+}
+
+function findButton(container: HTMLElement, text: string): HTMLButtonElement {
+	return Array.from(container.querySelectorAll('button')).find((b) =>
+		b.textContent?.includes(text),
+	) as HTMLButtonElement;
+}
+
+async function fillCredentials(container: HTMLElement) {
+	const username = container.querySelector('input[placeholder="admin"]') as HTMLInputElement;
+	const password = container.querySelector(
+		'input[placeholder="At least 8 characters"]',
+	) as HTMLInputElement;
+	const confirm = container.querySelector(
+		'input[placeholder="Re-enter password"]',
+	) as HTMLInputElement;
+	await fireEvent.input(username, { target: { value: 'admin' } });
+	await fireEvent.input(password, { target: { value: 'password123' } });
+	await fireEvent.input(confirm, { target: { value: 'password123' } });
+	return { username, password, confirm };
 }
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	apiClient.getAuthStatus.mockReset();
 	apiClient.getAuthStatus.mockResolvedValue(uninitializedStatus());
+	apiClient.getScrapers.mockResolvedValue(scrapersResponse());
+	apiClient.getConfig.mockResolvedValue(freshConfig());
+	apiClient.updateSecurityConfig.mockResolvedValue({ security: { allowed_directories: [] } } as unknown as Awaited<ReturnType<typeof apiClient.updateSecurityConfig>>);
+	apiClient.request.mockResolvedValue({ message: 'ok' });
 	toastStore.clear();
 	vi.spyOn(toastStore, 'success');
 	vi.spyOn(toastStore, 'info');
@@ -100,175 +124,57 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-describe('first-run setup allowed directories step', () => {
-	it('shows the credentials form before auth is initialized', async () => {
-		const { container, getByText } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
-		expect(container.textContent).toContain('Create the default username and password');
-		expect(getByText('Create Credentials')).toBeTruthy();
+describe('first-run setup wizard', () => {
+	it('shows the credentials step before auth is initialized', async () => {
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		expect(container.textContent).toContain('Admin Account');
+		expect(findButton(container, 'Continue')).toBeTruthy();
 	});
 
-	it('transitions to the allowed directories step after credentials are created', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
+	it('creates the admin account and advances to the directories step', async () => {
 		apiClient.setupAuth.mockResolvedValue(
 			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
 		);
-		apiClient.getConfig.mockResolvedValue(freshConfig());
-		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse());
 
 		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
 
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
+		await fireEvent.click(findButton(container, 'Continue'));
 
-		const form = username.closest('form') as HTMLFormElement;
-		await fireEvent.submit(form);
-
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
-		expect(container.textContent).toContain('you can change this later in Settings');
-		expect(apiClient.getConfig).toHaveBeenCalledTimes(1);
+		await waitFor(() => expect(apiClient.setupAuth).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		// directories/scrapers are staged — no config/security calls yet at step 1
+		expect(apiClient.getConfig).not.toHaveBeenCalled();
 		expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled();
 	});
 
-	it('persists allowed directories via the security endpoint on submit', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
+	it('hides the Back button on the directories step (credentials are committed)', async () => {
 		apiClient.setupAuth.mockResolvedValue(
 			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
 		);
-		apiClient.getConfig.mockResolvedValue(freshConfig());
-		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse(['/mnt/videos']));
 
 		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
 
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
-		await fireEvent.submit(username.closest('form') as HTMLFormElement);
-
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
-
-		const dirInput = container.querySelector(
-			'input[placeholder*="Add a directory"]',
-		) as HTMLInputElement;
-		expect(dirInput).toBeTruthy();
-		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
-		const addBtn = container.querySelector(
-			'button[title="Add allowed directory"]',
-		) as HTMLButtonElement;
-		await fireEvent.click(addBtn);
-		await tick();
-
-		const save = Array.from(container.querySelectorAll('button')).find((b) =>
-			b.textContent?.includes('Save & Continue'),
-		) as HTMLButtonElement;
-		expect(save).toBeTruthy();
-		await fireEvent.click(save);
-
-		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
-		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
-			expect.objectContaining({
-				allowed_directories: ['/mnt/videos'],
-				denied_directories: [],
-				allow_unc: false,
-				allowed_unc_servers: [],
-			}),
-		);
-		await waitFor(() => expect(vi.mocked(toastStore.success)).toHaveBeenCalled());
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		expect(findButton(container, 'Back')).toBeUndefined();
 	});
 
-	it('commits a typed directory on Enter without clicking the add button', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
+	it('stages directories and advances to the scrapers step without committing', async () => {
 		apiClient.setupAuth.mockResolvedValue(
 			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
 		);
-		apiClient.getConfig.mockResolvedValue(freshConfig());
-		apiClient.updateSecurityConfig.mockResolvedValue(securityResponse(['/mnt/videos']));
 
 		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
 
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
-		await fireEvent.submit(username.closest('form') as HTMLFormElement);
-
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
-
-		const dirInput = container.querySelector(
-			'input[placeholder*="Add a directory"]',
-		) as HTMLInputElement;
-		expect(dirInput).toBeTruthy();
-		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
-		await fireEvent.keyDown(dirInput, { key: 'Enter' });
-		await tick();
-
-		const save = Array.from(container.querySelectorAll('button')).find((b) =>
-			b.textContent?.includes('Save & Continue'),
-		) as HTMLButtonElement;
-		await fireEvent.click(save);
-
-		await waitFor(() =>
-			expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
-				expect.objectContaining({ allowed_directories: ['/mnt/videos'] }),
-			),
-		);
-	});
-
-	it('sends all four security fields including current defaults', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
-		apiClient.setupAuth.mockResolvedValue(
-			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
-		);
-		apiClient.getConfig.mockResolvedValue({
-			api: {
-				security: {
-					allowed_directories: [],
-					denied_directories: ['/sensitive'],
-					allow_unc: true,
-					allowed_unc_servers: ['\\\\srv\\share'],
-				},
-			},
-		} as unknown as Awaited<ReturnType<typeof apiClient.getConfig>>);
-		apiClient.updateSecurityConfig.mockResolvedValue(
-			securityResponse(['/mnt/videos'], {
-				denied_directories: ['/sensitive'],
-				allow_unc: true,
-				allowed_unc_servers: ['\\\\srv\\share'],
-			}),
-		);
-
-		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
-
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
-		await fireEvent.submit(username.closest('form') as HTMLFormElement);
-
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
 
 		const dirInput = container.querySelector(
 			'input[placeholder*="Add a directory"]',
@@ -279,10 +185,51 @@ describe('first-run setup allowed directories step', () => {
 		);
 		await tick();
 
-		const save = Array.from(container.querySelectorAll('button')).find((b) =>
-			b.textContent?.includes('Save & Continue'),
-		) as HTMLButtonElement;
-		await fireEvent.click(save);
+		await fireEvent.click(findButton(container, 'Continue'));
+
+		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
+		// staged — nothing committed yet
+		expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled();
+	});
+
+	it('commits staged directories and scraper selection together on Finish', async () => {
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
+		apiClient.getConfig.mockResolvedValue({
+			scrapers: { priority: [] },
+			api: {
+				security: {
+					allowed_directories: [],
+					denied_directories: ['/sensitive'],
+					allow_unc: true,
+					allowed_unc_servers: ['\\\\srv\\share'],
+				},
+			},
+		} as unknown as Awaited<ReturnType<typeof apiClient.getConfig>>);
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
+
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+
+		const dirInput = container.querySelector(
+			'input[placeholder*="Add a directory"]',
+		) as HTMLInputElement;
+		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
+		await fireEvent.click(
+			container.querySelector('button[title="Add allowed directory"]') as HTMLButtonElement,
+		);
+		await tick();
+
+		await fireEvent.click(findButton(container, 'Continue'));
+
+		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
+		await waitFor(() => expect(apiClient.getScrapers).toHaveBeenCalledTimes(1));
+
+		await fireEvent.click(findButton(container, 'Finish Setup'));
 
 		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
 		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
@@ -293,70 +240,84 @@ describe('first-run setup allowed directories step', () => {
 				allowed_unc_servers: ['\\\\srv\\share'],
 			}),
 		);
+		await waitFor(() => expect(apiClient.request).toHaveBeenCalledTimes(1));
+		expect(apiClient.request).toHaveBeenCalledWith(
+			'/api/v1/config',
+			expect.objectContaining({ method: 'PUT' }),
+		);
+		const calls = (apiClient.request as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+		const payload = JSON.parse((calls[0][1] as { body: string }).body);
+		expect(payload.scrapers.priority).toEqual(['r18', 'javlibrary']);
+		expect(payload.scrapers.r18.enabled).toBe(true);
+		expect(payload.scrapers.javlibrary.enabled).toBe(true);
+		await waitFor(() => expect(vi.mocked(toastStore.success)).toHaveBeenCalled());
 	});
 
-	it('skips the step without calling the security endpoint and toasts guidance', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
+	it('commits a typed directory on Enter before finishing', async () => {
 		apiClient.setupAuth.mockResolvedValue(
 			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
 		);
-		apiClient.getConfig.mockResolvedValue(freshConfig());
 
 		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
 
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
-		await fireEvent.submit(username.closest('form') as HTMLFormElement);
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
 
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
+		const dirInput = container.querySelector(
+			'input[placeholder*="Add a directory"]',
+		) as HTMLInputElement;
+		await fireEvent.input(dirInput, { target: { value: '/mnt/videos' } });
+		await fireEvent.keyDown(dirInput, { key: 'Enter' });
+		await tick();
 
-		const skipBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-			b.textContent?.includes('Skip for now'),
-		) as HTMLButtonElement;
-		expect(skipBtn).toBeTruthy();
-		await fireEvent.click(skipBtn);
+		await fireEvent.click(findButton(container, 'Continue'));
+		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
+		await fireEvent.click(findButton(container, 'Finish Setup'));
 
-		await waitFor(() =>
-			expect(vi.mocked(toastStore.info)).toHaveBeenCalledWith(
-				expect.stringContaining('Settings → Security'),
-				expect.any(Number),
-			),
+		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
+		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
+			expect.objectContaining({ allowed_directories: ['/mnt/videos'] }),
 		);
-		await waitFor(() => expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled());
-		expect(vi.mocked(toastStore.info)).toHaveBeenCalled();
 	});
 
-	it('surfaces a visible error when config loading fails but keeps the dirs gate stable', async () => {
-		apiClient.getAuthStatus
-			.mockResolvedValueOnce(uninitializedStatus())
-			.mockResolvedValueOnce(authenticatedStatus());
+	it('skips the directories step and still advances to scrapers', async () => {
 		apiClient.setupAuth.mockResolvedValue(
 			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
 		);
-		apiClient.getConfig.mockRejectedValue(new Error('network down'));
 
 		const { container } = render(Layout);
-		await waitFor(() => expect(container.textContent).toContain('First-Time Setup'));
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
 
-		const username = container.querySelector('#setup-username') as HTMLInputElement;
-		const password = container.querySelector('#setup-password') as HTMLInputElement;
-		const confirm = container.querySelector('#setup-password-confirm') as HTMLInputElement;
-		await fireEvent.input(username, { target: { value: 'admin' } });
-		await fireEvent.input(password, { target: { value: 'password123' } });
-		await fireEvent.input(confirm, { target: { value: 'password123' } });
-		await fireEvent.submit(username.closest('form') as HTMLFormElement);
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
 
-		await waitFor(() => expect(container.textContent).toContain('Add Allowed Directories'));
-		expect(container.textContent).toContain('Failed to load current security settings');
-		expect(container.textContent).toContain('network down');
-		expect(apiClient.getConfig).toHaveBeenCalledTimes(1);
+		await fireEvent.click(findButton(container, 'Skip for now'));
+
+		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
 		expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled();
+	});
+
+	it('shows a Back button on the scrapers step that returns to directories', async () => {
+		apiClient.setupAuth.mockResolvedValue(
+			authenticatedStatus() as unknown as Awaited<ReturnType<typeof apiClient.setupAuth>>,
+		);
+
+		const { container } = render(Layout);
+		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
+		await fillCredentials(container);
+		await fireEvent.click(findButton(container, 'Continue'));
+
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
+		await fireEvent.click(findButton(container, 'Continue'));
+
+		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
+		const back = findButton(container, 'Back');
+		expect(back).toBeTruthy();
+		await fireEvent.click(back);
+
+		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
 	});
 });

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -98,7 +98,7 @@ function scrapersResponse() {
 	] as unknown as Awaited<ReturnType<typeof apiClient.getScrapers>>;
 }
 
-function findButton(container: HTMLElement, text: string): HTMLButtonElement {
+function findButton(container: HTMLElement, text: string): HTMLButtonElement | undefined {
 	return Array.from(container.querySelectorAll('button')).find((b) =>
 		b.textContent?.includes(text),
 	) as HTMLButtonElement;
@@ -124,12 +124,12 @@ async function fillCredentials(container: HTMLElement) {
 // (acknowledges and advances).
 async function proceedToDirectories(container: HTMLElement) {
 	await fillCredentials(container);
-	await fireEvent.click(findButton(container, 'Continue'));
+	await fireEvent.click(findButton(container, 'Continue')!);
 	await waitFor(() => expect(apiClient.setupAuth).toHaveBeenCalledTimes(1));
 	await waitFor(() =>
 		expect(container.textContent).toContain('Your admin account is secured'),
 	);
-	await fireEvent.click(findButton(container, 'Continue to library setup'));
+	await fireEvent.click(findButton(container, 'Continue to library setup')!);
 	await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
 }
 
@@ -203,7 +203,7 @@ describe('first-run setup wizard', () => {
 		);
 		await tick();
 
-		await fireEvent.click(findButton(container, 'Continue'));
+		await fireEvent.click(findButton(container, 'Continue')!);
 
 		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
 		// staged — nothing committed yet
@@ -239,12 +239,12 @@ describe('first-run setup wizard', () => {
 		);
 		await tick();
 
-		await fireEvent.click(findButton(container, 'Continue'));
+		await fireEvent.click(findButton(container, 'Continue')!);
 
 		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
 		await waitFor(() => expect(apiClient.getScrapers).toHaveBeenCalledTimes(1));
 
-		await fireEvent.click(findButton(container, 'Finish Setup'));
+		await fireEvent.click(findButton(container, 'Finish Setup')!);
 
 		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
 		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
@@ -284,9 +284,9 @@ describe('first-run setup wizard', () => {
 		await fireEvent.keyDown(dirInput, { key: 'Enter' });
 		await tick();
 
-		await fireEvent.click(findButton(container, 'Continue'));
+		await fireEvent.click(findButton(container, 'Continue')!);
 		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
-		await fireEvent.click(findButton(container, 'Finish Setup'));
+		await fireEvent.click(findButton(container, 'Finish Setup')!);
 
 		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
 		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(
@@ -303,7 +303,7 @@ describe('first-run setup wizard', () => {
 		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
 		await proceedToDirectories(container);
 
-		await fireEvent.click(findButton(container, 'Skip for now'));
+		await fireEvent.click(findButton(container, 'Skip for now')!);
 
 		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
 		expect(apiClient.updateSecurityConfig).not.toHaveBeenCalled();
@@ -317,12 +317,12 @@ describe('first-run setup wizard', () => {
 		const { container } = render(Layout);
 		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
 		await proceedToDirectories(container);
-		await fireEvent.click(findButton(container, 'Continue'));
+		await fireEvent.click(findButton(container, 'Continue')!);
 
 		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
 		const back = findButton(container, 'Back');
 		expect(back).toBeTruthy();
-		await fireEvent.click(back);
+		await fireEvent.click(back!);
 
 		await waitFor(() => expect(container.textContent).toContain('Point Javinizer at your library'));
 	});
@@ -357,10 +357,10 @@ describe('first-run setup wizard', () => {
 			expect(container.textContent).toContain('/home/test/Videos'),
 		);
 
-		await fireEvent.click(findButton(container, 'Continue'));
+		await fireEvent.click(findButton(container, 'Continue')!);
 		await waitFor(() => expect(container.textContent).toContain('Choose your metadata sources'));
 		await waitFor(() => expect(apiClient.getScrapers).toHaveBeenCalledTimes(1));
-		await fireEvent.click(findButton(container, 'Finish Setup'));
+		await fireEvent.click(findButton(container, 'Finish Setup')!);
 
 		await waitFor(() => expect(apiClient.updateSecurityConfig).toHaveBeenCalledTimes(1));
 		expect(apiClient.updateSecurityConfig).toHaveBeenCalledWith(

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -389,6 +389,9 @@ describe('first-run setup wizard', () => {
 		localStorage.setItem('javinizer_session', 'old-session-id');
 		expect(localStorage.getItem('javinizer_test_stale')).toBe('stale');
 
+		document.cookie = 'javinizer_test=stale; path=/';
+		expect(document.cookie).toContain('javinizer_test');
+
 		const { container } = render(Layout);
 		await waitFor(() => expect(container.textContent).toContain('Create your admin account'));
 
@@ -396,6 +399,7 @@ describe('first-run setup wizard', () => {
 		expect(localStorage.getItem('javinizer_input_path')).toBeNull();
 		expect(localStorage.getItem('javinizer_session')).toBeNull();
 		expect(localStorage.length).toBe(0);
+		expect(document.cookie).not.toContain('javinizer_test');
 	});
 
 	it('does not clear localStorage when the app is already initialized', async () => {


### PR DESCRIPTION
## Summary

Rebuilds the first-run experience as a 3-step setup wizard (credentials → library folders → scrapers), with a credentials-confirmation interstitial, a safe default-directory prefill, and client-storage clearing on first-run.

## What changed

### 3-step setup wizard
Replace the inline setup form + allowed-directories gate with a split-screen wizard: credentials → library folders → scrapers. A dark brand rail (stepper) + content pane using a macOS-style crossfade + scale transition with smoothly animated container height between steps.

- Stage directories + scraper selection locally and commit them together at Finish; the admin account (`setupAuth`) remains the only pre-Finish commit since the scraper/config endpoints require an authenticated session.
- Hide Back after credentials are committed (irreversible); Back only appears on the scrapers step to edit staged directories.
- Fetch the scraper list lazily when the scrapers step is entered.

### Credentials confirmation interstitial
Previously, registering the admin account immediately advanced to the next page — the only feedback was a fleeting toast. Now, registration pauses on an explicit acknowledgement screen (animated success emblem + credential receipt: username, masked password, timestamp, active-session indicator) before the user presses "Continue to library setup" to advance.

### Safe default-directory prefill
After credentials are registered, the wizard pre-fills the directories list from `/api/v1/cwd`. The `/cwd` endpoint returns the first allowed dir if any, else the process CWD; when the CWD is root-like (desktop app launched from Finder, where CWD is `/`), it returns an empty string instead of falling back to the user's home directory (avoids granting read/write access to the whole home tree).

### Clear client storage on first-run
When the server reports `initialized: false` (first-run or reset), wipe all client `localStorage` and JS-accessible cookies so a user who wiped server-side Application Support data truly starts from scratch on the client too.

## Validation
- `go test ./internal/api/file/` — pass (incl. CWD-or-empty fallback tests)
- `go vet ./internal/api/file/` — clean
- `svelte-check` — 0 errors, 0 warnings
- `vitest` (full) — 375/375 pass
- macOS desktop app rebuilt and manually verified
