### PR TITLE
fix(worker): recover orphaned running/pending jobs on startup

### DIFF
--- a/internal/worker/job_store.go
+++ b/internal/worker/job_store.go
@@ -176,6 +176,35 @@ func (s *JobStore) loadFromDatabase() {
 			s.jobs[batchJob.ID] = batchJob
 		}
 	}
+
+	s.recoverOrphanedJobs()
+}
+
+// recoverOrphanedJobs marks jobs stuck in 'running' or 'pending' status as
+// 'failed' on startup. When the server restarts after a crash or kill, these
+// jobs have no live worker goroutine — they are orphaned zombies that can
+// neither be cancelled (no worker to process the context cancellation) nor
+// deleted (DeleteJob refuses running jobs). Marking them failed restores
+// normal Cancel/Delete functionality and gives the user a clear signal.
+func (s *JobStore) recoverOrphanedJobs() {
+	recovered := 0
+	for id, job := range s.jobs {
+		job.lifecycle.mu.Lock()
+		status := job.lifecycle.Status
+		if status != models.JobStatusRunning && status != models.JobStatusPending {
+			job.lifecycle.mu.Unlock()
+			continue
+		}
+		job.lifecycle.mu.Unlock()
+
+		job.lifecycle.MarkFailed()
+		s.persistence.PersistJob(job)
+		recovered++
+		logging.Warnf("Recovered orphaned job %s (was %s, marked failed)", id, status)
+	}
+	if recovered > 0 {
+		logging.Warnf("Recovered %d orphaned job(s) on startup", recovered)
+	}
 }
 
 // jobAdapters holds pre-built adapter components for a BatchJob.

