### PR TITLE
fix(r18devdump): seamless progress bar + clear selection after scrape

### DIFF
--- a/internal/api/r18devdump/handlers.go
+++ b/internal/api/r18devdump/handlers.go
@@ -21,6 +21,8 @@ import (
 	ws "github.com/javinizer/javinizer-go/internal/websocket"
 )
 
+var importHeartbeatInterval = 1500 * time.Millisecond
+
 const (
 	dumpJobID = "r18dev-dump-download"
 )
@@ -243,24 +245,7 @@ func (h *dumpHandler) startDownloadOrUpdate(c *gin.Context, updateOnly bool) {
 			// being reported.
 			importDone := make(chan struct{})
 			streamConsumed := make(chan struct{})
-			go func() {
-				select {
-				case <-streamConsumed:
-				case <-importDone:
-					return
-				}
-				h.broadcastProgress("importing", 0, 0)
-				ticker := time.NewTicker(1500 * time.Millisecond)
-				defer ticker.Stop()
-				for {
-					select {
-					case <-ticker.C:
-						h.broadcastProgress("importing", 0, 0)
-					case <-importDone:
-						return
-					}
-				}
-			}()
+			go h.runImportHeartbeat(streamConsumed, importDone)
 			defer close(importDone)
 			r = &eofDetectReader{r: r, onEOF: sync.OnceFunc(func() { close(streamConsumed) })}
 			var unlockReload func()
@@ -554,6 +539,29 @@ func (e *eofDetectReader) Read(p []byte) (int, error) {
 		e.once.Do(e.onEOF)
 	}
 	return n, err
+}
+
+// runImportHeartbeat broadcasts periodic "importing" progress frames while the
+// SQL import runs. It waits until streamConsumed is closed (the download
+// stream hit EOF) before starting, so "importing" frames never overlap with
+// "downloading" frames. It exits when importDone is closed.
+func (h *dumpHandler) runImportHeartbeat(streamConsumed, importDone <-chan struct{}) {
+	select {
+	case <-streamConsumed:
+	case <-importDone:
+		return
+	}
+	h.broadcastProgress("importing", 0, 0)
+	ticker := time.NewTicker(importHeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			h.broadcastProgress("importing", 0, 0)
+		case <-importDone:
+			return
+		}
+	}
 }
 
 // resolveDumpPath returns the configured dump sidecar path, applying the

--- a/internal/api/r18devdump/handlers.go
+++ b/internal/api/r18devdump/handlers.go
@@ -184,7 +184,21 @@ func (h *dumpHandler) startDownloadOrUpdate(c *gin.Context, updateOnly bool) {
 		h.dumpMu.RUnlock()
 	}
 
+	var (
+		progressMu     sync.Mutex
+		lastProgressAt time.Time
+		progressSeen   bool
+	)
 	progress := func(bytes, total int64) {
+		progressMu.Lock()
+		now := time.Now()
+		if progressSeen && now.Sub(lastProgressAt) < 500*time.Millisecond {
+			progressMu.Unlock()
+			return
+		}
+		progressSeen = true
+		lastProgressAt = now
+		progressMu.Unlock()
 		h.broadcastProgress("downloading", bytes, total)
 	}
 
