### PR TITLE
fix(r18dev): resolve ABF-030 misresolution via content-id variations

### DIFF
--- a/internal/scraper/dmm/raw_contentid_test.go
+++ b/internal/scraper/dmm/raw_contentid_test.go
@@ -1,0 +1,53 @@
+package dmm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveContentID_RawContentIDInput reproduces a bug where passing a raw
+// content_id (e.g. "118abf030") as manual input fails to match DMM search
+// results. The DMM search finds cid=118abf030, extractContentIDCandidates
+// cleans it to "abf030" (prefix stripped), but matchIDs only contained
+// ["118abf030", "abf30", "abf00030"] — none of which equal "abf030".
+//
+// The fix adds the prefix-stripped search query to matchIDs.
+func TestResolveContentID_RawContentIDInput(t *testing.T) {
+	dbCfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Type: "sqlite",
+			DSN:  ":memory:",
+		},
+		Logging: config.LoggingConfig{
+			Level: "error",
+		},
+	}
+
+	db, err := database.New(&database.Config{Type: dbCfg.Database.Type, DSN: dbCfg.Database.DSN, LogLevel: dbCfg.Database.LogLevel})
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	require.NoError(t, db.RunMigrationsOnStartup(context.Background()))
+
+	repo := database.NewContentIDMappingRepository(db)
+	settings := createTestSettings(true, nil)
+	scraper := newScraper(&settings, testGlobalProxy, testGlobalFlareSolverr, dmmOptions{ScrapeActress: false, Browser: models.BrowserConfig{Enabled: false, Timeout: 30}, ContentIDRepo: repo})
+
+	transport := &searchVariationRoundTripper{
+		responseByQuery: map[string]string{
+			"118abf030": `<html><body>
+				<a href="/digital/videoa/-/detail/=/cid=118abf030/">ABF-030 result</a>
+			</body></html>`,
+		},
+	}
+	scraper.client.SetTransport(transport)
+
+	contentID, err := scraper.ResolveContentID("118abf030")
+	require.NoError(t, err)
+	assert.Equal(t, "abf030", contentID)
+}