--- a/internal/worker/orphaned_job_recovery_test.go
+++ b/internal/worker/orphaned_job_recovery_test.go
@@ -175,8 +175,8 @@ func TestRecoverOrphanedJobs_PersistsRecoveredStatus(t *testing.T) {
 
 func TestRecoverOrphanedJobs_IntegrationWithLoadFromDatabase(t *testing.T) {
 	runningJob := &models.Job{
-		ID:        "loadtest-0001",
-		Status:    models.JobStatusRunning,
+		ID:         "loadtest-0001",
+		Status:     models.JobStatusRunning,
 		TotalFiles: 1,
 		Completed:  0,
 		Failed:     0,
@@ -186,8 +186,8 @@ func TestRecoverOrphanedJobs_IntegrationWithLoadFromDatabase(t *testing.T) {
 		StartedAt:  time.Now().Add(-1 * time.Hour),
 	}
 	pendingJob := &models.Job{
-		ID:        "loadtest-0002",
-		Status:    models.JobStatusPending,
+		ID:         "loadtest-0002",
+		Status:     models.JobStatusPending,
 		TotalFiles: 1,
 		Completed:  0,
 		Failed:     0,
@@ -197,8 +197,8 @@ func TestRecoverOrphanedJobs_IntegrationWithLoadFromDatabase(t *testing.T) {
 		StartedAt:  time.Now().Add(-30 * time.Minute),
 	}
 	completedJob := &models.Job{
-		ID:        "loadtest-0003",
-		Status:    models.JobStatusCompleted,
+		ID:         "loadtest-0003",
+		Status:     models.JobStatusCompleted,
 		TotalFiles: 1,
 		Completed:  1,
 		Failed:     0,

--- a/internal/worker/orphaned_job_recovery_test.go
+++ b/internal/worker/orphaned_job_recovery_test.go
@@ -1,0 +1,267 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecoverOrphanedJobs_RunningJobMarkedFailed(t *testing.T) {
+	store := NewInMemoryJobStore()
+
+	job := store.CreateJobBatch([]string{"/test/file.mp4"})
+	require.NotNil(t, job)
+
+	job.lifecycle.mu.Lock()
+	job.lifecycle.Status = models.JobStatusRunning
+	job.lifecycle.mu.Unlock()
+
+	store.recoverOrphanedJobs()
+
+	status, ok := store.GetJob(job.ID.String())
+	require.True(t, ok)
+	assert.Equal(t, models.JobStatusFailed, status.Status)
+	assert.NotNil(t, status.CompletedAt)
+}
+
+func TestRecoverOrphanedJobs_PendingJobMarkedFailed(t *testing.T) {
+	store := NewInMemoryJobStore()
+
+	job := store.CreateJobBatch([]string{"/test/file.mp4"})
+	require.NotNil(t, job)
+
+	job.lifecycle.mu.Lock()
+	job.lifecycle.Status = models.JobStatusPending
+	job.lifecycle.mu.Unlock()
+
+	store.recoverOrphanedJobs()
+
+	status, ok := store.GetJob(job.ID.String())
+	require.True(t, ok)
+	assert.Equal(t, models.JobStatusFailed, status.Status)
+	assert.NotNil(t, status.CompletedAt)
+}
+
+func TestRecoverOrphanedJobs_TerminalJobsUntouched(t *testing.T) {
+	store := NewInMemoryJobStore()
+
+	job := store.CreateJobBatch([]string{"/test/file.mp4"})
+	require.NotNil(t, job)
+
+	originalCompletedAt := time.Now()
+	originalProgress := 42.0
+
+	terminalStatuses := []models.JobStatus{
+		models.JobStatusCompleted,
+		models.JobStatusFailed,
+		models.JobStatusCancelled,
+		models.JobStatusOrganized,
+		models.JobStatusReverted,
+	}
+
+	for _, status := range terminalStatuses {
+		job.lifecycle.mu.Lock()
+		job.lifecycle.Status = status
+		job.lifecycle.CompletedAt = &originalCompletedAt
+		job.lifecycle.mu.Unlock()
+
+		job.results.mu.Lock()
+		job.results.Progress = originalProgress
+		job.results.mu.Unlock()
+
+		store.recoverOrphanedJobs()
+
+		result, ok := store.GetJob(job.ID.String())
+		require.True(t, ok)
+		assert.Equal(t, status, result.Status, "terminal job should not be recovered")
+		assert.Equal(t, originalProgress, result.Progress, "progress should be preserved for terminal jobs")
+		require.NotNil(t, result.CompletedAt)
+		assert.Equal(t, originalCompletedAt.Unix(), result.CompletedAt.Unix(), "completed_at should be preserved")
+	}
+}
+
+func TestRecoverOrphanedJobs_MultipleOrphanedJobs(t *testing.T) {
+	store := NewInMemoryJobStore()
+
+	job1 := store.CreateJobBatch([]string{"/test/file1.mp4"})
+	job2 := store.CreateJobBatch([]string{"/test/file2.mp4"})
+	job3 := store.CreateJobBatch([]string{"/test/file3.mp4"})
+
+	require.NotNil(t, job1)
+	require.NotNil(t, job2)
+	require.NotNil(t, job3)
+
+	job1.lifecycle.mu.Lock()
+	job1.lifecycle.Status = models.JobStatusRunning
+	job1.lifecycle.mu.Unlock()
+
+	job2.lifecycle.mu.Lock()
+	job2.lifecycle.Status = models.JobStatusPending
+	job2.lifecycle.mu.Unlock()
+
+	job3.lifecycle.mu.Lock()
+	job3.lifecycle.Status = models.JobStatusCompleted
+	completedAt := time.Now()
+	job3.lifecycle.CompletedAt = &completedAt
+	job3.lifecycle.mu.Unlock()
+
+	store.recoverOrphanedJobs()
+
+	s1, ok := store.GetJob(job1.ID.String())
+	require.True(t, ok)
+	s2, ok := store.GetJob(job2.ID.String())
+	require.True(t, ok)
+	s3, ok := store.GetJob(job3.ID.String())
+	require.True(t, ok)
+
+	assert.Equal(t, models.JobStatusFailed, s1.Status)
+	assert.Equal(t, models.JobStatusFailed, s2.Status)
+	assert.Equal(t, models.JobStatusCompleted, s3.Status)
+}
+
+func TestRecoverOrphanedJobs_EmptyStore(t *testing.T) {
+	store := NewInMemoryJobStore()
+
+	store.recoverOrphanedJobs()
+
+	assert.Empty(t, store.ListJobs())
+}
+
+func TestRecoverOrphanedJobs_RunningJobCanBeDeletedAfter(t *testing.T) {
+	store := NewInMemoryJobStore()
+
+	job := store.CreateJobBatch([]string{"/test/file.mp4"})
+	require.NotNil(t, job)
+
+	job.lifecycle.mu.Lock()
+	job.lifecycle.Status = models.JobStatusRunning
+	job.lifecycle.mu.Unlock()
+
+	err := store.DeleteJob(job.ID.String())
+	assert.Error(t, err, "cannot delete running job before recovery")
+
+	store.recoverOrphanedJobs()
+
+	err = store.DeleteJob(job.ID.String())
+	assert.NoError(t, err, "should be deletable after recovery marks it failed")
+
+	_, ok := store.GetJob(job.ID.String())
+	assert.False(t, ok, "job should be gone after delete")
+}
+
+func TestRecoverOrphanedJobs_PersistsRecoveredStatus(t *testing.T) {
+	fakePersist := &fakePersistencer{}
+	store := NewInMemoryJobStore(WithPersistence(fakePersist))
+
+	job := store.CreateJobBatch([]string{"/test/file.mp4"})
+	require.NotNil(t, job)
+
+	job.lifecycle.mu.Lock()
+	job.lifecycle.Status = models.JobStatusRunning
+	job.lifecycle.mu.Unlock()
+
+	fakePersist.calls = 0
+	store.recoverOrphanedJobs()
+
+	assert.Equal(t, 1, fakePersist.calls, "recovered job should be persisted")
+	assert.Equal(t, models.JobStatusFailed, fakePersist.lastStatus, "persisted status should be failed")
+	assert.NotNil(t, fakePersist.lastCompletedAt, "persisted completed_at should be set")
+}
+
+func TestRecoverOrphanedJobs_IntegrationWithLoadFromDatabase(t *testing.T) {
+	runningJob := &models.Job{
+		ID:        "loadtest-0001",
+		Status:    models.JobStatusRunning,
+		TotalFiles: 1,
+		Completed:  0,
+		Failed:     0,
+		Progress:   0,
+		Files:      `["/test/file.mp4"]`,
+		Results:    `{"domain":{}}`,
+		StartedAt:  time.Now().Add(-1 * time.Hour),
+	}
+	pendingJob := &models.Job{
+		ID:        "loadtest-0002",
+		Status:    models.JobStatusPending,
+		TotalFiles: 1,
+		Completed:  0,
+		Failed:     0,
+		Progress:   0,
+		Files:      `["/test/file2.mp4"]`,
+		Results:    `{"domain":{}}`,
+		StartedAt:  time.Now().Add(-30 * time.Minute),
+	}
+	completedJob := &models.Job{
+		ID:        "loadtest-0003",
+		Status:    models.JobStatusCompleted,
+		TotalFiles: 1,
+		Completed:  1,
+		Failed:     0,
+		Progress:   100,
+		Files:      `["/test/file3.mp4"]`,
+		Results:    `{"domain":{}}`,
+		StartedAt:  time.Now().Add(-2 * time.Hour),
+	}
+
+	fakePersist := &fakePersistencer{
+		jobs: []*models.Job{runningJob, pendingJob, completedJob},
+	}
+	store := NewInMemoryJobStore(WithPersistence(fakePersist))
+	store.loadFromDatabase()
+
+	jobs := store.ListJobs()
+	require.Len(t, jobs, 3)
+
+	for _, j := range jobs {
+		if j.ID.String() == "loadtest-0001" || j.ID.String() == "loadtest-0002" {
+			assert.Equal(t, models.JobStatusFailed, j.Status, "orphaned job should be recovered to failed")
+		}
+		if j.ID.String() == "loadtest-0003" {
+			assert.Equal(t, models.JobStatusCompleted, j.Status, "completed job should be untouched")
+		}
+	}
+
+	assert.GreaterOrEqual(t, fakePersist.persistCount, 2, "at least 2 recovered jobs should be persisted")
+}
+
+type fakePersistencer struct {
+	mu              sync.Mutex
+	calls           int
+	lastStatus      models.JobStatus
+	lastCompletedAt *time.Time
+	persistCount    int
+	jobs            []*models.Job
+}
+
+func (f *fakePersistencer) PersistJob(job *BatchJob) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.persistCount++
+	job.lifecycle.mu.RLock()
+	f.lastStatus = job.lifecycle.Status
+	f.lastCompletedAt = job.lifecycle.CompletedAt
+	job.lifecycle.mu.RUnlock()
+}
+
+func (f *fakePersistencer) PersistJobByID(id string) {}
+
+func (f *fakePersistencer) DeleteJobFromDB(id string) error { return nil }
+
+func (f *fakePersistencer) LoadJobs(_ context.Context) ([]models.Job, error) {
+	if f.jobs == nil {
+		return nil, nil
+	}
+	result := make([]models.Job, len(f.jobs))
+	for i, j := range f.jobs {
+		result[i] = *j
+	}
+	return result, nil
+}
+
+func (f *fakePersistencer) UpsertJob(_ *models.Job) error { return nil }


### PR DESCRIPTION
## Summary

Fixes orphaned "zombie" jobs that get stuck in `running` or `pending` status after a server crash/kill. These jobs have no live worker goroutine — they can't be cancelled (no worker to process the context cancellation) and can't be deleted (`DeleteJob` refuses running jobs), leaving them permanently stuck in the jobs list.

## The fix

Add a private `recoverOrphanedJobs()` method called at the end of `loadFromDatabase()` (runs on every `JobStore` construction / server startup). It:

1. Iterates all loaded jobs
2. For any with `running` or `pending` status (no live worker will ever complete them):
   - Calls `JobLifecycle.MarkFailed()` (sets status to `failed`, sets `completed_at`, closes the `done` channel)
   - Persists the change to the DB
   - Logs a warning: `"Recovered orphaned job <id> (was running, marked failed)"`
3. Terminal jobs (completed, failed, cancelled, organized, reverted) are untouched

This means on the next server restart after a crash, zombie jobs are automatically marked as `failed` — making them deletable and cancellable from the UI.

## Design decisions (per review)
- **Private** — not exposed on `JobStoreInterface`; startup-only, not a runtime API (prevents marking live running jobs as failed)
- **Uses `MarkFailed()`** lifecycle transition (not direct assignment) so the `done` channel is properly closed and `DeleteJob` works immediately
- **Preserves progress** — does not overwrite the existing persisted partial progress value
- **No temp dir cleanup** — preserves poster URLs; explicit deletion cleans temp dirs separately

## Tests (8)
- `RunningJobMarkedFailed` — running → failed
- `PendingJobMarkedFailed` — pending → failed
- `TerminalJobsUntouched` — all 5 terminal statuses preserved (with progress + completed_at assertions)
- `MultipleOrphanedJobs` — mixed running + pending + completed, only orphaned recovered
- `EmptyStore` — no jobs, no panic
- `RunningJobCanBeDeletedAfter` — can't delete running → recover → delete succeeds
- `PersistsRecoveredStatus` — fake persistencer verifies failed status + completed_at persisted
- `IntegrationWithLoadFromDatabase` — fake DB rows (running/pending/completed) → `loadFromDatabase` → recovery → verify only orphaned recovered

## Validation
- `go test ./internal/worker/` — pass
- `go test -race ./internal/worker/ -run TestRecoverOrphaned` — race-clean
- `go vet ./internal/worker/...` — clean
- Reviewed by GPT-5.6-sol (2 rounds, ship verdict)
