### PR TITLE
fix(security): deny root-resolving allowed_directories entries

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -31,10 +31,9 @@ api:
             - http://127.0.0.1:5174
 
         # Allowed directories for API file operations (organize, preview, etc.)
-        # Default is current working directory. For Docker, use /media
-        # Add your media library paths here
-        allowed_directories:
-            - .
+        # Empty list = deny-by-default until you choose a specific folder.
+        # Example entries: ~/Videos, /media, /mnt/nas/movies
+        allowed_directories: []
 
         # Explicitly deny specific directories (optional)
         denied_directories: []

--- a/internal/api/core/path_validation_test.go
+++ b/internal/api/core/path_validation_test.go
@@ -1798,3 +1798,17 @@ func TestIsUNCPath_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateScanPath_EmptyPathResolvesToCWD(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	cfg := &SecurityNarrowConfig{
+		AllowedDirectories: []string{"."},
+		DeniedDirectories:  []string{},
+	}
+
+	result, err := ValidateScanPath("", cfg)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result, "empty path should resolve to CWD")
+}

--- a/internal/api/core/path_validation_test.go
+++ b/internal/api/core/path_validation_test.go
@@ -76,9 +76,9 @@ func TestValidateScanPath(t *testing.T) {
 		},
 		{
 			name:      "nonexistent path",
-			inputPath: "/nonexistent/path/12345",
+			inputPath: filepath.Join(tempDir, "nonexistent/path/12345"),
 			securityCfg: &SecurityNarrowConfig{
-				AllowedDirectories: []string{"/"},
+				AllowedDirectories: []string{tempDir},
 				DeniedDirectories:  []string{},
 			},
 			expectedError: true,
@@ -117,7 +117,7 @@ func TestValidateScanPath_SystemDirectories(t *testing.T) {
 	}
 
 	securityCfg := &SecurityNarrowConfig{
-		AllowedDirectories: []string{"/"},
+		AllowedDirectories: []string{"/proc", "/sys", "/dev"},
 		DeniedDirectories:  []string{},
 	}
 
@@ -195,10 +195,10 @@ func TestValidateScanPath_EdgeCases(t *testing.T) {
 		errorContains string
 	}{
 		{
-			name:      "empty path defaults to current directory",
-			inputPath: "",
+			name:      "valid temp directory",
+			inputPath: tempDir,
 			securityCfg: &SecurityNarrowConfig{
-				AllowedDirectories: []string{"/"},
+				AllowedDirectories: []string{tempDir},
 				DeniedDirectories:  []string{},
 			},
 			expectedError: false,
@@ -214,9 +214,9 @@ func TestValidateScanPath_EdgeCases(t *testing.T) {
 		},
 		{
 			name:      "path with ./ prefix",
-			inputPath: "./",
+			inputPath: filepath.Join(tempDir, "."),
 			securityCfg: &SecurityNarrowConfig{
-				AllowedDirectories: []string{"/"},
+				AllowedDirectories: []string{tempDir},
 				DeniedDirectories:  []string{},
 			},
 			expectedError: false,
@@ -863,7 +863,7 @@ func TestIsDirAllowed_BuiltInDenied(t *testing.T) {
 				t.Skip("System directory doesn't exist on this platform")
 			}
 
-			allow := []string{"/"}
+			allow := []string{"/proc", "/sys", "/dev"}
 			deny := []string{}
 
 			result := isDirAllowed(tt.dir, allow, deny)
@@ -973,7 +973,7 @@ func TestValidateScanPath_TypedErrors(t *testing.T) {
 			name:      "pseudo-filesystem (/proc) returns ErrPathInDenylist even with allowlist",
 			inputPath: "/proc",
 			securityCfg: &SecurityNarrowConfig{
-				AllowedDirectories: []string{"/"},
+				AllowedDirectories: []string{"/proc"},
 			},
 			expectedErr: apperrors.ErrPathInDenylist,
 			skipIf:      "darwin windows",
@@ -1088,7 +1088,7 @@ func TestValidateScanPath_MinimalDenylistOnly(t *testing.T) {
 	}
 
 	securityCfg := &SecurityNarrowConfig{
-		AllowedDirectories: []string{"/"},
+		AllowedDirectories: []string{"/proc", "/sys", "/dev"},
 	}
 
 	for _, tt := range tests {
@@ -1230,7 +1230,7 @@ func TestValidateScanPath_DenylistPrefix(t *testing.T) {
 
 	t.Run("/dev/null IS blocked (within /dev)", func(t *testing.T) {
 		securityCfgAll := &SecurityNarrowConfig{
-			AllowedDirectories: []string{"/"},
+			AllowedDirectories: []string{"/dev"},
 			DeniedDirectories:  []string{},
 		}
 		if _, err := os.Stat("/dev/null"); os.IsNotExist(err) {
@@ -1244,7 +1244,7 @@ func TestValidateScanPath_DenylistPrefix(t *testing.T) {
 
 	t.Run("/sys/kernel IS blocked (within /sys)", func(t *testing.T) {
 		securityCfgAll := &SecurityNarrowConfig{
-			AllowedDirectories: []string{"/"},
+			AllowedDirectories: []string{"/sys"},
 			DeniedDirectories:  []string{},
 		}
 		if _, err := os.Stat("/sys/kernel"); os.IsNotExist(err) {
@@ -1718,7 +1718,7 @@ func TestValidateAndOpenPath_SystemDirectory(t *testing.T) {
 	}
 
 	securityCfg := &SecurityNarrowConfig{
-		AllowedDirectories: []string{"/"},
+		AllowedDirectories: []string{"/proc"},
 		DeniedDirectories:  []string{},
 	}
 

--- a/internal/api/core/path_validator.go
+++ b/internal/api/core/path_validator.go
@@ -126,7 +126,11 @@ func (v *PathValidator) validate(userPath string, target validateTarget) (string
 		}
 		hasValidEntry := false
 		for _, dir := range v.allow {
-			if strings.TrimSpace(dir) != "" {
+			if strings.TrimSpace(dir) == "" {
+				continue
+			}
+			_, usable := v.effectiveAllowedBase(dir)
+			if usable {
 				hasValidEntry = true
 				break
 			}
@@ -222,20 +226,48 @@ func (v *PathValidator) validate(userPath string, target validateTarget) (string
 	return canonicalPath, nil
 }
 
+// isFilesystemRoot reports whether path is a filesystem root:
+// "/" on Unix or a Windows drive root like "C:\\" / "C:/".
+func isFilesystemRoot(path string) bool {
+	if path == "/" || path == string(filepath.Separator) {
+		return true
+	}
+	if len(path) == 3 && path[1] == ':' && (path[2] == '\\' || path[2] == '/') {
+		return true
+	}
+	return false
+}
+
+// effectiveAllowedBase resolves a raw allowlist entry to its canonical
+// absolute form. Returns usable=false when the entry is blank or resolves to
+// a filesystem root (e.g. "." under CWD "/", or an explicit "/" or "C:\\").
+// Root-resolving entries are treated as unusable so they fail closed
+// (deny-by-default) rather than granting access to the entire filesystem.
+func (v *PathValidator) effectiveAllowedBase(rawBase string) (canonicalBase string, usable bool) {
+	if strings.TrimSpace(rawBase) == "" {
+		return "", false
+	}
+	expandedBase := expandHomeDir(rawBase)
+	absBase, err := filepath.Abs(expandedBase)
+	if err != nil {
+		return "", false
+	}
+	absBase = normalizePathForPlatform(absBase)
+	canonicalBase, err = v.canonicalizePath(absBase)
+	if err != nil {
+		return "", false
+	}
+	if isFilesystemRoot(canonicalBase) {
+		return "", false
+	}
+	return canonicalBase, true
+}
+
 // isAllowed checks if the canonical path falls within at least one allowed directory.
 func (v *PathValidator) isAllowed(canonicalPath string) bool {
 	for _, baseDir := range v.allow {
-		if strings.TrimSpace(baseDir) == "" {
-			continue
-		}
-		expandedBase := expandHomeDir(baseDir)
-		absBase, err := filepath.Abs(expandedBase)
-		if err != nil {
-			continue
-		}
-		absBase = normalizePathForPlatform(absBase)
-		canonicalBase, err := v.canonicalizePath(absBase)
-		if err != nil {
+		canonicalBase, usable := v.effectiveAllowedBase(baseDir)
+		if !usable {
 			continue
 		}
 		if isPathWithinCanonical(canonicalPath, canonicalBase) {
@@ -337,12 +369,17 @@ func (v *PathValidator) IsDirAllowed(dir string) bool {
 	}
 
 	// Deny by default when no allow list or allow list contains only blank strings
+	// or entries that resolve to a filesystem root.
 	if len(v.allow) == 0 {
 		return false
 	}
 	hasValidEntry := false
 	for _, dir := range v.allow {
-		if strings.TrimSpace(dir) != "" {
+		if strings.TrimSpace(dir) == "" {
+			continue
+		}
+		_, usable := v.effectiveAllowedBase(dir)
+		if usable {
 			hasValidEntry = true
 			break
 		}
@@ -353,19 +390,12 @@ func (v *PathValidator) IsDirAllowed(dir string) bool {
 
 	// Allowlist check
 	for _, allowed := range v.allow {
-		if strings.TrimSpace(allowed) == "" {
+		canonicalBase, usable := v.effectiveAllowedBase(allowed)
+		if !usable {
 			continue
 		}
-		expandedAllowed := expandHomeDir(allowed)
-		cleanAllowed := filepath.Clean(expandedAllowed)
-		if absAllowed, err := filepath.Abs(cleanAllowed); err == nil {
-			realAllowed, err := v.canonicalizePath(absAllowed)
-			if err != nil {
-				continue
-			}
-			if isPathWithinCanonical(resolved, realAllowed) {
-				return true
-			}
+		if isPathWithinCanonical(resolved, canonicalBase) {
+			return true
 		}
 	}
 
@@ -514,4 +544,11 @@ func isPathWithinCanonical(path, base string) bool {
 // packages that need the unified path-within check.
 func IsPathWithin(path, base string) bool {
 	return isPathWithinCanonical(path, base)
+}
+
+// IsFilesystemRoot is the exported version of isFilesystemRoot for use by
+// packages that need to validate allowlist entries (e.g. the security config
+// PUT handler rejecting root-resolving entries).
+func IsFilesystemRoot(path string) bool {
+	return isFilesystemRoot(path)
 }

--- a/internal/api/core/path_validator.go
+++ b/internal/api/core/path_validator.go
@@ -229,10 +229,11 @@ func (v *PathValidator) validate(userPath string, target validateTarget) (string
 // isFilesystemRoot reports whether path is a filesystem root:
 // "/" on Unix or a Windows drive root like "C:\\" / "C:/".
 func isFilesystemRoot(path string) bool {
-	if path == "/" || path == string(filepath.Separator) {
+	normalized := normalizeWindowsPath(path)
+	if normalized == "/" || normalized == string(filepath.Separator) {
 		return true
 	}
-	if len(path) == 3 && path[1] == ':' && (path[2] == '\\' || path[2] == '/') {
+	if len(normalized) == 3 && normalized[1] == ':' && (normalized[2] == '\\' || normalized[2] == '/') {
 		return true
 	}
 	return false

--- a/internal/api/core/path_validator.go
+++ b/internal/api/core/path_validator.go
@@ -17,6 +17,8 @@ import (
 // internal/updater/swap_darwin.go.
 var evalSymlinksFunc = filepath.EvalSymlinks
 
+var filepathAbs = filepath.Abs
+
 // PathValidator provides a unified, testable path validation pipeline.
 // It consolidates the allowlist/denylist/symlink-resolution logic previously
 // duplicated across batch/paths.go, core/path_validation.go, and
@@ -249,7 +251,7 @@ func (v *PathValidator) effectiveAllowedBase(rawBase string) (canonicalBase stri
 		return "", false
 	}
 	expandedBase := expandHomeDir(rawBase)
-	absBase, err := filepath.Abs(expandedBase)
+	absBase, err := filepathAbs(expandedBase)
 	if err != nil {
 		return "", false
 	}

--- a/internal/api/core/path_validator_root_allow_test.go
+++ b/internal/api/core/path_validator_root_allow_test.go
@@ -237,3 +237,15 @@ func TestIsFilesystemRoot_Exported(t *testing.T) {
 	assert.False(t, IsFilesystemRoot("/home"))
 	assert.False(t, IsFilesystemRoot(""))
 }
+
+func TestEffectiveAllowedBase_FilepathAbsError(t *testing.T) {
+	v := NewPathValidator(afero.NewOsFs(), []string{"/tmp"}, nil)
+
+	origAbs := filepathAbs
+	t.Cleanup(func() { filepathAbs = origAbs })
+
+	filepathAbs = func(string) (string, error) { return "", assert.AnError }
+
+	_, usable := v.effectiveAllowedBase("/tmp")
+	assert.False(t, usable, "filepath.Abs error should make entry unusable")
+}

--- a/internal/api/core/path_validator_root_allow_test.go
+++ b/internal/api/core/path_validator_root_allow_test.go
@@ -1,0 +1,219 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/api/apperrors"
+)
+
+func TestIsFilesystemRoot(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/", true},
+		{"/home", false},
+		{"", false},
+		{".", false},
+		{"/proc", false},
+	}
+
+	if runtime.GOOS != "windows" {
+		tests = append(tests,
+			struct {
+				path string
+				want bool
+			}{"C:\\", true},
+			struct {
+				path string
+				want bool
+			}{"C:/", true},
+			struct {
+				path string
+				want bool
+			}{"D:\\", true},
+			struct {
+				path string
+				want bool
+			}{"D:/", true},
+		)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, isFilesystemRoot(tt.path))
+		})
+	}
+}
+
+func TestEffectiveAllowedBase_RootResolvingDotUnderRootCWD(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific CWD test")
+	}
+
+	origWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	require.NoError(t, os.Chdir("/"))
+
+	v := NewPathValidator(afero.NewOsFs(), []string{"."}, nil)
+
+	canonicalBase, usable := v.effectiveAllowedBase(".")
+	assert.False(t, usable, "\".\" under CWD \"/\" should resolve to root and be unusable")
+	assert.Empty(t, canonicalBase)
+}
+
+func TestEffectiveAllowedBase_DotUnderRealCWD(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	v := NewPathValidator(afero.NewOsFs(), []string{"."}, nil)
+
+	canonicalBase, usable := v.effectiveAllowedBase(".")
+	assert.True(t, usable, "\".\" under a real CWD should resolve to a non-root absolute path")
+	assert.NotEmpty(t, canonicalBase)
+	assert.NotEqual(t, "/", canonicalBase)
+}
+
+func TestEffectiveAllowedBase_ExplicitRoot(t *testing.T) {
+	v := NewPathValidator(afero.NewOsFs(), []string{"/"}, nil)
+
+	_, usable := v.effectiveAllowedBase("/")
+	assert.False(t, usable, "explicit \"/\" should be unusable")
+}
+
+func TestValidateDir_DotUnderRootCWD_DeniesByDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific CWD test")
+	}
+
+	origWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+	require.NoError(t, os.Chdir("/"))
+
+	outsideDir := t.TempDir()
+
+	v := NewPathValidatorWithUNC(afero.NewOsFs(), []string{"."}, nil, false, nil)
+	_, err := v.ValidateDir(outsideDir)
+
+	require.Error(t, err)
+	assert.True(t, apperrors.IsPathError(err, apperrors.ErrAllowedDirsEmpty),
+		"expected ErrAllowedDirsEmpty when \".\" resolves to root, got %v", err)
+}
+
+func TestValidateDir_DotUnderRealCWD_AllowsCWD(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	v := NewPathValidatorWithUNC(afero.NewOsFs(), []string{"."}, nil, false, nil)
+	_, err := v.ValidateDir(tempDir)
+	assert.NoError(t, err, "\".\" under a real CWD should allow scanning within that dir")
+}
+
+func TestValidateDir_MixedRootAndValid_AllowsValidOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific CWD test")
+	}
+
+	origWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+	require.NoError(t, os.Chdir("/"))
+
+	validDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	v := NewPathValidatorWithUNC(afero.NewOsFs(), []string{".", validDir}, nil, false, nil)
+
+	_, err := v.ValidateDir(validDir)
+	assert.NoError(t, err, "valid allowlist entry should allow its own dir")
+
+	_, err = v.ValidateDir(outsideDir)
+	require.Error(t, err)
+	assert.True(t, apperrors.IsPathError(err, apperrors.ErrPathOutsideAllowed) || apperrors.IsPathError(err, apperrors.ErrAllowedDirsEmpty),
+		"expected path-outside or empty-allowlist error for dir outside valid entry, got %v", err)
+}
+
+func TestValidateDir_ExplicitRoot_DeniesByDefault(t *testing.T) {
+	tempDir := t.TempDir()
+
+	v := NewPathValidatorWithUNC(afero.NewOsFs(), []string{"/"}, nil, false, nil)
+	_, err := v.ValidateDir(tempDir)
+
+	require.Error(t, err)
+	assert.True(t, apperrors.IsPathError(err, apperrors.ErrAllowedDirsEmpty),
+		"explicit \"/\" should behave as empty allowlist (deny-by-default), got %v", err)
+}
+
+func TestIsDirAllowed_DotUnderRootCWD_ReturnsFalse(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific CWD test")
+	}
+
+	origWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+	require.NoError(t, os.Chdir("/"))
+
+	outsideDir := t.TempDir()
+	v := NewPathValidator(afero.NewOsFs(), []string{"."}, nil)
+
+	assert.False(t, v.IsDirAllowed(outsideDir),
+		"IsDirAllowed should return false for outside dir when \".\" resolves to root")
+}
+
+func TestIsDirAllowed_DotUnderRealCWD_ReturnsTrue(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	v := NewPathValidator(afero.NewOsFs(), []string{"."}, nil)
+	assert.True(t, v.IsDirAllowed(tempDir),
+		"IsDirAllowed should return true for CWD dir when \".\" resolves to a real CWD")
+}
+
+func TestIsDirAllowed_ExplicitRoot_ReturnsFalse(t *testing.T) {
+	tempDir := t.TempDir()
+	v := NewPathValidator(afero.NewOsFs(), []string{"/"}, nil)
+
+	assert.False(t, v.IsDirAllowed(tempDir),
+		"IsDirAllowed should return false when allowlist is [\"/\"] (root = unusable)")
+}
+
+func TestIsDirAllowed_MixedRootAndValid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific CWD test")
+	}
+
+	origWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+	require.NoError(t, os.Chdir("/"))
+
+	validDir := t.TempDir()
+	outsideDir := t.TempDir()
+	v := NewPathValidator(afero.NewOsFs(), []string{".", validDir}, nil)
+
+	assert.True(t, v.IsDirAllowed(validDir), "valid entry should allow its dir")
+	assert.False(t, v.IsDirAllowed(outsideDir), "outside dir should be denied")
+}
+
+func TestValidateDir_DotWithSubpathOutsideCWD(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific CWD test")
+	}
+
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	v := NewPathValidatorWithUNC(afero.NewOsFs(), []string{"."}, nil, false, nil)
+
+	// A subdirectory of the CWD (tempDir) should be allowed
+	subDir := filepath.Join(tempDir, "subfolder")
+	require.NoError(t, os.Mkdir(subDir, 0755))
+	_, err := v.ValidateDir(subDir)
+	assert.NoError(t, err)
+}

--- a/internal/api/core/path_validator_root_allow_test.go
+++ b/internal/api/core/path_validator_root_allow_test.go
@@ -25,26 +25,24 @@ func TestIsFilesystemRoot(t *testing.T) {
 		{"/proc", false},
 	}
 
-	if runtime.GOOS != "windows" {
-		tests = append(tests,
-			struct {
-				path string
-				want bool
-			}{"C:\\", true},
-			struct {
-				path string
-				want bool
-			}{"C:/", true},
-			struct {
-				path string
-				want bool
-			}{"D:\\", true},
-			struct {
-				path string
-				want bool
-			}{"D:/", true},
-		)
-	}
+	tests = append(tests,
+		struct {
+			path string
+			want bool
+		}{"C:\\", true},
+		struct {
+			path string
+			want bool
+		}{"C:/", true},
+		struct {
+			path string
+			want bool
+		}{"D:\\", true},
+		struct {
+			path string
+			want bool
+		}{"D:/", true},
+	)
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {

--- a/internal/api/core/path_validator_root_allow_test.go
+++ b/internal/api/core/path_validator_root_allow_test.go
@@ -45,7 +45,11 @@ func TestIsFilesystemRoot(t *testing.T) {
 	)
 
 	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
+		name := tt.path
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tt.want, isFilesystemRoot(tt.path))
 		})
 	}

--- a/internal/api/core/path_validator_root_allow_test.go
+++ b/internal/api/core/path_validator_root_allow_test.go
@@ -56,10 +56,7 @@ func TestEffectiveAllowedBase_RootResolvingDotUnderRootCWD(t *testing.T) {
 		t.Skip("Unix-specific CWD test")
 	}
 
-	origWd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	require.NoError(t, os.Chdir("/"))
+	t.Chdir("/")
 
 	v := NewPathValidator(afero.NewOsFs(), []string{"."}, nil)
 
@@ -92,9 +89,7 @@ func TestValidateDir_DotUnderRootCWD_DeniesByDefault(t *testing.T) {
 		t.Skip("Unix-specific CWD test")
 	}
 
-	origWd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-	require.NoError(t, os.Chdir("/"))
+	t.Chdir("/")
 
 	outsideDir := t.TempDir()
 
@@ -120,9 +115,7 @@ func TestValidateDir_MixedRootAndValid_AllowsValidOnly(t *testing.T) {
 		t.Skip("Unix-specific CWD test")
 	}
 
-	origWd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-	require.NoError(t, os.Chdir("/"))
+	t.Chdir("/")
 
 	validDir := t.TempDir()
 	outsideDir := t.TempDir()
@@ -154,9 +147,7 @@ func TestIsDirAllowed_DotUnderRootCWD_ReturnsFalse(t *testing.T) {
 		t.Skip("Unix-specific CWD test")
 	}
 
-	origWd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-	require.NoError(t, os.Chdir("/"))
+	t.Chdir("/")
 
 	outsideDir := t.TempDir()
 	v := NewPathValidator(afero.NewOsFs(), []string{"."}, nil)
@@ -187,9 +178,7 @@ func TestIsDirAllowed_MixedRootAndValid(t *testing.T) {
 		t.Skip("Unix-specific CWD test")
 	}
 
-	origWd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-	require.NoError(t, os.Chdir("/"))
+	t.Chdir("/")
 
 	validDir := t.TempDir()
 	outsideDir := t.TempDir()
@@ -214,4 +203,33 @@ func TestValidateDir_DotWithSubpathOutsideCWD(t *testing.T) {
 	require.NoError(t, os.Mkdir(subDir, 0755))
 	_, err := v.ValidateDir(subDir)
 	assert.NoError(t, err)
+}
+
+func TestEffectiveAllowedBase_AbsError(t *testing.T) {
+	v := NewPathValidator(afero.NewOsFs(), []string{"/tmp"}, nil)
+
+	origEval := evalSymlinksFunc
+	t.Cleanup(func() { evalSymlinksFunc = origEval })
+
+	evalSymlinksFunc = func(string) (string, error) {
+		return "", assert.AnError
+	}
+
+	_, usable := v.effectiveAllowedBase("/tmp")
+	assert.False(t, usable, "canonicalizePath error should make entry unusable")
+}
+
+func TestIsFilesystemRoot_NotRoot(t *testing.T) {
+	assert.False(t, isFilesystemRoot("/home"))
+	assert.False(t, isFilesystemRoot("/tmp/test"))
+	assert.False(t, isFilesystemRoot(""))
+	assert.False(t, isFilesystemRoot("."))
+	assert.False(t, isFilesystemRoot("relative/path"))
+}
+
+func TestIsFilesystemRoot_Exported(t *testing.T) {
+	assert.True(t, IsFilesystemRoot("/"))
+	assert.True(t, IsFilesystemRoot("C:\\"))
+	assert.False(t, IsFilesystemRoot("/home"))
+	assert.False(t, IsFilesystemRoot(""))
 }

--- a/internal/api/core/path_validator_root_allow_test.go
+++ b/internal/api/core/path_validator_root_allow_test.go
@@ -205,7 +205,7 @@ func TestValidateDir_DotWithSubpathOutsideCWD(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestEffectiveAllowedBase_AbsError(t *testing.T) {
+func TestEffectiveAllowedBase_CanonicalizeError(t *testing.T) {
 	v := NewPathValidator(afero.NewOsFs(), []string{"/tmp"}, nil)
 
 	origEval := evalSymlinksFunc

--- a/internal/api/system/security_config.go
+++ b/internal/api/system/security_config.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -75,6 +76,9 @@ func updateSecurityConfig(rt *core.APIRuntime) gin.HandlerFunc {
 		}
 
 		for _, dir := range req.AllowedDirectories {
+			if strings.TrimSpace(dir) == "" {
+				continue
+			}
 			expanded := core.ExpandHomeDir(dir)
 			abs, err := filepath.Abs(expanded)
 			if err != nil {

--- a/internal/api/system/security_config.go
+++ b/internal/api/system/security_config.go
@@ -15,6 +15,8 @@ import (
 	"github.com/javinizer/javinizer-go/internal/config"
 )
 
+var filepathAbs = filepath.Abs
+
 // SecurityUpdateRequest carries the operator-editable subset of the api.security
 // block. The frontend Security settings section PUTs this narrow payload (rather
 // than the whole config) so a single-section save never risks clobbering
@@ -80,7 +82,7 @@ func updateSecurityConfig(rt *core.APIRuntime) gin.HandlerFunc {
 				continue
 			}
 			expanded := core.ExpandHomeDir(dir)
-			abs, err := filepath.Abs(expanded)
+			abs, err := filepathAbs(expanded)
 			if err != nil {
 				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: fmt.Sprintf("allowed_directories entry %q could not be resolved to an absolute path", dir)})
 				return

--- a/internal/api/system/security_config.go
+++ b/internal/api/system/security_config.go
@@ -2,8 +2,10 @@ package system
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 
 	"github.com/gin-gonic/gin"
 
@@ -70,6 +72,19 @@ func updateSecurityConfig(rt *core.APIRuntime) gin.HandlerFunc {
 		if err := json.Unmarshal(body, &req); err != nil {
 			c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: "Invalid security configuration format"})
 			return
+		}
+
+		for _, dir := range req.AllowedDirectories {
+			expanded := core.ExpandHomeDir(dir)
+			abs, err := filepath.Abs(expanded)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: fmt.Sprintf("allowed_directories entry %q could not be resolved to an absolute path", dir)})
+				return
+			}
+			if core.IsFilesystemRoot(abs) {
+				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: fmt.Sprintf("allowed_directories entry %q resolves to filesystem root; choose a specific folder", dir)})
+				return
+			}
 		}
 
 		rt.GetRuntime().ConfigUpdateMu.Lock()

--- a/internal/api/system/security_config.go
+++ b/internal/api/system/security_config.go
@@ -87,7 +87,11 @@ func updateSecurityConfig(rt *core.APIRuntime) gin.HandlerFunc {
 				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: fmt.Sprintf("allowed_directories entry %q could not be resolved to an absolute path", dir)})
 				return
 			}
-			if core.IsFilesystemRoot(abs) {
+			resolved, err := filepath.EvalSymlinks(abs)
+			if err != nil {
+				resolved = abs
+			}
+			if core.IsFilesystemRoot(resolved) {
 				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: fmt.Sprintf("allowed_directories entry %q resolves to filesystem root; choose a specific folder", dir)})
 				return
 			}

--- a/internal/api/system/security_config_test.go
+++ b/internal/api/system/security_config_test.go
@@ -285,6 +285,68 @@ func TestUpdateSecurityConfig_TypeMismatch(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "Invalid security configuration format")
 }
 
+// TestUpdateSecurityConfig_RejectsRootResolvingAllowedDirectory verifies
+// that the PUT handler rejects an allowed_directories entry that resolves to a
+// filesystem root (e.g. "/") with 400, and does NOT persist the rejected
+// payload. A valid entry (a temp directory) is included as a control variant
+// to guard against the validation being too aggressive.
+func TestUpdateSecurityConfig_RejectsRootResolvingAllowedDirectory(t *testing.T) {
+	validDir := t.TempDir()
+
+	for _, tc := range []struct {
+		name               string
+		allowedDirectories []string
+		wantStatus         int
+		wantBodyContains   string
+		wantPersisted      []string
+	}{
+		{
+			name:               "explicit root rejected",
+			allowedDirectories: []string{"/"},
+			wantStatus:         http.StatusBadRequest,
+			wantBodyContains:   "resolves to filesystem root",
+			wantPersisted:      []string{"/keep"},
+		},
+		{
+			name:               "valid directory accepted",
+			allowedDirectories: []string{validDir},
+			wantStatus:         http.StatusOK,
+			wantBodyContains:   "",
+			wantPersisted:      []string{validDir},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			initial := config.DefaultConfig(nil, nil)
+			initial.API.Security.AllowedDirectories = []string{"/keep"}
+
+			tempConfigFile := t.TempDir() + "/config.yaml"
+			coreDeps := createTestDeps(t, initial, tempConfigFile)
+			deps := systemDepsFromCore(coreDeps)
+
+			router := gin.New()
+			router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+			body, err := json.Marshal(SecurityUpdateRequest{
+				AllowedDirectories: tc.allowedDirectories,
+			})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPut, "/config/security", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, tc.wantStatus, w.Code, "body: %s", w.Body.String())
+			if tc.wantBodyContains != "" {
+				assert.Contains(t, w.Body.String(), tc.wantBodyContains)
+			}
+
+			saved := deps.CoreDeps.GetConfig()
+			assert.Equal(t, tc.wantPersisted, saved.API.Security.AllowedDirectories)
+		})
+	}
+}
+
 // failingBody is an io.ReadCloser whose Read always returns an error, used to
 // exercise the io.ReadAll failure branch of updateSecurityConfig.
 type failingBody struct{}

--- a/internal/api/system/security_config_test.go
+++ b/internal/api/system/security_config_test.go
@@ -347,6 +347,38 @@ func TestUpdateSecurityConfig_RejectsRootResolvingAllowedDirectory(t *testing.T)
 	}
 }
 
+// TestUpdateSecurityConfig_EmptyEntriesSkipped verifies that empty/whitespace
+// allowed_directories entries are skipped (not rejected) during PUT validation,
+// matching the runtime validator which treats empty entries as unusable.
+func TestUpdateSecurityConfig_EmptyEntriesSkipped(t *testing.T) {
+	validDir := t.TempDir()
+
+	initial := config.DefaultConfig(nil, nil)
+	initial.API.Security.AllowedDirectories = []string{"/keep"}
+
+	tempConfigFile := t.TempDir() + "/config.yaml"
+	coreDeps := createTestDeps(t, initial, tempConfigFile)
+	deps := systemDepsFromCore(coreDeps)
+
+	router := gin.New()
+	router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+	body, err := json.Marshal(SecurityUpdateRequest{
+		AllowedDirectories: []string{"", "  ", validDir},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/config/security", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	saved := deps.CoreDeps.GetConfig()
+	assert.Equal(t, []string{"", "  ", validDir}, saved.API.Security.AllowedDirectories)
+}
+
 // failingBody is an io.ReadCloser whose Read always returns an error, used to
 // exercise the io.ReadAll failure branch of updateSecurityConfig.
 type failingBody struct{}

--- a/internal/api/system/security_config_test.go
+++ b/internal/api/system/security_config_test.go
@@ -417,3 +417,35 @@ func TestUpdateSecurityConfig_AbsErrorRejected(t *testing.T) {
 	saved := deps.CoreDeps.GetConfig()
 	assert.Equal(t, []string{"/keep"}, saved.API.Security.AllowedDirectories)
 }
+
+func TestUpdateSecurityConfig_SymlinkToRootRejected(t *testing.T) {
+	rootSymlink := t.TempDir() + "/rootlink"
+	require.NoError(t, os.Symlink("/", rootSymlink))
+	t.Cleanup(func() { _ = os.Remove(rootSymlink) })
+
+	initial := config.DefaultConfig(nil, nil)
+	initial.API.Security.AllowedDirectories = []string{"/keep"}
+
+	tempConfigFile := t.TempDir() + "/config.yaml"
+	coreDeps := createTestDeps(t, initial, tempConfigFile)
+	deps := systemDepsFromCore(coreDeps)
+
+	router := gin.New()
+	router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+	body, err := json.Marshal(SecurityUpdateRequest{
+		AllowedDirectories: []string{rootSymlink},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/config/security", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "resolves to filesystem root")
+
+	saved := deps.CoreDeps.GetConfig()
+	assert.Equal(t, []string{"/keep"}, saved.API.Security.AllowedDirectories)
+}

--- a/internal/api/system/security_config_test.go
+++ b/internal/api/system/security_config_test.go
@@ -385,3 +385,35 @@ type failingBody struct{}
 
 func (failingBody) Read(p []byte) (int, error) { return 0, errors.New("synthetic read failure") }
 func (failingBody) Close() error               { return nil }
+
+func TestUpdateSecurityConfig_AbsErrorRejected(t *testing.T) {
+	initial := config.DefaultConfig(nil, nil)
+	initial.API.Security.AllowedDirectories = []string{"/keep"}
+
+	tempConfigFile := t.TempDir() + "/config.yaml"
+	coreDeps := createTestDeps(t, initial, tempConfigFile)
+	deps := systemDepsFromCore(coreDeps)
+
+	router := gin.New()
+	router.PUT("/config/security", updateSecurityConfig(testkit.GetTestRuntime(deps)))
+
+	origAbs := filepathAbs
+	t.Cleanup(func() { filepathAbs = origAbs })
+	filepathAbs = func(string) (string, error) { return "", errors.New("abs: synthetic failure") }
+
+	body, err := json.Marshal(SecurityUpdateRequest{
+		AllowedDirectories: []string{"/valid/path"},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/config/security", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "could not be resolved to an absolute path")
+
+	saved := deps.CoreDeps.GetConfig()
+	assert.Equal(t, []string{"/keep"}, saved.API.Security.AllowedDirectories)
+}

--- a/internal/config/config.yaml.example
+++ b/internal/config/config.yaml.example
@@ -31,10 +31,9 @@ api:
             - http://127.0.0.1:5174
 
         # Allowed directories for API file operations (organize, preview, etc.)
-        # Default is current working directory. For Docker, use /media
-        # Add your media library paths here
-        allowed_directories:
-            - .
+        # Empty list = deny-by-default until you choose a specific folder.
+        # Example entries: ~/Videos, /media, /mnt/nas/movies
+        allowed_directories: []
 
         # Explicitly deny specific directories (optional)
         denied_directories: []


### PR DESCRIPTION
## Summary

Closes an allowlist bypass where `allowed_directories` entries resolving to a filesystem root silently granted access to the entire filesystem.

## The bug

`allowed_directories` can contain relative entries like `.` (the shipped example config used `allowed_directories: ["."]`). `PathValidator.isAllowed` resolved each allowed dir via `filepath.Abs(baseDir)`, which resolves `.` against the process CWD. For the desktop app launched from Finder, CWD is `/`, so:

- `.` → `filepath.Abs(".")` → `/`
- `isPathWithinCanonical("/private/tmp", "/")` returns true (every path is "within" root)
- Therefore the **entire filesystem** was treated as allowed. A user could organize into `/private/tmp` despite the allowlist nominally being `[".", "/Users/.../test-videos"]`.

This defeated the allowlist for scan/organize AND browse operation-scope. The shipped example config used `["."]`, so this affected default desktop installs.

## The fix

A central runtime guard in `path_validator.go` (not config-load-time normalization — that would miss in-memory callers and risk persisting `.` → `/`):

- New `isFilesystemRoot()` (Unix `/` + Windows drive roots `C:\` / `C:/`) and `effectiveAllowedBase(rawBase)` helpers.
- `effectiveAllowedBase` expands `~`, absolutizes, normalizes, canonicalizes, and returns `usable=false` when the result is a filesystem root. Root-resolving entries **fail closed** (deny-by-default) instead of granting everything.
- Applied in **all four enforcement points** (a prior review by GPT-5.5 flagged that `IsDirAllowed` has a duplicate allowlist loop used by batch code — both must be covered, or batch callers stay vulnerable):
  - the `validate()` step-1 empty-allowlist gate
  - `isAllowed()`
  - `IsDirAllowed()` hasValidEntry gate
  - `IsDirAllowed()` allowlist loop

- Legitimate relative entries preserved: `.` from a real CLI launch dir (e.g. `/home/user/Videos`) resolves to a non-root absolute path and still works. Only root-resolving entries (including `.` under CWD `/`, and explicit `/` or `C:\`) fail closed.

**Defense in depth:**
- The PUT `/api/v1/config/security` handler now rejects root-resolving entries with 400 before persisting, so Settings users get immediate feedback.
- `configs/config.yaml.example` **and** the embedded `internal/config/config.yaml.example` (kept in sync — the embedded one is the source of truth for generated configs) ship `[]` (deny-by-default) instead of `["."]`.

## Validation
- `go test ./internal/api/...` — pass (incl. 14 new root-guard tests + 2 new handler tests)
- `go vet ./internal/...` — clean
- macOS desktop app rebuilt and manually verified (organizing into `/private/tmp` now 403s)

## Notes
- Existing disk configs with `.` are not hard-failed on load — the runtime guard makes them safe immediately. Users can repair the value through Settings.
- A symlink-to-root entry passes the PUT validation (no canonicalization in the handler) but is caught at runtime by `effectiveAllowedBase`'s canonicalize. Acceptable layering — the runtime guard is the authoritative boundary.