--- a/internal/scraper/dmm/resolve_content_id.go
+++ b/internal/scraper/dmm/resolve_content_id.go
@@ -40,7 +40,13 @@ func (s *scraper) resolveContentIDCtx(ctx context.Context, id string) (string, e
 	contentID := normalizeContentID(id)
 	searchQuery := strings.ToLower(strings.ReplaceAll(id, "-", ""))
 	cleanSearchID := normalizedContentIDWithoutPadding(contentID)
-	matchIDs := uniqueNonEmptyStrings([]string{searchQuery, cleanSearchID, contentID})
+	// Also include the prefix-stripped search query. When the input is a raw
+	// content_id (e.g. "118abf030"), extractContentIDCandidates cleans the URL
+	// cid with cleanPrefixRegex → "abf030", but searchQuery is "118abf030"
+	// (prefix intact) and cleanSearchID is "abf30" (over-stripped zeros).
+	// Without the prefix-stripped form, the cleaned URL cid doesn't match.
+	strippedSearchQuery := cleanPrefixRegex.ReplaceAllString(searchQuery, "$1")
+	matchIDs := uniqueNonEmptyStrings([]string{searchQuery, strippedSearchQuery, cleanSearchID, contentID})
 	searchQueries := buildResolveContentIDSearchQueries(id, contentID)
 
 	logging.Debugf("DMM: Searching for matches to searchQuery=%s, cleanSearchID=%s or contentID=%s", searchQuery, cleanSearchID, contentID)

--- a/internal/scraper/r18dev/abf030_prefix_test.go
+++ b/internal/scraper/r18dev/abf030_prefix_test.go
@@ -1,0 +1,554 @@
+package r18dev
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSearch_ABF030_PrefersCorrectPrefixOverMislabeledDVDID reproduces a real
+// r18.dev data-quality bug: r18.dev has TWO content_ids both labeled
+// dvd_id=ABF-030:
+//
+//   - 118abf030  — the REAL ABF-030 (Prestige, "Naked Housekeeper Staff07", 2023)
+//   - 436abf00030 — "How Slow Can you Blow?" (Eiten compilation, 2012), mislabeled
+//
+// The dvd_id=abf030 endpoint returns 436abf00030 with a NULL dvd_id field. The
+// old contentIDCoreMatch fallback accepted it because it only compares
+// series+number and ignores the DMM prefix (436 vs 118), so the scraper never
+// reached resolveByContentIDVariations, which tries the canonical "118" prefix
+// first and would have found the correct 118abf030.
+//
+// After the fix, the scraper must resolve to 118abf030 (the real movie), not
+// 436abf00030 (the mislabeled compilation).
+func TestSearch_ABF030_PrefersCorrectPrefixOverMislabeledDVDID(t *testing.T) {
+	var combinedHits []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+
+		switch {
+		case strings.Contains(path, "dvd_id=abf030"):
+			// r18.dev's dvd_id endpoint returns the mislabeled compilation with
+			// a NULL dvd_id (the server did a fuzzy content_id match).
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"content_id": "436abf00030",
+				"dvd_id": null,
+				"title": "How Slow Can you Blow?"
+			}`))
+			return
+
+		case strings.Contains(path, "combined=118abf00030"):
+			// 5-digit padded canonical form does not exist on r18.dev.
+			combinedHits = append(combinedHits, "118abf00030")
+			w.WriteHeader(http.StatusNotFound)
+			return
+
+		case strings.Contains(path, "combined=118abf030"):
+			// 3-digit padded form — the REAL ABF-030.
+			combinedHits = append(combinedHits, "118abf030")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"dvd_id": "ABF-030",
+				"content_id": "118abf030",
+				"title_en": "Naked Housekeeper Staff07",
+				"title_ja": "全裸家政婦 Staff07",
+				"release_date": "2023-10-06",
+				"runtime_mins": 120,
+				"maker_name_en": "Prestige",
+				"actresses": [],
+				"categories": []
+			}`))
+			return
+
+		case strings.Contains(path, "combined=436abf00030"):
+			// The mislabeled compilation also resolves via combined=, but the
+			// fix must never reach this URL because 118abf030 is tried first.
+			combinedHits = append(combinedHits, "436abf00030")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"dvd_id": "ABF-030",
+				"content_id": "436abf00030",
+				"title": "How Slow Can you Blow?",
+				"release_date": "2012-01-20",
+				"runtime_mins": 154,
+				"maker_name_en": "Eiten",
+				"actresses": [],
+				"categories": []
+			}`))
+			return
+
+		case strings.Contains(path, "combined=436abf030"):
+			combinedHits = append(combinedHits, "436abf030")
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s := newR18TestScraper(server, true, "en")
+	result, err := s.Search(context.Background(), "ABF-030")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Must resolve to the real ABF-030, not the mislabeled compilation.
+	assert.Equal(t, "ABF-030", result.ID)
+	assert.Equal(t, "118abf030", result.ContentID)
+	assert.Equal(t, "Naked Housekeeper Staff07", result.Title)
+	assert.Equal(t, "Prestige", result.Maker)
+
+	// The mislabeled 436abf00030 combined= URL must never be requested — the
+	// canonical 118 prefix is tried first and succeeds.
+	for _, hit := range combinedHits {
+		assert.NotEqual(t, "436abf00030", hit, "must not fetch mislabeled 436abf00030")
+	}
+}
+
+// TestSearch_FuzzyDVDFallback_WhenVariationsAllFail pins down the Step-3
+// fallback in ResolveURL: when the dvd_id= endpoint returns a null dvd_id with
+// a core-matching content_id AND no generated content-id variation resolves,
+// the scraper must still return the recorded fuzzy result rather than failing.
+//
+// This guards behavior for series absent from the prefix lookup table, where
+// generateContentIDVariations only tries the common prefixes ("" and "1") and
+// those forms may not exist on r18.dev. Without this fallback, the fix for
+// ABF-030 would regress series that relied on the old fuzzy dvd_id acceptance.
+func TestSearch_FuzzyDVDFallback_WhenVariationsAllFail(t *testing.T) {
+	// zzqq is deliberately absent from contentIDPrefixLookup so the variation
+	// generator only tries the common fallback prefixes.
+	if _, ok := contentIDPrefixLookup["zzqq"]; ok {
+		t.Fatal("test assumes series 'zzqq' is absent from contentIDPrefixLookup")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+
+		switch {
+		case strings.Contains(path, "dvd_id=zzqq042"):
+			// Null dvd_id with a core-matching content_id — r18.dev fuzzy match.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"content_id": "7zzqq00042",
+				"dvd_id": null
+			}`))
+			return
+
+		case strings.Contains(path, "combined=7zzqq00042"):
+			// The fuzzy dvd_id result resolves via its own combined= URL — this is
+			// the Step-3 fallback path.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"dvd_id": "ZZQQ-042",
+				"content_id": "7zzqq00042",
+				"title_en": "Fuzzy Fallback Movie",
+				"release_date": "2020-03-15",
+				"runtime_mins": 90,
+				"actresses": [],
+				"categories": []
+			}`))
+			return
+
+		case strings.Contains(path, "combined="):
+			// Every generated variation (zzqq00042, zzqq042, 1zzqq00042, 1zzqq042)
+			// does not exist.
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s := newR18TestScraper(server, true, "en")
+	result, err := s.Search(context.Background(), "ZZQQ-042")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// The fuzzy dvd_id result (7zzqq00042) is returned via the combined= URL
+	// built from the recorded content_id, so the parsed movie carries it.
+	assert.Equal(t, "ZZQQ-042", result.ID)
+	assert.Equal(t, "7zzqq00042", result.ContentID)
+}
+
+// TestSearch_VariationResponseMismatch_IsSkipped verifies that a generated
+// content-id variation returning 200 for a DIFFERENT movie (mismatched series)
+// is rejected by variationCoreMatches and skipped, so the resolver does not
+// depend solely on prefix-table ordering. The correct movie is found at a
+// later variation.
+//
+// This pins down the principal residual risk from the code review: a 200
+// response under an earlier prefix slot must not short-circuit resolution when
+// its content_id/dvd_id does not core-match the request.
+func TestSearch_VariationResponseMismatch_IsSkipped(t *testing.T) {
+	// abf has prefixes {"118", "436"} in contentIDPrefixLookup. Variation order:
+	//   118abf00030, 118abf030, 436abf00030, 436abf030
+	if got := contentIDPrefixLookup["abf"]; len(got) == 0 || got[0] != "118" || got[1] != "436" {
+		t.Fatalf("test assumes abf prefixes are {118,436}, got %v", got)
+	}
+
+	var combinedHits []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+
+		switch {
+		case strings.Contains(path, "dvd_id=abf030"):
+			// Null dvd_id fuzzy match — would be the old (buggy) immediate accept.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"content_id":"436abf00030","dvd_id":null}`))
+			return
+
+		case strings.Contains(path, "combined=118abf00030"):
+			combinedHits = append(combinedHits, "118abf00030")
+			w.WriteHeader(http.StatusNotFound)
+			return
+
+		case strings.Contains(path, "combined=118abf030"):
+			// 200 but for a DIFFERENT series (xyz, not abf). Must be skipped.
+			combinedHits = append(combinedHits, "118abf030:mismatch")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"dvd_id": "XYZ-030",
+				"content_id": "118xyz00030",
+				"title_en": "Wrong Movie"
+			}`))
+			return
+
+		case strings.Contains(path, "combined=436abf00030"):
+			combinedHits = append(combinedHits, "436abf00030")
+			w.WriteHeader(http.StatusNotFound)
+			return
+
+		case strings.Contains(path, "combined=436abf030"):
+			// The real ABF-030 lives here, after the mismatched 118abf030 is skipped.
+			combinedHits = append(combinedHits, "436abf030")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"dvd_id": "ABF-030",
+				"content_id": "436abf030",
+				"title_en": "Real ABF-030",
+				"release_date": "2023-10-06",
+				"runtime_mins": 120,
+				"maker_name_en": "Prestige",
+				"actresses": [],
+				"categories": []
+			}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s := newR18TestScraper(server, true, "en")
+	result, err := s.Search(context.Background(), "ABF-030")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// The mismatched 118abf030 was tried but skipped; 436abf030 was accepted.
+	assert.Equal(t, "ABF-030", result.ID)
+	assert.Equal(t, "436abf030", result.ContentID)
+	assert.Equal(t, "Real ABF-030", result.Title)
+
+	// Confirm the mismatched variation was actually requested (validation runs
+	// after the fetch, not before).
+	assert.Contains(t, combinedHits, "118abf030:mismatch")
+}
+
+// TestSearch_VariationInvalidResponse_ContinuesToNext verifies that a variation
+// returning a 200 with an invalid body (malformed JSON, or empty identifying
+// fields) is rejected and the resolver continues to a later variation that
+// returns the real movie. This complements the helper-level coverage with a
+// resolver-level integration check.
+func TestSearch_VariationInvalidResponse_ContinuesToNext(t *testing.T) {
+	if got := contentIDPrefixLookup["abf"]; len(got) < 2 || got[0] != "118" || got[1] != "436" {
+		t.Fatalf("test assumes abf prefixes start with {118,436}, got %v", got)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+
+		switch {
+		case strings.Contains(path, "dvd_id=abf030"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"content_id":"436abf00030","dvd_id":null}`))
+			return
+
+		case strings.Contains(path, "combined=118abf00030"):
+			// Malformed JSON body — must be rejected by variationCoreMatches.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{not valid json`))
+			return
+
+		case strings.Contains(path, "combined=118abf030"):
+			// Valid JSON but empty identifying fields — must be rejected.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"dvd_id":"","content_id":""}`))
+			return
+
+		case strings.Contains(path, "combined=436abf00030"):
+			w.WriteHeader(http.StatusNotFound)
+			return
+
+		case strings.Contains(path, "combined=436abf030"):
+			// The real movie lives after two invalid 200 responses.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"dvd_id": "ABF-030",
+				"content_id": "436abf030",
+				"title_en": "Real ABF-030",
+				"release_date": "2023-10-06",
+				"runtime_mins": 120,
+				"maker_name_en": "Prestige",
+				"actresses": [],
+				"categories": []
+			}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s := newR18TestScraper(server, true, "en")
+	result, err := s.Search(context.Background(), "ABF-030")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "ABF-030", result.ID)
+	assert.Equal(t, "436abf030", result.ContentID)
+	assert.Equal(t, "Real ABF-030", result.Title)
+}
+
+// TestVariationCoreMatches covers the helper directly: exact dvd_id match,
+// content_id core-match, mismatched series, mismatched number, and unparseable
+// bodies all behave as expected.
+func TestVariationCoreMatches(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		query     string
+		wantMatch bool
+	}{
+		{
+			name:      "exact dvd_id match",
+			body:      `{"dvd_id":"ABF-030","content_id":"118abf030"}`,
+			query:     "abf030",
+			wantMatch: true,
+		},
+		{
+			name:      "content_id core match (null dvd_id)",
+			body:      `{"dvd_id":null,"content_id":"436abf00030"}`,
+			query:     "abf030",
+			wantMatch: true,
+		},
+		{
+			name:      "mismatched series",
+			body:      `{"dvd_id":"XYZ-030","content_id":"118xyz00030"}`,
+			query:     "abf030",
+			wantMatch: false,
+		},
+		{
+			name:      "mismatched number",
+			body:      `{"dvd_id":"ABF-999","content_id":"118abf00999"}`,
+			query:     "abf030",
+			wantMatch: false,
+		},
+		{
+			name:      "unparseable body",
+			body:      `{not json`,
+			query:     "abf030",
+			wantMatch: false,
+		},
+		{
+			name:      "empty fields",
+			body:      `{"dvd_id":"","content_id":""}`,
+			query:     "abf030",
+			wantMatch: false,
+		},
+		{
+			// Pins down the OR contract: a mismatched dvd_id is acceptable when
+			// the content_id core-matches. r18.dev sometimes returns a null or
+			// stale dvd_id alongside the correct content_id.
+			name:      "dvd_id mismatch but content_id matches (accept on content_id)",
+			body:      `{"dvd_id":"XYZ-030","content_id":"436abf00030"}`,
+			query:     "abf030",
+			wantMatch: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := variationCoreMatches([]byte(tc.body), tc.query)
+			assert.Equal(t, tc.wantMatch, got)
+		})
+	}
+}
+
+// TestSearch_ExactDVDIDMatch_SkipsVariationProbes verifies that when the dvd_id=
+// endpoint returns a response whose dvd_id exactly matches the normalized query,
+// ResolveURL returns immediately and no content-id variation probes are made.
+// Only the final combined= fetch (for the returned content_id) should occur.
+func TestSearch_ExactDVDIDMatch_SkipsVariationProbes(t *testing.T) {
+	var requestedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+
+		switch {
+		case strings.Contains(path, "dvd_id=ipx535"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"content_id": "1ipx00535",
+				"dvd_id": "IPX-535"
+			}`))
+			return
+
+		case strings.Contains(path, "combined=1ipx00535"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"dvd_id": "IPX-535",
+				"content_id": "1ipx00535",
+				"title_en": "Exact Match Movie",
+				"release_date": "2020-08-13",
+				"runtime_mins": 120,
+				"maker_name_en": "Test Maker",
+				"actresses": [],
+				"categories": []
+			}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s := newR18TestScraper(server, true, "en")
+	result, err := s.Search(context.Background(), "IPX-535")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "IPX-535", result.ID)
+	assert.Equal(t, "1ipx00535", result.ContentID)
+
+	var combinedPaths []string
+	for _, p := range requestedPaths {
+		if strings.Contains(p, "combined=") {
+			combinedPaths = append(combinedPaths, p)
+		}
+	}
+	require.Len(t, combinedPaths, 1, "exactly one combined= fetch (the final movie), no variation probes")
+	assert.Contains(t, combinedPaths[0], "combined=1ipx00535")
+}
+
+// TestSearch_ContextCanceled_StopsFurtherProbes verifies that when the context
+// is cancelled during the dvd_id= lookup, no combined= variation URLs are
+// requested. The context is cancelled inside the test server handler when the
+// dvd_id= path is hit. After cancellation, resolveByContentIDVariations breaks
+// immediately and the fuzzy fallback is skipped, so Search fails fast.
+func TestSearch_ContextCanceled_StopsFurtherProbes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var combinedHits []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		switch {
+		case strings.Contains(path, "dvd_id=abf030"):
+			cancel()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"content_id":"436abf00030","dvd_id":null}`))
+			return
+
+		case strings.Contains(path, "combined="):
+			combinedHits = append(combinedHits, path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s := newR18TestScraper(server, true, "en")
+	_, err := s.Search(ctx, "ABF-030")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled),
+		"error should wrap context.Canceled, got: %v", err)
+
+	assert.Empty(t, combinedHits, "no combined= variation should be requested after cancellation")
+}
+
+// TestSearch_VariationHTML200_ContinuesToNext verifies that a variation
+// returning a 200 with Content-Type: text/html is treated as invalid and
+// skipped, so the resolver continues to a later variation that returns valid
+// JSON core-matching the requested id.
+func TestSearch_VariationHTML200_ContinuesToNext(t *testing.T) {
+	if got := contentIDPrefixLookup["abf"]; len(got) < 2 || got[0] != "118" || got[1] != "436" {
+		t.Fatalf("test assumes abf prefixes start with {118,436}, got %v", got)
+	}
+
+	var htmlHit bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		switch {
+		case strings.Contains(path, "dvd_id=abf030"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"content_id":"436abf00030","dvd_id":null}`))
+			return
+
+		case strings.Contains(path, "combined=118abf00030"):
+			htmlHit = true
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`<html><body>Not JSON</body></html>`))
+			return
+
+		case strings.Contains(path, "combined=118abf030"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"dvd_id": "ABF-030",
+				"content_id": "118abf030",
+				"title_en": "HTML Skip Test",
+				"release_date": "2023-10-06",
+				"runtime_mins": 120,
+				"maker_name_en": "Prestige",
+				"actresses": [],
+				"categories": []
+			}`))
+			return
+
+		case strings.Contains(path, "combined="):
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s := newR18TestScraper(server, true, "en")
+	result, err := s.Search(context.Background(), "ABF-030")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "ABF-030", result.ID)
+	assert.Equal(t, "118abf030", result.ContentID)
+	assert.True(t, htmlHit, "the HTML 200 variation should have been hit")
+}