@@ -218,7 +232,37 @@ func (h *dumpHandler) startDownloadOrUpdate(c *gin.Context, updateOnly bool) {
 			}
 		}()
 		res, err := r18devdump.Download(ctx, client, currentSourceURL, progress, func(r io.Reader, d r18devdump.DownloadResult) error {
-			h.broadcastProgress("importing", 0, 0)
+			// The download streams the response body through gzip into Import,
+			// so the download progress callback and the SQL import run
+			// concurrently: Import pulls compressed bytes through the
+			// countingReader, which fires "downloading" frames. To keep the
+			// progress bar phase monotonic (downloading -> importing -> done)
+			// and avoid bouncing between the two visual states, the import
+			// heartbeat must only start AFTER the decompressed stream has been
+			// fully consumed (io.EOF), never while download progress is still
+			// being reported.
+			importDone := make(chan struct{})
+			streamConsumed := make(chan struct{})
+			go func() {
+				select {
+				case <-streamConsumed:
+				case <-importDone:
+					return
+				}
+				h.broadcastProgress("importing", 0, 0)
+				ticker := time.NewTicker(1500 * time.Millisecond)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ticker.C:
+						h.broadcastProgress("importing", 0, 0)
+					case <-importDone:
+						return
+					}
+				}
+			}()
+			defer close(importDone)
+			r = &eofDetectReader{r: r, onEOF: sync.OnceFunc(func() { close(streamConsumed) })}
 			var unlockReload func()
 			impRes, importErr := r18devdump.Import(ctx, r, path, r18devdump.ImportOptions{
 				SourceURL:  d.FinalURL,
@@ -484,13 +528,32 @@ func (h *dumpHandler) broadcastProgress(phase string, bytes, total int64) {
 
 func progressPercent(bytes, total int64) float64 {
 	if total <= 0 {
-		return 0
+		return -1
 	}
 	pct := float64(bytes) / float64(total) * 100
 	if pct > 100 {
 		return 100
 	}
 	return pct
+}
+
+// eofDetectReader wraps an io.Reader and invokes onEOF (exactly once) when the
+// underlying reader returns io.EOF. It is used to detect when the dump
+// download stream has been fully consumed by the SQL importer so the
+// "importing" heartbeat can begin without overlapping "downloading" progress
+// frames (which would cause the UI progress bar to bounce between phases).
+type eofDetectReader struct {
+	r     io.Reader
+	onEOF func()
+	once  sync.Once
+}
+
+func (e *eofDetectReader) Read(p []byte) (int, error) {
+	n, err := e.r.Read(p)
+	if err == io.EOF {
+		e.once.Do(e.onEOF)
+	}
+	return n, err
 }
 
 // resolveDumpPath returns the configured dump sidecar path, applying the

--- a/internal/api/r18devdump/handlers.go
+++ b/internal/api/r18devdump/handlers.go
@@ -31,15 +31,16 @@ const (
 // download/update operations. The dump download streams ~250MB over several
 // minutes, so only one may run at a time.
 type dumpHandler struct {
-	rt         *core.APIRuntime
-	mu         sync.Mutex
-	dumpMu     sync.RWMutex
-	running    bool
-	lastError  string // last download outcome; non-empty when the most recent run failed
-	httpClient *http.Client
-	reloadFn   func(cfg *config.Config, lockHeld bool) error
-	removeFn   func(string) error
-	done       chan struct{} // closed when the download goroutine finishes
+	rt                  *core.APIRuntime
+	mu                  sync.Mutex
+	dumpMu              sync.RWMutex
+	running             bool
+	lastError           string // last download outcome; non-empty when the most recent run failed
+	httpClient          *http.Client
+	reloadFn            func(cfg *config.Config, lockHeld bool) error
+	removeFn            func(string) error
+	broadcastProgressFn func(phase string, bytes, total int64)
+	done                chan struct{} // closed when the download goroutine finishes
 }
 
 func newDumpHandler(rt *core.APIRuntime) *dumpHandler {
@@ -486,6 +487,10 @@ func (h *dumpHandler) clearDump(c *gin.Context) {
 // the WebUI can render a progress bar. Non-blocking — if no WS clients are
 // connected, the message is silently dropped.
 func (h *dumpHandler) broadcastProgress(phase string, bytes, total int64) {
+	if h.broadcastProgressFn != nil {
+		h.broadcastProgressFn(phase, bytes, total)
+		return
+	}
 	rt := h.rt.GetRuntime()
 	if rt == nil {
 		return
@@ -550,6 +555,11 @@ func (h *dumpHandler) runImportHeartbeat(streamConsumed, importDone <-chan struc
 	case <-streamConsumed:
 	case <-importDone:
 		return
+	}
+	select {
+	case <-importDone:
+		return
+	default:
 	}
 	h.broadcastProgress("importing", 0, 0)
 	ticker := time.NewTicker(importHeartbeatInterval)

--- a/internal/api/r18devdump/handlers_test.go
+++ b/internal/api/r18devdump/handlers_test.go
@@ -479,6 +479,21 @@ func TestBroadcastProgress_WithHub(t *testing.T) {
 	h.broadcastProgress("error", 0, 0)
 }
 
+func TestBroadcastProgress_WithFn(t *testing.T) {
+	h, _, _ := newTestHandlerWithHub(t)
+
+	var calls []string
+	h.broadcastProgressFn = func(phase string, bytes, total int64) {
+		calls = append(calls, phase)
+	}
+	h.broadcastProgress("downloading", 50, 100)
+	h.broadcastProgress("importing", 0, 0)
+	h.broadcastProgress("done", 0, 0)
+	h.broadcastProgress("error", 0, 0)
+
+	assert.Equal(t, []string{"downloading", "importing", "done", "error"}, calls)
+}
+
 func TestRunImportHeartbeat_TickerFires(t *testing.T) {
 	h, _, _ := newTestHandlerWithHub(t)
 
@@ -511,6 +526,33 @@ func TestRunImportHeartbeat_ImportDoneFirst(t *testing.T) {
 
 	// Should return immediately without broadcasting.
 	h.runImportHeartbeat(streamConsumed, importDone)
+}
+
+func TestRunImportHeartbeat_BothClosedBeforeSchedule(t *testing.T) {
+	h, _, _ := newTestHandlerWithHub(t)
+
+	var mu sync.Mutex
+	var broadcasts []string
+	h.broadcastProgressFn = func(phase string, bytes, total int64) {
+		mu.Lock()
+		defer mu.Unlock()
+		broadcasts = append(broadcasts, phase)
+	}
+
+	// When both channels are closed before the goroutine starts, the initial
+	// select may pick either case. Loop many times so the streamConsumed path
+	// (which then hits the non-blocking re-check) is exercised deterministically.
+	for i := 0; i < 100; i++ {
+		streamConsumed := make(chan struct{})
+		importDone := make(chan struct{})
+		close(streamConsumed)
+		close(importDone)
+		h.runImportHeartbeat(streamConsumed, importDone)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, broadcasts, "no importing frame should be broadcast when importDone is already closed")
 }
 
 // --- reloadDump coverage ---

--- a/internal/api/r18devdump/handlers_test.go
+++ b/internal/api/r18devdump/handlers_test.go
@@ -566,7 +566,7 @@ func TestResolveDumpPath_Configured(t *testing.T) {
 }
 
 func TestProgressPercent(t *testing.T) {
-	assert.Equal(t, float64(0), progressPercent(0, 0))
+	assert.Equal(t, float64(-1), progressPercent(0, 0))
 	assert.Equal(t, float64(0), progressPercent(0, 100))
 	assert.Equal(t, float64(50), progressPercent(50, 100))
 	assert.Equal(t, float64(100), progressPercent(100, 100))

--- a/internal/api/r18devdump/handlers_test.go
+++ b/internal/api/r18devdump/handlers_test.go
@@ -479,6 +479,40 @@ func TestBroadcastProgress_WithHub(t *testing.T) {
 	h.broadcastProgress("error", 0, 0)
 }
 
+func TestRunImportHeartbeat_TickerFires(t *testing.T) {
+	h, _, _ := newTestHandlerWithHub(t)
+
+	orig := importHeartbeatInterval
+	importHeartbeatInterval = 1 * time.Millisecond
+
+	streamConsumed := make(chan struct{})
+	importDone := make(chan struct{})
+	close(streamConsumed) // simulate download stream EOF
+
+	exited := make(chan struct{})
+	go func() {
+		h.runImportHeartbeat(streamConsumed, importDone)
+		close(exited)
+	}()
+
+	// Let the ticker fire several times so the <-ticker.C branch executes.
+	time.Sleep(20 * time.Millisecond)
+	close(importDone)
+	<-exited // wait for the goroutine to exit before restoring the interval
+	importHeartbeatInterval = orig
+}
+
+func TestRunImportHeartbeat_ImportDoneFirst(t *testing.T) {
+	h, _, _ := newTestHandlerWithHub(t)
+
+	streamConsumed := make(chan struct{})
+	importDone := make(chan struct{})
+	close(importDone) // import finishes before stream is consumed
+
+	// Should return immediately without broadcasting.
+	h.runImportHeartbeat(streamConsumed, importDone)
+}
+
 // --- reloadDump coverage ---
 
 func TestReloadDump_Success(t *testing.T) {

--- a/internal/update/wiring_test.go
+++ b/internal/update/wiring_test.go
@@ -134,17 +134,27 @@ func TestService_StartBackgroundCheck_StubStopsOnCancel(t *testing.T) {
 	svc, chk := newStubService(t, true)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	svc.StartBackgroundCheck(ctx, 20*time.Millisecond)
+	// A longer interval widens the gap between ticks so a tick is less likely
+	// to be in-flight exactly when cancel() runs.
+	svc.StartBackgroundCheck(ctx, 50*time.Millisecond)
 
-	require.Eventually(t, func() bool { return chk.callsCount() >= 2 }, time.Second, 10*time.Millisecond,
+	require.Eventually(t, func() bool { return chk.callsCount() >= 2 }, 2*time.Second, 10*time.Millisecond,
 		"ticker must fire before cancellation")
 
-	callsBeforeCancel := chk.callsCount()
 	cancel()
 
-	// Wait several tick periods; no new calls must arrive after cancellation.
-	time.Sleep(120 * time.Millisecond)
-	assert.Equal(t, callsBeforeCancel, chk.callsCount(),
+	// A tick that was already in-flight when cancel() was called may finish
+	// before the goroutine observes ctx.Done() and exits, so it can bump the
+	// call count once after cancellation. Wait long enough for any in-flight
+	// check to complete and the goroutine to wind down, then record the count
+	// and assert no further calls arrive. The generous stabilization window
+	// keeps the test stable on slow Windows runners with unpredictable
+	// scheduling latency.
+	time.Sleep(150 * time.Millisecond)
+	callsAfterCancel := chk.callsCount()
+
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, callsAfterCancel, chk.callsCount(),
 		"no further checks after context cancel")
 }
 

--- a/web/frontend/src/lib/components/settings/sections/R18DevDumpSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/R18DevDumpSection.svelte
@@ -235,6 +235,15 @@
 		return msg;
 	}
 
+	let isIndeterminate = $derived(
+		!downloadProgress ||
+		downloadProgress.progress <= 0 ||
+		(downloadProgress.message !== 'downloading'),
+	);
+	let barWidth = $derived(
+		isIndeterminate ? 0 : (downloadProgress?.progress ?? 0),
+	);
+
 	$effect(() => {
 		fetchStatus();
 		return () => { polling = false; };
@@ -317,15 +326,14 @@
 							<RefreshCw class="h-4 w-4 animate-spin"></RefreshCw>
 							{progressPhase()}
 						</div>
-						{#if downloadProgress && downloadProgress.progress > 0}
-							<div class="w-full bg-muted rounded-full h-2 overflow-hidden">
-								<div class="bg-primary h-full transition-all duration-300" style="width: {downloadProgress.progress}%"></div>
-							</div>
+						<div class="w-full bg-muted rounded-full h-2 overflow-hidden">
+							<div
+								class="bg-primary h-full rounded-full transition-[width] duration-300 ease-out {isIndeterminate ? 'r18dev-progress-indeterminate' : ''}"
+								style={isIndeterminate ? '' : `width: ${barWidth}%`}
+							></div>
+						</div>
+						{#if !isIndeterminate && downloadProgress}
 							<div class="text-xs text-muted-foreground text-right">{Math.round(downloadProgress.progress)}%</div>
-						{:else}
-							<div class="w-full bg-muted rounded-full h-2 overflow-hidden">
-								<div class="bg-muted-foreground/30 h-full animate-pulse" style="width: 30%"></div>
-							</div>
 						{/if}
 					</div>
 				{:else}
@@ -379,15 +387,14 @@
 							<RefreshCw class="h-4 w-4 animate-spin"></RefreshCw>
 							{progressPhase()}
 						</div>
-						{#if downloadProgress && downloadProgress.progress > 0}
-							<div class="w-full bg-muted rounded-full h-2 overflow-hidden">
-								<div class="bg-primary h-full transition-all duration-300" style="width: {downloadProgress.progress}%"></div>
-							</div>
+						<div class="w-full bg-muted rounded-full h-2 overflow-hidden">
+							<div
+								class="bg-primary h-full rounded-full transition-[width] duration-300 ease-out {isIndeterminate ? 'r18dev-progress-indeterminate' : ''}"
+								style={isIndeterminate ? '' : `width: ${barWidth}%`}
+							></div>
+						</div>
+						{#if !isIndeterminate && downloadProgress}
 							<div class="text-xs text-muted-foreground text-right">{Math.round(downloadProgress.progress)}%</div>
-						{:else}
-							<div class="w-full bg-muted rounded-full h-2 overflow-hidden">
-								<div class="bg-muted-foreground/30 h-full animate-pulse" style="width: 30%"></div>
-							</div>
 						{/if}
 					</div>
 				{:else}
@@ -475,3 +482,16 @@
 		</div>
 	{/if}
 </SettingsSection>
+
+<style>
+	.r18dev-progress-indeterminate {
+		position: relative;
+		width: 40%;
+		animation: r18dev-indeterminate-slide 1.4s ease-in-out infinite;
+	}
+
+	@keyframes r18dev-indeterminate-slide {
+		0% { transform: translateX(-100%); }
+		100% { transform: translateX(250%); }
+	}
+</style>

--- a/web/frontend/src/routes/browse/+page.svelte
+++ b/web/frontend/src/routes/browse/+page.svelte
@@ -205,7 +205,9 @@
 				const status = job.status?.toLowerCase();
 				if (status && JOB_SUCCESS_STATUSES.has(status)) {
 					stopCompletionPoll();
-					clearSelection();
+					if ((job.failed ?? 0) === 0) {
+						clearSelection();
+					}
 					clearPendingJob();
 				} else if (isTerminalStatus(status)) {
 					// failed / cancelled — keep selection so the user can retry

--- a/web/frontend/src/routes/browse/+page.svelte
+++ b/web/frontend/src/routes/browse/+page.svelte
@@ -181,6 +181,7 @@
 	const STORAGE_KEY_PENDING_JOB = 'javinizer_browse_pending_job';
 	const JOB_SUCCESS_STATUSES = new Set(['completed', 'organized', 'reverted']);
 	let pendingJobId: string | null = $state(null);
+	let launchedFiles: string[] | null = $state(null);
 	let completionPoll: ReturnType<typeof setInterval> | null = null;
 
 	function stopCompletionPoll() {
@@ -190,8 +191,15 @@
 		}
 	}
 
+	function sameSelection(a: string[], b: string[]): boolean {
+		if (a.length !== b.length) return false;
+		const setB = new Set(b);
+		return a.every((f) => setB.has(f));
+	}
+
 	function clearPendingJob() {
 		pendingJobId = null;
+		launchedFiles = null;
 		try {
 			sessionStorage.removeItem(STORAGE_KEY_PENDING_JOB);
 		} catch {}
@@ -205,7 +213,7 @@
 				const status = job.status?.toLowerCase();
 				if (status && JOB_SUCCESS_STATUSES.has(status)) {
 					stopCompletionPoll();
-					if ((job.failed ?? 0) === 0) {
+					if ((job.failed ?? 0) === 0 && launchedFiles && sameSelection(launchedFiles, selectedFiles)) {
 						clearSelection();
 					}
 					clearPendingJob();
@@ -447,6 +455,7 @@
 				operation_mode: effectiveOperationMode,
 			});
 			startJob(response.job_id);
+			launchedFiles = [...selectedFiles];
 			pendingJobId = response.job_id;
 			try {
 				sessionStorage.setItem(STORAGE_KEY_PENDING_JOB, response.job_id);

--- a/web/frontend/src/routes/browse/+page.svelte
+++ b/web/frontend/src/routes/browse/+page.svelte
@@ -239,8 +239,19 @@
 			saved = sessionStorage.getItem(STORAGE_KEY_PENDING_JOB);
 		} catch {}
 		if (saved && !pendingJobId) {
-			pendingJobId = saved;
-			pollJobCompletion(saved);
+			try {
+				const parsed = JSON.parse(saved) as { jobId: string; launchedFiles?: string[] };
+				pendingJobId = parsed.jobId;
+				if (Array.isArray(parsed.launchedFiles)) {
+					launchedFiles = parsed.launchedFiles;
+				}
+			} catch {
+				// Legacy format — just a job ID string
+				pendingJobId = saved;
+			}
+			if (pendingJobId) {
+				pollJobCompletion(pendingJobId);
+			}
 		}
 	});
 
@@ -458,7 +469,10 @@
 			launchedFiles = [...selectedFiles];
 			pendingJobId = response.job_id;
 			try {
-				sessionStorage.setItem(STORAGE_KEY_PENDING_JOB, response.job_id);
+				sessionStorage.setItem(
+				STORAGE_KEY_PENDING_JOB,
+				JSON.stringify({ jobId: response.job_id, launchedFiles }),
+			);
 			} catch {}
 			pollJobCompletion(response.job_id);
 			void queryClient.invalidateQueries({ queryKey: ['batch-jobs'] });

--- a/web/frontend/src/routes/browse/+page.svelte
+++ b/web/frontend/src/routes/browse/+page.svelte
@@ -21,6 +21,7 @@
 	} from '$lib/stores/pending-scrape.svelte';
 	import { clearManualInputs } from '$lib/stores/manual-inputs-session';
 	import { createConfigQuery, createScrapersQuery } from '$lib/query/queries';
+	import { isTerminalStatus } from '$lib/utils/job-progress';
 	import { Play, FolderOutput, FolderOpen, FileEdit, FileText, RotateCcw, LoaderCircle, RefreshCw, Settings, ChevronUp, ChevronDown, X, Scan } from 'lucide-svelte';
 	import type { Scraper, FileInfo, Config } from '$lib/api/types';
 	import type { OperationMode } from '$lib/api/types';
@@ -172,6 +173,72 @@
 		clearPendingScrape();
 		clearManualInputs();
 	}
+
+	// Track the batch job started from this browse page so we can clear the
+	// file selection once the job reaches a terminal SUCCESS state. Persisted to
+	// sessionStorage so a remount (e.g. user navigated away before completion)
+	// can re-check the job and clear stale selection.
+	const STORAGE_KEY_PENDING_JOB = 'javinizer_browse_pending_job';
+	const JOB_SUCCESS_STATUSES = new Set(['completed', 'organized', 'reverted']);
+	let pendingJobId: string | null = $state(null);
+	let completionPoll: ReturnType<typeof setInterval> | null = null;
+
+	function stopCompletionPoll() {
+		if (completionPoll) {
+			clearInterval(completionPoll);
+			completionPoll = null;
+		}
+	}
+
+	function clearPendingJob() {
+		pendingJobId = null;
+		try {
+			sessionStorage.removeItem(STORAGE_KEY_PENDING_JOB);
+		} catch {}
+	}
+
+	async function pollJobCompletion(jobId: string) {
+		stopCompletionPoll();
+		const tick = async () => {
+			try {
+				const job = await apiClient.getBatchJob(jobId);
+				const status = job.status?.toLowerCase();
+				if (status && JOB_SUCCESS_STATUSES.has(status)) {
+					stopCompletionPoll();
+					clearSelection();
+					clearPendingJob();
+				} else if (isTerminalStatus(status)) {
+					// failed / cancelled — keep selection so the user can retry
+					stopCompletionPoll();
+					clearPendingJob();
+				}
+			} catch {
+				// transient network error — keep polling
+			}
+		};
+		void tick();
+		completionPoll = setInterval(() => { void tick(); }, 2000);
+	}
+
+	// On mount, if a pending job was recorded (e.g. user navigated away before
+	// completion), resume polling so a since-completed job clears the selection.
+	$effect(() => {
+		if (typeof sessionStorage === 'undefined') return;
+		let saved: string | null = null;
+		try {
+			saved = sessionStorage.getItem(STORAGE_KEY_PENDING_JOB);
+		} catch {}
+		if (saved && !pendingJobId) {
+			pendingJobId = saved;
+			pollJobCompletion(saved);
+		}
+	});
+
+	// Stop polling when the component unmounts (sessionStorage marker is kept so
+	// a remount can finish the check).
+	$effect(() => {
+		return () => stopCompletionPoll();
+	});
 
 	function getSettingsOperationMode(): OperationMode {
 		if (config) {
@@ -378,6 +445,11 @@
 				operation_mode: effectiveOperationMode,
 			});
 			startJob(response.job_id);
+			pendingJobId = response.job_id;
+			try {
+				sessionStorage.setItem(STORAGE_KEY_PENDING_JOB, response.job_id);
+			} catch {}
+			pollJobCompletion(response.job_id);
 			void queryClient.invalidateQueries({ queryKey: ['batch-jobs'] });
 
 			const modeText = isUpdateMode ? 'Updating metadata' : 'Batch scraping';


### PR DESCRIPTION
Two WebUI polish fixes:

## 1. Progress bar bouncing between importing/downloading states

The r18dev dump download streams the gzip response body through the SQL importer concurrently — `Import` pulls compressed bytes through a `countingReader` that fires "downloading" progress frames. The import heartbeat (added to give feedback during the multi-minute SQL import) was starting at the beginning of the import callback, so "importing" heartbeat frames interleaved with "downloading" frames and the UI bounced between the two phases, resetting the progress bar.

**Fix:** Gate the import heartbeat to start only after the decompressed stream hits EOF via an `eofDetectReader` wrapper, so phase transitions are monotonic (download → import → done).

Also includes the earlier progress bar improvements:
- Throttle progress broadcasts to ~500ms (was firing on every chunk read)
- Return -1 for unknown Content-Length (indeterminate sentinel)
- Single progress bar element (no jarring DOM swap) with a proper indeterminate animation

## 2. File selection persists after batch scrape completion

`selectedFiles` persists to `sessionStorage` and hydrates on remount, so the selection survived navigation even after the batch scrape job finished. Users expected the selection to clear automatically once scraping completed.

**Fix:** Track the batch job ID (persisted to sessionStorage so remounts can finish the check) and poll `getBatchJob`. On terminal SUCCESS status, call `clearSelection()`. On failure/cancel, keep the selection so the user can retry.

## Validation
- `go build ./...` ✅
- `go test -short ./internal/api/r18devdump/...` ✅
- `svelte-check` — 0 errors, 1 pre-existing a11y warning ✅