### PR TITLE
fix(imageutil): upgrade DMM covers/posters to high-res awsimgsrc CDN

### DIFF
--- a/internal/imageutil/miss_test.go
+++ b/internal/imageutil/miss_test.go
@@ -34,7 +34,7 @@ func TestGetOptimalPosterURL_ConstructURLFails(t *testing.T) {
 
 func TestGetOptimalPosterURL_AwsimgsrcDirect(t *testing.T) {
 	// Test with an already-awsimgsrc URL
-	coverURL := "https://awsimgsrc.dmm.com/dig/video/ipx00535/ipx00535pl.jpg"
+	coverURL := "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg"
 
 	// Create a small test image for the server to serve
 	img := image.NewRGBA(image.Rect(0, 0, 1000, 1500))
@@ -51,7 +51,7 @@ func TestGetOptimalPosterURL_AwsimgsrcDirect(t *testing.T) {
 	defer server.Close()
 
 	// Override the URL to point to our test server
-	testURL := server.URL + "/dig/video/ipx00535/ipx00535ps.jpg"
+	testURL := server.URL + "/dig/digital/video/ipx00535/ipx00535ps.jpg"
 	posterURL, shouldCrop := GetOptimalPosterURL(coverURL, server.Client())
 	// The URL construction changes pl.jpg -> ps.jpg for awsimgsrc
 	// Since it can't reach the real server, it falls back
@@ -84,24 +84,26 @@ func TestGetOptimalPosterURL_DigitalVideoPattern(t *testing.T) {
 }
 
 func TestGetOptimalPosterURL_NilClient(t *testing.T) {
-	// Test with nil client - should use default client and fall back
-	coverURL := "https://pics.dmm.co.jp/digital/video/sone00860/sone00860pl.jpg"
+	// Test with nil client - should use default client. Use a content ID that
+	// does not exist on the CDN so the poster fetch reliably fails and the
+	// function falls back to cropping the cover (deterministic, no network
+	// dependency on a live title).
+	coverURL := "https://pics.dmm.co.jp/digital/video/zznonexistenttest999/zznonexistenttest999pl.jpg"
 	posterURL, shouldCrop := GetOptimalPosterURL(coverURL, nil)
-	// Can't reach real server, falls back to cover (shouldCrop=true to crop the cover).
 	assert.True(t, shouldCrop)
-	_ = posterURL
+	assert.Equal(t, coverURL, posterURL)
 }
 
 // --- constructAwsimgsrcPosterURL tests ---
 
 func TestConstructAwsimgsrcPosterURL_DigitalVideo(t *testing.T) {
 	result := constructAwsimgsrcPosterURL("https://pics.dmm.co.jp/digital/video/sone00860/sone00860pl.jpg")
-	assert.Equal(t, "https://awsimgsrc.dmm.com/dig/video/sone00860/sone00860ps.jpg", result)
+	assert.Equal(t, "https://awsimgsrc.dmm.com/dig/digital/video/sone00860/sone00860ps.jpg", result)
 }
 
 func TestConstructAwsimgsrcPosterURL_DigitalAmateur(t *testing.T) {
 	result := constructAwsimgsrcPosterURL("https://pics.dmm.co.jp/digital/amateur/siro00860/siro00860pl.jpg")
-	assert.Equal(t, "https://awsimgsrc.dmm.com/dig/amateur/siro00860/siro00860ps.jpg", result)
+	assert.Equal(t, "https://awsimgsrc.dmm.com/dig/digital/amateur/siro00860/siro00860ps.jpg", result)
 }
 
 func TestConstructAwsimgsrcPosterURL_MonoMovie(t *testing.T) {
@@ -110,8 +112,8 @@ func TestConstructAwsimgsrcPosterURL_MonoMovie(t *testing.T) {
 }
 
 func TestConstructAwsimgsrcPosterURL_AlreadyAwsimgsrc(t *testing.T) {
-	result := constructAwsimgsrcPosterURL("https://awsimgsrc.dmm.com/dig/video/sone00860/sone00860pl.jpg")
-	assert.Equal(t, "https://awsimgsrc.dmm.com/dig/video/sone00860/sone00860ps.jpg", result)
+	result := constructAwsimgsrcPosterURL("https://awsimgsrc.dmm.com/dig/digital/video/sone00860/sone00860pl.jpg")
+	assert.Equal(t, "https://awsimgsrc.dmm.com/dig/digital/video/sone00860/sone00860ps.jpg", result)
 }
 
 func TestConstructAwsimgsrcPosterURL_Empty(t *testing.T) {
@@ -125,9 +127,10 @@ func TestConstructAwsimgsrcPosterURL_NoMatch(t *testing.T) {
 }
 
 func TestConstructAwsimgsrcPosterURL_UnknownPath(t *testing.T) {
-	// Unknown path pattern - should try the simpler format
+	// Unknown path pattern on pics.dmm.co.jp returns empty (only recognized
+	// digital/video, digital/amateur, mono/movie paths are rewritable).
 	result := constructAwsimgsrcPosterURL("https://pics.dmm.co.jp/other/video/sone00860/sone00860pl.jpg")
-	assert.Contains(t, result, "dig/video/sone00860/sone00860ps.jpg")
+	assert.Equal(t, "", result)
 }
 
 // --- CropPosterWithBounds error cases ---

--- a/internal/imageutil/poster.go
+++ b/internal/imageutil/poster.go
@@ -7,6 +7,7 @@ import (
 	_ "image/png"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -67,54 +68,89 @@ func GetOptimalPosterURL(coverURL string, client *http.Client) (posterURL string
 }
 
 // constructAwsimgsrcPosterURL converts a cover URL to an awsimgsrc poster URL
+// (ps.jpg). It is a thin wrapper around constructAwsimgsrcURL.
+//
 // Example: https://pics.dmm.co.jp/digital/video/sone00860/sone00860pl.jpg
 //
-//	-> https://awsimgsrc.dmm.com/dig/video/sone00860/sone00860ps.jpg
+//	-> https://awsimgsrc.dmm.com/dig/digital/video/sone00860/sone00860ps.jpg
 //
 // Example: https://pics.dmm.co.jp/mono/movie/adult/118abw001/118abw001pl.jpg
 //
 //	-> https://awsimgsrc.dmm.com/dig/mono/movie/118abw001/118abw001ps.jpg
 func constructAwsimgsrcPosterURL(coverURL string) string {
+	return constructAwsimgsrcURL(coverURL, "ps.jpg")
+}
+
+// constructAwsimgsrcURL converts a pics.dmm.co.jp (or already-awsimgsrc)
+// cover URL to its awsimgsrc.dmm.com equivalent using the requested filename
+// suffix (e.g. "ps.jpg" for posters, "pl.jpg" for high-res covers). Returns
+// "" if coverURL does not match a known DMM cover pattern.
+//
+// Path mapping (verified against the live CDN):
+//   - digital/video/{id}/{id}pl.jpg    -> dig/digital/video/{id}/{id}{suffix}
+//   - digital/amateur/{id}/{id}pl.jpg  -> dig/digital/amateur/{id}/{id}{suffix}
+//   - mono/movie/adult/{id}/{id}pl.jpg -> dig/mono/movie/{id}/{id}{suffix}
+//
+// When the input is already on awsimgsrc.dmm.com / awsimgsrc.dmm.co.jp, only
+// the filename suffix is swapped.
+func constructAwsimgsrcURL(coverURL, suffix string) string {
 	if coverURL == "" {
 		return ""
 	}
 
-	// Pattern 1: digital/video/[id]/[id]pl.jpg -> dig/video/[id]/[id]ps.jpg
-	// Pattern 2: mono/movie/adult/[id]/[id]pl.jpg -> dig/mono/movie/[id]/[id]ps.jpg
-	// Pattern 3: awsimgsrc already - just replace pl.jpg with ps.jpg
-
-	// If it's already awsimgsrc, just replace pl.jpg with ps.jpg
-	if strings.Contains(coverURL, "awsimgsrc.dmm.com") || strings.Contains(coverURL, "awsimgsrc.dmm.co.jp") {
-		return strings.Replace(coverURL, "pl.jpg", "ps.jpg", 1)
+	u, err := url.Parse(coverURL)
+	if err != nil {
+		return ""
 	}
 
-	// Extract the content ID from the URL
-	// Pattern: .../[id]/[id]pl.jpg
+	if isAwsimgsrcHost(u.Hostname()) {
+		return swapDMMCoverSuffix(coverURL, suffix)
+	}
+
+	if u.Hostname() != picsDMMHost {
+		return ""
+	}
+
 	re := regexp.MustCompile(`/([\w\d]+)/([\w\d]+)pl\.jpg$`)
 	matches := re.FindStringSubmatch(coverURL)
 	if len(matches) < 3 {
 		return ""
 	}
 
-	contentID := matches[2] // The ID part (e.g., sone00860, 118abw001)
+	contentID := matches[2]
 
-	// Determine the path structure
 	var awsimgsrcPath string
-	if strings.Contains(coverURL, "/digital/video/") {
-		// Digital video pattern: dig/video/[id]/[id]ps.jpg
-		awsimgsrcPath = fmt.Sprintf("dig/video/%s/%sps.jpg", contentID, contentID)
-	} else if strings.Contains(coverURL, "/digital/amateur/") {
-		// Amateur pattern: dig/amateur/[id]/[id]ps.jpg
-		awsimgsrcPath = fmt.Sprintf("dig/amateur/%s/%sps.jpg", contentID, contentID)
-	} else if strings.Contains(coverURL, "/mono/movie/") {
-		// Mono movie pattern: dig/mono/movie/[id]/[id]ps.jpg
-		awsimgsrcPath = fmt.Sprintf("dig/mono/movie/%s/%sps.jpg", contentID, contentID)
-	} else {
-		// Unknown pattern, try the simpler format
-		awsimgsrcPath = fmt.Sprintf("dig/video/%s/%sps.jpg", contentID, contentID)
+	switch {
+	case strings.Contains(coverURL, "/digital/video/"):
+		awsimgsrcPath = fmt.Sprintf("dig/digital/video/%s/%s%s", contentID, contentID, suffix)
+	case strings.Contains(coverURL, "/digital/amateur/"):
+		awsimgsrcPath = fmt.Sprintf("dig/digital/amateur/%s/%s%s", contentID, contentID, suffix)
+	case strings.Contains(coverURL, "/mono/movie/"):
+		awsimgsrcPath = fmt.Sprintf("dig/mono/movie/%s/%s%s", contentID, contentID, suffix)
+	default:
+		return ""
 	}
 
 	return fmt.Sprintf("https://awsimgsrc.dmm.com/%s", awsimgsrcPath)
+}
+
+func isAwsimgsrcHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "awsimgsrc.dmm.com" || host == "awsimgsrc.dmm.co.jp"
+}
+
+// swapDMMCoverSuffix replaces the trailing cover/poster suffix of a DMM
+// image URL with the requested suffix. Recognized source suffixes are
+// pl.jpg and ps.jpg; URLs ending in anything else are returned unchanged.
+func swapDMMCoverSuffix(url, suffix string) string {
+	switch {
+	case strings.HasSuffix(url, "pl.jpg"):
+		return url[:len(url)-len("pl.jpg")] + suffix
+	case strings.HasSuffix(url, "ps.jpg"):
+		return url[:len(url)-len("ps.jpg")] + suffix
+	default:
+		return url
+	}
 }
 
 // GetImageDimensions fetches an image and returns its dimensions

--- a/internal/imageutil/poster_test.go
+++ b/internal/imageutil/poster_test.go
@@ -20,7 +20,7 @@ func TestConstructAwsimgsrcPosterURL(t *testing.T) {
 		{
 			name:        "digital video format",
 			coverURL:    "https://pics.dmm.co.jp/digital/video/sone00860/sone00860pl.jpg",
-			expectedURL: "https://awsimgsrc.dmm.com/dig/video/sone00860/sone00860ps.jpg",
+			expectedURL: "https://awsimgsrc.dmm.com/dig/digital/video/sone00860/sone00860ps.jpg",
 		},
 		{
 			name:        "mono movie format",
@@ -29,8 +29,8 @@ func TestConstructAwsimgsrcPosterURL(t *testing.T) {
 		},
 		{
 			name:        "awsimgsrc already - pl.jpg",
-			coverURL:    "https://awsimgsrc.dmm.com/dig/video/ipx00535/ipx00535pl.jpg",
-			expectedURL: "https://awsimgsrc.dmm.com/dig/video/ipx00535/ipx00535ps.jpg",
+			coverURL:    "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg",
+			expectedURL: "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535ps.jpg",
 		},
 		{
 			name:        "awsimgsrc mono format - pl.jpg",
@@ -50,7 +50,7 @@ func TestConstructAwsimgsrcPosterURL(t *testing.T) {
 		{
 			name:        "digital amateur format",
 			coverURL:    "https://pics.dmm.co.jp/digital/amateur/oreco183/oreco183pl.jpg",
-			expectedURL: "https://awsimgsrc.dmm.com/dig/amateur/oreco183/oreco183ps.jpg",
+			expectedURL: "https://awsimgsrc.dmm.com/dig/digital/amateur/oreco183/oreco183ps.jpg",
 		},
 		{
 			name:        "awsimgsrc.dmm.co.jp domain",
@@ -152,41 +152,32 @@ func TestGetOptimalPosterURL_WithHTTPServer(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		coverURL        string
 		posterImageData []byte
 		posterStatus    int
-		expectedPoster  string // "awsimgsrc" or "cover"
 		expectedCrop    bool
 	}{
 		{
 			name:            "high quality poster - use awsimgsrc",
-			coverURL:        "https://pics.dmm.co.jp/digital/video/sone00860/sone00860pl.jpg",
 			posterImageData: highQualityImage,
 			posterStatus:    http.StatusOK,
-			expectedPoster:  "cover",
-			expectedCrop:    true, // test server isn't on awsimgsrc.dmm.com, so the constructed ps.jpg URL 404s and the cover is returned for cropping
+			expectedCrop:    false, // meets MinPoster dimensions: return ps.jpg directly
 		},
 		{
 			name:            "low quality poster - fallback to cover",
-			coverURL:        "https://pics.dmm.co.jp/digital/video/sone00860/sone00860pl.jpg",
 			posterImageData: lowQualityImage,
 			posterStatus:    http.StatusOK,
-			expectedPoster:  "cover",
-			expectedCrop:    true, // no high-quality portrait: caller must crop the cover
+			expectedCrop:    true, // too small: caller must crop the cover
 		},
 		{
 			name:            "poster not found - fallback to cover",
-			coverURL:        "https://pics.dmm.co.jp/digital/video/sone00860/sone00860pl.jpg",
 			posterImageData: nil,
 			posterStatus:    http.StatusNotFound,
-			expectedPoster:  "cover",
 			expectedCrop:    true, // no high-quality portrait: caller must crop the cover
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create mock server
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if tt.posterStatus != http.StatusOK {
 					w.WriteHeader(tt.posterStatus)
@@ -198,34 +189,28 @@ func TestGetOptimalPosterURL_WithHTTPServer(t *testing.T) {
 			}))
 			defer server.Close()
 
-			// Override the cover URL to point to our test server
-			// The function will construct an awsimgsrc URL, but we need to test the dimension checking logic
-			// So we'll test with a URL that already points to awsimgsrc (our test server)
-			testCoverURL := server.URL + "/digital/video/sone00860/sone00860pl.jpg"
-
-			client := &http.Client{Timeout: 5 * time.Second}
+			// Use a real awsimgsrc.dmm.com cover URL (so constructAwsimgsrcURL
+			// takes the already-awsimgsrc branch and produces a ps.jpg URL on
+			// the same host), but intercept HTTP requests via a custom transport
+			// that routes awsimgsrc.dmm.com to our local test server. This lets
+			// us exercise the dimension-checking logic without hitting the real
+			// CDN.
+			testCoverURL := "https://awsimgsrc.dmm.com/dig/digital/video/sone00860/sone00860pl.jpg"
+			client := &http.Client{
+				Timeout: 5 * time.Second,
+				Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					req.URL.Scheme = server.URL[:strings.Index(server.URL, ":")]
+					req.URL.Host = server.URL[strings.Index(server.URL, ":")+3:]
+					return http.DefaultTransport.RoundTrip(req)
+				}),
+			}
 			posterURL, shouldCrop := GetOptimalPosterURL(testCoverURL, client)
 
 			if shouldCrop != tt.expectedCrop {
-				t.Errorf("shouldCrop = %v, want %v", shouldCrop, tt.expectedCrop)
-			}
-
-			// Since GetOptimalPosterURL tries to fetch from awsimgsrc.dmm.com (which won't work in tests),
-			// it will fall back to coverURL. This is expected behavior.
-			// In a real scenario, this would work, but for testing we verify the fallback logic.
-			if tt.expectedPoster == "cover" {
-				if !contains(posterURL, testCoverURL) && posterURL != testCoverURL {
-					// It's okay if it constructed an awsimgsrc URL but that would fail,
-					// so it falls back to cover
-					t.Logf("Poster URL fallback behavior verified")
-				}
+				t.Errorf("shouldCrop = %v, want %v (posterURL=%s)", shouldCrop, tt.expectedCrop, posterURL)
 			}
 		})
 	}
-}
-
-func contains(s, substr string) bool {
-	return strings.Contains(s, substr)
 }
 
 func TestGetImageDimensions(t *testing.T) {
@@ -379,9 +364,9 @@ func TestConstructAwsimgsrcPosterURL_UnknownPattern(t *testing.T) {
 		expectedURL string
 	}{
 		{
-			name:        "unknown path with valid ID pattern",
+			name:        "unknown path with valid ID pattern returns empty",
 			coverURL:    "https://pics.dmm.co.jp/some/other/path/abc123/abc123pl.jpg",
-			expectedURL: "https://awsimgsrc.dmm.com/dig/video/abc123/abc123ps.jpg",
+			expectedURL: "",
 		},
 		{
 			name:        "URL with different extension",
@@ -391,7 +376,7 @@ func TestConstructAwsimgsrcPosterURL_UnknownPattern(t *testing.T) {
 		{
 			name:        "URL without ID repetition - uses last ID",
 			coverURL:    "https://pics.dmm.co.jp/digital/video/sone00860/differentidpl.jpg",
-			expectedURL: "https://awsimgsrc.dmm.com/dig/video/differentid/differentidps.jpg",
+			expectedURL: "https://awsimgsrc.dmm.com/dig/digital/video/differentid/differentidps.jpg",
 		},
 	}
 
@@ -413,18 +398,18 @@ func TestNormalizeThenConstructPosterURL(t *testing.T) {
 	}{
 		{
 			name:        "awsimgsrc CDN rewritten then poster constructed",
-			rawCoverURL: "https://awsimgsrc.dmm.co.jp/pics_dig/video/sone00860/sone00860pl.jpg",
-			expectedURL: "https://awsimgsrc.dmm.com/dig/video/sone00860/sone00860ps.jpg",
+			rawCoverURL: "https://awsimgsrc.dmm.co.jp/pics_dig/digital/video/sone00860/sone00860pl.jpg",
+			expectedURL: "https://awsimgsrc.dmm.com/dig/digital/video/sone00860/sone00860ps.jpg",
 		},
 		{
 			name:        "digital video cover produces correct poster",
 			rawCoverURL: "https://pics.dmm.co.jp/digital/video/sone00860/sone00860pl.jpg",
-			expectedURL: "https://awsimgsrc.dmm.com/dig/video/sone00860/sone00860ps.jpg",
+			expectedURL: "https://awsimgsrc.dmm.com/dig/digital/video/sone00860/sone00860ps.jpg",
 		},
 		{
 			name:        "digital amateur cover produces correct poster",
 			rawCoverURL: "https://pics.dmm.co.jp/digital/amateur/oreco183/oreco183pl.jpg",
-			expectedURL: "https://awsimgsrc.dmm.com/dig/amateur/oreco183/oreco183ps.jpg",
+			expectedURL: "https://awsimgsrc.dmm.com/dig/digital/amateur/oreco183/oreco183ps.jpg",
 		},
 	}
 
@@ -438,4 +423,75 @@ func TestNormalizeThenConstructPosterURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConstructAwsimgsrcURL_HostValidation verifies the blocker fix: only
+// pics.dmm.co.jp (or already-awsimgsrc) URLs are rewritten. Non-DMM URLs
+// that happen to match the path pattern must be left alone (return "").
+func TestConstructAwsimgsrcURL_HostValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		coverURL    string
+		suffix      string
+		expectedURL string
+	}{
+		{
+			name:        "non-DMM host with digital video path returns empty",
+			coverURL:    "https://example.com/digital/video/foo/foopl.jpg",
+			suffix:      "pl.jpg",
+			expectedURL: "",
+		},
+		{
+			name:        "non-DMM host with matching pattern returns empty",
+			coverURL:    "https://evil.com/awsimgsrc.dmm.com/dig/video/foo/foopl.jpg",
+			suffix:      "ps.jpg",
+			expectedURL: "",
+		},
+		{
+			name:        "already-awsimgsrc host suffix swap",
+			coverURL:    "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg",
+			suffix:      "ps.jpg",
+			expectedURL: "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535ps.jpg",
+		},
+		{
+			name:        "already-awsimgsrc ps.jpg to pl.jpg",
+			coverURL:    "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535ps.jpg",
+			suffix:      "pl.jpg",
+			expectedURL: "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg",
+		},
+		{
+			name:        "awsimgsrc.dmm.co.jp host recognized",
+			coverURL:    "https://awsimgsrc.dmm.co.jp/pics_dig/video/sone00860/sone00860pl.jpg",
+			suffix:      "ps.jpg",
+			expectedURL: "https://awsimgsrc.dmm.co.jp/pics_dig/video/sone00860/sone00860ps.jpg",
+		},
+		{
+			name:        "pics host unknown path returns empty",
+			coverURL:    "https://pics.dmm.co.jp/unknown/segment/foo/foopl.jpg",
+			suffix:      "ps.jpg",
+			expectedURL: "",
+		},
+		{
+			name:        "pics host no pl.jpg suffix returns empty",
+			coverURL:    "https://pics.dmm.co.jp/digital/video/foo/foops.jpg",
+			suffix:      "pl.jpg",
+			expectedURL: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := constructAwsimgsrcURL(tt.coverURL, tt.suffix)
+			if result != tt.expectedURL {
+				t.Errorf("constructAwsimgsrcURL(%q, %q) = %q, want %q",
+					tt.coverURL, tt.suffix, result, tt.expectedURL)
+			}
+		})
+	}
+}
+
+type roundTripperFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/internal/imageutil/poster_test.go
+++ b/internal/imageutil/poster_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConstructAwsimgsrcPosterURL(t *testing.T) {
@@ -488,6 +491,39 @@ func TestConstructAwsimgsrcURL_HostValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConstructAwsimgsrcURL_UnparseableURL covers the url.Parse error
+// branch (lines 102-104): a cover URL containing a raw control character is
+// rejected by url.Parse, so constructAwsimgsrcURL must return "".
+func TestConstructAwsimgsrcURL_UnparseableURL(t *testing.T) {
+	// \x7f (DEL) in the host is rejected by url.Parse with
+	// "invalid control character in URL".
+	result := constructAwsimgsrcURL("https://exa\x7fmple.com/image.jpg", "pl.jpg")
+	assert.Equal(t, "", result, "unparseable URL should return empty string")
+}
+
+// TestConstructAwsimgsrcURL_AwsimgsrcUnknownSuffix covers the default branch
+// of swapDMMCoverSuffix (lines 151-152): an already-awsimgsrc URL whose
+// filename ends in a suffix other than pl.jpg/ps.jpg (here jp.jpg) must be
+// returned unchanged.
+func TestConstructAwsimgsrcURL_AwsimgsrcUnknownSuffix(t *testing.T) {
+	coverURL := "https://awsimgsrc.dmm.com/dig/digital/video/sone00560/sone00560jp.jpg"
+	// swapDMMCoverSuffix hits the default case since the URL ends in jp.jpg,
+	// not pl.jpg or ps.jpg; the URL is returned unchanged.
+	result := constructAwsimgsrcURL(coverURL, "pl.jpg")
+	assert.Equal(t, coverURL, result)
+}
+
+// TestGetImageDimensions_NewRequestError covers the http.NewRequest error
+// branch (lines 165-167): a URL containing a raw space is rejected by
+// http.NewRequest ("invalid character in host name"), which fails before
+// client.Do is ever called.
+func TestGetImageDimensions_NewRequestError(t *testing.T) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, _, err := GetImageDimensions("https://exa mple.com/image.jpg", client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create request")
 }
 
 type roundTripperFunc func(req *http.Request) (*http.Response, error)

--- a/internal/imageutil/screenshot.go
+++ b/internal/imageutil/screenshot.go
@@ -16,6 +16,11 @@ var (
 	dmmImageExtRegex = regexp.MustCompile(`(?i)\.jpe?g$`)
 )
 
+// picsDMMHost is the hostname serving DMM cover/poster/screenshot images
+// at their canonical (lower-resolution) URLs. awsimgsrc.dmm.com serves
+// higher-resolution equivalents.
+const picsDMMHost = "pics.dmm.co.jp"
+
 // IsDMMHost returns true if the hostname belongs to a DMM-owned domain
 // (dmm.co.jp, dmm.com, and their subdomains).
 func IsDMMHost(host string) bool {
@@ -47,7 +52,7 @@ func NormalizeDMMScreenshotURL(raw string) string {
 		raw = "https:" + raw
 	}
 
-	raw = strings.Replace(raw, "awsimgsrc.dmm.co.jp/pics_dig", "pics.dmm.co.jp", 1)
+	raw = strings.Replace(raw, "awsimgsrc.dmm.co.jp/pics_dig", picsDMMHost, 1)
 
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -105,7 +110,7 @@ func DiscoverScreenshots(coverURL string, client *http.Client) []string {
 		return nil
 	}
 
-	if u.Hostname() != "pics.dmm.co.jp" {
+	if u.Hostname() != picsDMMHost {
 		return nil
 	}
 
@@ -210,11 +215,12 @@ func probeScreenshots(dir, contentID string, client *http.Client) []string {
 	return screenshots
 }
 
-// UpgradeCoverResolution upgrades cover image URLs to their highest-resolution
-// variant. It applies two transformations:
+// UpgradeCoverResolution upgrades cover image filenames to their
+// highest-resolution suffix variant:
 //   - ps.jpg → pl.jpg (for all URLs, including amateur)
 //   - jp.jpg → pl.jpg (for non-amateur URLs only)
 //
+// It does NOT change the CDN host — use UpgradeDMMCoverCDN for that.
 // Screenshot-style filenames (e.g., ipx00535jp-1.jpg) are left unchanged
 // because the suffix check uses HasSuffix rather than Contains.
 func UpgradeCoverResolution(rawURL string) string {
@@ -223,6 +229,17 @@ func UpgradeCoverResolution(rawURL string) string {
 	}
 	if !strings.Contains(rawURL, "/amateur/") && strings.HasSuffix(rawURL, "jp.jpg") {
 		rawURL = rawURL[:len(rawURL)-len("jp.jpg")] + "pl.jpg"
+	}
+	return rawURL
+}
+
+// UpgradeDMMCoverCDN rewrites a pics.dmm.co.jp cover URL to its
+// higher-resolution equivalent on the awsimgsrc.dmm.com CDN (e.g.
+// 800×501 → 2184×1368 for SONE-560). Returns the input unchanged for
+// non-pics URLs or URLs that don't match a known DMM cover pattern.
+func UpgradeDMMCoverCDN(rawURL string) string {
+	if upgraded := constructAwsimgsrcURL(rawURL, "pl.jpg"); upgraded != "" {
+		return upgraded
 	}
 	return rawURL
 }

--- a/internal/imageutil/screenshot_test.go
+++ b/internal/imageutil/screenshot_test.go
@@ -271,3 +271,54 @@ func TestUpgradeCoverResolution(t *testing.T) {
 		})
 	}
 }
+
+func TestUpgradeDMMCoverCDN(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "pics digital video pl.jpg upgraded to awsimgsrc",
+			url:      "https://pics.dmm.co.jp/digital/video/sone00560/sone00560pl.jpg",
+			expected: "https://awsimgsrc.dmm.com/dig/digital/video/sone00560/sone00560pl.jpg",
+		},
+		{
+			name:     "pics mono movie pl.jpg upgraded to awsimgsrc",
+			url:      "https://pics.dmm.co.jp/mono/movie/adult/118abw001/118abw001pl.jpg",
+			expected: "https://awsimgsrc.dmm.com/dig/mono/movie/118abw001/118abw001pl.jpg",
+		},
+		{
+			name:     "pics amateur pl.jpg upgraded to awsimgsrc",
+			url:      "https://pics.dmm.co.jp/digital/amateur/oreco183/oreco183pl.jpg",
+			expected: "https://awsimgsrc.dmm.com/dig/digital/amateur/oreco183/oreco183pl.jpg",
+		},
+		{
+			name:     "already awsimgsrc pl.jpg unchanged (idempotent)",
+			url:      "https://awsimgsrc.dmm.com/dig/digital/video/sone00560/sone00560pl.jpg",
+			expected: "https://awsimgsrc.dmm.com/dig/digital/video/sone00560/sone00560pl.jpg",
+		},
+		{
+			name:     "non-DMM URL unchanged",
+			url:      "https://example.com/digital/video/foo/foopl.jpg",
+			expected: "https://example.com/digital/video/foo/foopl.jpg",
+		},
+		{
+			name:     "pics amateur jp.jpg unchanged (no pl.jpg suffix)",
+			url:      "https://pics.dmm.co.jp/digital/amateur/oreco183/oreco183jp.jpg",
+			expected: "https://pics.dmm.co.jp/digital/amateur/oreco183/oreco183jp.jpg",
+		},
+		{
+			name:     "empty string unchanged",
+			url:      "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := UpgradeDMMCoverCDN(tt.url)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/scraper/dmm/dmm_test.go
+++ b/internal/scraper/dmm/dmm_test.go
@@ -467,7 +467,7 @@ func TestParseHTML_OldSite(t *testing.T) {
 	assert.Len(t, result.Actresses, 2)
 	// Actresses may be in either order
 	// assert.Equal(t, "Test Actress", result.Actresses[0].JapaneseName)
-	assert.Equal(t, "https://pics.dmm.co.jp/digital/video/ipx00535/ipx00535pl.jpg", result.CoverURL)
+	assert.Equal(t, "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg", result.CoverURL)
 	assert.Len(t, result.ScreenshotURL, 2)
 }
 
@@ -1188,22 +1188,22 @@ func TestExtractCoverURL_EdgeCases(t *testing.T) {
 			name:        "Digital video cover",
 			html:        `<img src="https://pics.dmm.co.jp/digital/video/ipx00535/ipx00535ps.jpg" />`,
 			isNewSite:   false,
-			expected:    "https://pics.dmm.co.jp/digital/video/ipx00535/ipx00535pl.jpg",
-			description: "Should replace ps.jpg with pl.jpg for larger image",
+			expected:    "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg",
+			description: "Should replace ps.jpg with pl.jpg and upgrade to awsimgsrc CDN",
 		},
 		{
 			name:        "Physical DVD cover",
 			html:        `<img src="https://pics.dmm.co.jp/mono/movie/adult/abp420/abp420ps.jpg" />`,
 			isNewSite:   false,
-			expected:    "https://pics.dmm.co.jp/mono/movie/adult/abp420/abp420pl.jpg",
-			description: "Should replace ps.jpg with pl.jpg for DVD",
+			expected:    "https://awsimgsrc.dmm.com/dig/mono/movie/abp420/abp420pl.jpg",
+			description: "Should replace ps.jpg with pl.jpg and upgrade to awsimgsrc CDN for DVD",
 		},
 		{
 			name:        "Amateur cover",
 			html:        `<img src="https://pics.dmm.co.jp/digital/amateur/xyz123/xyz123ps.jpg" />`,
 			isNewSite:   false,
-			expected:    "https://pics.dmm.co.jp/digital/amateur/xyz123/xyz123pl.jpg",
-			description: "Should handle amateur category covers",
+			expected:    "https://awsimgsrc.dmm.com/dig/digital/amateur/xyz123/xyz123pl.jpg",
+			description: "Should handle amateur category covers and upgrade to awsimgsrc CDN",
 		},
 		{
 			name:        "No cover image",

--- a/internal/scraper/dmm/jsonld.go
+++ b/internal/scraper/dmm/jsonld.go
@@ -163,7 +163,7 @@ func extractMetadataFromJSONLD(doc *goquery.Document) map[string]any {
 		if len(images) > 0 {
 			// First image is usually the cover
 			// Images already normalized by getImagesFromJSONLD -> imageutil.NormalizeDMMScreenshotURL
-			metadata["cover_url"] = imageutil.UpgradeCoverResolution(images[0])
+			metadata["cover_url"] = imageutil.UpgradeDMMCoverCDN(imageutil.UpgradeCoverResolution(images[0]))
 
 			// Rest are screenshots (skip first which is cover)
 			if len(images) > 1 {

--- a/internal/scraper/dmm/jsonld_test.go
+++ b/internal/scraper/dmm/jsonld_test.go
@@ -394,7 +394,7 @@ func TestExtractMetadataFromJSONLD(t *testing.T) {
 			expectedKeys: []string{"title", "cover_url", "screenshots"},
 			checkValues: map[string]interface{}{
 				"title":     "Normalized Movie",
-				"cover_url": "https://pics.dmm.co.jp/digital/video/ipx00535/ipx00535pl.jpg",
+				"cover_url": "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg",
 			},
 		},
 	}

--- a/internal/scraper/dmm/media.go
+++ b/internal/scraper/dmm/media.go
@@ -23,12 +23,13 @@ func (s *scraper) extractCoverURL(doc *goquery.Document, isNewSite bool, content
 		html, _ := doc.Html()
 		matches := coverPsRegex.FindStringSubmatch(html)
 		if len(matches) > 1 {
-			return imageutil.UpgradeCoverResolution(imageutil.NormalizeDMMScreenshotURL(matches[1]))
+			return imageutil.UpgradeDMMCoverCDN(imageutil.UpgradeCoverResolution(imageutil.NormalizeDMMScreenshotURL(matches[1])))
 		}
 		return ""
 	}
 	coverURL = imageutil.NormalizeDMMScreenshotURL(coverURL)
 	coverURL = imageutil.UpgradeCoverResolution(coverURL)
+	coverURL = imageutil.UpgradeDMMCoverCDN(coverURL)
 	return coverURL
 }
 

--- a/internal/scraper/dmm/search_success_test.go
+++ b/internal/scraper/dmm/search_success_test.go
@@ -143,7 +143,7 @@ func TestGetURLAndSearch_SuccessWithCachedContentID(t *testing.T) {
 	assert.Equal(t, "Director Name", result.Director)
 	assert.Equal(t, "Maker Name", result.Maker)
 	assert.Equal(t, "Label Name", result.Label)
-	assert.Equal(t, "https://pics.dmm.co.jp/digital/video/ipx00535/ipx00535pl.jpg", result.CoverURL)
+	assert.Equal(t, "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg", result.CoverURL)
 	assert.Len(t, result.ScreenshotURL, 2)
 	assert.Len(t, result.Genres, 2)
 	assert.Len(t, result.Actresses, 1)

--- a/internal/scraper/dmm/video_dmm.go
+++ b/internal/scraper/dmm/video_dmm.go
@@ -48,18 +48,7 @@ func (s *scraper) extractCoverURLNewSite(doc *goquery.Document, contentID string
 	coverURL, exists := doc.Find(`meta[property="og:image"]`).Attr("content")
 	logging.Debugf("DMM Streaming: og:image exists=%v, value=%s", exists, coverURL)
 	if exists && coverURL != "" {
-		// Normalize consistently with the background-image path: fix
-		// protocol-relative "//pics.dmm.co.jp/..." URLs (og:image and <img>
-		// fallbacks can return these without a scheme), remap the CDN host, and
-		// strip the query. Using the shared helper keeps all cover-URL sources
-		// normalized the same way instead of only the background-image path.
-		coverURL = imageutil.NormalizeDMMScreenshotURL(coverURL)
-		// Replace 'ps.jpg' with 'pl.jpg' for larger image
-		coverURL = strings.Replace(coverURL, "ps.jpg", "pl.jpg", 1)
-		// Remove query parameters
-		if idx := strings.Index(coverURL, "?"); idx != -1 {
-			coverURL = coverURL[:idx]
-		}
+		coverURL = imageutil.UpgradeDMMCoverCDN(imageutil.UpgradeCoverResolution(imageutil.NormalizeDMMScreenshotURL(coverURL)))
 		logging.Debugf("DMM Streaming: Final cover URL from og:image: %s", coverURL)
 		return coverURL
 	}
@@ -87,16 +76,7 @@ func (s *scraper) extractCoverURLNewSite(doc *goquery.Document, contentID string
 	})
 
 	if bgImageURL != "" {
-		// Normalize the URL
-		coverURL = imageutil.NormalizeDMMScreenshotURL(bgImageURL)
-		// For amateur videos, keep jp.jpg suffix (pl.jpg doesn't exist for amateur videos)
-		// For regular videos, convert to pl.jpg for larger image
-		if !strings.Contains(coverURL, "/amateur/") {
-			// Replace 'jp.jpg' with 'pl.jpg' for larger image (non-amateur videos)
-			coverURL = strings.Replace(coverURL, "jp.jpg", "pl.jpg", 1)
-			// Also handle standard 'ps.jpg' -> 'pl.jpg' conversion
-			coverURL = strings.Replace(coverURL, "ps.jpg", "pl.jpg", 1)
-		}
+		coverURL = imageutil.UpgradeDMMCoverCDN(imageutil.UpgradeCoverResolution(imageutil.NormalizeDMMScreenshotURL(bgImageURL)))
 		logging.Debugf("DMM Streaming: Final cover URL from background-image: %s", coverURL)
 		return coverURL
 	}
@@ -106,11 +86,7 @@ func (s *scraper) extractCoverURLNewSite(doc *goquery.Document, contentID string
 	coverURL, _ = doc.Find(`img[src*="pl.jpg"]`).First().Attr("src")
 	logging.Debugf("DMM Streaming: img[src*='pl.jpg'] found: %s", coverURL)
 	if coverURL != "" {
-		// Convert to regular pics.dmm.co.jp URL and remove query parameters
-		coverURL = strings.Replace(coverURL, "awsimgsrc.dmm.co.jp/pics_dig", "pics.dmm.co.jp", 1)
-		if idx := strings.Index(coverURL, "?"); idx != -1 {
-			coverURL = coverURL[:idx]
-		}
+		coverURL = imageutil.UpgradeDMMCoverCDN(imageutil.UpgradeCoverResolution(imageutil.NormalizeDMMScreenshotURL(coverURL)))
 		logging.Debugf("DMM Streaming: Final cover URL from img tag: %s", coverURL)
 		return coverURL
 	}
@@ -131,10 +107,8 @@ func (s *scraper) extractCoverURLNewSite(doc *goquery.Document, contentID string
 	// Note: Amateur videos use 'jp.jpg' suffix, not 'pl.jpg' (pl.jpg doesn't exist for amateur videos)
 	// DMM serves cover assets on lowercase paths, so normalize to lowercase
 	if contentID != "" {
-		// Normalize to lowercase to match DMM's URL structure
 		normalizedID := strings.ToLower(contentID)
-		// Try amateur video pattern (amateur videos use jp.jpg, not pl.jpg)
-		coverURL = "https://pics.dmm.co.jp/digital/amateur/" + normalizedID + "/" + normalizedID + "jp.jpg"
+		coverURL = imageutil.UpgradeDMMCoverCDN(imageutil.UpgradeCoverResolution("https://pics.dmm.co.jp/digital/amateur/" + normalizedID + "/" + normalizedID + "jp.jpg"))
 		logging.Debugf("DMM Streaming: Constructed amateur cover URL from content ID '%s': %s", contentID, coverURL)
 		return coverURL
 	}

--- a/internal/scraper/dmm/video_dmm_test.go
+++ b/internal/scraper/dmm/video_dmm_test.go
@@ -74,13 +74,13 @@ func TestExtractCoverURLNewSite(t *testing.T) {
 	}{
 		{
 			name:     "from og:image",
-			html:     `<html><head><meta property="og:image" content="https://awsimgsrc.dmm.co.jp/pics_dig/video/ipx00535/ipx00535ps.jpg"></head><body></body></html>`,
-			expected: "https://pics.dmm.co.jp/video/ipx00535/ipx00535pl.jpg",
+			html:     `<html><head><meta property="og:image" content="https://awsimgsrc.dmm.co.jp/pics_dig/digital/video/ipx00535/ipx00535ps.jpg"></head><body></body></html>`,
+			expected: "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg",
 		},
 		{
 			name:     "from og:image with query params",
-			html:     `<html><head><meta property="og:image" content="https://awsimgsrc.dmm.co.jp/pics_dig/video/ipx00535/ipx00535ps.jpg?size=large"></head><body></body></html>`,
-			expected: "https://pics.dmm.co.jp/video/ipx00535/ipx00535pl.jpg",
+			html:     `<html><head><meta property="og:image" content="https://awsimgsrc.dmm.co.jp/pics_dig/digital/video/ipx00535/ipx00535ps.jpg?size=large"></head><body></body></html>`,
+			expected: "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg",
 		},
 		{
 			name:     "from CSS background-image with protocol-relative URL (amateur video keeps jp.jpg)",
@@ -108,19 +108,19 @@ func TestExtractCoverURLNewSite(t *testing.T) {
 			expected: "https://pics.dmm.co.jp/digital/amateur/oreco183/oreco183jp.jpg",
 		},
 		{
-			name:     "from CSS background-image with regular video (converts jp.jpg to pl.jpg)",
+			name:     "from CSS background-image with regular video (converts jp.jpg to pl.jpg + awsimgsrc CDN)",
 			html:     `<html><body><div style="background-image: url(//pics.dmm.co.jp/digital/video/ipx00535/ipx00535jp.jpg);"></div></body></html>`,
-			expected: "https://pics.dmm.co.jp/digital/video/ipx00535/ipx00535pl.jpg",
+			expected: "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg",
 		},
 		{
 			name:     "from img tag",
-			html:     `<html><head></head><body><img src="https://awsimgsrc.dmm.co.jp/pics_dig/video/ipx00535/ipx00535pl.jpg?v=1" /></body></html>`,
-			expected: "https://pics.dmm.co.jp/video/ipx00535/ipx00535pl.jpg",
+			html:     `<html><head></head><body><img src="https://awsimgsrc.dmm.co.jp/pics_dig/digital/video/ipx00535/ipx00535pl.jpg?v=1" /></body></html>`,
+			expected: "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg",
 		},
 		{
 			name:     "from img tag with awsimgsrc.dmm.com domain and query params",
-			html:     `<html><head></head><body><img src="https://awsimgsrc.dmm.com/dig/video/ipx00535/ipx00535pl.jpg?v=1" /></body></html>`,
-			expected: "https://awsimgsrc.dmm.com/dig/video/ipx00535/ipx00535pl.jpg",
+			html:     `<html><head></head><body><img src="https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg?v=1" /></body></html>`,
+			expected: "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg",
 		},
 		{
 			name:      "fallback to constructed URL from content ID (amateur video uses jp.jpg)",

--- a/internal/scraper/javbus/javbus.go
+++ b/internal/scraper/javbus/javbus.go
@@ -333,6 +333,7 @@ func (s *scraper) parseDetailPage(doc *goquery.Document, sourceURL, fallbackID s
 
 	result.CoverURL = imageutil.NormalizeDMMScreenshotURL(extractCoverURL(doc, sourceURL))
 	result.CoverURL = imageutil.UpgradeCoverResolution(result.CoverURL)
+	result.CoverURL = imageutil.UpgradeDMMCoverCDN(result.CoverURL)
 	posterURL, shouldCrop := imageutil.GetOptimalPosterURL(result.CoverURL, s.client.GetClient())
 	result.ShouldCropPoster = shouldCrop
 	if shouldCrop {

--- a/internal/scraper/javlibrary/javlibrary.go
+++ b/internal/scraper/javlibrary/javlibrary.go
@@ -411,6 +411,7 @@ func (s *scraper) parseDetailPage(html string, id string, sourceURL string, lang
 	// Media URLs
 	result.CoverURL = imageutil.NormalizeDMMScreenshotURL(s.extractCoverURL(html))
 	result.CoverURL = imageutil.UpgradeCoverResolution(result.CoverURL)
+	result.CoverURL = imageutil.UpgradeDMMCoverCDN(result.CoverURL)
 
 	rawScreenshots := s.extractScreenshotURLs(html)
 	normalizedScreenshots := make([]string, 0, len(rawScreenshots))

--- a/internal/scraper/libredmm/libredmm.go
+++ b/internal/scraper/libredmm/libredmm.go
@@ -487,6 +487,7 @@ func payloadToResult(payload *moviePayload, sourceURL, fallbackID string, client
 
 	result.CoverURL = imageutil.NormalizeDMMScreenshotURL(scraperutil.ResolveURL(sourceURL, payload.CoverImageURL))
 	result.CoverURL = imageutil.UpgradeCoverResolution(result.CoverURL)
+	result.CoverURL = imageutil.UpgradeDMMCoverCDN(result.CoverURL)
 	if result.CoverURL != "" {
 		posterURL, shouldCrop := imageutil.GetOptimalPosterURL(result.CoverURL, client)
 		result.ShouldCropPoster = shouldCrop

--- a/internal/scraper/libredmm/libredmm_test.go
+++ b/internal/scraper/libredmm/libredmm_test.go
@@ -927,8 +927,9 @@ func TestPayloadToResult_CoverURLFallback(t *testing.T) {
 
 	result := payloadToResult(payload, "https://www.libredmm.com/movies/ABP-880.json", "ABP-880", client)
 	require.NotNil(t, result)
-	assert.Equal(t, coverURL, result.CoverURL)
-	assert.Equal(t, coverURL, result.PosterURL)
+	expectedCoverURL := "https://awsimgsrc.dmm.com/dig/digital/video/118abp880/118abp880pl.jpg"
+	assert.Equal(t, expectedCoverURL, result.CoverURL)
+	assert.Equal(t, expectedCoverURL, result.PosterURL)
 }
 
 // TestStripJSONSuffix tests JSON suffix stripping

--- a/internal/scraper/r18dev/dump_result.go
+++ b/internal/scraper/r18dev/dump_result.go
@@ -214,6 +214,7 @@ func (s *scraper) resolveDumpMediaURLs(d *models.DumpMovie, result *models.Scrap
 	if coverURL != "" {
 		coverURL = imageutil.NormalizeDMMScreenshotURL(coverURL)
 		coverURL = imageutil.UpgradeCoverResolution(coverURL)
+		coverURL = imageutil.UpgradeDMMCoverCDN(coverURL)
 		result.CoverURL = coverURL
 	}
 

--- a/internal/scraper/r18dev/r18dev.go
+++ b/internal/scraper/r18dev/r18dev.go
@@ -590,6 +590,8 @@ func resolveMediaURLs(ctx context.Context, s *scraper, data *r18Response, result
 	if coverImageURL != "" {
 		coverImageURL = imageutil.NormalizeDMMScreenshotURL(coverImageURL)
 		coverImageURL = imageutil.UpgradeCoverResolution(coverImageURL)
+		// Keep coverImageURL on pics.dmm.co.jp for now — DiscoverScreenshots
+		// (below) requires it. UpgradeDMMCoverCDN is applied after discovery.
 		result.CoverURL = coverImageURL
 
 		posterURL, shouldCrop := imageutil.GetOptimalPosterURL(coverImageURL, s.client.GetClient())
@@ -644,6 +646,19 @@ func resolveMediaURLs(ctx context.Context, s *scraper, data *r18Response, result
 			logging.Debugf("r18dev: Discovered %d screenshots via cover URL probing for %s", len(discovered), result.ID)
 			result.ScreenshotURL = discovered
 		}
+	}
+
+	// Upgrade cover (and any cover-derived poster) to the high-res awsimgsrc
+	// CDN. Applied after DiscoverScreenshots, which requires the pics.dmm.co.jp
+	// host. If the poster was set to the cover for cropping (shouldCrop=true
+	// and resolveAwsimgsrcPoster found nothing), upgrade it too so the crop uses
+	// the high-res source.
+	if result.CoverURL != "" {
+		upgradedCover := imageutil.UpgradeDMMCoverCDN(result.CoverURL)
+		if result.PosterURL == result.CoverURL {
+			result.PosterURL = upgradedCover
+		}
+		result.CoverURL = upgradedCover
 	}
 
 	// Parse trailer - try top-level sample_url first (newer API), then nested Sample (older API)

--- a/internal/scraper/r18dev/r18dev_test.go
+++ b/internal/scraper/r18dev/r18dev_test.go
@@ -192,6 +192,13 @@ func TestScraper_Search_Success(t *testing.T) {
 	// Override base URL for testing (we need to modify the client to use test server)
 	// For now, we'll test the parsing logic separately since we can't easily override the URL
 
+	// Disable network for the poster dimension probe so the poster falls back to
+	// the cover deterministically (the awsimgsrc poster URL is otherwise fetched
+	// against the real CDN, making the assertion network-dependent).
+	scraper.client.GetClient().Transport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("network disabled")
+	})
+
 	// Test parseResponse directly instead
 	var data r18Response
 	err := json.Unmarshal(loadTestData(t, "ipx535_full_response.json"), &data)
@@ -246,9 +253,11 @@ func TestScraper_Search_Success(t *testing.T) {
 	assert.Equal(t, "桜 もも", actress.JapaneseName)
 	assert.Contains(t, actress.ThumbURL, "sakura_momo.jpg")
 
-	// Verify cover/poster URLs
-	assert.Equal(t, "https://pics.dmm.co.jp/digital/video/ipx00535/ipx00535pl.jpg", result.PosterURL)
-	assert.Equal(t, "https://pics.dmm.co.jp/digital/video/ipx00535/ipx00535pl.jpg", result.CoverURL)
+	// Verify cover/poster URLs (cover upgraded to awsimgsrc CDN; poster falls back
+	// to the cover because the dimension probe is network-disabled).
+	expectedCoverURL := "https://awsimgsrc.dmm.com/dig/digital/video/ipx00535/ipx00535pl.jpg"
+	assert.Equal(t, expectedCoverURL, result.PosterURL)
+	assert.Equal(t, expectedCoverURL, result.CoverURL)
 
 	// Verify screenshots
 	require.Len(t, result.ScreenshotURL, 2)
@@ -2163,4 +2172,11 @@ func TestSearch_AP288_BlankDVDID(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Equal(t, "AP-288", result.ID)
 	assert.Equal(t, "1ap00288", result.ContentID)
+}
+
+// roundTripperFunc is a test helper for HTTP round tripper.
+type roundTripperFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }


### PR DESCRIPTION
## Summary

DMM cover and poster images were being downloaded at low resolution (`pics.dmm.co.jp`, e.g. 800×501) even though a much higher-resolution variant exists on `awsimgsrc.dmm.com` (e.g. 2184×1368 for SONE-560). Two bugs caused this:

1. **Broken poster path**: `constructAwsimgsrcPosterURL` generated `dig/video/` paths that **404 on every digital video title**. The correct path is `dig/digital/video/` (same for `dig/amateur/` → `dig/digital/amateur/`). This made the poster-upgrade feature effectively dead code — it always fell back to cropping the cover.

2. **Cover never upgraded to CDN**: `UpgradeCoverResolution` only swapped filename suffixes (`ps.jpg→pl.jpg`) but stayed on `pics.dmm.co.jp`, so covers never got the high-res `awsimgsrc` variant.

## Changes

### `internal/imageutil`
- **Split** `UpgradeCoverResolution` (suffix-only) and new `UpgradeDMMCoverCDN` (CDN host rewrite) — each does one thing.
- **Fixed** path mapping in `constructAwsimgsrcURL`: `dig/video/` → `dig/digital/video/`, `dig/amateur/` → `dig/digital/amateur/`.
- **Added host validation** to `constructAwsimgsrcURL` so non-DMM URLs are never rewritten (parses URL, requires exact `pics.dmm.co.jp` host or already-awsimgsrc).
- **Deleted** `reverseAwsimgsrcToPics` — no longer needed (the reverse-mapping workaround for `DiscoverScreenshots`).
- **Reverted** `DiscoverScreenshots` to its original form (only accepts `pics.dmm.co.jp`).

### Scraper call sites
- All scrapers (javbus, dmm, javlibrary, r18dev, libredmm) now apply `UpgradeDMMCoverCDN(UpgradeCoverResolution(...))` at the final cover assignment.
- The new-site `extractCoverURLNewSite` fallback (og:image, background-image, img-tag, constructed-amateur paths) now routes through the same pipeline instead of ad-hoc normalization that skipped the CDN upgrade.
- **r18dev** defers `UpgradeDMMCoverCDN` until after `DiscoverScreenshots` (which requires the `pics.dmm.co.jp` host), then upgrades both `CoverURL` and `PosterURL` (if it equaled the cover).

## Why screenshots are not upgraded
Verified empirically that `awsimgsrc.dmm.com` serves **identical bytes** to `pics.dmm.co.jp` for screenshot files (`jp-N.jpg`) — no resolution gain. Only covers (`pl.jpg`) and posters (`ps.jpg`) have higher-res variants on the awsimgsrc CDN. So screenshots correctly stay on `pics.dmm.co.jp`.

## Validation
- `go test ./...` — pass
- `go vet ./...` — clean
- `golangci-lint run` — 0 issues
- Pre-commit hooks (gofmt, go vet, `go test -short`, build, swagger) — pass
- Parent-orchestrated review loop (3 fresh-context reviewers: correctness/regressions, tests/validation, simplicity/maintainability) — no blockers found

## Test coverage
- New `TestUpgradeDMMCoverCDN` covers: pics digital/video, pics mono/movie, pics amateur, already-awsimgsrc idempotency, non-DMM unchanged, amateur `jp.jpg` unchanged, empty string.
- `TestConstructAwsimgsrcURL_HostValidation` covers non-DMM hosts, substring-in-path attacks, already-awsimgsrc suffix swaps, unknown paths, missing suffix.
- Scraper tests updated to assert awsimgsrc-upgraded cover URLs across dmm, r18dev, libredmm.