### PR TITLE
feat(web): display actress names in first-name order when config enabled

### DIFF
--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -932,6 +932,7 @@ export interface OutputConfig {
 	actress_delimiter: string;
 	max_title_length: number;
 	max_path_length: number;
+	first_name_order?: boolean;
 	max_poster_height: number;
 	move_subtitles: boolean;
 	subtitle_extensions: string[];

--- a/web/frontend/src/lib/components/ActressEditor.svelte
+++ b/web/frontend/src/lib/components/ActressEditor.svelte
@@ -7,6 +7,8 @@
 	import { portalToBody } from '$lib/actions/portal';
 	import { apiClient } from '$lib/api/client';
 	import type { Movie, Actress, ActressAliasGroup } from '$lib/api/types';
+	import { formatActressName } from '$lib/utils/actress';
+	import { createConfigQuery } from '$lib/query/queries';
 	import Button from './ui/Button.svelte';
 	import Card from './ui/Card.svelte';
 	import { Plus, SquarePen, Trash2, X, Save, Search } from 'lucide-svelte';
@@ -22,6 +24,8 @@
 	}
 
 	let { movie, onUpdate, onPersistEdits, actressSources, showFieldSources = false, savingEdits = false, organizing = false }: Props = $props();
+	const configQuery = createConfigQuery();
+	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
 
 	let actresses = $state<Actress[]>([]);
 	let showEditModal = $state(false);
@@ -183,13 +187,7 @@
 
 	// Helper to get full name
 	function getFullName(actress: Actress): string {
-		if (actress.last_name && actress.first_name) {
-			return `${actress.last_name} ${actress.first_name}`;
-		}
-		if (actress.first_name) {
-			return actress.first_name;
-		}
-		return actress.japanese_name || 'Unknown';
+		return formatActressName(actress, firstNameOrder);
 	}
 
 	function notifyParent() {

--- a/web/frontend/src/lib/components/MetadataCard.svelte
+++ b/web/frontend/src/lib/components/MetadataCard.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { Movie } from '$lib/api/types';
 	import { formatDuration } from '$lib/utils';
+	import { formatActressName } from '$lib/utils/actress';
+	import { createConfigQuery } from '$lib/query/queries';
 	import { Calendar, Clock, Star, Film } from 'lucide-svelte';
 	import Card from './ui/Card.svelte';
 	import Button from './ui/Button.svelte';
@@ -12,6 +14,8 @@
 	}
 
 	let { movie, onEdit, selected = false }: Props = $props();
+	const configQuery = createConfigQuery();
+	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
 </script>
 
 <Card class="overflow-hidden {selected ? 'ring-2 ring-primary' : ''}">