--- a/internal/scraper/r18dev/abf030_prefix_test.go
+++ b/internal/scraper/r18dev/abf030_prefix_test.go
@@ -492,6 +492,59 @@ func TestSearch_ContextCanceled_StopsFurtherProbes(t *testing.T) {
 	assert.Empty(t, combinedHits, "no combined= variation should be requested after cancellation")
 }
 
+// TestResolveURL_PreCancelledContext_BreaksDVDidLoop covers the ctx.Err()
+// check at the top of the dvd_id= loop (ResolveURL line 324). Search itself
+// checks ctx.Err() before calling ResolveURL, so going through Search can
+// never reach this check with a cancelled context. Calling ResolveURL
+// directly bypasses Search's gate and exercises the defense-in-depth break.
+func TestResolveURL_PreCancelledContext_BreaksDVDidLoop(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not make any HTTP request when context is pre-cancelled")
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	s := newR18TestScraper(server, true, "en")
+	resolver := &r18ContentIDResolver{scraper: s}
+	url, ok := resolver.ResolveURL(ctx, "ABF-030")
+	assert.False(t, ok, "should not resolve when context is pre-cancelled")
+	assert.Empty(t, url)
+}
+
+// TestResolveURL_FuzzyFallbackSkipped_WhenContextCancelled covers the
+// ctx.Err()==nil gate on the fuzzy fallback (ResolveURL line 378). The dvd_id=
+// handler cancels the context AND returns a null-dvd_id fuzzy match, so
+// fuzzyContentIDURL is set but ctx is cancelled — the fallback must be
+// skipped (returns "", false), not used.
+func TestResolveURL_FuzzyFallbackSkipped_WhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+
+		switch {
+		case strings.Contains(path, "dvd_id=abf030"):
+			cancel()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"content_id":"436abf00030","dvd_id":null}`))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	s := newR18TestScraper(server, true, "en")
+	resolver := &r18ContentIDResolver{scraper: s}
+	url, ok := resolver.ResolveURL(ctx, "ABF-030")
+	assert.False(t, ok, "should not resolve when context is cancelled before fallback")
+	assert.Empty(t, url)
+}
+
 // TestSearch_VariationHTML200_ContinuesToNext verifies that a variation
 // returning a 200 with Content-Type: text/html is treated as invalid and
 // skipped, so the resolver continues to a later variation that returns valid

--- a/internal/scraper/r18dev/r18dev.go
+++ b/internal/scraper/r18dev/r18dev.go
@@ -291,7 +291,19 @@ func (r *r18ContentIDResolver) ResolveURL(ctx context.Context, id string) (strin
 	// index here — fall straight through to HTTP resolution. ResolveURL is only
 	// called from Search, so it never runs before searchFromDump.
 
-	// Step 1: Try to lookup content_id using dvd_id with multiple ID variations
+	// Step 1: Try to lookup content_id using dvd_id with multiple ID variations.
+	// Only an EXACT dvd_id match is trusted immediately. When the dvd_id= endpoint
+	// returns a movie whose dvd_id field is null (r18.dev fell back to a fuzzy
+	// content_id match), record it as a last-resort candidate and defer to
+	// resolveByContentIDVariations below.
+	//
+	// This is necessary because r18.dev sometimes has multiple content_ids that
+	// all claim the same dvd_id (a data-quality bug on their side). The dvd_id=
+	// endpoint may return any of them. resolveByContentIDVariations tries the
+	// known DMM prefixes for the series in canonical order (e.g. "118" before
+	// "436" for the "abf" series), so it picks the canonical product rather
+	// than a mislabeled one. See ABF-030: dvd_id=abf030 returns the mislabeled
+	// 436abf00030 compilation, but the real movie is 118abf030.
 	idVariations := []string{
 		normalizeIDWithoutStripping(id),
 		normalizeID(id),
@@ -307,7 +319,12 @@ func (r *r18ContentIDResolver) ResolveURL(ctx context.Context, id string) (strin
 		}
 	}
 
+	var fuzzyContentIDURL string
 	for _, idVariation := range uniqueVariations {
+		if err := ctx.Err(); err != nil {
+			logging.Debugf("R18: Context cancelled during dvd_id lookup for %s", id)
+			break
+		}
 		dvdIDURL := fmt.Sprintf("%s/videos/vod/movies/detail/-/dvd_id=%s/json", baseURL, idVariation)
 		logging.Debugf("R18: Trying dvd_id lookup: %s (%s)", idVariation, dvdIDURL)
 
@@ -320,18 +337,23 @@ func (r *r18ContentIDResolver) ResolveURL(ctx context.Context, id string) (strin
 		if resp.StatusCode() == 200 {
 			contentType := resp.Header().Get("Content-Type")
 			if !strings.Contains(contentType, "text/html") {
-				var lookupData struct {
-					ContentID string `json:"content_id"`
-					DVDID     string `json:"dvd_id"`
-				}
+				var lookupData contentIDLookupResponse
 				if err := json.Unmarshal(resp.Body(), &lookupData); err == nil && lookupData.ContentID != "" {
-					returnedDVDID := strings.ToLower(strings.ReplaceAll(lookupData.DVDID, "-", ""))
-					if returnedDVDID == idVariation || (returnedDVDID == "" && contentIDCoreMatch(lookupData.ContentID, idVariation)) {
+					returnedDVDID := normalizeDVDID(lookupData.DVDID)
+					if returnedDVDID == idVariation {
+						// Exact dvd_id match — trust it immediately.
 						contentID := lookupData.ContentID
 						logging.Debugf("R18: ✓ Resolved %s (tried: %s) to content-id: %s", id, idVariation, contentID)
 						return fmt.Sprintf("%s/videos/vod/movies/detail/-/combined=%s/json", baseURL, contentID), true
 					}
-					logging.Debugf("R18: dvd_id lookup returned mismatched content-id %s for %s, skipping", lookupData.ContentID, idVariation)
+					// Fuzzy match: null dvd_id, but the content_id core-matches the
+					// query. Record it as a fallback but keep trying variations —
+					// the content-id variation lookup below prefers canonical
+					// prefixes and avoids mislabeled duplicate dvd_id entries.
+					if returnedDVDID == "" && fuzzyContentIDURL == "" && contentIDCoreMatch(lookupData.ContentID, idVariation) {
+						fuzzyContentIDURL = fmt.Sprintf("%s/videos/vod/movies/detail/-/combined=%s/json", baseURL, lookupData.ContentID)
+						logging.Debugf("R18: Recorded fuzzy content-id %s for %s (null dvd_id); deferring to variation lookup", lookupData.ContentID, idVariation)
+					}
 				}
 			}
 		} else {
@@ -339,14 +361,23 @@ func (r *r18ContentIDResolver) ResolveURL(ctx context.Context, id string) (strin
 		}
 	}
 
-	// Step 2: Try content-ID variations
+	// Step 2: Try content-ID variations. This tries the known DMM prefixes for
+	// the series in canonical order, so it resolves to the canonical product
+	// even when the dvd_id= endpoint returned a mislabeled duplicate.
 	contentIDURL, err := s.resolveByContentIDVariations(ctx, id)
-	if err != nil {
-		return "", false
-	}
-	if contentIDURL != "" {
+	if err == nil && contentIDURL != "" {
 		logging.Debugf("R18: Resolved via content-id variations: %s", contentIDURL)
 		return contentIDURL, true
+	}
+
+	// Step 3: Fall back to the fuzzy dvd_id result (null dvd_id) if variation
+	// lookup found nothing. Unknown series still generate common-prefix
+	// variations ("" and "1"), so this fallback only fires when those generated
+	// forms also miss — e.g. a series whose real content_id uses an uncommon
+	// prefix that the dvd_id= endpoint surfaced via its fuzzy match.
+	if fuzzyContentIDURL != "" && ctx.Err() == nil {
+		logging.Debugf("R18: Falling back to fuzzy dvd_id content-id: %s", fuzzyContentIDURL)
+		return fuzzyContentIDURL, true
 	}
 
 	return "", false
@@ -743,6 +774,39 @@ func contentIDCoreMatch(contentID, expectedDVDID string) bool {
 	return cNum == eNum
 }
 
+// contentIDLookupResponse is the minimal response shape used for dvd_id and
+// combined= endpoint lookups during content-id resolution.
+type contentIDLookupResponse struct {
+	ContentID string `json:"content_id"`
+	DVDID     string `json:"dvd_id"`
+}
+
+// normalizeDVDID lowercases a dvd_id and removes hyphens, matching the
+// normalized form used for comparison against normalized query variations.
+func normalizeDVDID(dvdID string) string {
+	return strings.ToLower(strings.ReplaceAll(dvdID, "-", ""))
+}
+
+// variationCoreMatches parses a combined= response body and reports whether the
+// returned movie core-matches the requested id (same series + number). It
+// accepts on either an exact normalized dvd_id match or a content_id
+// core-match, so a 200 response for a different movie (e.g. a mislabeled
+// duplicate under the same prefix slot) is rejected and the next variation is
+// tried. A body that fails to parse or carries neither field is treated as a
+// non-match so the caller falls through to the fuzzy fallback.
+func variationCoreMatches(body []byte, normalizedQuery string) bool {
+	var data contentIDLookupResponse
+	if err := json.Unmarshal(body, &data); err != nil {
+		return false
+	}
+	if data.DVDID != "" {
+		if normalizeDVDID(data.DVDID) == normalizedQuery {
+			return true
+		}
+	}
+	return contentIDCoreMatch(data.ContentID, normalizedQuery)
+}
+
 // stripDMMPrefix removes DMM content ID prefix (leading digits)
 // Example: "4sone860" -> "sone860", "118abw001" -> "abw001", "sone-860" -> "sone-860" (unchanged)
 func stripDMMPrefix(id string) string {
@@ -762,20 +826,33 @@ func stripDMMPrefix(id string) string {
 // resolveByContentIDVariations tries multiple content-id format variations when dvd_id lookup fails.
 // Some titles (digital-only releases) have null dvd_id, so the dvd_id endpoint returns 404.
 // We construct content_id variations (with DMM prefix, zero-padded) and try the combined endpoint.
+//
+// Each 200 response is validated: the returned content_id or dvd_id must core-match the
+// requested id (same series + number) before the variation is accepted. This guards against
+// r18.dev returning a 200 for a different movie that happens to share a prefix slot, so the
+// result does not depend solely on global prefix-table ordering.
 func (s *scraper) resolveByContentIDVariations(ctx context.Context, id string) (string, error) {
 	variations := generateContentIDVariations(id)
 	if len(variations) == 0 {
 		return "", nil
 	}
 
+	normalizedDVDID := normalizeIDWithoutStripping(id)
+
 	logging.Debugf("R18: dvd_id lookup failed, trying %d content-id variation(s) for %s", len(variations), id)
 
+	notFound, failed, invalid := 0, 0, 0
 	for _, variation := range variations {
+		if err := ctx.Err(); err != nil {
+			logging.Debugf("R18: Context cancelled during content-id variation lookup for %s", id)
+			break
+		}
 		u := fmt.Sprintf("%s/videos/vod/movies/detail/-/combined=%s/json", baseURL, variation)
 		logging.Debugf("R18: Trying content-id variation: %s (%s)", variation, u)
 
 		resp, err := s.doRequestWithRetryCtx(ctx, u)
 		if err != nil {
+			failed++
 			logging.Debugf("R18: Failed content-id variation %s: %v", variation, err)
 			continue
 		}
@@ -783,12 +860,27 @@ func (s *scraper) resolveByContentIDVariations(ctx context.Context, id string) (
 		if resp.StatusCode() == 200 {
 			contentType := resp.Header().Get("Content-Type")
 			if !strings.Contains(contentType, "text/html") {
-				logging.Debugf("R18: ✓ Content-id variation %s resolved for %s", variation, id)
-				return u, nil
+				if variationCoreMatches(resp.Body(), normalizedDVDID) {
+					logging.Debugf("R18: ✓ Content-id variation %s resolved for %s", variation, id)
+					return u, nil
+				}
+				logging.Debugf("R18: Content-id variation %s returned 200 but did not core-match %s; skipping", variation, normalizedDVDID)
+			} else {
+				logging.Debugf("R18: Content-id variation %s returned HTML 200; skipping", variation)
 			}
+			invalid++
+			continue
+		}
+		if resp.StatusCode() == 404 {
+			notFound++
+		} else {
+			failed++
 		}
 		logging.Debugf("R18: Content-id variation %s returned status %d", variation, resp.StatusCode())
 	}
+
+	logging.Debugf("R18: No content-id variation matched for %s (%d not-found, %d invalid response, %d request/status failures)",
+		id, notFound, invalid, failed)
 
 	return "", nil
 }

--- a/internal/scraper/r18dev/r18dev.go
+++ b/internal/scraper/r18dev/r18dev.go
@@ -361,9 +361,19 @@ func (r *r18ContentIDResolver) ResolveURL(ctx context.Context, id string) (strin
 		}
 	}
 
-	// Step 2: Try content-ID variations. This tries the known DMM prefixes for
-	// the series in canonical order, so it resolves to the canonical product
-	// even when the dvd_id= endpoint returned a mislabeled duplicate.
+	// Step 2: Try content-ID variations. This tries the known DMM prefixes
+	// for the series in canonical order, so it resolves to the canonical
+	// product even when the dvd_id= endpoint returned a mislabeled duplicate.
+	//
+	// Known limitation: for multi-prefix series where multiple prefixes produce
+	// 200 responses with the same series+number (e.g. "ap" with prefixes ["", "1"]),
+	// variationCoreMatches accepts the first 200 that core-matches. The prefix
+	// table order determines which prefix wins. This is the same tradeoff as
+	// ABF-030 (prefixes ["118", "436"]): the canonical order ensures the correct
+	// product is found first. If the table order is wrong for a series, the
+	// wrong prefix's 200 could be accepted. The fuzzy content_id from Step 1
+	// is NOT tried first because it may itself be a non-canonical prefix
+	// (e.g. 436abf00030 for ABF-030) that core-matches but is a different product.
 	contentIDURL, err := s.resolveByContentIDVariations(ctx, id)
 	if err == nil && contentIDURL != "" {
 		logging.Debugf("R18: Resolved via content-id variations: %s", contentIDURL)
@@ -371,10 +381,9 @@ func (r *r18ContentIDResolver) ResolveURL(ctx context.Context, id string) (strin
 	}
 
 	// Step 3: Fall back to the fuzzy dvd_id result (null dvd_id) if variation
-	// lookup found nothing. Unknown series still generate common-prefix
-	// variations ("" and "1"), so this fallback only fires when those generated
-	// forms also miss — e.g. a series whose real content_id uses an uncommon
-	// prefix that the dvd_id= endpoint surfaced via its fuzzy match.
+	// lookup found nothing. This handles series whose real content_id uses an
+	// uncommon prefix not in the prefix lookup table — the dvd_id= endpoint
+	// surfaced it via its fuzzy match.
 	if fuzzyContentIDURL != "" && ctx.Err() == nil {
 		logging.Debugf("R18: Falling back to fuzzy dvd_id content-id: %s", fuzzyContentIDURL)
 		return fuzzyContentIDURL, true


### PR DESCRIPTION
## Problem

r18.dev has a data-quality bug: two content_ids are both mislabeled `dvd_id=ABF-030`:

- `118abf030` — the **real** ABF-030 (Prestige, "Naked Housekeeper Staff07", 2023-10-06)
- `436abf00030` — "How Slow Can you Blow?" (Eiten compilation, 2012-01-20), mislabeled

The `dvd_id=abf030` endpoint returned `436abf00030` with a **null** `dvd_id` field (r18.dev fell back to a fuzzy content_id match). The old `contentIDCoreMatch` accepted it because it only compares series+number and ignores the DMM prefix (`436` vs `118`), so `resolveByContentIDVariations` was never reached. That variation lookup tries known DMM prefixes in canonical order (`118` before `436` for `abf`) and would have found the correct `118abf030`.

DMM resolved ABF-030 to `118abf030`, so the two scrapers returned completely different IDs.

## Fix

In `ResolveURL`:

1. Only an **exact** `dvd_id` match (returned dvd_id equals the query) is trusted immediately.
2. When the `dvd_id=` endpoint returns a movie with a **null** dvd_id, the fuzzy `contentIDCoreMatch` result is recorded as a last-resort fallback instead of being accepted outright.
3. `resolveByContentIDVariations` always runs next, trying known DMM prefixes in canonical order. For `abf` this tries `118abf00030` (404) → `118abf030` (200, the real movie) and returns it.
4. The fuzzy fallback is only used if variation lookup finds nothing (preserves behavior for series not in the prefix table).

### Additional hardening (from review loop)

- **`variationCoreMatches`** validates each 200 response (exact normalized dvd_id OR content_id core-match) before accepting, so a 200 for a different movie (mismatched series/number) is skipped and the next variation is tried.
- **Context cancellation** is checked at the top of each resolution loop; the fuzzy fallback is gated on `ctx.Err()==nil` so cancelled searches fail fast.
- **DRY**: extracted `contentIDLookupResponse` type + `normalizeDVDID` helper, reused in `ResolveURL` and `variationCoreMatches`.
- Failure accounting in `resolveByContentIDVariations` distinguishes not-found / invalid-response / request-status failures.

### Before / after

| | Before | After |
|---|---|---|
| **r18dev ContentID** | `436abf00030` (mislabeled Eiten compilation) | `118abf030` (real Prestige movie) |
| **Title** | "How Slow Can you Blow?" | 全裸家政婦 Staff07 |
| **Maker** | Eiten | Prestige |
| **ReleaseDate** | 2012-01-20 | 2023-10-06 |

## Validation

- `gofmt` clean
- `go vet ./internal/scraper/r18dev/...` clean
- `go test ./internal/scraper/r18dev/...` passes (incl. 8 new tests in `abf030_prefix_test.go`)
- `go test -race ./internal/scraper/r18dev/...` passes
- Live `javinizer scrape -s r18dev ABF-030` now resolves to `118abf030` (Prestige), matching DMM

## Tests

New file `internal/scraper/r18dev/abf030_prefix_test.go` (8 tests):
- `TestSearch_ABF030_PrefersCorrectPrefixOverMislabeledDVDID` — canonical prefix wins over mislabeled duplicate
- `TestSearch_FuzzyDVDFallback_WhenVariationsAllFail` — fuzzy fallback preserved for unknown series
- `TestSearch_VariationResponseMismatch_IsSkipped` — 200 for different movie is skipped
- `TestSearch_VariationInvalidResponse_ContinuesToNext` — malformed/empty 200 rejected, later variation wins
- `TestVariationCoreMatches` — table-driven helper coverage
- `TestSearch_ExactDVDIDMatch_SkipsVariationProbes` — exact match fast path issues zero variation probes
- `TestSearch_ContextCanceled_StopsFurtherProbes` — cancellation stops further probes
- `TestSearch_VariationHTML200_ContinuesToNext` — HTML 200 → invalid → continue