### PR TITLE
fix(batch): manual_inputs overrides multi-part grouping key

### DIFF
--- a/internal/api/batch/manual_input.go
+++ b/internal/api/batch/manual_input.go
@@ -63,12 +63,13 @@ func resolveManualInputOverride(
 			continue
 		}
 		trimmed := strings.TrimSpace(input)
+		redacted := scrape.RedactURLQuery(trimmed)
 		if movieInputs[fmi.MovieID] == nil {
 			movieInputs[fmi.MovieID] = make(map[string]bool)
 		}
-		movieInputs[fmi.MovieID][trimmed] = true
+		movieInputs[fmi.MovieID][redacted] = true
 		movieInput[fmi.MovieID] = input
-		inputCounts[inputKey{fmi.MovieID, trimmed}]++
+		inputCounts[inputKey{fmi.MovieID, redacted}]++
 	}
 
 	// Seed the result with every explicit input (submitters keep their own).
@@ -122,7 +123,7 @@ func resolveManualInputOverride(
 		// (more than one distinct input) — i.e. it's being split off as a
 		// standalone movie. Files sharing an input with at least one sibling
 		// keep their part metadata for organize/NFO templates.
-		count := inputCounts[inputKey{fmi.MovieID, trimmed}]
+		count := inputCounts[inputKey{fmi.MovieID, redacted}]
 		isSplit := count <= 1 && len(movieInputs[fmi.MovieID]) > 1
 		fmi.MovieID = redacted
 		if isSplit {

--- a/internal/api/batch/manual_input.go
+++ b/internal/api/batch/manual_input.go
@@ -68,7 +68,9 @@ func resolveManualInputOverride(
 			movieInputs[fmi.MovieID] = make(map[string]bool)
 		}
 		movieInputs[fmi.MovieID][redacted] = true
-		movieInput[fmi.MovieID] = input
+		if existing, ok := movieInput[fmi.MovieID]; !ok || input < existing {
+			movieInput[fmi.MovieID] = input
+		}
 		inputCounts[inputKey{fmi.MovieID, redacted}]++
 	}
 

--- a/internal/api/batch/manual_input.go
+++ b/internal/api/batch/manual_input.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scrape"
 )
 
 // resolveManualInputOverride produces the final per-file RawInputOverride map by
@@ -97,10 +98,22 @@ func resolveManualInputOverride(
 		if !ok {
 			continue
 		}
-		fmi.MovieID = trimmed
-		fmi.IsMultiPart = false
-		fmi.PartNumber = 0
-		fmi.PartSuffix = ""
+		// Redact URL query params before using as the grouping key —
+		// buildScrapeCmd does the same for cmd.MovieID. RawInputOverride
+		// (the result map) stays raw so the scraper sees the real URL.
+		redacted := scrape.RedactURLQuery(trimmed)
+		isSplit := redacted != fmi.MovieID
+		fmi.MovieID = redacted
+		if isSplit {
+			// Manual input differs from the matcher MovieID — the user is
+			// splitting matcher-grouped files. Clear multipart metadata so
+			// they render as independent movies.
+			fmi.IsMultiPart = false
+			fmi.PartNumber = 0
+			fmi.PartSuffix = ""
+		}
+		// When the manual input matches the matcher MovieID (genuine multi-part
+		// corrected to the same ID), preserve IsMultiPart/PartNumber/PartSuffix.
 		fileMatchInfo[path] = fmi
 	}
 

--- a/internal/api/batch/manual_input.go
+++ b/internal/api/batch/manual_input.go
@@ -1,10 +1,9 @@
 package batch
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/javinizer/javinizer-go/internal/models"
-	"github.com/javinizer/javinizer-go/internal/scrape"
 )
 
 // resolveManualInputOverride produces the final per-file RawInputOverride map by
