### PR TITLE
fix(imageutil): lower MinPoster threshold to accept real DMM posters

### DIFF
--- a/internal/imageutil/poster.go
+++ b/internal/imageutil/poster.go
@@ -16,11 +16,16 @@ import (
 	"github.com/javinizer/javinizer-go/internal/logging"
 )
 
-// MinPosterWidth and MinPosterHeight are the minimum pixel dimensions for a high-quality portrait poster.
+// MinPosterWidth and MinPosterHeight are the minimum pixel dimensions for a
+// usable portrait poster. Real DMM awsimgsrc posters (ps.jpg) range from
+// ~714x972 (e.g. MIHD-001) up to ~1032x1469, so the floor is set below the
+// smallest observed real poster with margin. Placeholders / thumbnails served
+// for missing titles are well under this (and usually 404 anyway), so they are
+// still rejected in favor of cropping the high-res cover.
 const (
-	MinPosterWidth = 800
+	MinPosterWidth = 600
 
-	MinPosterHeight = 1000
+	MinPosterHeight = 800
 
 	maxDimensionReadBytes = 256 * 1024
 )

--- a/internal/imageutil/poster_test.go
+++ b/internal/imageutil/poster_test.go
@@ -151,6 +151,7 @@ func (b *testBuffer) Bytes() []byte {
 func TestGetOptimalPosterURL_WithHTTPServer(t *testing.T) {
 	// Create test images with different dimensions
 	highQualityImage := createTestJPEG(t, 1000, 1500) // Meets requirements
+	mihdImage := createTestJPEG(t, 714, 972)          // Real MIHD-001 poster size
 	lowQualityImage := createTestJPEG(t, 500, 700)    // Too small
 
 	tests := []struct {
@@ -164,6 +165,12 @@ func TestGetOptimalPosterURL_WithHTTPServer(t *testing.T) {
 			posterImageData: highQualityImage,
 			posterStatus:    http.StatusOK,
 			expectedCrop:    false, // meets MinPoster dimensions: return ps.jpg directly
+		},
+		{
+			name:            "real DMM poster below old threshold (MIHD-001 714x972)",
+			posterImageData: mihdImage,
+			posterStatus:    http.StatusOK,
+			expectedCrop:    false, // real poster art preferred over cropping the landscape cover
 		},
 		{
 			name:            "low quality poster - fallback to cover",


### PR DESCRIPTION
## Summary

Follow-up to #124. PR #124 fixed `constructAwsimgsrcPosterURL` so awsimgsrc `ps.jpg` posters are now reachable, but the `MinPosterWidth/Height = 800/1000` threshold rejected legitimate posters like **MIHD-001** (`mihd00001ps.jpg`, 714×972), causing the scraper to fall back to cropping the landscape cover (`pl.jpg`) instead of using the real portrait poster art.

### Root cause
The 800×1000 threshold predates the path fix in #124 and was never calibrated against real posters. Sampling real DMM awsimgsrc posters shows they range from **714×972 (MIHD-001) up to ~1032×1469** — many fall below 800×1000.

| Title | `ps.jpg` dimensions | Old threshold (800×1000) | New (600×800) |
|-------|---------------------|------------------------|---------------|
| SONE-086 | 1032×1468 | ✅ accepted | ✅ accepted |
| SONE-560 | 990×1368 | ✅ accepted | ✅ accepted |
| **MIHD-001** | **714×972** | ❌ rejected → cropped cover | ✅ accepted |
| 404/placeholder | ~90×122 | ✅ rejected | ✅ rejected |

### Fix
Lower `MinPosterWidth`/`MinPosterHeight` from `800`/`1000` to `600`/`800` in `internal/imageutil/poster.go`:
- Accepts MIHD-001 (714×972) with margin → returns `mihd00001ps.jpg` directly instead of cropping the cover.
- Still rejects placeholders/thumbnails (the existing `500×700` "too small" test case stays valid).
- 404s are already handled by the status check before the dimension check.
- Applies to all call sites that reference the constants: `GetOptimalPosterURL` (dmm, javbus, javlibrary) and r18dev's `resolveAwsimgsrcPoster`.

### Verification
- Live repro against `awsimgsrc.dmm.com` for MIHD-001: now returns `mihd00001ps.jpg` with `shouldCrop=false` (previously returned the cover `pl.jpg` with `shouldCrop=true`).
- `go test ./internal/imageutil/... ./internal/scraper/r18dev/... ./internal/scraper/dmm/...` — pass
- `go vet` + `gofmt` — clean
- Pre-commit hooks (gofmt, go vet, `go test -short`, build, swagger) — pass

### Test coverage
Added a regression test case mirroring MIHD-001 (714×972 poster → `shouldCrop=false`) in `TestGetOptimalPosterURL_WithHTTPServer`.