### PR TITLE
fix(ci): pin actions/github-script to v7 tag in anti-spam workflow

### DIFF
--- a/.github/workflows/anti-spam.yml
+++ b/.github/workflows/anti-spam.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check for spam attachments / patch drops
-        uses: actions/github-script@60a0d8308c434a1e126febd7568c7e5c8c1f8664 # v7
+        uses: actions/github-script@v7
         with:
           script: |
             const payload = context.payload;


### PR DESCRIPTION
## Summary

Fixes the "Anti-Spam Filter" CI workflow that has been failing on every issue/PR comment since the `actions/github-script` commit SHA it referenced was removed/force-pushed from the upstream repo.

## The fix

The workflow `.github/workflows/anti-spam.yml` referenced `actions/github-script@60a0d8308c434a1e126febd7568c7e5c8c1f8664` (with a `# v7` comment). That SHA no longer exists in the `actions/github-script` repository, causing every `issue_comment`-triggered run to fail with:

```
Unable to resolve action `actions/github-script@60a0d8308c434a1e126febd7568c7e5c8c1f8664`,
unable to find version `60a0d8308c434a1e126febd7568c7e5c8c1f8664`
```

Pinned to the `v7` tag instead of the dead commit SHA.

## Validation
No code changes — workflow YAML only. The fix will be validated on the next issue_comment trigger.
