### PR TITLE
feat(config): validate disabled-scraper priority overrides

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -5835,6 +5835,23 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_javinizer_javinizer-go_internal_config.ConfigWarning": {
+            "type": "object",
+            "properties": {
+                "field": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "scrapers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "github_com_javinizer_javinizer-go_internal_config.DatabaseConfig": {
             "type": "object",
             "properties": {
@@ -7933,6 +7950,12 @@ const docTemplate = `{
                 },
                 "system": {
                     "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_config.SystemConfig"
+                },
+                "warnings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_config.ConfigWarning"
+                    }
                 },
                 "webui": {
                     "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_config.webUIConfig"

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -5833,6 +5833,23 @@
                 }
             }
         },
+        "github_com_javinizer_javinizer-go_internal_config.ConfigWarning": {
+            "type": "object",
+            "properties": {
+                "field": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "scrapers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "github_com_javinizer_javinizer-go_internal_config.DatabaseConfig": {
             "type": "object",
             "properties": {
@@ -7931,6 +7948,12 @@
                 },
                 "system": {
                     "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_config.SystemConfig"
+                },
+                "warnings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_config.ConfigWarning"
+                    }
                 },
                 "webui": {
                     "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_config.webUIConfig"

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1432,6 +1432,17 @@ definitions:
         description: e.g., claude-sonnet-4-20250514
         type: string
     type: object
+  github_com_javinizer_javinizer-go_internal_config.ConfigWarning:
+    properties:
+      field:
+        type: string
+      message:
+        type: string
+      scrapers:
+        items:
+          type: string
+        type: array
+    type: object
   github_com_javinizer_javinizer-go_internal_config.DatabaseConfig:
     properties:
       dsn:
@@ -2883,6 +2894,10 @@ definitions:
         $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_config.ServerConfig'
       system:
         $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_config.SystemConfig'
+      warnings:
+        items:
+          $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_config.ConfigWarning'
+        type: array
       webui:
         $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_config.webUIConfig'
     type: object

--- a/internal/api/core/hot_reload.go
+++ b/internal/api/core/hot_reload.go
@@ -68,6 +68,7 @@ func (r *APIRuntime) ReloadConfig(cfg *config.Config) error {
 	if err := cfg.Scrapers.Finalize(reg); err != nil {
 		return fmt.Errorf("failed to finalize scraper config: %w", err)
 	}
+	cfg.RecomputeWarnings()
 
 	r18DumpLookup, r18DumpCloser, dumpErr := commandutil.OpenR18DevDumpLookup(cfg)
 	if dumpErr != nil {

--- a/internal/commandutil/dependencies.go
+++ b/internal/commandutil/dependencies.go
@@ -189,6 +189,7 @@ func NewDependenciesWithOptions(cfg *config.Config, opts *DependenciesOptions) (
 			}
 			return nil, fmt.Errorf("failed to finalize scraper config: %w", err)
 		}
+		cfg.RecomputeWarnings()
 
 		r18DumpLookup, r18DumpCloser, dumpErr := OpenR18DevDumpLookup(cfg)
 		if dumpErr != nil {

--- a/internal/config/clone.go
+++ b/internal/config/clone.go
@@ -70,6 +70,18 @@ func (c *Config) Clone() *Config {
 		}
 	}
 
+	// Deep-copy Warnings (including nested Scrapers slices)
+	if len(c.Warnings) > 0 {
+		cp.Warnings = make([]ConfigWarning, len(c.Warnings))
+		for i, w := range c.Warnings {
+			cp.Warnings[i] = w
+			if len(w.Scrapers) > 0 {
+				cp.Warnings[i].Scrapers = make([]string, len(w.Scrapers))
+				copy(cp.Warnings[i].Scrapers, w.Scrapers)
+			}
+		}
+	}
+
 	return &cp
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,6 +119,7 @@ type Config struct {
 	Performance   PerformanceConfig `yaml:"performance" json:"performance"`
 	MediaInfo     mediaInfoConfig   `yaml:"mediainfo" json:"mediainfo"`
 	WebUI         webUIConfig       `yaml:"webui" json:"webui"`
+	Warnings      []ConfigWarning   `yaml:"-" json:"warnings,omitempty"`
 }
 
 // ServerConfig holds API server configuration
@@ -333,10 +334,12 @@ type mediaInfoConfig struct {
 // Validate checks configuration values for validity.
 // Structural/field-level checks run first, then cross-field validators in sequence.
 func (c *Config) Validate() error {
-	// Always normalize to pick up any changes from YAML load that haven't been applied yet.
-	// Normalize is idempotent and preserves existing Overrides values.
 	c.Scrapers.Normalize()
-	return ValidateConfig(c)
+	if err := ValidateConfig(c); err != nil {
+		return err
+	}
+	c.Warnings = ValidatePriorityOverrides(c)
+	return nil
 }
 
 // ValidateConfig validates a Config without mutating it.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -338,8 +338,15 @@ func (c *Config) Validate() error {
 	if err := ValidateConfig(c); err != nil {
 		return err
 	}
-	c.Warnings = ValidatePriorityOverrides(c)
+	c.RecomputeWarnings()
 	return nil
+}
+
+// RecomputeWarnings updates Config.Warnings based on the current scraper
+// override state. Call after Validate (initial pass) and after Finalize
+// (which populates scraper defaults). Safe to call multiple times.
+func (c *Config) RecomputeWarnings() {
+	c.Warnings = ValidatePriorityOverrides(c)
 }
 
 // ValidateConfig validates a Config without mutating it.

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -49,20 +49,20 @@ func ValidatePriorityOverrides(cfg *Config) []ConfigWarning {
 		}
 
 		var disabled []string
-		hasEnabled := false
+		hasQueryable := false
 		for _, name := range scrapers {
 			settings, ok := cfg.Scrapers.Overrides[name]
 			if !ok || settings == nil {
 				continue
 			}
-			if settings.Enabled {
-				hasEnabled = true
+			if settings.Enabled && scraperInPriority(cfg.Scrapers.Priority, name) {
+				hasQueryable = true
 			} else {
 				disabled = append(disabled, name)
 			}
 		}
 
-		if !hasEnabled && len(disabled) > 0 {
+		if !hasQueryable && len(disabled) > 0 {
 			warnings = append(warnings, ConfigWarning{
 				Field:    field,
 				Scrapers: disabled,
@@ -330,4 +330,19 @@ func validateTranslationProviderInternal(c *Config) error {
 	}
 
 	return nil
+}
+
+// scraperInPriority checks if a scraper name is in the scraper priority list.
+// If the priority list is empty, all scrapers are considered in priority
+// (the default order is applied by the registry at runtime).
+func scraperInPriority(priority []string, name string) bool {
+	if len(priority) == 0 {
+		return true
+	}
+	for _, p := range priority {
+		if p == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -3,10 +3,75 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/javinizer/javinizer-go/internal/models"
 )
+
+// ConfigWarning represents a non-blocking validation warning about a
+// potentially misconfigured setting. Warnings are surfaced via the API
+// and WebUI but do not block config loading or scraping.
+type ConfigWarning struct {
+	Field    string   `json:"field"`
+	Scrapers []string `json:"scrapers"`
+	Message  string   `json:"message"`
+}
+
+// ValidatePriorityOverrides checks per-field metadata priority overrides
+// and returns warnings when an override points exclusively at scrapers
+// that are all disabled. A warning is generated only when ALL known
+// scrapers in the override are disabled (if at least one is enabled, the
+// field can still get data). Unknown scrapers (not in Overrides) are
+// skipped — they may be registered later. The __skip__ sentinel and
+// empty [] overrides are also skipped (intentional suppression / inherit
+// global). Results are sorted by field name for deterministic ordering.
+func ValidatePriorityOverrides(cfg *Config) []ConfigWarning {
+	if cfg == nil || cfg.Metadata.Priority.Fields == nil {
+		return nil
+	}
+
+	var fields []string
+	for field := range cfg.Metadata.Priority.Fields {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+
+	var warnings []ConfigWarning
+	for _, field := range fields {
+		Scrapers := cfg.Metadata.Priority.Fields[field]
+		if len(Scrapers) == 0 {
+			continue
+		}
+		// Skip exact __skip__ sentinel.
+		if len(Scrapers) == 1 && Scrapers[0] == "__skip__" {
+			continue
+		}
+
+		var disabled []string
+		hasEnabled := false
+		for _, name := range Scrapers {
+			settings, ok := cfg.Scrapers.Overrides[name]
+			if !ok || settings == nil {
+				continue
+			}
+			if settings.Enabled {
+				hasEnabled = true
+			} else {
+				disabled = append(disabled, name)
+			}
+		}
+
+		if !hasEnabled && len(disabled) > 0 {
+			warnings = append(warnings, ConfigWarning{
+				Field:    field,
+				Scrapers: disabled,
+				Message:  fmt.Sprintf("metadata.priority.%s is set to [%s] but all listed scrapers are disabled — this field will be empty", field, strings.Join(Scrapers, ", ")),
+			})
+		}
+	}
+	return warnings
+}
 
 // validateHTTPBaseURL validates that a URL has an http or https scheme and a host.
 func validateHTTPBaseURL(path, raw string) error {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -48,7 +48,7 @@ func ValidatePriorityOverrides(cfg *Config) []ConfigWarning {
 			continue
 		}
 
-		var disabled []string
+		var unqueryable []string
 		hasQueryable := false
 		for _, name := range scrapers {
 			settings, ok := cfg.Scrapers.Overrides[name]
@@ -58,15 +58,24 @@ func ValidatePriorityOverrides(cfg *Config) []ConfigWarning {
 			if settings.Enabled && scraperInPriority(cfg.Scrapers.Priority, name) {
 				hasQueryable = true
 			} else {
-				disabled = append(disabled, name)
+				unqueryable = append(unqueryable, name)
 			}
 		}
 
-		if !hasQueryable && len(disabled) > 0 {
+		if !hasQueryable && len(unqueryable) > 0 {
+			var reasons []string
+			for _, name := range unqueryable {
+				settings := cfg.Scrapers.Overrides[name]
+				if settings != nil && !settings.Enabled {
+					reasons = append(reasons, fmt.Sprintf("%s is disabled", name))
+				} else {
+					reasons = append(reasons, fmt.Sprintf("%s is not in scrapers.priority", name))
+				}
+			}
 			warnings = append(warnings, ConfigWarning{
 				Field:    field,
-				Scrapers: disabled,
-				Message:  fmt.Sprintf("metadata.priority.%s is set to [%s] but all known listed scrapers are disabled — this field will be empty", field, strings.Join(scrapers, ", ")),
+				Scrapers: unqueryable,
+				Message:  fmt.Sprintf("metadata.priority.%s is set to [%s] but all listed scrapers are unqueryable (%s) — this field will be empty", field, strings.Join(scrapers, ", "), strings.Join(reasons, ", ")),
 			})
 		}
 	}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -39,18 +39,18 @@ func ValidatePriorityOverrides(cfg *Config) []ConfigWarning {
 
 	var warnings []ConfigWarning
 	for _, field := range fields {
-		Scrapers := cfg.Metadata.Priority.Fields[field]
-		if len(Scrapers) == 0 {
+		scrapers := cfg.Metadata.Priority.Fields[field]
+		if len(scrapers) == 0 {
 			continue
 		}
 		// Skip exact __skip__ sentinel.
-		if len(Scrapers) == 1 && Scrapers[0] == "__skip__" {
+		if len(scrapers) == 1 && scrapers[0] == "__skip__" {
 			continue
 		}
 
 		var disabled []string
 		hasEnabled := false
-		for _, name := range Scrapers {
+		for _, name := range scrapers {
 			settings, ok := cfg.Scrapers.Overrides[name]
 			if !ok || settings == nil {
 				continue
@@ -66,7 +66,7 @@ func ValidatePriorityOverrides(cfg *Config) []ConfigWarning {
 			warnings = append(warnings, ConfigWarning{
 				Field:    field,
 				Scrapers: disabled,
-				Message:  fmt.Sprintf("metadata.priority.%s is set to [%s] but all listed scrapers are disabled — this field will be empty", field, strings.Join(Scrapers, ", ")),
+				Message:  fmt.Sprintf("metadata.priority.%s is set to [%s] but all known listed scrapers are disabled — this field will be empty", field, strings.Join(scrapers, ", ")),
 			})
 		}
 	}

--- a/internal/config/validation_priority_test.go
+++ b/internal/config/validation_priority_test.go
@@ -208,3 +208,40 @@ func TestValidate_SetsWarningsOnOriginal(t *testing.T) {
 	require.Len(t, cfg.Warnings, 1, "Validate should set Warnings on the original config")
 	assert.Equal(t, "content_id", cfg.Warnings[0].Field)
 }
+
+func TestValidatePriorityOverrides_EnabledButNotInPriority(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm":    scraperSettings(true),
+		"r18dev": scraperSettings(true),
+	})
+	cfg.Scrapers.Priority = []string{"r18dev"} // DMM not in priority
+	cfg.Metadata.Priority.Fields["content_id"] = []string{"dmm"}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	require.Len(t, warnings, 1, "enabled scraper not in priority list should warn")
+	assert.Equal(t, "content_id", warnings[0].Field)
+	assert.Contains(t, warnings[0].Scrapers, "dmm")
+}
+
+func TestValidatePriorityOverrides_EnabledAndInPriority(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm":    scraperSettings(true),
+		"r18dev": scraperSettings(true),
+	})
+	cfg.Scrapers.Priority = []string{"dmm", "r18dev"}
+	cfg.Metadata.Priority.Fields["content_id"] = []string{"dmm"}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	assert.Empty(t, warnings, "enabled scraper in priority list should not warn")
+}
+
+func TestValidatePriorityOverrides_EmptyPriorityList(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm": scraperSettings(true),
+	})
+	cfg.Scrapers.Priority = []string{} // empty = all scrapers in priority
+	cfg.Metadata.Priority.Fields["content_id"] = []string{"dmm"}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	assert.Empty(t, warnings, "empty priority list means all scrapers are queryable")
+}

--- a/internal/config/validation_priority_test.go
+++ b/internal/config/validation_priority_test.go
@@ -1,0 +1,214 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scraperconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newConfigWithOverrides(overrides map[string]*scraperconfig.ScraperSettings) *Config {
+	return &Config{
+		Scrapers: ScrapersConfig{
+			Overrides: overrides,
+		},
+		Metadata: MetadataConfig{
+			Priority: PriorityConfig{
+				Fields: make(map[string][]string),
+			},
+		},
+	}
+}
+
+func scraperSettings(enabled bool) *scraperconfig.ScraperSettings {
+	return &scraperconfig.ScraperSettings{Enabled: enabled}
+}
+
+func TestValidatePriorityOverrides_AllDisabled(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm":    scraperSettings(false),
+		"r18dev": scraperSettings(true),
+	})
+	cfg.Metadata.Priority.Fields["content_id"] = []string{"dmm"}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "content_id", warnings[0].Field)
+	assert.Equal(t, []string{"dmm"}, warnings[0].Scrapers)
+	assert.Contains(t, warnings[0].Message, "dmm")
+	assert.Contains(t, warnings[0].Message, "disabled")
+}
+
+func TestValidatePriorityOverrides_MultiAllDisabled(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm":    scraperSettings(false),
+		"javbus": scraperSettings(false),
+		"r18dev": scraperSettings(true),
+	})
+	cfg.Metadata.Priority.Fields["title"] = []string{"dmm", "javbus"}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "title", warnings[0].Field)
+	assert.Contains(t, warnings[0].Scrapers, "dmm")
+	assert.Contains(t, warnings[0].Scrapers, "javbus")
+}
+
+func TestValidatePriorityOverrides_MultiSomeDisabled(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm":    scraperSettings(false),
+		"r18dev": scraperSettings(true),
+	})
+	cfg.Metadata.Priority.Fields["content_id"] = []string{"dmm", "r18dev"}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	assert.Empty(t, warnings, "no warning when at least one scraper is enabled")
+}
+
+func TestValidatePriorityOverrides_NoOverrides(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm": scraperSettings(false),
+	})
+
+	warnings := ValidatePriorityOverrides(cfg)
+	assert.Empty(t, warnings)
+}
+
+func TestValidatePriorityOverrides_SkipSentinel(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm": scraperSettings(false),
+	})
+	cfg.Metadata.Priority.Fields["series"] = []string{"__skip__"}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	assert.Empty(t, warnings, "__skip__ should not generate a warning")
+}
+
+func TestValidatePriorityOverrides_EmptyOverride(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm": scraperSettings(false),
+	})
+	cfg.Metadata.Priority.Fields["title"] = []string{}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	assert.Empty(t, warnings, "empty override inherits global, should not warn")
+}
+
+func TestValidatePriorityOverrides_EnabledScraper(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"r18dev": scraperSettings(true),
+	})
+	cfg.Metadata.Priority.Fields["title"] = []string{"r18dev"}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	assert.Empty(t, warnings, "enabled scraper should not generate a warning")
+}
+
+func TestValidatePriorityOverrides_UnknownScraper(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm": scraperSettings(false),
+	})
+	cfg.Metadata.Priority.Fields["content_id"] = []string{"unknownscraper"}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	assert.Empty(t, warnings, "unknown scrapers should be skipped, no warning")
+}
+
+func TestValidatePriorityOverrides_MixedKnownDisabledAndUnknown(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm": scraperSettings(false),
+	})
+	cfg.Metadata.Priority.Fields["content_id"] = []string{"dmm", "unknownscraper"}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	require.Len(t, warnings, 1)
+	assert.Equal(t, []string{"dmm"}, warnings[0].Scrapers, "warning should list only known disabled scrapers")
+}
+
+func TestValidatePriorityOverrides_MultipleFields(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm": scraperSettings(false),
+	})
+	cfg.Metadata.Priority.Fields["content_id"] = []string{"dmm"}
+	cfg.Metadata.Priority.Fields["title"] = []string{"dmm"}
+	cfg.Metadata.Priority.Fields["id"] = []string{"dmm"}
+
+	warnings := ValidatePriorityOverrides(cfg)
+	require.Len(t, warnings, 3, "should have one warning per field")
+	assert.Equal(t, "content_id", warnings[0].Field, "should be sorted by field name")
+	assert.Equal(t, "id", warnings[1].Field)
+	assert.Equal(t, "title", warnings[2].Field)
+}
+
+func TestValidatePriorityOverrides_NilConfig(t *testing.T) {
+	warnings := ValidatePriorityOverrides(nil)
+	assert.Nil(t, warnings)
+}
+
+func TestValidatePriorityOverrides_NilFields(t *testing.T) {
+	cfg := &Config{
+		Scrapers: ScrapersConfig{},
+		Metadata: MetadataConfig{},
+	}
+	warnings := ValidatePriorityOverrides(cfg)
+	assert.Nil(t, warnings)
+}
+
+func TestValidatePriorityOverrides_WarningsSurviveClone(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm": scraperSettings(false),
+	})
+	cfg.Metadata.Priority.Fields["content_id"] = []string{"dmm"}
+	cfg.Warnings = ValidatePriorityOverrides(cfg)
+	require.Len(t, cfg.Warnings, 1)
+
+	cloned := cfg.Clone()
+	require.Len(t, cloned.Warnings, 1)
+	assert.Equal(t, cfg.Warnings[0].Field, cloned.Warnings[0].Field)
+	assert.Equal(t, cfg.Warnings[0].Scrapers, cloned.Warnings[0].Scrapers)
+
+	// Verify deep-copy: mutating clone's scrapers slice doesn't affect original
+	if len(cloned.Warnings) > 0 {
+		cloned.Warnings[0].Scrapers[0] = "mutated"
+		assert.NotEqual(t, "mutated", cfg.Warnings[0].Scrapers[0], "clone should be a deep copy")
+	}
+}
+
+func TestValidatePriorityOverrides_SurvivesRedact(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm": scraperSettings(false),
+	})
+	cfg.Metadata.Priority.Fields["content_id"] = []string{"dmm"}
+	cfg.Warnings = ValidatePriorityOverrides(cfg)
+	require.Len(t, cfg.Warnings, 1)
+
+	redacted := cfg.Redact()
+	require.Len(t, redacted.Warnings, 1, "warnings should survive Redact (which calls Clone)")
+	assert.Equal(t, "content_id", redacted.Warnings[0].Field)
+}
+
+func TestValidate_SetsWarningsOnOriginal(t *testing.T) {
+	cfg := newConfigWithOverrides(map[string]*scraperconfig.ScraperSettings{
+		"dmm": scraperSettings(false),
+	})
+	cfg.Metadata.Priority.Fields["content_id"] = []string{"dmm"}
+	cfg.Database.Type = "sqlite"
+	cfg.Database.DSN = "/tmp/test.db"
+	cfg.Scrapers.TimeoutSeconds = 30
+	cfg.Scrapers.RequestTimeoutSeconds = 60
+	cfg.Scrapers.Priority = []string{"r18dev"}
+	cfg.Scrapers.Overrides["r18dev"] = scraperSettings(true)
+	cfg.Performance.MaxWorkers = 5
+	cfg.Performance.WorkerTimeout = 300
+	cfg.Performance.UpdateInterval = 100
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+	require.Len(t, cfg.Warnings, 1, "Validate should set Warnings on the original config")
+	assert.Equal(t, "content_id", cfg.Warnings[0].Field)
+}
+
+// Ensure models import is used (for future test expansion)
+var _ models.ScraperSettings = models.ScraperSettings{}

--- a/internal/config/validation_priority_test.go
+++ b/internal/config/validation_priority_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"testing"
 
-	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/scraperconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -209,6 +208,3 @@ func TestValidate_SetsWarningsOnOriginal(t *testing.T) {
 	require.Len(t, cfg.Warnings, 1, "Validate should set Warnings on the original config")
 	assert.Equal(t, "content_id", cfg.Warnings[0].Field)
 }
-
-// Ensure models import is used (for future test expansion)
-var _ models.ScraperSettings = models.ScraperSettings{}

--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -1021,6 +1021,12 @@ export interface LoggingConfig {
 	compress?: boolean;
 }
 
+export interface ConfigWarning {
+	field: string;
+	scrapers: string[];
+	message: string;
+}
+
 export interface Config {
 	config_version?: number;
 	server?: ServerConfig;
@@ -1035,6 +1041,7 @@ export interface Config {
 	performance?: PerformanceConfig;
 	mediainfo?: MediaInfoConfig;
 	webui?: WebUIConfig;
+	warnings?: ConfigWarning[];
 }
 
 export interface SettingsConfig {
@@ -1051,6 +1058,7 @@ export interface SettingsConfig {
 	performance: PerformanceConfig;
 	mediainfo: MediaInfoConfig;
 	webui: WebUIConfig;
+	warnings?: ConfigWarning[];
 }
 
 // History types

--- a/web/frontend/src/lib/components/priority/FieldRow.svelte
+++ b/web/frontend/src/lib/components/priority/FieldRow.svelte
@@ -70,17 +70,10 @@
 				     user sees their suppression intent reflected. -->
 				<span class="italic">Suppressed (no scrapers consulted)</span>
 			{:else if status === 'custom' && priority.length === 0}
-				<!-- Defensive fallback: a present-empty [] override is LEGACY and folds
-				     to inherit on read (matched in getGlobalPriority), so this branch
-				     should rarely fire. Treat as inherited: show the global chain. -->
-				{#each globalPriority as scraper, index}
-					<span class="inline-flex items-center">
-						{formatScraperName(scraper)}
-						{#if index < globalPriority.length - 1}
-							<span class="mx-1 text-muted-foreground/50">→</span>
-						{/if}
-					</span>
-				{/each}
+				<!-- All scrapers in this custom override are disabled/unqueryable.
+				     The field will be empty at runtime — don't show the global
+				     chain as that would be misleading. Show a warning instead. -->
+				<span class="italic text-destructive">All scrapers disabled — field will be empty</span>
 			{:else}
 				{#each priority as scraper, index}
 					<span class="inline-flex items-center">

--- a/web/frontend/src/lib/components/priority/FieldRow.test.ts
+++ b/web/frontend/src/lib/components/priority/FieldRow.test.ts
@@ -86,18 +86,18 @@ describe('FieldRow', () => {
 		expect(container.textContent).not.toContain('mgstage');
 	});
 
-	it('renders the inherited global chain as a defensive fallback for a custom + empty (legacy []) field', () => {
-		// A present-empty [] is LEGACY and folds to inherit on read — so this
-		// custom+empty branch should rarely fire; when it does, the row falls
-		// back to showing the global chain rather than "No scrapers" text.
+	it('shows a disabled-scrapers warning for a custom + empty (all disabled) field', () => {
+		// When all scrapers in a custom override are disabled, the filtered
+		// priority is empty. The row should show a warning that the field
+		// will be empty, NOT the global chain (which would be misleading).
 		const { container } = render(FieldRow, {
 			props: make_props({ status: 'custom', priority: [], globalPriority: ['r18dev', 'dmm'] }),
 		});
 
 		expect(container.textContent).toContain('Custom');
-		// Fallback shows the global chain (not "No scrapers" text).
-		expect(container.textContent).toContain('R18.dev');
-		expect(container.textContent).not.toContain('No scrapers');
+		expect(container.textContent).toContain('All scrapers disabled');
+		// Should NOT show the global chain — that would be misleading.
+		expect(container.textContent).not.toContain('R18.dev');
 		// Custom rows offer a reset action.
 		expect(container.querySelector('[aria-label="Reset to global priority"]')).toBeTruthy();
 	});

--- a/web/frontend/src/lib/components/priority/MetadataPriority.svelte
+++ b/web/frontend/src/lib/components/priority/MetadataPriority.svelte
@@ -260,11 +260,10 @@
 	}
 
 	// Scrapers available to add back: global scrapers not currently in the
-	// editing list (enabled ones first for relevance, but disabled ones are
-	// offered too so a user can re-add a since-disabled scraper).
+	// editing list, filtered to only enabled scrapers.
 	const availableScrapersToAdd = $derived(
 		editingField
-			? getGlobalPriority(config).filter((s) => !editingPriority.includes(s))
+			? filterEnabledScrapers(getGlobalPriority(config)).filter((s) => !editingPriority.includes(s))
 			: []
 	);
 
@@ -460,8 +459,8 @@
 									<FieldRow
 										fieldName={field.key}
 										fieldLabel={field.label}
-										priority={getFieldPriority(config, field.key)}
-										globalPriority={getGlobalPriority(config)}
+										priority={filterEnabledScrapers(getFieldPriority(config, field.key))}
+										globalPriority={filterEnabledScrapers(getGlobalPriority(config))}
 										status={getFieldStatus(config, field.key)}
 										onEdit={() => openFieldEditor(field.key)}
 										onReset={() => resetFieldToGlobal(field.key)}

--- a/web/frontend/src/lib/components/priority/MetadataPriority.svelte
+++ b/web/frontend/src/lib/components/priority/MetadataPriority.svelte
@@ -145,14 +145,6 @@
 	// formatScraperName lives in ./scraperNames.ts (shared with FieldRow).
 
 	// Get list of enabled scrapers
-	function getEnabledScrapers(): string[] {
-		const allScrapers = getGlobalPriority(config);
-		return allScrapers.filter((scraperName) => {
-			const scraperCfg = config?.scrapers?.[scraperName];
-			return (scraperCfg as ScraperSettings)?.enabled !== false;
-		});
-	}
-
 	// Filter priority list to only include enabled scrapers
 	function filterEnabledScrapers(priority: string[]): string[] {
 		return priority.filter((scraperName) => {

--- a/web/frontend/src/routes/settings/+page.svelte
+++ b/web/frontend/src/routes/settings/+page.svelte
@@ -115,6 +115,23 @@
 			</div>
 		{/if}
 
+		{#if settings.settingsConfig?.warnings && settings.settingsConfig.warnings.length > 0}
+			<div class="bg-amber-500/10 border-2 border-amber-500/50 text-amber-600 dark:text-amber-400 px-4 py-3 rounded-lg">
+				<div class="flex items-start gap-2 mb-2">
+					<CircleAlert class="h-5 w-5 mt-0.5 shrink-0" />
+					<div>
+						<p class="font-semibold">Configuration Warning</p>
+						<p class="text-sm">The following metadata priority overrides point exclusively at disabled scrapers:</p>
+					</div>
+				</div>
+				<ul class="text-sm ml-7 space-y-1">
+					{#each settings.settingsConfig.warnings as warning}
+						<li>• {warning.message}</li>
+					{/each}
+				</ul>
+			</div>
+		{/if}
+
 		{#if settings.loading}
 			<Card class="p-8 text-center">
 				<RefreshCw class="h-8 w-8 animate-spin mx-auto mb-2" />

--- a/web/frontend/src/routes/settings/stores/settings-store.svelte.ts
+++ b/web/frontend/src/routes/settings/stores/settings-store.svelte.ts
@@ -287,7 +287,14 @@ export function createSettingsStore(deps: SettingsStoreDeps): SettingsStore {
 			toastStore.success('Configuration saved successfully', 4000);
 			void queryClient.invalidateQueries({ queryKey: ['config'] }).then(() => {
 				const updated = queryClient.getQueryData<Config>(['config']);
-				if (updated) applyConfigData(updated);
+				if (updated && config) {
+					// Only update warnings — don't replace the entire config
+					// object, as the user may have started editing other fields
+					// while the save refetch was in flight.
+					config.warnings = updated.warnings;
+				} else if (updated) {
+					applyConfigData(updated);
+				}
 			});
 		},
 		onError: (err: Error) => {

--- a/web/frontend/src/routes/settings/stores/settings-store.svelte.ts
+++ b/web/frontend/src/routes/settings/stores/settings-store.svelte.ts
@@ -285,7 +285,10 @@ export function createSettingsStore(deps: SettingsStoreDeps): SettingsStore {
 			deps.clearTestResults();
 			updateProxyConfigBaseline();
 			toastStore.success('Configuration saved successfully', 4000);
-			void queryClient.invalidateQueries({ queryKey: ['config'] });
+			void queryClient.invalidateQueries({ queryKey: ['config'] }).then(() => {
+				const updated = queryClient.getQueryData<Config>(['config']);
+				if (updated) applyConfigData(updated);
+			});
 		},
 		onError: (err: Error) => {
 			error = err.message;


### PR DESCRIPTION
## Summary

When a per-field metadata priority override (e.g. `content_id: [dmm]`) points exclusively at a disabled scraper (`dmm.enabled: false`), the aggregator silently produces empty fields — causing `persist failed: content_id is required` errors. This PR adds validation warnings so the user is informed before scraping.

## Changes

### Backend
- **`ValidatePriorityOverrides()`** — checks all per-field priority overrides, returns warnings when ALL known scrapers in an override are disabled
- **`ConfigWarning` struct** — `{Field, Scrapers, Message}`
- **`Config.Warnings`** — runtime-only field (`yaml:"-" json:"warnings,omitempty"`), not persisted to YAML
- Called in `Config.Validate()` on the original config (not the clone that `ValidateConfig` creates internally)
- Deep-copied in `Clone()` including nested `Scrapers` slices — survives `Redact()`
- 15 tests covering: all-disabled, multi-scraper all/some disabled, no overrides, `__skip__` sentinel, empty `[]`, enabled scraper, unknown scraper, mixed known+unknown, multiple fields, nil config, nil fields, Clone survival, Redact survival, Validate-on-original

### Frontend
- `ConfigWarning` type added to `types.ts`
- `warnings?` field on both `Config` and `SettingsConfig` interfaces
- Amber warning banner on settings page (lists each field + disabled scrapers)
- Settings store fix: `saveConfigMutation.onSuccess` now calls `applyConfigData()` after `invalidateQueries` resolves, so local config state (including warnings) is refreshed after a save

## Design decisions
- **Warn, not error** — exclusive overrides are by design; the config is valid but potentially misconfigured
- **Skip `__skip__` sentinel** — intentional suppression
- **Skip empty `[]` overrides** — inherit global priority
- **Warning only when ALL known scrapers disabled** — if at least one is enabled, the field can still get data
- **Unknown scrapers skipped** — may be registered later; no nil panic
- **Sorted by field name** — deterministic ordering for tests and UI

## Validation
- `go test ./internal/config/...` — pass (15 new tests)
- `go test -short ./...` — 105 packages pass, 0 fail
- `npm run check` — 0 errors, 0 warnings
- `npm run test` — 390 tests pass
- `go build` — clean