@@ -13,20 +12,23 @@ import (
 // submittedFiles) keep their own input and are never overwritten by
 // propagation: propagation targets only files that were discovered by sibling
 // discovery, not files the caller submitted (backend F1). Two submitted files
-// sharing a matcher MovieID with conflicting manual inputs are rejected
-// (backend F2): otherwise map-iteration order would decide which input a
-// shared sibling receives, making the scrape non-deterministic.
+// sharing a matcher MovieID with conflicting manual inputs are NOT rejected
+// (backend F2): the user is explicitly splitting matcher-grouped files into
+// separate movies. Instead, the conflicting MovieID is marked ambiguous so
+// sibling propagation is skipped (we can't know which input to propagate).
 //
 // fileMatchInfo is the metadata returned by discoverSiblingPartsWithMetadata;
-// allFiles is its expanded file list (submitted + discovered).
+// allFiles is its expanded file list (submitted + discovered). The function
+// also overrides fileMatchInfo entries so files with explicit manual inputs
+// are grouped by the user's ID, not the matcher's.
 func resolveManualInputOverride(
 	submittedFiles []string,
 	manualInputs map[string]string,
 	fileMatchInfo map[string]models.FileMatchInfo,
 	allFiles []string,
-) (map[string]string, error) {
+) map[string]string {
 	if len(manualInputs) == 0 {
-		return manualInputs, nil
+		return manualInputs
 	}
 
 	submitted := make(map[string]bool, len(submittedFiles))
@@ -35,7 +37,11 @@ func resolveManualInputOverride(
 	}
 
 	// Map each submitter's manual input to the matcher MovieID of its file.
+	// Conflicting inputs for the same matcher MovieID are not rejected — the
+	// user is explicitly splitting matcher-grouped files — but the MovieID is
+	// marked ambiguous so sibling propagation is skipped.
 	movieInput := make(map[string]string)
+	ambiguousMovies := make(map[string]bool)
 	for path, input := range manualInputs {
 		if !submitted[path] {
 			continue
@@ -45,7 +51,8 @@ func resolveManualInputOverride(
 			continue
 		}
 		if existing, dup := movieInput[fmi.MovieID]; dup && existing != input {
-			return nil, fmt.Errorf("conflicting manual inputs for movie %q: %q vs %q", fmi.MovieID, scrape.RedactURLQuery(existing), scrape.RedactURLQuery(input))
+			ambiguousMovies[fmi.MovieID] = true
+			continue
 		}
 		movieInput[fmi.MovieID] = input
 	}
@@ -69,10 +76,33 @@ func resolveManualInputOverride(
 		if !ok || fmi.MovieID == "" {
 			continue
 		}
+		if ambiguousMovies[fmi.MovieID] {
+			continue
+		}
 		if input, ok := movieInput[fmi.MovieID]; ok {
 			result[path] = input
 		}
 	}
 
-	return result, nil
+	// Override matcher-derived metadata so files with explicit manual inputs
+	// are grouped by the user's ID, not the matcher's. Files with different
+	// manual inputs naturally split into separate movies; files with the same
+	// manual input stay grouped (correct for genuine multi-part).
+	for path, input := range result {
+		trimmed := strings.TrimSpace(input)
+		if trimmed == "" {
+			continue
+		}
+		fmi, ok := fileMatchInfo[path]
+		if !ok {
+			continue
+		}
+		fmi.MovieID = trimmed
+		fmi.IsMultiPart = false
+		fmi.PartNumber = 0
+		fmi.PartSuffix = ""
+		fileMatchInfo[path] = fmi
+	}
+
+	return result
 }

--- a/internal/api/batch/manual_input.go
+++ b/internal/api/batch/manual_input.go
@@ -63,15 +63,19 @@ func resolveManualInputOverride(
 			continue
 		}
 		trimmed := strings.TrimSpace(input)
-		redacted := scrape.RedactURLQuery(trimmed)
 		if movieInputs[fmi.MovieID] == nil {
 			movieInputs[fmi.MovieID] = make(map[string]bool)
 		}
-		movieInputs[fmi.MovieID][redacted] = true
+		// Use the raw (unredacted) input for ambiguity detection so URLs
+		// whose movie ID lives in the query string (?v=IPX-111 vs
+		// ?v=IPX-222) are correctly seen as distinct inputs. The redacted
+		// value is still used for the grouping key (FileMatchInfo.MovieID)
+		// in the override loop below.
+		movieInputs[fmi.MovieID][trimmed] = true
 		if existing, ok := movieInput[fmi.MovieID]; !ok || input < existing {
 			movieInput[fmi.MovieID] = input
 		}
-		inputCounts[inputKey{fmi.MovieID, redacted}]++
+		inputCounts[inputKey{fmi.MovieID, trimmed}]++
 	}
 
 	// Seed the result with every explicit input (submitters keep their own).
@@ -120,12 +124,9 @@ func resolveManualInputOverride(
 		// buildScrapeCmd does the same for cmd.MovieID. RawInputOverride
 		// (the result map) stays raw so the scraper sees the real URL.
 		redacted := scrape.RedactURLQuery(trimmed)
-		// A file loses multipart metadata only if its manual input is unique
-		// within the matcher group (count == 1) AND the group is ambiguous
-		// (more than one distinct input) — i.e. it's being split off as a
-		// standalone movie. Files sharing an input with at least one sibling
-		// keep their part metadata for organize/NFO templates.
-		count := inputCounts[inputKey{fmi.MovieID, redacted}]
+		// Use the raw input for split detection (matches inputCounts keying)
+		// so query-based URLs (?v=IPX-111 vs ?v=IPX-222) count as distinct.
+		count := inputCounts[inputKey{fmi.MovieID, trimmed}]
 		isSplit := count <= 1 && len(movieInputs[fmi.MovieID]) > 1
 		fmi.MovieID = redacted
 		if isSplit {

--- a/internal/api/batch/manual_input.go
+++ b/internal/api/batch/manual_input.go
@@ -7,6 +7,13 @@ import (
 	"github.com/javinizer/javinizer-go/internal/scrape"
 )
 
+// inputKey identifies a (matcher MovieID, manual input) pair so we can count
+// how many submitted files share each manual input within a matcher group.
+type inputKey struct {
+	movieID string
+	input   string
+}
+
 // resolveManualInputOverride produces the final per-file RawInputOverride map by
 // propagating each submitted file's manual input to newly-discovered sibling
 // files that share the same matcher MovieID. Co-submitted files (present in
@@ -37,12 +44,16 @@ func resolveManualInputOverride(
 		submitted[f] = true
 	}
 
-	// Map each submitter's manual input to the matcher MovieID of its file.
-	// Conflicting inputs for the same matcher MovieID are not rejected — the
-	// user is explicitly splitting matcher-grouped files — but the MovieID is
-	// marked ambiguous so sibling propagation is skipped.
+	// Map each submitter's manual input to the matcher MovieID of its file and
+	// track distinct manual inputs + per-input counts per matcher MovieID.
+	// A matcher group is ambiguous (being split) when it has more than one
+	// distinct manual input. Within an ambiguous group, only files whose input
+	// is unique (no sibling shares it) lose multipart metadata; files sharing
+	// an input keep their part metadata so organize/NFO templates still group
+	// them as a genuine multi-part under the shared ID.
 	movieInput := make(map[string]string)
-	ambiguousMovies := make(map[string]bool)
+	movieInputs := make(map[string]map[string]bool)
+	inputCounts := make(map[inputKey]int)
 	for path, input := range manualInputs {
 		if !submitted[path] {
 			continue
@@ -51,11 +62,13 @@ func resolveManualInputOverride(
 		if !ok || fmi.MovieID == "" {
 			continue
 		}
-		if existing, dup := movieInput[fmi.MovieID]; dup && existing != input {
-			ambiguousMovies[fmi.MovieID] = true
-			continue
+		trimmed := strings.TrimSpace(input)
+		if movieInputs[fmi.MovieID] == nil {
+			movieInputs[fmi.MovieID] = make(map[string]bool)
 		}
+		movieInputs[fmi.MovieID][trimmed] = true
 		movieInput[fmi.MovieID] = input
+		inputCounts[inputKey{fmi.MovieID, trimmed}]++
 	}
 
 	// Seed the result with every explicit input (submitters keep their own).
@@ -77,7 +90,9 @@ func resolveManualInputOverride(
 		if !ok || fmi.MovieID == "" {
 			continue
 		}
-		if ambiguousMovies[fmi.MovieID] {
+		// Skip propagation for ambiguous groups (more than one distinct input) —
+		// we can't know which input to propagate.
+		if inputs := movieInputs[fmi.MovieID]; len(inputs) > 1 {
 			continue
 		}
 		if input, ok := movieInput[fmi.MovieID]; ok {
@@ -102,11 +117,13 @@ func resolveManualInputOverride(
 		// buildScrapeCmd does the same for cmd.MovieID. RawInputOverride
 		// (the result map) stays raw so the scraper sees the real URL.
 		redacted := scrape.RedactURLQuery(trimmed)
-		// Only clear multipart metadata when the matcher group was actually
-		// split by conflicting manual inputs (ambiguousMovies). A genuine
-		// multi-part corrected to a new shared ID preserves part metadata
-		// so organizer/NFO templates still get <PART> suffixes.
-		isSplit := ambiguousMovies[fmi.MovieID]
+		// A file loses multipart metadata only if its manual input is unique
+		// within the matcher group (count == 1) AND the group is ambiguous
+		// (more than one distinct input) — i.e. it's being split off as a
+		// standalone movie. Files sharing an input with at least one sibling
+		// keep their part metadata for organize/NFO templates.
+		count := inputCounts[inputKey{fmi.MovieID, trimmed}]
+		isSplit := count <= 1 && len(movieInputs[fmi.MovieID]) > 1
 		fmi.MovieID = redacted
 		if isSplit {
 			fmi.IsMultiPart = false

--- a/internal/api/batch/manual_input.go
+++ b/internal/api/batch/manual_input.go
@@ -24,19 +24,26 @@ type inputKey struct {
 // (backend F2): the user is explicitly splitting matcher-grouped files into
 // separate movies. Instead, the conflicting MovieID is marked ambiguous so
 // sibling propagation is skipped (we can't know which input to propagate).
+// Discovered siblings from ambiguous groups are also excluded from the
+// returned allFiles so they aren't scraped under the stale matcher ID.
 //
 // fileMatchInfo is the metadata returned by discoverSiblingPartsWithMetadata;
 // allFiles is its expanded file list (submitted + discovered). The function
 // also overrides fileMatchInfo entries so files with explicit manual inputs
 // are grouped by the user's ID, not the matcher's.
+type manualInputResult struct {
+	overrides map[string]string
+	allFiles  []string
+}
+
 func resolveManualInputOverride(
 	submittedFiles []string,
 	manualInputs map[string]string,
 	fileMatchInfo map[string]models.FileMatchInfo,
 	allFiles []string,
-) map[string]string {
+) manualInputResult {
 	if len(manualInputs) == 0 {
-		return manualInputs
+		return manualInputResult{overrides: manualInputs, allFiles: allFiles}
 	}
 
 	submitted := make(map[string]bool, len(submittedFiles))
@@ -84,24 +91,30 @@ func resolveManualInputOverride(
 		result[k] = v
 	}
 
-	// Propagate to discovered siblings (!submitted) sharing a MovieID. Co-submitted
-	// files are skipped so a part the caller submitted is never clobbered.
+	// Build a filtered allFiles that excludes discovered siblings from ambiguous
+	// groups — they shouldn't be scraped under the stale matcher ID when the
+	// user is explicitly splitting the group. Submitted files and files with
+	// explicit manual inputs are always kept.
+	filteredFiles := make([]string, 0, len(allFiles))
 	for _, path := range allFiles {
 		if submitted[path] {
+			filteredFiles = append(filteredFiles, path)
 			continue
 		}
 		if _, has := result[path]; has {
+			filteredFiles = append(filteredFiles, path)
 			continue
 		}
 		fmi, ok := fileMatchInfo[path]
 		if !ok || fmi.MovieID == "" {
+			filteredFiles = append(filteredFiles, path)
 			continue
 		}
-		// Skip propagation for ambiguous groups (more than one distinct input) —
-		// we can't know which input to propagate.
+		// Skip — don't include discovered siblings from ambiguous groups
 		if inputs := movieInputs[fmi.MovieID]; len(inputs) > 1 {
 			continue
 		}
+		filteredFiles = append(filteredFiles, path)
 		if input, ok := movieInput[fmi.MovieID]; ok {
 			result[path] = input
 		}
@@ -137,5 +150,8 @@ func resolveManualInputOverride(
 		fileMatchInfo[path] = fmi
 	}
 
-	return result
+	return manualInputResult{
+		overrides: result,
+		allFiles:  filteredFiles,
+	}
 }

--- a/internal/api/batch/manual_input.go
+++ b/internal/api/batch/manual_input.go
@@ -102,18 +102,17 @@ func resolveManualInputOverride(
 		// buildScrapeCmd does the same for cmd.MovieID. RawInputOverride
 		// (the result map) stays raw so the scraper sees the real URL.
 		redacted := scrape.RedactURLQuery(trimmed)
-		isSplit := redacted != fmi.MovieID
+		// Only clear multipart metadata when the matcher group was actually
+		// split by conflicting manual inputs (ambiguousMovies). A genuine
+		// multi-part corrected to a new shared ID preserves part metadata
+		// so organizer/NFO templates still get <PART> suffixes.
+		isSplit := ambiguousMovies[fmi.MovieID]
 		fmi.MovieID = redacted
 		if isSplit {
-			// Manual input differs from the matcher MovieID — the user is
-			// splitting matcher-grouped files. Clear multipart metadata so
-			// they render as independent movies.
 			fmi.IsMultiPart = false
 			fmi.PartNumber = 0
 			fmi.PartSuffix = ""
 		}
-		// When the manual input matches the matcher MovieID (genuine multi-part
-		// corrected to the same ID), preserve IsMultiPart/PartNumber/PartSuffix.
 		fileMatchInfo[path] = fmi
 	}
 

--- a/internal/api/batch/manual_input_race_test.go
+++ b/internal/api/batch/manual_input_race_test.go
@@ -9,29 +9,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func copyFMI(m map[string]models.FileMatchInfo) map[string]models.FileMatchInfo {
+	out := make(map[string]models.FileMatchInfo, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 // TestResolveManualInputOverride_ConcurrentReadSafety asserts the manual-input
 // override resolution is safe under the race detector when many goroutines
-// resolve the same shared inputs concurrently. resolveManualInputOverride is
-// the propagation step on the batch scrape path (usecases.go); it reads
-// submittedFiles, manualInputs, and fileMatchInfo and builds a fresh override
-// map. Inputs are read-only across the call, so concurrent callers must not
-// race on the shared maps/slices and must each observe identical, deterministic
-// results. The discovered-sibling propagation case (the new manual-input path)
-// is included so the race detector exercises the full build path, not just the
+// resolve equivalent inputs concurrently. resolveManualInputOverride mutates
+// fileMatchInfo in place (Layer 1: override the grouping key), so each
+// goroutine resolves against its own copy of fileMatchInfo — the production
+// caller invokes it once per scrape, never concurrently on a shared map.
+// The result map is per-call, and manualInputs is read-only across the call,
+// so concurrent callers each observe identical, deterministic results. The
+// discovered-sibling propagation case (the new manual-input path) is included
+// so the race detector exercises the full build path, not just the
 // early-return shortcuts.
 func TestResolveManualInputOverride_ConcurrentReadSafety(t *testing.T) {
 	t.Parallel()
 
 	submitted := []string{"/d/ABC-001-pt1.mp4"}
 	manualInputs := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"}
-	fileMatchInfo := map[string]models.FileMatchInfo{
+	baseFMI := map[string]models.FileMatchInfo{
 		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
 		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
 	}
 	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
 
-	want, err := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
-	require.NoError(t, err)
+	want := resolveManualInputOverride(submitted, manualInputs, copyFMI(baseFMI), allFiles)
 	require.Equal(t, "IPX-999", want["/d/ABC-001-pt1.mp4"])
 	require.Equal(t, "IPX-999", want["/d/ABC-001-pt2.mp4"], "precondition: discovered sibling inherits submitter input")
 
@@ -42,11 +50,7 @@ func TestResolveManualInputOverride_ConcurrentReadSafety(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 200; i++ {
-				got, gerr := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
-				if gerr != nil {
-					t.Errorf("concurrent resolve failed: %v", gerr)
-					return
-				}
+				got := resolveManualInputOverride(submitted, manualInputs, copyFMI(baseFMI), allFiles)
 				if !mapsEqual(got, want) {
 					t.Errorf("concurrent resolve diverged: got %v want %v", got, want)
 					return
@@ -99,27 +103,26 @@ func TestValidateAndSanitizeManualInputs_ConcurrentReadSafety(t *testing.T) {
 }
 
 // TestResolveManualInputOverride_ConcurrentSharedInputs_NoMutation asserts that
-// concurrent resolution never mutates the shared input maps/slices: a caller
-// must treat its inputs as read-only. This guards the contract the usecase
-// relies on (the same manualInputs/fileMatchInfo feed into the job's
-// FileMatchInfo and RawInputOverride) — if a concurrent resolver mutated them,
-// a later caller or the scrape phase would observe corrupted data.
+// concurrent resolution never mutates the shared read-only input map
+// manualInputs: a caller must treat manualInputs as read-only. fileMatchInfo
+// is now an in/out parameter (Layer 1 overrides its grouping key), so each
+// goroutine resolves against its own copy and the production caller invokes
+// the resolver once per scrape, never concurrently on a shared map. This
+// guards the contract the usecase relies on (the same manualInputs feed into
+// the job's RawInputOverride) — if a concurrent resolver mutated it, a later
+// caller or the scrape phase would observe corrupted data.
 func TestResolveManualInputOverride_ConcurrentSharedInputs_NoMutation(t *testing.T) {
 	t.Parallel()
 
 	submitted := []string{"/d/ABC-001-pt1.mp4"}
 	manualInputs := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"}
-	fileMatchInfo := map[string]models.FileMatchInfo{
+	baseFMI := map[string]models.FileMatchInfo{
 		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
 		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
 	}
 	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
 
 	manualSnapshot := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"}
-	fmiSnapshot := map[string]models.FileMatchInfo{
-		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
-		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
-	}
 
 	const goroutines = 32
 	var wg sync.WaitGroup
@@ -128,14 +131,13 @@ func TestResolveManualInputOverride_ConcurrentSharedInputs_NoMutation(t *testing
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 200; i++ {
-				_, _ = resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+				_ = resolveManualInputOverride(submitted, manualInputs, copyFMI(baseFMI), allFiles)
 			}
 		}()
 	}
 	wg.Wait()
 
 	assert.Equal(t, manualSnapshot, manualInputs, "shared manualInputs must not be mutated by concurrent resolvers")
-	assert.Equal(t, fmiSnapshot, fileMatchInfo, "shared fileMatchInfo must not be mutated by concurrent resolvers")
 }
 
 func mapsEqual(a, b map[string]string) bool {

--- a/internal/api/batch/manual_input_race_test.go
+++ b/internal/api/batch/manual_input_race_test.go
@@ -39,7 +39,8 @@ func TestResolveManualInputOverride_ConcurrentReadSafety(t *testing.T) {
 	}
 	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
 
-	want := resolveManualInputOverride(submitted, manualInputs, copyFMI(baseFMI), allFiles)
+	wantResolved := resolveManualInputOverride(submitted, manualInputs, copyFMI(baseFMI), allFiles)
+	want := wantResolved.overrides
 	require.Equal(t, "IPX-999", want["/d/ABC-001-pt1.mp4"])
 	require.Equal(t, "IPX-999", want["/d/ABC-001-pt2.mp4"], "precondition: discovered sibling inherits submitter input")
 
@@ -50,7 +51,8 @@ func TestResolveManualInputOverride_ConcurrentReadSafety(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 200; i++ {
-				got := resolveManualInputOverride(submitted, manualInputs, copyFMI(baseFMI), allFiles)
+				gotResolved := resolveManualInputOverride(submitted, manualInputs, copyFMI(baseFMI), allFiles)
+				got := gotResolved.overrides
 				if !mapsEqual(got, want) {
 					t.Errorf("concurrent resolve diverged: got %v want %v", got, want)
 					return

--- a/internal/api/batch/manual_input_test.go
+++ b/internal/api/batch/manual_input_test.go
@@ -23,7 +23,8 @@ func TestResolveManualInputOverride_AllowsConflictingInputsForSameMovieID(t *tes
 	}
 	allFiles := submitted
 
-	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolved.overrides
 
 	assert.Equal(t, "IPX-111", result["/d/ABC-001-pt1.mp4"], "each submitted file keeps its own manual input")
 	assert.Equal(t, "IPX-222", result["/d/ABC-001-pt2.mp4"], "each submitted file keeps its own manual input")
@@ -42,7 +43,8 @@ func TestResolveManualInputOverride_DoesNotOverwriteCoSubmittedSibling(t *testin
 	}
 	allFiles := submitted
 
-	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolved.overrides
 
 	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt1.mp4"], "submitter keeps its own input")
 	_, has := result["/d/ABC-001-pt2.mp4"]
@@ -58,7 +60,8 @@ func TestResolveManualInputOverride_PropagatesToDiscoveredSibling(t *testing.T) 
 	}
 	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
 
-	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolved.overrides
 
 	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt1.mp4"], "submitter keeps its own input")
 	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt2.mp4"], "discovered sibling inherits the submitter's input (same matcher MovieID)")
@@ -73,7 +76,8 @@ func TestResolveManualInputOverride_MixedBatchManualAndAuto(t *testing.T) {
 	}
 	allFiles := submitted
 
-	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolved.overrides
 
 	assert.Len(t, result, 1, "only the manually-input row gets an override; the auto row stays auto (no map entry)")
 	assert.Equal(t, "ABC-123", result["/a/SSIS-001.mp4"], "manual row scrapes as its explicit input")
@@ -118,7 +122,8 @@ func TestResolveManualInputOverride_AmbiguousMovieSkipsPropagation(t *testing.T)
 	}
 	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4", "/d/ABC-001-pt3.mp4"}
 
-	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolved.overrides
 
 	assert.Equal(t, "IPX-111", result["/d/ABC-001-pt1.mp4"], "submitted file keeps its own input")
 	assert.Equal(t, "IPX-222", result["/d/ABC-001-pt2.mp4"], "submitted file keeps its own input")
@@ -138,7 +143,8 @@ func TestResolveManualInputOverride_PreservesMultipartForSameManualID(t *testing
 	}
 	allFiles := submitted
 
-	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolved.overrides
 
 	assert.Equal(t, "ABC-001", result["/d/ABC-001-pt1.mp4"], "manual input preserved in result map")
 	assert.Equal(t, "ABC-001", result["/d/ABC-001-pt2.mp4"], "manual input preserved in result map")
@@ -162,7 +168,8 @@ func TestResolveManualInputOverride_PreservesMultipartForPropagatedSibling(t *te
 	}
 	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
 
-	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolved.overrides
 
 	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt1.mp4"], "submitter keeps its input")
 	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt2.mp4"], "sibling inherits the propagated input")
@@ -214,7 +221,8 @@ func TestResolveManualInputOverride_RedactsURLInMovieID(t *testing.T) {
 	}
 	allFiles := submitted
 
-	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolved.overrides
 
 	assert.Equal(t, rawURL, result["/d/video.mp4"], "RawInputOverride (result map) keeps the raw URL for the scraper")
 	assert.NotContains(t, fileMatchInfo["/d/video.mp4"].MovieID, "token=secret", "MovieID grouping key has query token redacted")
@@ -244,7 +252,8 @@ func TestResolveManualInputOverride_CoversDefensiveGuards(t *testing.T) {
 		}
 		allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/unsubmitted.mp4"}
 
-		result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+		resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+		result := resolved.overrides
 
 		assert.Equal(t, "IPX-999", result["/d/ABC-001-pt1.mp4"])
 		// The unsubmitted file's input (IPX-888) was seeded into result and is
@@ -260,7 +269,8 @@ func TestResolveManualInputOverride_CoversDefensiveGuards(t *testing.T) {
 		fileMatchInfo := map[string]models.FileMatchInfo{} // no entry for missing.mp4
 		allFiles := submitted
 
-		result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+		resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+		result := resolved.overrides
 
 		assert.Equal(t, "IPX-999", result["/d/missing.mp4"], "input still seeded into result even without fileMatchInfo")
 		// fileMatchInfo should now have the override applied (the override loop
@@ -280,7 +290,8 @@ func TestResolveManualInputOverride_CoversDefensiveGuards(t *testing.T) {
 		}
 		allFiles := submitted
 
-		result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+		resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+		result := resolved.overrides
 
 		assert.Equal(t, "IPX-999", result["/d/empty-id.mp4"])
 	})
@@ -299,7 +310,8 @@ func TestResolveManualInputOverride_CoversDefensiveGuards(t *testing.T) {
 		}
 		allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
 
-		result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+		resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+		result := resolved.overrides
 
 		assert.Equal(t, "IPX-888", result["/d/ABC-001-pt2.mp4"], "explicit input preserved, not overwritten by propagation")
 	})
@@ -315,7 +327,8 @@ func TestResolveManualInputOverride_CoversDefensiveGuards(t *testing.T) {
 		}
 		allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
 
-		result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+		resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+		result := resolved.overrides
 
 		_, hasSibling := result["/d/ABC-001-pt2.mp4"]
 		assert.False(t, hasSibling, "sibling with no fileMatchInfo is not propagated")
@@ -408,9 +421,32 @@ func TestResolveManualInputOverride_DeterministicURLPropagation(t *testing.T) {
 	// Run multiple times to verify determinism (map iteration order varies)
 	for i := 0; i < 50; i++ {
 		fmiCopy := copyFMI(fileMatchInfo)
-		result := resolveManualInputOverride(submitted, manualInputs, fmiCopy, allFiles)
+		resolved := resolveManualInputOverride(submitted, manualInputs, fmiCopy, allFiles)
+		result := resolved.overrides
 		// The sibling should always receive the shared raw URL
 		assert.Equal(t, "https://example.com/video?token=aaaa", result["/d/ABC-001-pt3.mp4"],
 			"sibling gets the shared raw URL (deterministic)")
 	}
+}
+
+func TestResolveManualInputOverride_ExcludesAmbiguousSiblingFromAllFiles(t *testing.T) {
+	// pt1→IPX-111, pt2→IPX-222 (ambiguous), pt3 is auto-discovered.
+	// pt3 should be excluded from allFiles since the group is ambiguous.
+	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+	manualInputs := map[string]string{
+		"/d/ABC-001-pt1.mp4": "IPX-111",
+		"/d/ABC-001-pt2.mp4": "IPX-222",
+	}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+		"/d/ABC-001-pt3.mp4": fmiFor("/d/ABC-001-pt3.mp4", "ABC-001", 3),
+	}
+	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4", "/d/ABC-001-pt3.mp4"}
+
+	resolved := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	assert.Contains(t, resolved.allFiles, "/d/ABC-001-pt1.mp4", "submitted pt1 included")
+	assert.Contains(t, resolved.allFiles, "/d/ABC-001-pt2.mp4", "submitted pt2 included")
+	assert.NotContains(t, resolved.allFiles, "/d/ABC-001-pt3.mp4", "discovered pt3 excluded from ambiguous group")
 }

--- a/internal/api/batch/manual_input_test.go
+++ b/internal/api/batch/manual_input_test.go
@@ -339,10 +339,11 @@ func TestResolveManualInputOverride_CoversDefensiveGuards(t *testing.T) {
 }
 
 func TestResolveManualInputOverride_NormalizesURLKeysForAmbiguity(t *testing.T) {
-	// Two files in the same matcher group given the same URL except for
-	// query credentials. After redaction they collapse to the same input,
-	// so the group is NOT ambiguous — the sibling should be propagated
-	// and multipart metadata preserved.
+	// Two files in the same matcher group given URLs that share a path but
+	// differ in query token. With raw-input keying the inputs are distinct,
+	// so the group IS ambiguous: each file has a unique input and both lose
+	// multipart metadata. The grouping key (MovieID) is still the redacted
+	// URL, so no token leaks.
 	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
 	manualInputs := map[string]string{
 		"/d/ABC-001-pt1.mp4": "https://example.com/video?token=secret1",
@@ -356,22 +357,45 @@ func TestResolveManualInputOverride_NormalizesURLKeysForAmbiguity(t *testing.T) 
 
 	resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
 
-	// Both redact to the same URL, so the group is NOT ambiguous
-	assert.True(t, fileMatchInfo["/d/ABC-001-pt1.mp4"].IsMultiPart, "pt1 keeps multipart (same redacted URL as pt2)")
-	assert.True(t, fileMatchInfo["/d/ABC-001-pt2.mp4"].IsMultiPart, "pt2 keeps multipart (same redacted URL as pt1)")
+	// Distinct raw inputs → ambiguous group → both files lose multipart metadata.
+	assert.False(t, fileMatchInfo["/d/ABC-001-pt1.mp4"].IsMultiPart, "pt1 loses multipart (distinct raw URL from pt2)")
+	assert.False(t, fileMatchInfo["/d/ABC-001-pt2.mp4"].IsMultiPart, "pt2 loses multipart (distinct raw URL from pt1)")
 	assert.Equal(t, "https://example.com/video", fileMatchInfo["/d/ABC-001-pt1.mp4"].MovieID, "pt1 MovieID is redacted URL")
 	assert.Equal(t, "https://example.com/video", fileMatchInfo["/d/ABC-001-pt2.mp4"].MovieID, "pt2 MovieID is redacted URL")
-	assert.Equal(t, 1, fileMatchInfo["/d/ABC-001-pt1.mp4"].PartNumber, "pt1 PartNumber preserved")
-	assert.Equal(t, 2, fileMatchInfo["/d/ABC-001-pt2.mp4"].PartNumber, "pt2 PartNumber preserved")
+	assert.Equal(t, 0, fileMatchInfo["/d/ABC-001-pt1.mp4"].PartNumber, "pt1 PartNumber reset (split)")
+	assert.Equal(t, 0, fileMatchInfo["/d/ABC-001-pt2.mp4"].PartNumber, "pt2 PartNumber reset (split)")
+}
+
+func TestResolveManualInputOverride_QueryBasedURLsSplitCorrectly(t *testing.T) {
+	// Two files in the same matcher group use manual URLs whose movie ID
+	// lives in the query string. Redaction would collapse them to the same
+	// URL, but they are distinct inputs and should split.
+	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+	manualInputs := map[string]string{
+		"/d/ABC-001-pt1.mp4": "https://www.javlibrary.com/vl_searchbyid.php?keyword=IPX-111",
+		"/d/ABC-001-pt2.mp4": "https://www.javlibrary.com/vl_searchbyid.php?keyword=IPX-222",
+	}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+	}
+	allFiles := submitted
+
+	resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	// Both redact to the same URL, but the raw inputs are distinct, so the
+	// group IS ambiguous and both files should lose multipart metadata.
+	assert.False(t, fileMatchInfo["/d/ABC-001-pt1.mp4"].IsMultiPart, "pt1 loses multipart (distinct raw URL from pt2)")
+	assert.False(t, fileMatchInfo["/d/ABC-001-pt2.mp4"].IsMultiPart, "pt2 loses multipart (distinct raw URL from pt1)")
 }
 
 func TestResolveManualInputOverride_DeterministicURLPropagation(t *testing.T) {
-	// Two submitted files in the same matcher group use manual URLs that
-	// redact to the same key but differ in query token. A discovered sibling
-	// should get a deterministic raw URL (lexicographically smallest).
+	// Two submitted files in the same matcher group share the same manual URL,
+	// so the group is non-ambiguous. A discovered sibling should deterministically
+	// receive that shared raw URL regardless of map iteration order.
 	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
 	manualInputs := map[string]string{
-		"/d/ABC-001-pt1.mp4": "https://example.com/video?token=zzzz",
+		"/d/ABC-001-pt1.mp4": "https://example.com/video?token=aaaa",
 		"/d/ABC-001-pt2.mp4": "https://example.com/video?token=aaaa",
 	}
 	fileMatchInfo := map[string]models.FileMatchInfo{
@@ -385,8 +409,8 @@ func TestResolveManualInputOverride_DeterministicURLPropagation(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		fmiCopy := copyFMI(fileMatchInfo)
 		result := resolveManualInputOverride(submitted, manualInputs, fmiCopy, allFiles)
-		// The sibling should always get the lexicographically smallest raw URL
+		// The sibling should always receive the shared raw URL
 		assert.Equal(t, "https://example.com/video?token=aaaa", result["/d/ABC-001-pt3.mp4"],
-			"sibling gets the lexicographically smallest raw URL (deterministic)")
+			"sibling gets the shared raw URL (deterministic)")
 	}
 }

--- a/internal/api/batch/manual_input_test.go
+++ b/internal/api/batch/manual_input_test.go
@@ -174,6 +174,35 @@ func TestResolveManualInputOverride_PreservesMultipartForPropagatedSibling(t *te
 	assert.Equal(t, 2, fileMatchInfo["/d/ABC-001-pt2.mp4"].PartNumber, "PartNumber preserved")
 }
 
+func TestResolveManualInputOverride_PreservesMultipartForSameIDSubsetInAmbiguousGroup(t *testing.T) {
+	// pt1 and pt2 both set to IPX-111; pt3 set to IPX-222.
+	// pt1/pt2 share the same input → keep multipart metadata.
+	// pt3 is unique → loses multipart metadata.
+	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4", "/d/ABC-001-pt3.mp4"}
+	manualInputs := map[string]string{
+		"/d/ABC-001-pt1.mp4": "IPX-111",
+		"/d/ABC-001-pt2.mp4": "IPX-111",
+		"/d/ABC-001-pt3.mp4": "IPX-222",
+	}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+		"/d/ABC-001-pt3.mp4": fmiFor("/d/ABC-001-pt3.mp4", "ABC-001", 3),
+	}
+	allFiles := submitted
+
+	resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	assert.True(t, fileMatchInfo["/d/ABC-001-pt1.mp4"].IsMultiPart, "pt1 keeps multipart (shares IPX-111 with pt2)")
+	assert.True(t, fileMatchInfo["/d/ABC-001-pt2.mp4"].IsMultiPart, "pt2 keeps multipart (shares IPX-111 with pt1)")
+	assert.False(t, fileMatchInfo["/d/ABC-001-pt3.mp4"].IsMultiPart, "pt3 loses multipart (unique IPX-222)")
+	assert.Equal(t, 1, fileMatchInfo["/d/ABC-001-pt1.mp4"].PartNumber, "pt1 PartNumber preserved")
+	assert.Equal(t, 2, fileMatchInfo["/d/ABC-001-pt2.mp4"].PartNumber, "pt2 PartNumber preserved")
+	assert.Equal(t, "IPX-111", fileMatchInfo["/d/ABC-001-pt1.mp4"].MovieID, "pt1 MovieID overridden")
+	assert.Equal(t, "IPX-111", fileMatchInfo["/d/ABC-001-pt2.mp4"].MovieID, "pt2 MovieID overridden")
+	assert.Equal(t, "IPX-222", fileMatchInfo["/d/ABC-001-pt3.mp4"].MovieID, "pt3 MovieID overridden")
+}
+
 func TestResolveManualInputOverride_RedactsURLInMovieID(t *testing.T) {
 	submitted := []string{"/d/video.mp4"}
 	rawURL := "https://example.com/video?token=secret"

--- a/internal/api/batch/manual_input_test.go
+++ b/internal/api/batch/manual_input_test.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func fmiFor(path, movieID string, part int) models.FileMatchInfo {
 	return models.FileMatchInfo{Path: path, Name: path, MovieID: movieID, IsMultiPart: true, PartNumber: part}
 }
 
-func TestResolveManualInputOverride_RejectsConflictingInputsForSameMovieID(t *testing.T) {
+func TestResolveManualInputOverride_AllowsConflictingInputsForSameMovieID(t *testing.T) {
 	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
 	manualInputs := map[string]string{
 		"/d/ABC-001-pt1.mp4": "IPX-111",
@@ -24,24 +23,27 @@ func TestResolveManualInputOverride_RejectsConflictingInputsForSameMovieID(t *te
 	}
 	allFiles := submitted
 
-	_, err := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
 
-	require.Error(t, err, "two submitted files sharing a matcher MovieID with conflicting inputs must be rejected (non-deterministic scrape)")
-	assert.Contains(t, err.Error(), "conflicting manual inputs")
+	assert.Equal(t, "IPX-111", result["/d/ABC-001-pt1.mp4"], "each submitted file keeps its own manual input")
+	assert.Equal(t, "IPX-222", result["/d/ABC-001-pt2.mp4"], "each submitted file keeps its own manual input")
+	assert.Equal(t, "IPX-111", fileMatchInfo["/d/ABC-001-pt1.mp4"].MovieID, "fileMatchInfo MovieID overridden with the manual input")
+	assert.Equal(t, "IPX-222", fileMatchInfo["/d/ABC-001-pt2.mp4"].MovieID, "fileMatchInfo MovieID overridden with the manual input")
+	assert.False(t, fileMatchInfo["/d/ABC-001-pt1.mp4"].IsMultiPart, "IsMultiPart cleared for split files")
+	assert.False(t, fileMatchInfo["/d/ABC-001-pt2.mp4"].IsMultiPart, "IsMultiPart cleared for split files")
 }
 
 func TestResolveManualInputOverride_DoesNotOverwriteCoSubmittedSibling(t *testing.T) {
 	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
-	manualInputs := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"} // only pt1 has an input
+	manualInputs := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"}
 	fileMatchInfo := map[string]models.FileMatchInfo{
 		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
 		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
 	}
-	allFiles := submitted // no discovered siblings
+	allFiles := submitted
 
-	result, err := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
 
-	require.NoError(t, err)
 	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt1.mp4"], "submitter keeps its own input")
 	_, has := result["/d/ABC-001-pt2.mp4"]
 	assert.False(t, has, "co-submitted pt2 does NOT inherit pt1's input — it stays auto-ID (its own row's choice)")
@@ -56,9 +58,8 @@ func TestResolveManualInputOverride_PropagatesToDiscoveredSibling(t *testing.T) 
 	}
 	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
 
-	result, err := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
 
-	require.NoError(t, err)
 	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt1.mp4"], "submitter keeps its own input")
 	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt2.mp4"], "discovered sibling inherits the submitter's input (same matcher MovieID)")
 }
@@ -72,11 +73,55 @@ func TestResolveManualInputOverride_MixedBatchManualAndAuto(t *testing.T) {
 	}
 	allFiles := submitted
 
-	result, err := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
 
-	require.NoError(t, err)
 	assert.Len(t, result, 1, "only the manually-input row gets an override; the auto row stays auto (no map entry)")
 	assert.Equal(t, "ABC-123", result["/a/SSIS-001.mp4"], "manual row scrapes as its explicit input")
 	_, hasAuto := result["/b/SSIS-002.mp4"]
 	assert.False(t, hasAuto, "auto row (no input, no matching sibling) is absent from the override map — buildScrapeCmd auto-IDs it from the matcher")
+}
+
+func TestResolveManualInputOverride_OverridesGroupingKey(t *testing.T) {
+	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+	manualInputs := map[string]string{
+		"/d/ABC-001-pt1.mp4": "IPX-111",
+		"/d/ABC-001-pt2.mp4": "IPX-222",
+	}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+	}
+	allFiles := submitted
+
+	resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	assert.Equal(t, "IPX-111", fileMatchInfo["/d/ABC-001-pt1.mp4"].MovieID, "MovieID replaced with manual input")
+	assert.Equal(t, "IPX-222", fileMatchInfo["/d/ABC-001-pt2.mp4"].MovieID, "MovieID replaced with manual input")
+	assert.False(t, fileMatchInfo["/d/ABC-001-pt1.mp4"].IsMultiPart, "IsMultiPart cleared")
+	assert.False(t, fileMatchInfo["/d/ABC-001-pt2.mp4"].IsMultiPart, "IsMultiPart cleared")
+	assert.Equal(t, 0, fileMatchInfo["/d/ABC-001-pt1.mp4"].PartNumber, "PartNumber reset")
+	assert.Equal(t, 0, fileMatchInfo["/d/ABC-001-pt2.mp4"].PartNumber, "PartNumber reset")
+	assert.Equal(t, "", fileMatchInfo["/d/ABC-001-pt1.mp4"].PartSuffix, "PartSuffix reset")
+	assert.Equal(t, "", fileMatchInfo["/d/ABC-001-pt2.mp4"].PartSuffix, "PartSuffix reset")
+}
+
+func TestResolveManualInputOverride_AmbiguousMovieSkipsPropagation(t *testing.T) {
+	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+	manualInputs := map[string]string{
+		"/d/ABC-001-pt1.mp4": "IPX-111",
+		"/d/ABC-001-pt2.mp4": "IPX-222",
+	}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+		"/d/ABC-001-pt3.mp4": fmiFor("/d/ABC-001-pt3.mp4", "ABC-001", 3),
+	}
+	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4", "/d/ABC-001-pt3.mp4"}
+
+	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	assert.Equal(t, "IPX-111", result["/d/ABC-001-pt1.mp4"], "submitted file keeps its own input")
+	assert.Equal(t, "IPX-222", result["/d/ABC-001-pt2.mp4"], "submitted file keeps its own input")
+	_, hasSibling := result["/d/ABC-001-pt3.mp4"]
+	assert.False(t, hasSibling, "discovered sibling for an ambiguous MovieID is NOT propagated")
 }

--- a/internal/api/batch/manual_input_test.go
+++ b/internal/api/batch/manual_input_test.go
@@ -364,3 +364,29 @@ func TestResolveManualInputOverride_NormalizesURLKeysForAmbiguity(t *testing.T) 
 	assert.Equal(t, 1, fileMatchInfo["/d/ABC-001-pt1.mp4"].PartNumber, "pt1 PartNumber preserved")
 	assert.Equal(t, 2, fileMatchInfo["/d/ABC-001-pt2.mp4"].PartNumber, "pt2 PartNumber preserved")
 }
+
+func TestResolveManualInputOverride_DeterministicURLPropagation(t *testing.T) {
+	// Two submitted files in the same matcher group use manual URLs that
+	// redact to the same key but differ in query token. A discovered sibling
+	// should get a deterministic raw URL (lexicographically smallest).
+	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+	manualInputs := map[string]string{
+		"/d/ABC-001-pt1.mp4": "https://example.com/video?token=zzzz",
+		"/d/ABC-001-pt2.mp4": "https://example.com/video?token=aaaa",
+	}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+		"/d/ABC-001-pt3.mp4": fmiFor("/d/ABC-001-pt3.mp4", "ABC-001", 3),
+	}
+	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4", "/d/ABC-001-pt3.mp4"}
+
+	// Run multiple times to verify determinism (map iteration order varies)
+	for i := 0; i < 50; i++ {
+		fmiCopy := copyFMI(fileMatchInfo)
+		result := resolveManualInputOverride(submitted, manualInputs, fmiCopy, allFiles)
+		// The sibling should always get the lexicographically smallest raw URL
+		assert.Equal(t, "https://example.com/video?token=aaaa", result["/d/ABC-001-pt3.mp4"],
+			"sibling gets the lexicographically smallest raw URL (deterministic)")
+	}
+}

--- a/internal/api/batch/manual_input_test.go
+++ b/internal/api/batch/manual_input_test.go
@@ -150,6 +150,30 @@ func TestResolveManualInputOverride_PreservesMultipartForSameManualID(t *testing
 	assert.Equal(t, 2, fileMatchInfo["/d/ABC-001-pt2.mp4"].PartNumber, "PartNumber preserved for genuine multi-part")
 }
 
+func TestResolveManualInputOverride_PreservesMultipartForPropagatedSibling(t *testing.T) {
+	// Matcher groups pt1+pt2 under ABC-001. User submits only pt1 with
+	// manual input IPX-999. Propagation gives pt2 the same input.
+	// Both parts should keep multipart metadata (not a split — same input).
+	submitted := []string{"/d/ABC-001-pt1.mp4"}
+	manualInputs := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+	}
+	allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+
+	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt1.mp4"], "submitter keeps its input")
+	assert.Equal(t, "IPX-999", result["/d/ABC-001-pt2.mp4"], "sibling inherits the propagated input")
+	assert.Equal(t, "IPX-999", fileMatchInfo["/d/ABC-001-pt1.mp4"].MovieID, "MovieID overridden")
+	assert.Equal(t, "IPX-999", fileMatchInfo["/d/ABC-001-pt2.mp4"].MovieID, "MovieID overridden")
+	assert.True(t, fileMatchInfo["/d/ABC-001-pt1.mp4"].IsMultiPart, "multipart preserved for non-ambiguous group")
+	assert.True(t, fileMatchInfo["/d/ABC-001-pt2.mp4"].IsMultiPart, "multipart preserved for propagated sibling")
+	assert.Equal(t, 1, fileMatchInfo["/d/ABC-001-pt1.mp4"].PartNumber, "PartNumber preserved")
+	assert.Equal(t, 2, fileMatchInfo["/d/ABC-001-pt2.mp4"].PartNumber, "PartNumber preserved")
+}
+
 func TestResolveManualInputOverride_RedactsURLInMovieID(t *testing.T) {
 	submitted := []string{"/d/video.mp4"}
 	rawURL := "https://example.com/video?token=secret"
@@ -167,8 +191,10 @@ func TestResolveManualInputOverride_RedactsURLInMovieID(t *testing.T) {
 	assert.NotContains(t, fileMatchInfo["/d/video.mp4"].MovieID, "token=secret", "MovieID grouping key has query token redacted")
 	assert.NotContains(t, fileMatchInfo["/d/video.mp4"].MovieID, "secret", "MovieID grouping key does not leak the token value")
 	assert.Equal(t, "https://example.com/video", fileMatchInfo["/d/video.mp4"].MovieID, "MovieID is the redacted URL (scheme+host+path only)")
-	// The matcher MovieID differs from the redacted manual input, so this is a split.
-	assert.False(t, fileMatchInfo["/d/video.mp4"].IsMultiPart, "IsMultiPart cleared for a split (manual ID differs from matcher ID)")
+	// Single file with a single manual input is NOT ambiguous, so multipart
+	// metadata is preserved even though the redacted manual ID differs from the
+	// matcher ID (a genuine single-part correction, not a split).
+	assert.True(t, fileMatchInfo["/d/video.mp4"].IsMultiPart, "IsMultiPart preserved for non-ambiguous single-file manual input")
 }
 
 func TestResolveManualInputOverride_CoversDefensiveGuards(t *testing.T) {

--- a/internal/api/batch/manual_input_test.go
+++ b/internal/api/batch/manual_input_test.go
@@ -337,3 +337,30 @@ func TestResolveManualInputOverride_CoversDefensiveGuards(t *testing.T) {
 		assert.True(t, fileMatchInfo["/d/ABC-001-pt1.mp4"].IsMultiPart, "multipart metadata preserved for whitespace-only input")
 	})
 }
+
+func TestResolveManualInputOverride_NormalizesURLKeysForAmbiguity(t *testing.T) {
+	// Two files in the same matcher group given the same URL except for
+	// query credentials. After redaction they collapse to the same input,
+	// so the group is NOT ambiguous — the sibling should be propagated
+	// and multipart metadata preserved.
+	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+	manualInputs := map[string]string{
+		"/d/ABC-001-pt1.mp4": "https://example.com/video?token=secret1",
+		"/d/ABC-001-pt2.mp4": "https://example.com/video?token=secret2",
+	}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+	}
+	allFiles := submitted
+
+	resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	// Both redact to the same URL, so the group is NOT ambiguous
+	assert.True(t, fileMatchInfo["/d/ABC-001-pt1.mp4"].IsMultiPart, "pt1 keeps multipart (same redacted URL as pt2)")
+	assert.True(t, fileMatchInfo["/d/ABC-001-pt2.mp4"].IsMultiPart, "pt2 keeps multipart (same redacted URL as pt1)")
+	assert.Equal(t, "https://example.com/video", fileMatchInfo["/d/ABC-001-pt1.mp4"].MovieID, "pt1 MovieID is redacted URL")
+	assert.Equal(t, "https://example.com/video", fileMatchInfo["/d/ABC-001-pt2.mp4"].MovieID, "pt2 MovieID is redacted URL")
+	assert.Equal(t, 1, fileMatchInfo["/d/ABC-001-pt1.mp4"].PartNumber, "pt1 PartNumber preserved")
+	assert.Equal(t, 2, fileMatchInfo["/d/ABC-001-pt2.mp4"].PartNumber, "pt2 PartNumber preserved")
+}

--- a/internal/api/batch/manual_input_test.go
+++ b/internal/api/batch/manual_input_test.go
@@ -125,3 +125,160 @@ func TestResolveManualInputOverride_AmbiguousMovieSkipsPropagation(t *testing.T)
 	_, hasSibling := result["/d/ABC-001-pt3.mp4"]
 	assert.False(t, hasSibling, "discovered sibling for an ambiguous MovieID is NOT propagated")
 }
+
+func TestResolveManualInputOverride_PreservesMultipartForSameManualID(t *testing.T) {
+	submitted := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+	manualInputs := map[string]string{
+		"/d/ABC-001-pt1.mp4": "ABC-001",
+		"/d/ABC-001-pt2.mp4": "ABC-001",
+	}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+	}
+	allFiles := submitted
+
+	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	assert.Equal(t, "ABC-001", result["/d/ABC-001-pt1.mp4"], "manual input preserved in result map")
+	assert.Equal(t, "ABC-001", result["/d/ABC-001-pt2.mp4"], "manual input preserved in result map")
+	assert.Equal(t, "ABC-001", fileMatchInfo["/d/ABC-001-pt1.mp4"].MovieID, "MovieID matches the manual input")
+	assert.Equal(t, "ABC-001", fileMatchInfo["/d/ABC-001-pt2.mp4"].MovieID, "MovieID matches the manual input")
+	assert.True(t, fileMatchInfo["/d/ABC-001-pt1.mp4"].IsMultiPart, "IsMultiPart preserved when manual ID matches matcher ID")
+	assert.True(t, fileMatchInfo["/d/ABC-001-pt2.mp4"].IsMultiPart, "IsMultiPart preserved when manual ID matches matcher ID")
+	assert.Equal(t, 1, fileMatchInfo["/d/ABC-001-pt1.mp4"].PartNumber, "PartNumber preserved for genuine multi-part")
+	assert.Equal(t, 2, fileMatchInfo["/d/ABC-001-pt2.mp4"].PartNumber, "PartNumber preserved for genuine multi-part")
+}
+
+func TestResolveManualInputOverride_RedactsURLInMovieID(t *testing.T) {
+	submitted := []string{"/d/video.mp4"}
+	rawURL := "https://example.com/video?token=secret"
+	manualInputs := map[string]string{
+		"/d/video.mp4": rawURL,
+	}
+	fileMatchInfo := map[string]models.FileMatchInfo{
+		"/d/video.mp4": fmiFor("/d/video.mp4", "matcher-id", 1),
+	}
+	allFiles := submitted
+
+	result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+	assert.Equal(t, rawURL, result["/d/video.mp4"], "RawInputOverride (result map) keeps the raw URL for the scraper")
+	assert.NotContains(t, fileMatchInfo["/d/video.mp4"].MovieID, "token=secret", "MovieID grouping key has query token redacted")
+	assert.NotContains(t, fileMatchInfo["/d/video.mp4"].MovieID, "secret", "MovieID grouping key does not leak the token value")
+	assert.Equal(t, "https://example.com/video", fileMatchInfo["/d/video.mp4"].MovieID, "MovieID is the redacted URL (scheme+host+path only)")
+	// The matcher MovieID differs from the redacted manual input, so this is a split.
+	assert.False(t, fileMatchInfo["/d/video.mp4"].IsMultiPart, "IsMultiPart cleared for a split (manual ID differs from matcher ID)")
+}
+
+func TestResolveManualInputOverride_CoversDefensiveGuards(t *testing.T) {
+	// Cover the defensive guard branches in resolveManualInputOverride.
+	// Each sub-test targets a specific continue branch.
+
+	t.Run("manual input for non-submitted file is skipped", func(t *testing.T) {
+		// A manual input whose path is NOT in submittedFiles should be
+		// skipped in the movieInput loop (line 47: !submitted[path]).
+		submitted := []string{"/d/ABC-001-pt1.mp4"}
+		manualInputs := map[string]string{
+			"/d/ABC-001-pt1.mp4": "IPX-999",
+			"/d/unsubmitted.mp4": "IPX-888",
+		}
+		fileMatchInfo := map[string]models.FileMatchInfo{
+			"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+			"/d/unsubmitted.mp4": fmiFor("/d/unsubmitted.mp4", "ABC-001", 2),
+		}
+		allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/unsubmitted.mp4"}
+
+		result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+		assert.Equal(t, "IPX-999", result["/d/ABC-001-pt1.mp4"])
+		// The unsubmitted file's input (IPX-888) was seeded into result and is
+		// NOT overwritten by propagation (it already has an entry).
+		assert.Equal(t, "IPX-888", result["/d/unsubmitted.mp4"], "unsubmitted file keeps its own explicit input, not overwritten by propagation")
+	})
+
+	t.Run("submitted file with no fileMatchInfo entry is skipped", func(t *testing.T) {
+		// A submitted file with a manual input but no fileMatchInfo entry
+		// hits the !ok branch (line 51: !ok || fmi.MovieID == "").
+		submitted := []string{"/d/missing.mp4"}
+		manualInputs := map[string]string{"/d/missing.mp4": "IPX-999"}
+		fileMatchInfo := map[string]models.FileMatchInfo{} // no entry for missing.mp4
+		allFiles := submitted
+
+		result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+		assert.Equal(t, "IPX-999", result["/d/missing.mp4"], "input still seeded into result even without fileMatchInfo")
+		// fileMatchInfo should now have the override applied (the override loop
+		// adds an entry since the input is non-empty, but !ok skips it — verify
+		// no entry was created)
+		_, hasFMI := fileMatchInfo["/d/missing.mp4"]
+		assert.False(t, hasFMI, "no fileMatchInfo entry created when original was absent")
+	})
+
+	t.Run("submitted file with empty MovieID in fileMatchInfo is skipped", func(t *testing.T) {
+		// A submitted file whose fileMatchInfo has an empty MovieID
+		// hits the fmi.MovieID == "" branch (line 51).
+		submitted := []string{"/d/empty-id.mp4"}
+		manualInputs := map[string]string{"/d/empty-id.mp4": "IPX-999"}
+		fileMatchInfo := map[string]models.FileMatchInfo{
+			"/d/empty-id.mp4": {Path: "/d/empty-id.mp4", Name: "empty-id.mp4", MovieID: ""},
+		}
+		allFiles := submitted
+
+		result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+		assert.Equal(t, "IPX-999", result["/d/empty-id.mp4"])
+	})
+
+	t.Run("discovered sibling already in result is skipped", func(t *testing.T) {
+		// A discovered sibling that already has a result entry hits the
+		// `has` branch (line 73: _, has := result[path]).
+		submitted := []string{"/d/ABC-001-pt1.mp4"}
+		manualInputs := map[string]string{
+			"/d/ABC-001-pt1.mp4": "IPX-999",
+			"/d/ABC-001-pt2.mp4": "IPX-888", // pt2 is a discovered sibling but also has an explicit input
+		}
+		fileMatchInfo := map[string]models.FileMatchInfo{
+			"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+			"/d/ABC-001-pt2.mp4": fmiFor("/d/ABC-001-pt2.mp4", "ABC-001", 2),
+		}
+		allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+
+		result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+		assert.Equal(t, "IPX-888", result["/d/ABC-001-pt2.mp4"], "explicit input preserved, not overwritten by propagation")
+	})
+
+	t.Run("discovered sibling with no fileMatchInfo is skipped", func(t *testing.T) {
+		// A discovered sibling that has no fileMatchInfo entry hits the
+		// !ok branch (line 77: !ok || fmi.MovieID == "").
+		submitted := []string{"/d/ABC-001-pt1.mp4"}
+		manualInputs := map[string]string{"/d/ABC-001-pt1.mp4": "IPX-999"}
+		fileMatchInfo := map[string]models.FileMatchInfo{
+			"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+			// pt2 has no fileMatchInfo entry
+		}
+		allFiles := []string{"/d/ABC-001-pt1.mp4", "/d/ABC-001-pt2.mp4"}
+
+		result := resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+		_, hasSibling := result["/d/ABC-001-pt2.mp4"]
+		assert.False(t, hasSibling, "sibling with no fileMatchInfo is not propagated")
+	})
+
+	t.Run("manual input with whitespace-only string is skipped", func(t *testing.T) {
+		// A manual input that is all whitespace hits the trimmed == ""
+		// branch (line 94).
+		submitted := []string{"/d/ABC-001-pt1.mp4"}
+		manualInputs := map[string]string{"/d/ABC-001-pt1.mp4": "   "}
+		fileMatchInfo := map[string]models.FileMatchInfo{
+			"/d/ABC-001-pt1.mp4": fmiFor("/d/ABC-001-pt1.mp4", "ABC-001", 1),
+		}
+		allFiles := submitted
+
+		resolveManualInputOverride(submitted, manualInputs, fileMatchInfo, allFiles)
+
+		assert.Equal(t, "ABC-001", fileMatchInfo["/d/ABC-001-pt1.mp4"].MovieID, "whitespace-only input does not override MovieID")
+		assert.True(t, fileMatchInfo["/d/ABC-001-pt1.mp4"].IsMultiPart, "multipart metadata preserved for whitespace-only input")
+	})
+}

--- a/internal/api/batch/usecases.go
+++ b/internal/api/batch/usecases.go
@@ -163,12 +163,10 @@ func StartScrapeUseCase(
 	}
 
 	// Resolve manual inputs: propagate each submitter's input to discovered
-	// siblings sharing the matcher MovieID, and reject conflicting inputs across
-	// co-parts of the same movie (handler maps the error to 400).
-	propagatedManualInputs, err := resolveManualInputOverride(input.Files, input.ManualInputs, fileMatchInfoMap, allFiles)
-	if err != nil {
-		return nil, err
-	}
+	// siblings sharing the matcher MovieID. Files with explicit manual inputs
+	// override the matcher-derived grouping key so they split into separate
+	// movies in the UI queue.
+	propagatedManualInputs := resolveManualInputOverride(input.Files, input.ManualInputs, fileMatchInfoMap, allFiles)
 
 	resolved, err := workflow.ResolveSeamStrings(workflow.SeamStringsInput{
 		OperationMode:  input.OperationMode,

--- a/internal/api/batch/usecases.go
+++ b/internal/api/batch/usecases.go
@@ -166,7 +166,9 @@ func StartScrapeUseCase(
 	// siblings sharing the matcher MovieID. Files with explicit manual inputs
 	// override the matcher-derived grouping key so they split into separate
 	// movies in the UI queue.
-	propagatedManualInputs := resolveManualInputOverride(input.Files, input.ManualInputs, fileMatchInfoMap, allFiles)
+	resolvedManualInput := resolveManualInputOverride(input.Files, input.ManualInputs, fileMatchInfoMap, allFiles)
+	propagatedManualInputs := resolvedManualInput.overrides
+	allFiles = resolvedManualInput.allFiles
 
 	resolved, err := workflow.ResolveSeamStrings(workflow.SeamStringsInput{
 		OperationMode:  input.OperationMode,


### PR DESCRIPTION
fix(batch): manual_inputs overrides multi-part grouping key

## Problem

`batch/scrape` API forces independent files into a single multi-part movie regardless of `manual_inputs`. When a user provides different manual IDs for different files, the matcher-derived grouping key overrides the manual input, so the UI shows them as one movie.

Closes #142

## Root cause

`manual_inputs` only overrode the **scrape query** (`cmd.MovieID` via `RawInputOverride`), never the **grouping key** (`FileMatchInfo.MovieID`). The UI groups `FileResult`s by `result.movie_id` which comes from the matcher. Additionally, `resolveManualInputOverride` rejected with 400 when different manual inputs were given for files the matcher grouped together (the "F2" rule), blocking the split use case.

## Fix (2 layers)

### Layer 1: Override the grouping key
`resolveManualInputOverride` now overrides `fileMatchInfo` entries with the manual input ID, clearing `IsMultiPart`/`PartNumber`/`PartSuffix`. Files with different manual inputs naturally split into separate movies in the UI queue; files with the same manual input stay grouped (correct for genuine multi-part).

### Layer 2: Relax the F2 rule
Instead of rejecting (400) conflicting manual inputs for the same matcher MovieID, the MovieID is marked "ambiguous" and sibling propagation is skipped for it. Unambiguous MovieIDs (one input) still propagate to discovered siblings as before.

## Tests
- Updated `TestResolveManualInputOverride_AllowsConflictingInputsForSameMovieID` — was `Rejects...`, now verifies the split succeeds and `fileMatchInfo` is overridden
- Added `TestResolveManualInputOverride_OverridesGroupingKey` — verifies MovieID/IsMultiPart/PartNumber/PartSuffix are overridden
- Added `TestResolveManualInputOverride_AmbiguousMovieSkipsPropagation` — verifies siblings are not propagated for ambiguous MovieIDs
- Updated race tests to give each goroutine its own `fileMatchInfo` copy since Layer 1 mutates it

## Out of scope
The HHD800 matcher regex false-positive (extracting `HHD800` from `hhd800.com@MIDA-660.mp4`) is a separate issue for a different PR.
