### PR TITLE
fix(web): respect actress_language_ja preference in name display

### DIFF
--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -933,6 +933,7 @@ export interface OutputConfig {
 	max_title_length: number;
 	max_path_length: number;
 	first_name_order?: boolean;
+	actress_language_ja?: boolean;
 	max_poster_height: number;
 	move_subtitles: boolean;
 	subtitle_extensions: string[];

--- a/web/frontend/src/lib/components/ActressEditor.svelte
+++ b/web/frontend/src/lib/components/ActressEditor.svelte
@@ -26,6 +26,7 @@
 	let { movie, onUpdate, onPersistEdits, actressSources, showFieldSources = false, savingEdits = false, organizing = false }: Props = $props();
 	const configQuery = createConfigQuery();
 	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
+	let japaneseNames = $derived(configQuery.data?.output?.actress_language_ja ?? false);
 
 	let actresses = $state<Actress[]>([]);
 	let showEditModal = $state(false);
@@ -187,7 +188,7 @@
 
 	// Helper to get full name
 	function getFullName(actress: Actress): string {
-		return formatActressName(actress, firstNameOrder);
+		return formatActressName(actress, { firstNameOrder, japaneseNames });
 	}
 
 	function notifyParent() {

--- a/web/frontend/src/lib/components/ActressEditor.svelte
+++ b/web/frontend/src/lib/components/ActressEditor.svelte
@@ -26,7 +26,10 @@
 	let { movie, onUpdate, onPersistEdits, actressSources, showFieldSources = false, savingEdits = false, organizing = false }: Props = $props();
 	const configQuery = createConfigQuery();
 	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
-	let japaneseNames = $derived(configQuery.data?.output?.actress_language_ja ?? false);
+	let japaneseNames = $derived(
+		(configQuery.data?.output?.actress_language_ja ?? false) ||
+		(configQuery.data?.metadata?.nfo?.actress_language_ja ?? false)
+	);
 
 	let actresses = $state<Actress[]>([]);
 	let showEditModal = $state(false);

--- a/web/frontend/src/lib/components/MetadataCard.svelte
+++ b/web/frontend/src/lib/components/MetadataCard.svelte
@@ -16,6 +16,7 @@
 	let { movie, onEdit, selected = false }: Props = $props();
 	const configQuery = createConfigQuery();
 	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
+	let japaneseNames = $derived(configQuery.data?.output?.actress_language_ja ?? false);
 </script>
 
 <Card class="overflow-hidden {selected ? 'ring-2 ring-primary' : ''}">
@@ -106,7 +107,7 @@
 				<div class="flex flex-wrap gap-1">
 					{#each movie.actresses.slice(0, 3) as actress}
 						<span class="px-2 py-1 bg-primary/10 text-primary rounded-md text-xs">
-							{formatActressName(actress, firstNameOrder)}
+							{formatActressName(actress, { firstNameOrder, japaneseNames })}
 						</span>
 					{/each}
 					{#if movie.actresses.length > 3}

--- a/web/frontend/src/lib/components/MetadataCard.svelte
+++ b/web/frontend/src/lib/components/MetadataCard.svelte
@@ -16,7 +16,10 @@
 	let { movie, onEdit, selected = false }: Props = $props();
 	const configQuery = createConfigQuery();
 	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
-	let japaneseNames = $derived(configQuery.data?.output?.actress_language_ja ?? false);
+	let japaneseNames = $derived(
+		(configQuery.data?.output?.actress_language_ja ?? false) ||
+		(configQuery.data?.metadata?.nfo?.actress_language_ja ?? false)
+	);
 </script>
 
 <Card class="overflow-hidden {selected ? 'ring-2 ring-primary' : ''}">

--- a/web/frontend/src/lib/utils/actress.test.ts
+++ b/web/frontend/src/lib/utils/actress.test.ts
@@ -71,7 +71,7 @@ describe('formatActressName', () => {
 
 	for (const tc of cases) {
 		it(tc.name, () => {
-			expect(formatActressName(makeActress(tc.actress), tc.firstNameOrder)).toBe(tc.want);
+			expect(formatActressName(makeActress(tc.actress), { firstNameOrder: tc.firstNameOrder })).toBe(tc.want);
 		});
 	}
 
@@ -83,6 +83,45 @@ describe('formatActressName', () => {
 			japanese_name: '',
 			thumb_url: 'http://example.com/x.jpg'
 		};
-		expect(formatActressName(actress, true)).toBe('Sara Aoyama');
+		expect(formatActressName(actress, { firstNameOrder: true })).toBe('Sara Aoyama');
+	});
+
+	// japaneseNames flag — mirrors backend models.FormatActressName JapaneseNames
+	// branch (internal/models/actress_format.go:27-29): when true and a
+	// japanese_name is present it takes precedence over first/last ordering.
+	it('japaneseNames=true prefers japanese_name over romanized', () => {
+		const actress = makeActress({ first_name: 'Sara', last_name: 'Aoyama', japanese_name: '青山 sarah' });
+		expect(formatActressName(actress, { firstNameOrder: true, japaneseNames: true })).toBe('青山 sarah');
+		expect(formatActressName(actress, { firstNameOrder: false, japaneseNames: true })).toBe('青山 sarah');
+	});
+
+	it('japaneseNames=true with only romanized falls back to romanized (order still applies)', () => {
+		expect(
+			formatActressName(makeActress({ first_name: 'Sara', last_name: 'Aoyama' }), {
+				firstNameOrder: true,
+				japaneseNames: true
+			})
+		).toBe('Sara Aoyama');
+		expect(
+			formatActressName(makeActress({ first_name: 'Sara', last_name: 'Aoyama' }), {
+				firstNameOrder: false,
+				japaneseNames: true
+			})
+		).toBe('Aoyama Sara');
+	});
+
+	it('japaneseNames=false with both names returns romanized (unaffected)', () => {
+		const actress = makeActress({ first_name: 'Sara', last_name: 'Aoyama', japanese_name: '青山 sarah' });
+		expect(formatActressName(actress, { firstNameOrder: true, japaneseNames: false })).toBe('Sara Aoyama');
+		expect(formatActressName(actress, { firstNameOrder: false, japaneseNames: false })).toBe('Aoyama Sara');
+	});
+
+	it('japaneseNames=true with only japanese_name returns japanese_name', () => {
+		expect(
+			formatActressName(makeActress({ first_name: '', last_name: '', japanese_name: '青山 sarah' }), {
+				firstNameOrder: false,
+				japaneseNames: true
+			})
+		).toBe('青山 sarah');
 	});
 });

--- a/web/frontend/src/lib/utils/actress.ts
+++ b/web/frontend/src/lib/utils/actress.ts
@@ -4,12 +4,24 @@ export interface ActressName {
 	japanese_name?: string;
 }
 
+export interface FormatActressNameOptions {
+	firstNameOrder?: boolean;
+	japaneseNames?: boolean;
+}
+
 export function formatActressName<T extends ActressName>(
 	actress: T,
-	firstNameOrder: boolean
+	opts?: FormatActressNameOptions
 ): string {
+	const firstNameOrder = opts?.firstNameOrder ?? false;
+	const japaneseNames = opts?.japaneseNames ?? false;
+
 	const first = actress.first_name ?? '';
 	const last = actress.last_name ?? '';
+
+	if (japaneseNames && actress.japanese_name) {
+		return actress.japanese_name;
+	}
 
 	if (first === '' && last === '') {
 		if (actress.japanese_name) {

--- a/web/frontend/src/routes/actresses/+page.svelte
+++ b/web/frontend/src/routes/actresses/+page.svelte
@@ -22,6 +22,7 @@
 	const queryClient = useQueryClient();
 	const configQuery = createConfigQuery();
 	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
+	let japaneseNames = $derived(configQuery.data?.output?.actress_language_ja ?? false);
 	let importFile = $state<HTMLInputElement | null>(null);
 
 	const exportMutation = createMutation(() => ({
@@ -203,33 +204,33 @@
 									actresses={store.actresses}
 									selectedIds={store.selectedIds}
 									itemDelay={store.itemDelay}
-									getDisplayName={(actress) => store.getDisplayName(actress, firstNameOrder)}
+									getDisplayName={(actress) => store.getDisplayName(actress, firstNameOrder, japaneseNames)}
 									isSelected={store.isSelected}
 									onToggleSelection={store.toggleSelection}
 									onStartEdit={store.startEdit}
-									onRemoveActress={(actress) => store.removeActress(actress, firstNameOrder)}
+									onRemoveActress={(actress) => store.removeActress(actress, firstNameOrder, japaneseNames)}
 									deletePending={store.deleteActressMutation.isPending}
 								/>
 							{:else if store.viewMode === 'compact'}
 								<ActressCompactView
 									actresses={store.actresses}
 									itemDelay={store.itemDelay}
-									getDisplayName={(actress) => store.getDisplayName(actress, firstNameOrder)}
+									getDisplayName={(actress) => store.getDisplayName(actress, firstNameOrder, japaneseNames)}
 									isSelected={store.isSelected}
 									onToggleSelection={store.toggleSelection}
 									onStartEdit={store.startEdit}
-									onRemoveActress={(actress) => store.removeActress(actress, firstNameOrder)}
+									onRemoveActress={(actress) => store.removeActress(actress, firstNameOrder, japaneseNames)}
 									deletePending={store.deleteActressMutation.isPending}
 								/>
 							{:else}
 								<ActressTableView
 									actresses={store.actresses}
 									itemDelay={store.itemDelay}
-									getDisplayName={(actress) => store.getDisplayName(actress, firstNameOrder)}
+									getDisplayName={(actress) => store.getDisplayName(actress, firstNameOrder, japaneseNames)}
 									isSelected={store.isSelected}
 									onToggleSelection={store.toggleSelection}
 									onStartEdit={store.startEdit}
-									onRemoveActress={(actress) => store.removeActress(actress, firstNameOrder)}
+									onRemoveActress={(actress) => store.removeActress(actress, firstNameOrder, japaneseNames)}
 									deletePending={store.deleteActressMutation.isPending}
 								/>
 							{/if}
@@ -261,7 +262,7 @@
 	mergePreviewFetching={store.mergePreviewQuery.isFetching}
 	mergeSummary={store.mergeSummary}
 	mergePending={store.mergeActressMutation.isPending}
-	getActressLabelByID={(id) => store.getActressLabelByID(id, firstNameOrder)}
+	getActressLabelByID={(id) => store.getActressLabelByID(id, firstNameOrder, japaneseNames)}
 	onCloseMergeModal={store.closeMergeModal}
 	onResetMergeQueueAndPreview={store.resetMergeQueueAndPreview}
 	onApplyCurrentMerge={store.applyCurrentMerge}

--- a/web/frontend/src/routes/actresses/+page.svelte
+++ b/web/frontend/src/routes/actresses/+page.svelte
@@ -22,7 +22,10 @@
 	const queryClient = useQueryClient();
 	const configQuery = createConfigQuery();
 	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
-	let japaneseNames = $derived(configQuery.data?.output?.actress_language_ja ?? false);
+	let japaneseNames = $derived(
+		(configQuery.data?.output?.actress_language_ja ?? false) ||
+		(configQuery.data?.metadata?.nfo?.actress_language_ja ?? false)
+	);
 	let importFile = $state<HTMLInputElement | null>(null);
 
 	const exportMutation = createMutation(() => ({

--- a/web/frontend/src/routes/actresses/stores/actress-store.svelte.ts
+++ b/web/frontend/src/routes/actresses/stores/actress-store.svelte.ts
@@ -224,14 +224,14 @@ export function createActressStore() {
 		};
 	}
 
-	function getDisplayName(actress: Actress, firstNameOrder: boolean): string {
-		return formatActressName(actress, firstNameOrder);
+	function getDisplayName(actress: Actress, firstNameOrder: boolean, japaneseNames: boolean): string {
+		return formatActressName(actress, { firstNameOrder, japaneseNames });
 	}
 
-	function getActressLabelByID(id: number, firstNameOrder: boolean): string {
+	function getActressLabelByID(id: number, firstNameOrder: boolean, japaneseNames: boolean): string {
 		const actress = actresses.find((item) => item.id === id);
 		if (!actress) return `Actress #${id}`;
-		return `#${id} - ${getDisplayName(actress, firstNameOrder)}`;
+		return `#${id} - ${getDisplayName(actress, firstNameOrder, japaneseNames)}`;
 	}
 
 	function isSelected(actress: Actress): boolean {
@@ -306,9 +306,9 @@ export function createActressStore() {
 		saveActressMutation.mutate(toPayload());
 	}
 
-	async function removeActress(actress: Actress, firstNameOrder: boolean) {
+	async function removeActress(actress: Actress, firstNameOrder: boolean, japaneseNames: boolean) {
 		if (!actress.id) return;
-		const name = getDisplayName(actress, firstNameOrder);
+		const name = getDisplayName(actress, firstNameOrder, japaneseNames);
 		if (
 			!(await confirmDialog('Delete Actress', `Delete actress "${name}"?`, {
 				confirmLabel: 'Delete',

--- a/web/frontend/src/routes/review/[jobId]/components/SourceViewerModal.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/SourceViewerModal.svelte
@@ -35,7 +35,7 @@
 			get: (r) =>
 				r.actresses
 					?.filter((a) => (a.first_name ?? '') !== '' || (a.last_name ?? '') !== '' || (a.japanese_name ?? '') !== '')
-					.map((a) => formatActressName(a, firstNameOrder))
+					.map((a) => formatActressName(a, { firstNameOrder, japaneseNames }))
 					.join(', ') ?? ''
 		},
 		{ key: 'genres', label: 'Genres', kind: 'list', get: (r) => r.genres?.filter(Boolean).join(', ') ?? '' },
@@ -55,6 +55,7 @@
 
 	const configQuery = createConfigQuery();
 	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
+	let japaneseNames = $derived(configQuery.data?.output?.actress_language_ja ?? false);
 
 	interface Props {
 		show: boolean;

--- a/web/frontend/src/routes/review/[jobId]/components/SourceViewerModal.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/SourceViewerModal.svelte
@@ -55,7 +55,10 @@
 
 	const configQuery = createConfigQuery();
 	let firstNameOrder = $derived(configQuery.data?.output?.first_name_order ?? false);
-	let japaneseNames = $derived(configQuery.data?.output?.actress_language_ja ?? false);
+	let japaneseNames = $derived(
+		(configQuery.data?.output?.actress_language_ja ?? false) ||
+		(configQuery.data?.metadata?.nfo?.actress_language_ja ?? false)
+	);
 
 	interface Props {
 		show: boolean;


### PR DESCRIPTION
## Summary

Follow-up to #127 that addresses the Codex P2 review finding: `formatActressName` didn't honor the `output.actress_language_ja` preference.

## The regression (Codex P2 on #127)

PR #127 introduced `formatActressName(actress, firstNameOrder)` which respects `output.first_name_order`. But Codex flagged:

> **P2: Respect Japanese-name output preference** — When `output.actress_language_ja: true` and an actress has both romanized AND Japanese names, the backend output formatter prefers `japanese_name`, but this helper has no way to receive that flag. It only falls back to Japanese when first/last are empty. This makes the updated UI show romanized names while generated output still uses Japanese names, and it also regresses MetadataCard's previous Japanese-name display for those records.

Specifically, `MetadataCard.svelte` previously was `{actress.japanese_name || first last}` (preferred Japanese), but the helper changed it to prefer romanized names — a regression for users with `actress_language_ja: true`.

## Fix

Thread the `actress_language_ja` flag through `formatActressName` so it mirrors the backend `models.FormatActressName` `JapaneseNames` option.

### 1. Expose `actress_language_ja` to the frontend
- Added `actress_language_ja?: boolean;` to the `OutputConfig` TS type (`web/frontend/src/lib/api/types.ts`). Backend already serializes it.

### 2. Updated `formatActressName` helper
- Switched signature to options object: `formatActressName(actress, { firstNameOrder?, japaneseNames? })` — cleaner than 3 positional booleans.
- Added the `JapaneseNames` branch: when `japaneseNames=true` AND `japanese_name` is non-empty, returns `japanese_name` **before** the first/last logic — matching the backend precedence at `internal/models/actress_format.go:21-23`.

### 3. Wired the flag into all 4 display sites
Each site now reads both `first_name_order` AND `actress_language_ja` via `createConfigQuery()` + `$derived`:
- **MetadataCard** — now prefers `japanese_name` when `actress_language_ja=true` (fixes the regression)
- **ActressEditor** (`getFullName`)
- **actress-store** (`getDisplayName`, `getActressLabelByID`, `removeActress` — all now require both flags, no defaults per the B1 fix pattern)
- **SourceViewerModal**

The `+page.svelte` wrappers pass both flags to the store functions.

### 4. Tests
- 4 new cases covering the `japaneseNames` matrix:
  - `japaneseNames=true` + both romanized + japanese → returns `japanese_name`
  - `japaneseNames=true` + only romanized → returns romanized (first/last order still applies)
  - `japaneseNames=false` + both → returns romanized (existing behavior, unaffected)
  - `japaneseNames=true` + only japanese → returns `japanese_name`
- 10 existing tests adapted to the new options-object signature.
- 390 frontend tests total pass.

## Validation
- `cd web/frontend && npm run test` — 390 tests pass
- `cd web/frontend && npm run check` (svelte-check) — 0 errors, 0 warnings
- `go test ./...` — pass
- `go vet ./...` — clean
- `golangci-lint run` — 0 issues

## Local review
Fresh-context reviewers (2 rounds): 0 blockers. Both confirmed the `JapaneseNames` precedence matches the backend, all display sites wired, all callers updated, original MetadataCard regression fixed.

@codex review