@@ -102,7 +106,7 @@
 				<div class="flex flex-wrap gap-1">
 					{#each movie.actresses.slice(0, 3) as actress}
 						<span class="px-2 py-1 bg-primary/10 text-primary rounded-md text-xs">
-							{actress.japanese_name || `${actress.first_name || ''} ${actress.last_name || ''}`.trim() || 'Unknown'}
+							{formatActressName(actress, firstNameOrder)}
 						</span>
 					{/each}
 					{#if movie.actresses.length > 3}

--- a/web/frontend/src/lib/utils/actress.test.ts
+++ b/web/frontend/src/lib/utils/actress.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { formatActressName } from './actress';
+import type { ActressName } from './actress';
+
+function makeActress(over: Partial<ActressName>): ActressName {
+	return { first_name: '', last_name: '', japanese_name: '', ...over };
+}
+
+describe('formatActressName', () => {
+	const cases: Array<{
+		name: string;
+		actress: Partial<ActressName>;
+		firstNameOrder: boolean;
+		want: string;
+	}> = [
+		{
+			name: 'both names present, first-name order',
+			actress: { first_name: 'Sara', last_name: 'Aoyama' },
+			firstNameOrder: true,
+			want: 'Sara Aoyama'
+		},
+		{
+			name: 'both names present, last-name order',
+			actress: { first_name: 'Sara', last_name: 'Aoyama' },
+			firstNameOrder: false,
+			want: 'Aoyama Sara'
+		},
+		{
+			name: 'only first name, first-name order',
+			actress: { first_name: 'Sara', last_name: '' },
+			firstNameOrder: true,
+			want: 'Sara'
+		},
+		{
+			name: 'only first name, last-name order',
+			actress: { first_name: 'Sara', last_name: '' },
+			firstNameOrder: false,
+			want: 'Sara'
+		},
+		{
+			name: 'only last name, first-name order',
+			actress: { first_name: '', last_name: 'Aoyama' },
+			firstNameOrder: true,
+			want: 'Aoyama'
+		},
+		{
+			name: 'only last name, last-name order',
+			actress: { first_name: '', last_name: 'Aoyama' },
+			firstNameOrder: false,
+			want: 'Aoyama'
+		},
+		{
+			name: 'no names, japanese_name present',
+			actress: { first_name: '', last_name: '', japanese_name: '青山 sarah' },
+			firstNameOrder: false,
+			want: '青山 sarah'
+		},
+		{
+			name: 'no names, no japanese_name',
+			actress: { first_name: '', last_name: '', japanese_name: '' },
+			firstNameOrder: false,
+			want: 'Unknown'
+		},
+		{
+			name: 'no names, no japanese_name, first-name order',
+			actress: { first_name: '', last_name: '', japanese_name: '' },
+			firstNameOrder: true,
+			want: 'Unknown'
+		}
+	];
+
+	for (const tc of cases) {
+		it(tc.name, () => {
+			expect(formatActressName(makeActress(tc.actress), tc.firstNameOrder)).toBe(tc.want);
+		});
+	}
+
+	it('accepts Actress-like objects with extra fields', () => {
+		const actress = {
+			id: 1,
+			first_name: 'Sara',
+			last_name: 'Aoyama',
+			japanese_name: '',
+			thumb_url: 'http://example.com/x.jpg'
+		};
+		expect(formatActressName(actress, true)).toBe('Sara Aoyama');
+	});
+});

--- a/web/frontend/src/lib/utils/actress.ts
+++ b/web/frontend/src/lib/utils/actress.ts
@@ -1,0 +1,38 @@
+export interface ActressName {
+	first_name?: string;
+	last_name?: string;
+	japanese_name?: string;
+}
+
+export function formatActressName<T extends ActressName>(
+	actress: T,
+	firstNameOrder: boolean
+): string {
+	const first = actress.first_name ?? '';
+	const last = actress.last_name ?? '';
+
+	if (first === '' && last === '') {
+		if (actress.japanese_name) {
+			return actress.japanese_name;
+		}
+		return 'Unknown';
+	}
+
+	if (firstNameOrder) {
+		if (first !== '' && last !== '') {
+			return `${first} ${last}`;
+		}
+		if (first !== '') {
+			return first;
+		}
+		return last;
+	}
+
+	if (first !== '' && last !== '') {
+		return `${last} ${first}`;
+	}
+	if (last !== '') {
+		return last;
+	}
+	return first;
+}

--- a/web/frontend/src/routes/actresses/+page.svelte
+++ b/web/frontend/src/routes/actresses/+page.svelte
@@ -207,7 +207,7 @@
 									isSelected={store.isSelected}
 									onToggleSelection={store.toggleSelection}
 									onStartEdit={store.startEdit}
-									onRemoveActress={store.removeActress}
+									onRemoveActress={(actress) => store.removeActress(actress, firstNameOrder)}
 									deletePending={store.deleteActressMutation.isPending}
 								/>
 							{:else if store.viewMode === 'compact'}
@@ -218,7 +218,7 @@
 									isSelected={store.isSelected}
 									onToggleSelection={store.toggleSelection}
 									onStartEdit={store.startEdit}
-									onRemoveActress={store.removeActress}
+									onRemoveActress={(actress) => store.removeActress(actress, firstNameOrder)}
 									deletePending={store.deleteActressMutation.isPending}
 								/>
 							{:else}
@@ -229,7 +229,7 @@
 									isSelected={store.isSelected}
 									onToggleSelection={store.toggleSelection}
 									onStartEdit={store.startEdit}
-									onRemoveActress={store.removeActress}
+									onRemoveActress={(actress) => store.removeActress(actress, firstNameOrder)}
 									deletePending={store.deleteActressMutation.isPending}
 								/>
 							{/if}
@@ -261,7 +261,7 @@
 	mergePreviewFetching={store.mergePreviewQuery.isFetching}
 	mergeSummary={store.mergeSummary}
 	mergePending={store.mergeActressMutation.isPending}
-	getActressLabelByID={store.getActressLabelByID}
+	getActressLabelByID={(id) => store.getActressLabelByID(id, firstNameOrder)}
 	onCloseMergeModal={store.closeMergeModal}
 	onResetMergeQueueAndPreview={store.resetMergeQueueAndPreview}
 	onApplyCurrentMerge={store.applyCurrentMerge}

--- a/web/frontend/src/routes/actresses/+page.svelte
+++ b/web/frontend/src/routes/actresses/+page.svelte
@@ -16,9 +16,12 @@
 	import ActressTableView from './components/ActressTableView.svelte';
 	import ActressMergeModal from './components/ActressMergeModal.svelte';
 	import ActressPagination from './components/ActressPagination.svelte';
+	import { createConfigQuery } from '$lib/query/queries';
 
 	const store = createActressStore();
 	const queryClient = useQueryClient();
+	const configQuery = createConfigQuery();
+	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
 	let importFile = $state<HTMLInputElement | null>(null);
 
 	const exportMutation = createMutation(() => ({
@@ -200,7 +203,7 @@
 									actresses={store.actresses}
 									selectedIds={store.selectedIds}
 									itemDelay={store.itemDelay}
-									getDisplayName={store.getDisplayName}
+									getDisplayName={(actress) => store.getDisplayName(actress, firstNameOrder)}
 									isSelected={store.isSelected}
 									onToggleSelection={store.toggleSelection}
 									onStartEdit={store.startEdit}
@@ -211,7 +214,7 @@
 								<ActressCompactView
 									actresses={store.actresses}
 									itemDelay={store.itemDelay}
-									getDisplayName={store.getDisplayName}
+									getDisplayName={(actress) => store.getDisplayName(actress, firstNameOrder)}
 									isSelected={store.isSelected}
 									onToggleSelection={store.toggleSelection}
 									onStartEdit={store.startEdit}
@@ -222,7 +225,7 @@
 								<ActressTableView
 									actresses={store.actresses}
 									itemDelay={store.itemDelay}
-									getDisplayName={store.getDisplayName}
+									getDisplayName={(actress) => store.getDisplayName(actress, firstNameOrder)}
 									isSelected={store.isSelected}
 									onToggleSelection={store.toggleSelection}
 									onStartEdit={store.startEdit}

--- a/web/frontend/src/routes/actresses/stores/actress-store.svelte.ts
+++ b/web/frontend/src/routes/actresses/stores/actress-store.svelte.ts
@@ -224,14 +224,14 @@ export function createActressStore() {
 		};
 	}
 
-	function getDisplayName(actress: Actress, firstNameOrder: boolean = false): string {
+	function getDisplayName(actress: Actress, firstNameOrder: boolean): string {
 		return formatActressName(actress, firstNameOrder);
 	}
 
-	function getActressLabelByID(id: number): string {
+	function getActressLabelByID(id: number, firstNameOrder: boolean): string {
 		const actress = actresses.find((item) => item.id === id);
 		if (!actress) return `Actress #${id}`;
-		return `#${id} - ${getDisplayName(actress)}`;
+		return `#${id} - ${getDisplayName(actress, firstNameOrder)}`;
 	}
 
 	function isSelected(actress: Actress): boolean {
@@ -306,9 +306,9 @@ export function createActressStore() {
 		saveActressMutation.mutate(toPayload());
 	}
 
-	async function removeActress(actress: Actress) {
+	async function removeActress(actress: Actress, firstNameOrder: boolean) {
 		if (!actress.id) return;
-		const name = getDisplayName(actress);
+		const name = getDisplayName(actress, firstNameOrder);
 		if (
 			!(await confirmDialog('Delete Actress', `Delete actress "${name}"?`, {
 				confirmLabel: 'Delete',

--- a/web/frontend/src/routes/actresses/stores/actress-store.svelte.ts
+++ b/web/frontend/src/routes/actresses/stores/actress-store.svelte.ts
@@ -4,6 +4,7 @@ import { createQuery, createMutation, useQueryClient } from '@tanstack/svelte-qu
 import { apiClient } from '$lib/api/client';
 import { toastStore } from '$lib/stores/toast';
 import type { Actress, ActressUpsertRequest, ActressMergeResolution } from '$lib/api/types';
+import { formatActressName } from '$lib/utils/actress';
 
 export type ActressForm = {
 	dmm_id: string;
@@ -223,12 +224,8 @@ export function createActressStore() {
 		};
 	}
 
-	function getDisplayName(actress: Actress): string {
-		if (actress.last_name && actress.first_name)
-			return `${actress.last_name} ${actress.first_name}`;
-		if (actress.first_name) return actress.first_name;
-		if (actress.japanese_name) return actress.japanese_name;
-		return 'Unnamed';
+	function getDisplayName(actress: Actress, firstNameOrder: boolean = false): string {
+		return formatActressName(actress, firstNameOrder);
 	}
 
 	function getActressLabelByID(id: number): string {

--- a/web/frontend/src/routes/review/[jobId]/components/SourceViewerModal.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/SourceViewerModal.svelte
@@ -6,6 +6,8 @@
 	import type { ScraperResult } from '$lib/api/types';
 	import Button from '$lib/components/ui/Button.svelte';
 	import Card from '$lib/components/ui/Card.svelte';
+	import { formatActressName } from '$lib/utils/actress';
+	import { createConfigQuery } from '$lib/query/queries';
 
 	interface FieldDef {
 		key: string;
@@ -32,8 +34,8 @@
 			kind: 'list',
 			get: (r) =>
 				r.actresses
-					?.map((a) => [a.first_name, a.last_name].filter(Boolean).join(' '))
-					.filter(Boolean)
+					?.map((a) => formatActressName(a, firstNameOrder))
+					.filter((n) => n !== '' && n !== 'Unknown')
 					.join(', ') ?? ''
 		},
 		{ key: 'genres', label: 'Genres', kind: 'list', get: (r) => r.genres?.filter(Boolean).join(', ') ?? '' },
@@ -50,6 +52,9 @@
 					: ''
 		}
 	];
+
+	const configQuery = createConfigQuery();
+	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
 
 	interface Props {
 		show: boolean;

--- a/web/frontend/src/routes/review/[jobId]/components/SourceViewerModal.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/SourceViewerModal.svelte
@@ -34,8 +34,8 @@
 			kind: 'list',
 			get: (r) =>
 				r.actresses
-					?.map((a) => formatActressName(a, firstNameOrder))
-					.filter((n) => n !== '' && n !== 'Unknown')
+					?.filter((a) => (a.first_name ?? '') !== '' || (a.last_name ?? '') !== '' || (a.japanese_name ?? '') !== '')
+					.map((a) => formatActressName(a, firstNameOrder))
 					.join(', ') ?? ''
 		},
 		{ key: 'genres', label: 'Genres', kind: 'list', get: (r) => r.genres?.filter(Boolean).join(', ') ?? '' },


### PR DESCRIPTION
## Summary

When `output.first_name_order` is enabled (true), the UI now displays actress names in first-name order (`FirstName LastName`) instead of the default last-name order (`LastName FirstName`). The backend already had this flag for file/folder naming and NFO generation, but the web UI never read it — every display site hardcoded its own order, and the flag was not even in the frontend `OutputConfig` type.

## Changes

### 1. Expose the config flag to the frontend
- Added `first_name_order?: boolean` to the `OutputConfig` TS type (`web/frontend/src/lib/api/types.ts`). The backend was already serializing it via `GET /api/v1/config`, so no backend change was needed.

### 2. Shared `formatActressName` helper
- New: `web/frontend/src/lib/utils/actress.ts` — mirrors the backend `models.FormatActressName` (`internal/models/actress_format.go`) fallback chain:
  - Both names present: `FirstName LastName` (flag true) or `LastName FirstName` (flag false)
  - Only one name: return that name
  - Neither: fall back to `japanese_name`, then `"Unknown"`

### 3. Wired all 4 display sites (reactively)
Each site reads the flag via `createConfigQuery()` + `$derived(... ?? false)` (TanStack Query deduplicates by shared `['config']` key, so no duplicate requests):
- **MetadataCard** — actress chips on movie cards
- **ActressEditor** — `getFullName` in the edit modal, search, and list
- **actress-store `getDisplayName`** — used by Cards/Compact/Table views, merge modal, and delete confirmation
- **SourceViewerModal** — actress list in the scraper source comparison

### 4. No default params that hide missed callers
The store functions (`getDisplayName`, `getActressLabelByID`, `removeActress`) require `firstNameOrder` as a required parameter — TypeScript errors if a future caller forgets it. This prevented a real bug (round 1 review found the merge modal and delete confirm were silently using the wrong order because of a default param).

### 5. Fixed pre-existing inconsistency
Before this change, different UI surfaces showed names in different orders:
- MetadataCard showed `First Last` (always)
- ActressEditor and actress-store showed `Last First` (always)
- SourceViewerModal showed `First Last` (always)

Now they are all unified behind one config flag and one helper.

## Tests
- New `web/frontend/src/lib/utils/actress.test.ts` — 10 table-driven tests covering both orders, single-name cases, japanese_name fallback, unknown fallback, and structural typing.
- All 386 frontend tests pass; svelte-check 0 errors/warnings.
- `go test ./...` pass; `go vet` clean; `golangci-lint` 0 issues.

## Review
Local review loop run (2 rounds, fresh-context reviewers):
- Round 1: found 1 blocker (default param `firstNameOrder=false` hid missed callers in merge modal + delete confirm) → fixed in `dd19e3fe`.
- Round 2: 0 issues. Both reviewers confirmed B1 fix complete, all display sites wired, no missed callers, frontend/backend parity verified.

@codex review
