### PR TITLE
docs(desktop): use PowerShell syntax for APPDATA in migration snippets

### DIFF
--- a/docs/17-desktop-app.md
+++ b/docs/17-desktop-app.md
@@ -234,16 +234,16 @@ The portable paths resolve as:
 2. **Copy your config**:
    ```powershell
    # Create the data directory if it doesn't exist
-   mkdir "%APPDATA%\Javinizer" -Force
+   mkdir "$env:APPDATA\Javinizer" -Force
    # Copy your CLI config
-   copy configs\config.yaml "%APPDATA%\Javinizer\config.yaml"
+   copy configs\config.yaml "$env:APPDATA\Javinizer\config.yaml"
    ```
 
 3. **Copy your database** (optional — preserves job history, scraped metadata,
    genre replacements, actress records):
    ```powershell
-   mkdir "%APPDATA%\Javinizer\data" -Force
-   copy data\javinizer.db "%APPDATA%\Javinizer\data\javinizer.db"
+   mkdir "$env:APPDATA\Javinizer\data" -Force
+   copy data\javinizer.db "$env:APPDATA\Javinizer\data\javinizer.db"
    ```
 
 4. **Update `allowed_directories`** — the desktop app launches from


### PR DESCRIPTION
## Summary

The Windows migration code blocks in `docs/17-desktop-app.md` used CMD-style `%APPDATA%` inside PowerShell double-quoted strings:

```powershell
mkdir "%APPDATA%\Javinizer" -Force
copy configs\config.yaml "%APPDATA%\Javinizer\config.yaml"
```

**PowerShell does not expand `%VAR%`** — that is CMD syntax. Inside a PowerShell double-quoted string, `"%APPDATA%\Javinizer"` is treated as a literal string, so these commands create a folder literally named `%APPDATA%\Javinizer` relative to the current working directory, instead of `C:\Users\<user>\AppData\Roaming\Javinizer`. Users following the migration guide ended up with their config and database in the wrong location — a likely contributor to the "some users have it in `%APPDATA%\Roaming` and some directly under `%APPDATA%`" confusion.

### Fix
Switch the four affected snippets to `$env:APPDATA`, the correct PowerShell environment-variable syntax:

```powershell
mkdir "$env:APPDATA\Javinizer" -Force
copy configs\config.yaml "$env:APPDATA\Javinizer\config.yaml"
```

### Scope
Only the executable PowerShell code blocks were changed (lines 237, 239, 245, 246). The prose/table references like `` `%APPDATA%\Javinizer\` `` are left unchanged — they document the env-var path and are not executable code.

### Verification
Pre-commit hooks (gofmt, go vet, `go test -short`, build, swagger) — pass.