### PR TITLE
fix(timeout): enforce configurable timeouts and guard against hard-coded literals

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,3 +23,4 @@ commits to main — GitHub only auto-closes on the keywords.
 - [ ] `make lint` passes (golangci-lint)
 - [ ] Commit messages follow `type(scope): summary` (≤72 chars)
 - [ ] Linked the issue with `Closes #NN` (if a related issue exists)
+- [ ] If adding a `*_timeout_seconds` or `*_timeout` config field, confirmed it is read by a runtime code path outside the config package (the grep lint guard only catches hard-coded timeout literals, not unread config fields)

--- a/Makefile
+++ b/Makefile
@@ -221,8 +221,13 @@ check-import-guard:
 i18n-check:
 	@bash scripts/i18n-check.sh
 
+# Check for hard-coded http.Client{Timeout: ...} literals outside the allowlist.
+# Prevents the #152 bug class (config timeout shadowed by a hard-coded literal).
+check-no-hardcoded-timeouts:
+	@./scripts/check_no_hardcoded_timeouts.sh
+
 # Run full CI test suite
-ci: vet lint vuln coverage-check test-race config-drift check-import-guard check-mocks i18n-check
+ci: vet lint vuln coverage-check test-race config-drift check-import-guard check-mocks i18n-check check-no-hardcoded-timeouts
 	@echo "All CI checks passed!"
 
 # Run full CI suite including frontend tests

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/panicutil"
 	"github.com/javinizer/javinizer-go/internal/scrape"
 	"github.com/javinizer/javinizer-go/internal/scraperutil"
+	"github.com/javinizer/javinizer-go/internal/timeout"
 	"github.com/javinizer/javinizer-go/internal/workflow"
 	"github.com/spf13/cobra"
 )
@@ -161,7 +162,14 @@ func Run(ctx context.Context, cmd *cobra.Command, args []string, configFile stri
 	forceRefresh, _ := cmd.Flags().GetBool("force")
 	scrapersFlag, _ := cmd.Flags().GetStringSlice("scrapers")
 
-	result, _, err := wf.Scrape(ctx, scrape.ScrapeCmd{
+	scrapeCtx := ctx
+	if cfg.Scrapers.RequestTimeoutSeconds > 0 {
+		resolved := timeout.FromConfig("scrapers.request_timeout_seconds", cfg.Scrapers.RequestTimeoutSeconds, 0)
+		var cancel context.CancelFunc
+		scrapeCtx, cancel = context.WithTimeout(ctx, resolved.Duration)
+		defer cancel()
+	}
+	result, _, err := wf.Scrape(scrapeCtx, scrape.ScrapeCmd{
 		MovieID:          id,
 		ForceRefresh:     forceRefresh,
 		SelectedScrapers: scrapersFlag,

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -174,6 +174,9 @@ func Run(ctx context.Context, cmd *cobra.Command, args []string, configFile stri
 		ForceRefresh:     forceRefresh,
 		SelectedScrapers: scrapersFlag,
 	})
+	if scrapeCtx.Err() != nil {
+		return nil, nil, fmt.Errorf("scrape timed out")
+	}
 	if err != nil {
 		if result != nil && result.Movie != nil {
 			return result.Movie, result.ScraperResults, err

--- a/cmd/javinizer/commands/tui/command.go
+++ b/cmd/javinizer/commands/tui/command.go
@@ -221,6 +221,7 @@ func run(cmd *cobra.Command, args []string) error {
 			worker.BatchJobConfig{
 				MaxWorkers:      processorCfg.MaxWorkers,
 				WorkerTimeout:   processorCfg.WorkerTimeout,
+				RequestTimeout:  processorCfg.RequestTimeout,
 				ScraperPriority: processorCfg.ScraperPriority,
 				NFOEnabled:      processorCfg.NFOEnabled,
 			},

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -1265,8 +1265,8 @@ api:
 scrapers:
   user_agent: ""  # Default: Chrome-like UA. r18dev uses the Javinizer UA automatically.
   referer: "https://www.dmm.co.jp/"
-  timeout_seconds: 30
-  request_timeout_seconds: 60
+  timeout_seconds: 30          # per-HTTP-request timeout (1–300, default 30)
+  request_timeout_seconds: 60  # overall scrape operation timeout (1–600, default 60); wraps each scraper Search()/Scrape() call as a nested context within performance.worker_timeout
   priority:
     - r18dev
     - libredmm

--- a/internal/api/core/config_narrowing.go
+++ b/internal/api/core/config_narrowing.go
@@ -49,8 +49,9 @@ type APIConfig struct {
 	AllowRevert   bool   // cfg.Output.Operation.AllowRevert
 
 	// Performance
-	MaxWorkers    int           // cfg.Performance.MaxWorkers
-	WorkerTimeout time.Duration // cfg.Performance.WorkerTimeout converted to time.Duration
+	MaxWorkers     int           // cfg.Performance.MaxWorkers
+	WorkerTimeout  time.Duration // cfg.Performance.WorkerTimeout converted to time.Duration
+	RequestTimeout time.Duration // cfg.Scrapers.RequestTimeoutSeconds converted to time.Duration
 
 	// Matching
 	RegexEnabled bool   // cfg.Matching.RegexEnabled
@@ -86,6 +87,7 @@ type BatchNarrowConfig struct {
 	OperationMode      string        // resolved operation mode for batch execution
 	MaxWorkers         int           // worker pool concurrency
 	WorkerTimeout      time.Duration // worker execution timeout
+	RequestTimeout     time.Duration // overall scrape operation timeout
 	ScraperPriority    []string      // scraper source ordering
 	NFOEnabled         bool          // whether NFO generation is active
 	ScraperUserAgent   string        // user-agent for poster downloads
@@ -138,6 +140,7 @@ func (c APIConfig) BatchConfig() *BatchNarrowConfig {
 		OperationMode:      c.OperationMode,
 		MaxWorkers:         c.MaxWorkers,
 		WorkerTimeout:      c.WorkerTimeout,
+		RequestTimeout:     c.RequestTimeout,
 		ScraperPriority:    c.ScraperPriority,
 		NFOEnabled:         c.NFOEnabled,
 		ScraperUserAgent:   c.ScraperUserAgent,
@@ -196,6 +199,7 @@ func (c APIConfig) MatcherConfig() *MatcherNarrowConfig {
 // cfg.Output.MediaFormat.MaxPosterHeight,
 // cfg.Output.Download, cfg.Output.Download.DownloadProxy,
 // cfg.Performance.MaxWorkers, cfg.Performance.WorkerTimeout,
+// cfg.Scrapers.RequestTimeoutSeconds,
 // cfg.Matching.RegexEnabled, cfg.Matching.RegexPattern,
 // cfg.System.TempDir, cfg.System.VersionCheckEnabled,
 // cfg.Logging.Level, cfg.Database.DSN, cfg.Database.LogLevel
@@ -232,6 +236,7 @@ func ConfigFromAppConfig(cfg *config.Config) APIConfig {
 		AllowRevert:         cfg.Output.Operation.AllowRevert,
 		MaxWorkers:          cfg.Performance.MaxWorkers,
 		WorkerTimeout:       time.Duration(cfg.Performance.WorkerTimeout) * time.Second,
+		RequestTimeout:      time.Duration(cfg.Scrapers.RequestTimeoutSeconds) * time.Second,
 		RegexEnabled:        cfg.Matching.RegexEnabled,
 		RegexPattern:        cfg.Matching.RegexPattern,
 		TempDir:             cfg.System.TempDir,

--- a/internal/api/core/runtime_manager.go
+++ b/internal/api/core/runtime_manager.go
@@ -403,13 +403,7 @@ func (s *RuntimeSnapshot) BatchJobFactory() worker.BatchJobFactoryInterface {
 		return nil
 	}
 	matcherIface := s.Matcher()
-	workerBatchCfg := worker.BatchJobConfig{
-		MaxWorkers:      batchCfg.MaxWorkers,
-		WorkerTimeout:   batchCfg.WorkerTimeout,
-		RequestTimeout:  batchCfg.RequestTimeout,
-		ScraperPriority: batchCfg.ScraperPriority,
-		NFOEnabled:      batchCfg.NFOEnabled,
-	}
+	workerBatchCfg := worker.BatchJobConfig{MaxWorkers: batchCfg.MaxWorkers, WorkerTimeout: batchCfg.WorkerTimeout, RequestTimeout: batchCfg.RequestTimeout, ScraperPriority: batchCfg.ScraperPriority, NFOEnabled: batchCfg.NFOEnabled}
 	return worker.NewBatchJobFactory(
 		r.deps.JobStore,
 		nil, // WF is per-job (BatchWorkflow), not shared across all jobs
@@ -543,13 +537,7 @@ func (r *APIRuntime) buildBatchJobFactory() any {
 	}
 
 	matcher := r.NewMatcher()
-	workerBatchCfg := worker.BatchJobConfig{
-		MaxWorkers:      batchCfg.MaxWorkers,
-		WorkerTimeout:   batchCfg.WorkerTimeout,
-		RequestTimeout:  batchCfg.RequestTimeout,
-		ScraperPriority: batchCfg.ScraperPriority,
-		NFOEnabled:      batchCfg.NFOEnabled,
-	}
+	workerBatchCfg := worker.BatchJobConfig{MaxWorkers: batchCfg.MaxWorkers, WorkerTimeout: batchCfg.WorkerTimeout, RequestTimeout: batchCfg.RequestTimeout, ScraperPriority: batchCfg.ScraperPriority, NFOEnabled: batchCfg.NFOEnabled}
 
 	// Re-hydrate reconstructed jobs with infrastructure deps (matcher, posterGen,
 	// batchCfg) that were not available at JobStore construction time. This

--- a/internal/api/core/runtime_manager.go
+++ b/internal/api/core/runtime_manager.go
@@ -406,6 +406,7 @@ func (s *RuntimeSnapshot) BatchJobFactory() worker.BatchJobFactoryInterface {
 	workerBatchCfg := worker.BatchJobConfig{
 		MaxWorkers:      batchCfg.MaxWorkers,
 		WorkerTimeout:   batchCfg.WorkerTimeout,
+		RequestTimeout:  batchCfg.RequestTimeout,
 		ScraperPriority: batchCfg.ScraperPriority,
 		NFOEnabled:      batchCfg.NFOEnabled,
 	}
@@ -545,6 +546,7 @@ func (r *APIRuntime) buildBatchJobFactory() any {
 	workerBatchCfg := worker.BatchJobConfig{
 		MaxWorkers:      batchCfg.MaxWorkers,
 		WorkerTimeout:   batchCfg.WorkerTimeout,
+		RequestTimeout:  batchCfg.RequestTimeout,
 		ScraperPriority: batchCfg.ScraperPriority,
 		NFOEnabled:      batchCfg.NFOEnabled,
 	}

--- a/internal/api/movie/compare_handler.go
+++ b/internal/api/movie/compare_handler.go
@@ -1,6 +1,7 @@
 package movie
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -84,7 +85,13 @@ func compareNFO(deps MovieDeps) gin.HandlerFunc {
 			return
 		}
 
-		result, err := wf.Compare(c.Request.Context(), workflow.CompareCmd{
+		compareCtx := c.Request.Context()
+		if deps.RequestTimeout > 0 {
+			var cancel context.CancelFunc
+			compareCtx, cancel = context.WithTimeout(compareCtx, deps.RequestTimeout)
+			defer cancel()
+		}
+		result, err := wf.Compare(compareCtx, workflow.CompareCmd{
 			MovieID:          movieID,
 			NFOPath:          validatedPath,
 			ScalarStrategy:   resolved.ScalarStrategy,

--- a/internal/api/movie/compare_handler.go
+++ b/internal/api/movie/compare_handler.go
@@ -100,6 +100,10 @@ func compareNFO(deps MovieDeps) gin.HandlerFunc {
 			ArrayStrategy:    resolved.ArrayStrategy,
 			SelectedScrapers: req.SelectedScrapers,
 		})
+		if compareCtx.Err() != nil {
+			c.JSON(http.StatusGatewayTimeout, contracts.ErrorResponse{Error: "compare timed out"})
+			return
+		}
 		if err != nil {
 			// Map typed seam errors to appropriate HTTP status codes.
 			// Per GL2-3: use errors.Is() instead of strings.Contains()

--- a/internal/api/movie/compare_handler.go
+++ b/internal/api/movie/compare_handler.go
@@ -86,10 +86,12 @@ func compareNFO(deps MovieDeps) gin.HandlerFunc {
 		}
 
 		compareCtx := c.Request.Context()
-		if deps.RequestTimeout > 0 {
-			var cancel context.CancelFunc
-			compareCtx, cancel = context.WithTimeout(compareCtx, deps.RequestTimeout)
-			defer cancel()
+		if deps.RequestTimeoutFn != nil {
+			if rt := deps.RequestTimeoutFn(); rt > 0 {
+				var cancel context.CancelFunc
+				compareCtx, cancel = context.WithTimeout(compareCtx, rt)
+				defer cancel()
+			}
 		}
 		result, err := wf.Compare(compareCtx, workflow.CompareCmd{
 			MovieID:          movieID,

--- a/internal/api/movie/rescrape.go
+++ b/internal/api/movie/rescrape.go
@@ -55,10 +55,12 @@ func rescrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			return
 		}
 		scrapeCtx := c.Request.Context()
-		if deps.RequestTimeout > 0 {
-			var cancel context.CancelFunc
-			scrapeCtx, cancel = context.WithTimeout(scrapeCtx, deps.RequestTimeout)
-			defer cancel()
+		if deps.RequestTimeoutFn != nil {
+			if rt := deps.RequestTimeoutFn(); rt > 0 {
+				var cancel context.CancelFunc
+				scrapeCtx, cancel = context.WithTimeout(scrapeCtx, rt)
+				defer cancel()
+			}
 		}
 		result, _, err := wf.Scrape(scrapeCtx, cmd)
 		if err != nil {

--- a/internal/api/movie/rescrape.go
+++ b/internal/api/movie/rescrape.go
@@ -63,13 +63,12 @@ func rescrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			}
 		}
 		result, _, err := wf.Scrape(scrapeCtx, cmd)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: err.Error()})
-			return
-		}
-
 		if scrapeCtx.Err() != nil {
 			c.JSON(http.StatusGatewayTimeout, contracts.ErrorResponse{Error: "scrape timed out"})
+			return
+		}
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: err.Error()})
 			return
 		}
 

--- a/internal/api/movie/rescrape.go
+++ b/internal/api/movie/rescrape.go
@@ -1,6 +1,7 @@
 package movie
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -53,7 +54,13 @@ func rescrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: "workflow not available"})
 			return
 		}
-		result, _, err := wf.Scrape(c.Request.Context(), cmd)
+		scrapeCtx := c.Request.Context()
+		if deps.RequestTimeout > 0 {
+			var cancel context.CancelFunc
+			scrapeCtx, cancel = context.WithTimeout(scrapeCtx, deps.RequestTimeout)
+			defer cancel()
+		}
+		result, _, err := wf.Scrape(scrapeCtx, cmd)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: err.Error()})
 			return

--- a/internal/api/movie/rescrape.go
+++ b/internal/api/movie/rescrape.go
@@ -68,6 +68,11 @@ func rescrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			return
 		}
 
+		if scrapeCtx.Err() != nil {
+			c.JSON(http.StatusGatewayTimeout, contracts.ErrorResponse{Error: "scrape timed out"})
+			return
+		}
+
 		if result.Status == scrape.StatusFailed {
 			errMsg := "No results from selected scrapers"
 			if result.Message != "" {

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -1,6 +1,7 @@
 package movie
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -62,7 +63,13 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: "workflow not available"})
 			return
 		}
-		result, _, err := wf.Scrape(c.Request.Context(), cmd)
+		scrapeCtx := c.Request.Context()
+		if deps.RequestTimeout > 0 {
+			var cancel context.CancelFunc
+			scrapeCtx, cancel = context.WithTimeout(scrapeCtx, deps.RequestTimeout)
+			defer cancel()
+		}
+		result, _, err := wf.Scrape(scrapeCtx, cmd)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: err.Error()})
 			return

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -72,13 +72,12 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			}
 		}
 		result, _, err := wf.Scrape(scrapeCtx, cmd)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: err.Error()})
-			return
-		}
-
 		if scrapeCtx.Err() != nil {
 			c.JSON(http.StatusGatewayTimeout, contracts.ErrorResponse{Error: "scrape timed out"})
+			return
+		}
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: err.Error()})
 			return
 		}
 

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -64,10 +64,12 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			return
 		}
 		scrapeCtx := c.Request.Context()
-		if deps.RequestTimeout > 0 {
-			var cancel context.CancelFunc
-			scrapeCtx, cancel = context.WithTimeout(scrapeCtx, deps.RequestTimeout)
-			defer cancel()
+		if deps.RequestTimeoutFn != nil {
+			if rt := deps.RequestTimeoutFn(); rt > 0 {
+				var cancel context.CancelFunc
+				scrapeCtx, cancel = context.WithTimeout(scrapeCtx, rt)
+				defer cancel()
+			}
 		}
 		result, _, err := wf.Scrape(scrapeCtx, cmd)
 		if err != nil {

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -77,6 +77,11 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			return
 		}
 
+		if scrapeCtx.Err() != nil {
+			c.JSON(http.StatusGatewayTimeout, contracts.ErrorResponse{Error: "scrape timed out"})
+			return
+		}
+
 		if result.Status == scrape.StatusFailed {
 			errMsg := "Movie not found"
 			if result.Message != "" {

--- a/internal/api/movie/service.go
+++ b/internal/api/movie/service.go
@@ -19,11 +19,11 @@ type WorkflowFunc func() workflow.WorkflowInterface
 // Replaces the removed MovieService — handlers take this directly,
 // matching the ActressDeps pattern used in the actress package.
 type MovieDeps struct {
-	MovieRepo      database.MovieRepositoryInterface
-	WorkflowFn     WorkflowFunc
-	PosterGen      poster.PosterGenerator
-	AllowedDirs    []string
-	RequestTimeout time.Duration
+	MovieRepo        database.MovieRepositoryInterface
+	WorkflowFn       WorkflowFunc
+	PosterGen        poster.PosterGenerator
+	AllowedDirs      []string
+	RequestTimeoutFn func() time.Duration
 }
 
 // NewMovieDeps creates a MovieDeps from the given repository and options.
@@ -53,9 +53,10 @@ func WithPosterGen(pg poster.PosterGenerator) MovieDepsOption {
 	return func(d *MovieDeps) { d.PosterGen = pg }
 }
 
-// WithRequestTimeout sets the overall scrape operation timeout.
-func WithRequestTimeout(dur time.Duration) MovieDepsOption {
-	return func(d *MovieDeps) { d.RequestTimeout = dur }
+// WithRequestTimeoutFn sets a getter that returns the live request timeout,
+// so config reloads are reflected without re-registering routes.
+func WithRequestTimeoutFn(fn func() time.Duration) MovieDepsOption {
+	return func(d *MovieDeps) { d.RequestTimeoutFn = fn }
 }
 
 // getWorkflow returns a workflow instance or nil if unavailable.

--- a/internal/api/movie/service.go
+++ b/internal/api/movie/service.go
@@ -2,6 +2,7 @@ package movie
 
 import (
 	"context"
+	"time"
 
 	"github.com/javinizer/javinizer-go/internal/database"
 	"github.com/javinizer/javinizer-go/internal/models"
@@ -18,10 +19,11 @@ type WorkflowFunc func() workflow.WorkflowInterface
 // Replaces the removed MovieService — handlers take this directly,
 // matching the ActressDeps pattern used in the actress package.
 type MovieDeps struct {
-	MovieRepo   database.MovieRepositoryInterface
-	WorkflowFn  WorkflowFunc
-	PosterGen   poster.PosterGenerator
-	AllowedDirs []string
+	MovieRepo      database.MovieRepositoryInterface
+	WorkflowFn     WorkflowFunc
+	PosterGen      poster.PosterGenerator
+	AllowedDirs    []string
+	RequestTimeout time.Duration
 }
 
 // NewMovieDeps creates a MovieDeps from the given repository and options.
@@ -49,6 +51,11 @@ func WithAllowedDirs(dirs []string) MovieDepsOption {
 // WithPosterGen sets the poster generator for temp poster creation during scrape/rescrape.
 func WithPosterGen(pg poster.PosterGenerator) MovieDepsOption {
 	return func(d *MovieDeps) { d.PosterGen = pg }
+}
+
+// WithRequestTimeout sets the overall scrape operation timeout.
+func WithRequestTimeout(dur time.Duration) MovieDepsOption {
+	return func(d *MovieDeps) { d.RequestTimeout = dur }
 }
 
 // getWorkflow returns a workflow instance or nil if unavailable.

--- a/internal/api/movie/timeout_coverage_test.go
+++ b/internal/api/movie/timeout_coverage_test.go
@@ -49,6 +49,10 @@ func (w *deadlineCapturingWorkflow) Compare(ctx context.Context, cmd workflow.Co
 	dl, ok := ctx.Deadline()
 	w.gotDeadline = ok
 	w.deadline = dl
+	if w.blockUntilCancel {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
 	return &workflow.CompareResult{}, nil
 }
 
@@ -199,6 +203,35 @@ func TestRescrapeMovie_RequestTimeoutExpired(t *testing.T) {
 
 	body := `{"selected_scrapers":["r18dev"],"force":false}`
 	req := httptest.NewRequest(http.MethodPost, "/movies/TEST-001/rescrape", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusGatewayTimeout, w.Code)
+}
+
+func TestCompareNFO_RequestTimeoutExpired(t *testing.T) {
+	tmpDir := t.TempDir()
+	nfoPath := filepath.Join(tmpDir, "test.nfo")
+	err := os.WriteFile(nfoPath, []byte("<movie></movie>"), 0644)
+	require.NoError(t, err)
+
+	wf := &deadlineCapturingWorkflow{blockUntilCancel: true}
+	deps := MovieDeps{
+		WorkflowFn:       func() workflow.WorkflowInterface { return wf },
+		RequestTimeoutFn: func() time.Duration { return 50 * time.Millisecond },
+		AllowedDirs:      []string{tmpDir},
+	}
+
+	router := gin.New()
+	router.POST("/movies/:id/compare-nfo", compareNFO(deps))
+
+	bodyBytes, err := json.Marshal(map[string]interface{}{
+		"nfo_path":          nfoPath,
+		"selected_scrapers": []string{"r18dev"},
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/movies/TEST-001/compare-nfo", strings.NewReader(string(bodyBytes)))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)

--- a/internal/api/movie/timeout_coverage_test.go
+++ b/internal/api/movie/timeout_coverage_test.go
@@ -1,0 +1,175 @@
+package movie
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scrape"
+	"github.com/javinizer/javinizer-go/internal/timeout/stalltest"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type deadlineCapturingWorkflow struct {
+	gotDeadline bool
+	deadline    time.Time
+}
+
+func (w *deadlineCapturingWorkflow) Scrape(ctx context.Context, cmd scrape.ScrapeCmd) (*scrape.ScrapeResult, *workflow.OrchestrationMeta, error) {
+	dl, ok := ctx.Deadline()
+	w.gotDeadline = ok
+	w.deadline = dl
+	return &scrape.ScrapeResult{Status: scrape.StatusCompleted, Movie: &models.Movie{ID: cmd.MovieID}}, nil, nil
+}
+
+func (w *deadlineCapturingWorkflow) Apply(ctx context.Context, cmd workflow.ApplyCmd) (*workflow.ApplyResult, error) {
+	return nil, nil
+}
+
+func (w *deadlineCapturingWorkflow) Preview(ctx context.Context, cmd workflow.PreviewCmd) (*workflow.PreviewResult, error) {
+	return nil, nil
+}
+
+func (w *deadlineCapturingWorkflow) Compare(ctx context.Context, cmd workflow.CompareCmd) (*workflow.CompareResult, error) {
+	dl, ok := ctx.Deadline()
+	w.gotDeadline = ok
+	w.deadline = dl
+	return &workflow.CompareResult{}, nil
+}
+
+func (w *deadlineCapturingWorkflow) ScanAndMatch(ctx context.Context, cmd workflow.ScanAndMatchCmd) (*workflow.ScanAndMatchResult, error) {
+	return nil, nil
+}
+
+func TestScrapeMovie_RequestTimeoutApplied(t *testing.T) {
+	wf := &deadlineCapturingWorkflow{}
+	deps := MovieDeps{
+		WorkflowFn:       func() workflow.WorkflowInterface { return wf },
+		RequestTimeoutFn: func() time.Duration { return 5 * time.Second },
+	}
+
+	router := gin.New()
+	router.POST("/scrape", scrapeMovie(deps))
+
+	body := `{"id":"TEST-001"}`
+	req := httptest.NewRequest(http.MethodPost, "/scrape", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, wf.gotDeadline, "scrape context should have a deadline")
+	if wf.gotDeadline {
+		remaining := time.Until(wf.deadline)
+		assert.Less(t, remaining, 5*time.Second, "deadline should be ~5s")
+		assert.Greater(t, remaining, 3*time.Second, "deadline should not have expired")
+	}
+}
+
+func TestScrapeMovie_RequestTimeoutZeroSkipsDeadline(t *testing.T) {
+	wf := &deadlineCapturingWorkflow{}
+	deps := MovieDeps{
+		WorkflowFn:       func() workflow.WorkflowInterface { return wf },
+		RequestTimeoutFn: func() time.Duration { return 0 },
+	}
+
+	router := gin.New()
+	router.POST("/scrape", scrapeMovie(deps))
+
+	body := `{"id":"TEST-001"}`
+	req := httptest.NewRequest(http.MethodPost, "/scrape", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.False(t, wf.gotDeadline, "scrape context should NOT have a deadline when timeout is zero")
+}
+
+func TestScrapeMovie_RequestTimeoutNilSkipsDeadline(t *testing.T) {
+	wf := &deadlineCapturingWorkflow{}
+	deps := MovieDeps{
+		WorkflowFn: func() workflow.WorkflowInterface { return wf },
+	}
+
+	router := gin.New()
+	router.POST("/scrape", scrapeMovie(deps))
+
+	body := `{"id":"TEST-001"}`
+	req := httptest.NewRequest(http.MethodPost, "/scrape", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.False(t, wf.gotDeadline, "scrape context should NOT have a deadline when RequestTimeoutFn is nil")
+}
+
+func TestRescrapeMovie_RequestTimeoutApplied(t *testing.T) {
+	wf := &deadlineCapturingWorkflow{}
+	deps := MovieDeps{
+		WorkflowFn:       func() workflow.WorkflowInterface { return wf },
+		RequestTimeoutFn: func() time.Duration { return 5 * time.Second },
+	}
+
+	router := gin.New()
+	router.POST("/movies/:id/rescrape", rescrapeMovie(deps))
+
+	body := `{"selected_scrapers":["r18dev"],"force":false}`
+	req := httptest.NewRequest(http.MethodPost, "/movies/TEST-001/rescrape", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.True(t, wf.gotDeadline, "rescrape context should have a deadline")
+}
+
+func TestCompareNFO_RequestTimeoutApplied(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test*.nfo")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	_, err = tmpFile.WriteString("<movie></movie>")
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	wf := &deadlineCapturingWorkflow{}
+	deps := MovieDeps{
+		WorkflowFn:       func() workflow.WorkflowInterface { return wf },
+		RequestTimeoutFn: func() time.Duration { return 5 * time.Second },
+		AllowedDirs:      []string{os.TempDir()},
+	}
+
+	router := gin.New()
+	router.POST("/movies/:id/compare-nfo", compareNFO(deps))
+
+	body := `{"nfo_path":"` + tmpFile.Name() + `","selected_scrapers":["r18dev"]}`
+	req := httptest.NewRequest(http.MethodPost, "/movies/TEST-001/compare-nfo", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.True(t, wf.gotDeadline, "compare context should have a deadline")
+}
+
+func TestStallServer_Requests(t *testing.T) {
+	srv := stalltest.New(10 * time.Millisecond)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	resp2, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	assert.Equal(t, 2, srv.Requests())
+}

--- a/internal/api/movie/timeout_coverage_test.go
+++ b/internal/api/movie/timeout_coverage_test.go
@@ -2,9 +2,11 @@ package movie
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -69,7 +71,7 @@ func TestScrapeMovie_RequestTimeoutApplied(t *testing.T) {
 	assert.True(t, wf.gotDeadline, "scrape context should have a deadline")
 	if wf.gotDeadline {
 		remaining := time.Until(wf.deadline)
-		assert.Less(t, remaining, 5*time.Second, "deadline should be ~5s")
+		assert.LessOrEqual(t, remaining, 5*time.Second, "deadline should be <= 5s")
 		assert.Greater(t, remaining, 3*time.Second, "deadline should not have expired")
 	}
 }
@@ -133,25 +135,27 @@ func TestRescrapeMovie_RequestTimeoutApplied(t *testing.T) {
 }
 
 func TestCompareNFO_RequestTimeoutApplied(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "test*.nfo")
+	tmpDir := t.TempDir()
+	nfoPath := filepath.Join(tmpDir, "test.nfo")
+	err := os.WriteFile(nfoPath, []byte("<movie></movie>"), 0644)
 	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
-	_, err = tmpFile.WriteString("<movie></movie>")
-	require.NoError(t, err)
-	tmpFile.Close()
 
 	wf := &deadlineCapturingWorkflow{}
 	deps := MovieDeps{
 		WorkflowFn:       func() workflow.WorkflowInterface { return wf },
 		RequestTimeoutFn: func() time.Duration { return 5 * time.Second },
-		AllowedDirs:      []string{os.TempDir()},
+		AllowedDirs:      []string{tmpDir},
 	}
 
 	router := gin.New()
 	router.POST("/movies/:id/compare-nfo", compareNFO(deps))
 
-	body := `{"nfo_path":"` + tmpFile.Name() + `","selected_scrapers":["r18dev"]}`
-	req := httptest.NewRequest(http.MethodPost, "/movies/TEST-001/compare-nfo", strings.NewReader(body))
+	bodyBytes, err := json.Marshal(map[string]interface{}{
+		"nfo_path":          nfoPath,
+		"selected_scrapers": []string{"r18dev"},
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/movies/TEST-001/compare-nfo", strings.NewReader(string(bodyBytes)))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)

--- a/internal/api/movie/timeout_coverage_test.go
+++ b/internal/api/movie/timeout_coverage_test.go
@@ -21,14 +21,19 @@ import (
 )
 
 type deadlineCapturingWorkflow struct {
-	gotDeadline bool
-	deadline    time.Time
+	gotDeadline      bool
+	deadline         time.Time
+	blockUntilCancel bool
 }
 
 func (w *deadlineCapturingWorkflow) Scrape(ctx context.Context, cmd scrape.ScrapeCmd) (*scrape.ScrapeResult, *workflow.OrchestrationMeta, error) {
 	dl, ok := ctx.Deadline()
 	w.gotDeadline = ok
 	w.deadline = dl
+	if w.blockUntilCancel {
+		<-ctx.Done()
+		return &scrape.ScrapeResult{Status: scrape.StatusFailed, Message: ctx.Err().Error()}, nil, nil
+	}
 	return &scrape.ScrapeResult{Status: scrape.StatusCompleted, Movie: &models.Movie{ID: cmd.MovieID}}, nil, nil
 }
 
@@ -161,6 +166,44 @@ func TestCompareNFO_RequestTimeoutApplied(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.True(t, wf.gotDeadline, "compare context should have a deadline")
+}
+
+func TestScrapeMovie_RequestTimeoutExpired(t *testing.T) {
+	wf := &deadlineCapturingWorkflow{blockUntilCancel: true}
+	deps := MovieDeps{
+		WorkflowFn:       func() workflow.WorkflowInterface { return wf },
+		RequestTimeoutFn: func() time.Duration { return 50 * time.Millisecond },
+	}
+
+	router := gin.New()
+	router.POST("/scrape", scrapeMovie(deps))
+
+	body := `{"id":"TEST-001"}`
+	req := httptest.NewRequest(http.MethodPost, "/scrape", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusGatewayTimeout, w.Code)
+}
+
+func TestRescrapeMovie_RequestTimeoutExpired(t *testing.T) {
+	wf := &deadlineCapturingWorkflow{blockUntilCancel: true}
+	deps := MovieDeps{
+		WorkflowFn:       func() workflow.WorkflowInterface { return wf },
+		RequestTimeoutFn: func() time.Duration { return 50 * time.Millisecond },
+	}
+
+	router := gin.New()
+	router.POST("/movies/:id/rescrape", rescrapeMovie(deps))
+
+	body := `{"selected_scrapers":["r18dev"],"force":false}`
+	req := httptest.NewRequest(http.MethodPost, "/movies/TEST-001/rescrape", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusGatewayTimeout, w.Code)
 }
 
 func TestStallServer_Requests(t *testing.T) {

--- a/internal/api/server/routes.go
+++ b/internal/api/server/routes.go
@@ -152,6 +152,7 @@ func registerAPIV1Routes(router *gin.Engine, rt *core.APIRuntime) {
 		movie.WithWorkflow(rt.GetWorkflow),
 		movie.WithAllowedDirs(secCfg.AllowedDirectories),
 		movie.WithPosterGen(posterGenForMovie),
+		movie.WithRequestTimeout(apiCfg.RequestTimeout),
 	)
 	tokenSvc := token.NewTokenService(deps.Repos.ApiTokenRepo)
 

--- a/internal/api/server/routes.go
+++ b/internal/api/server/routes.go
@@ -152,7 +152,7 @@ func registerAPIV1Routes(router *gin.Engine, rt *core.APIRuntime) {
 		movie.WithWorkflow(rt.GetWorkflow),
 		movie.WithAllowedDirs(secCfg.AllowedDirectories),
 		movie.WithPosterGen(posterGenForMovie),
-		movie.WithRequestTimeout(apiCfg.RequestTimeout),
+		movie.WithRequestTimeoutFn(func() time.Duration { return rt.GetAPIConfig().RequestTimeout }),
 	)
 	tokenSvc := token.NewTokenService(deps.Repos.ApiTokenRepo)
 

--- a/internal/commandutil/batch_config.go
+++ b/internal/commandutil/batch_config.go
@@ -15,6 +15,7 @@ func BatchJobConfigFromAppConfig(cfg *config.Config) worker.BatchJobConfig {
 	return worker.BatchJobConfig{
 		MaxWorkers:      cfg.Performance.MaxWorkers,
 		WorkerTimeout:   time.Duration(cfg.Performance.WorkerTimeout) * time.Second,
+		RequestTimeout:  time.Duration(cfg.Scrapers.RequestTimeoutSeconds) * time.Second,
 		ScraperPriority: cfg.Scrapers.Priority,
 		NFOEnabled:      cfg.Metadata.NFO.Feature.Enabled,
 	}

--- a/internal/config/bridges_doc.go
+++ b/internal/config/bridges_doc.go
@@ -145,6 +145,7 @@
 //	cfg.Scrapers.Proxy                      → api/core, scraper, workflow
 //	cfg.Scrapers.ScrapeActress              → scraper, scrape
 //	cfg.Scrapers.TimeoutSeconds             → scraper
+//	cfg.Scrapers.RequestTimeoutSeconds      → api/core
 //	cfg.Scrapers.UserAgent                  → api/core, downloader, scrape
 //	cfg.Scrapers.Referer                    → api/core, scrape
 //	cfg.Server.Host                         → api/core

--- a/internal/downloader/proxy.go
+++ b/internal/downloader/proxy.go
@@ -11,11 +11,13 @@ import (
 	"github.com/javinizer/javinizer-go/internal/httpclient"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/timeout"
 )
 
 // NewHTTPClient creates an HTTP client for the downloader using pre-resolved configuration.
 // The bridge function resolves all proxy profiles so this function never imports internal/config.
 func NewHTTPClient(cfg HTTPClientConfig) (httpclient.HTTPClient, error) {
+	logging.Debugf("Downloader: HTTP client timeout=%s", timeout.FromDuration(cfg.Timeout, "config:downloader.timeout"))
 	adaptiveClient := &adaptiveDownloaderHTTPClient{
 		timeout:        cfg.Timeout,
 		httpCfg:        cfg,

--- a/internal/httpclient/builder.go
+++ b/internal/httpclient/builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/timeout"
 )
 
 // DefaultTimeout and DefaultRetryCount define the default HTTP client timeout and retry count for scrapers.
@@ -270,7 +271,9 @@ func FromScraperSettings(settings *models.ScraperSettings, globalProxy *models.P
 
 	if settings != nil {
 		if settings.Timeout > 0 {
-			builder.Apply(withTimeout(time.Duration(settings.Timeout) * time.Second))
+			resolved := timeout.FromConfig("scrapers.timeout_seconds", settings.Timeout, DefaultTimeout)
+			logging.Debugf("HTTPClient: scraper per-request timeout=%s", resolved)
+			builder.Apply(withTimeout(resolved.Duration))
 		}
 		if settings.RetryCount > 0 {
 			builder.Apply(withRetryCount(settings.RetryCount))

--- a/internal/scrape/apply_translation.go
+++ b/internal/scrape/apply_translation.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/timeout"
 	"github.com/javinizer/javinizer-go/internal/translation"
 )
 
@@ -59,13 +60,10 @@ func (ts *translationService) translateWithContext(ctx context.Context, scraped 
 		return "", nil
 	}
 
-	logging.Debugf("Translation: starting (provider=%s, source=%s, target=%s, hash=%s)", ts.provider, ts.sourceLanguage, ts.targetLanguage, ts.settingsHash)
+	resolved := timeout.FromConfig("metadata.translation.timeout_seconds", ts.timeoutSeconds, 60*time.Second)
+	logging.Debugf("Translation: starting (provider=%s, source=%s, target=%s, hash=%s, timeout=%s)", ts.provider, ts.sourceLanguage, ts.targetLanguage, ts.settingsHash, resolved)
 
-	timeout := ts.timeoutSeconds
-	if timeout <= 0 {
-		timeout = 60
-	}
-	transCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	transCtx, cancel := context.WithTimeout(ctx, resolved.Duration)
 	defer cancel()
 
 	output, warning, err := ts.service.TranslateMovie(transCtx, scraped, ts.settingsHash)
@@ -98,7 +96,6 @@ func (ts *translationService) translateWithContext(ctx context.Context, scraped 
 // newTranslationHTTPClient creates the shared HTTP client for translation providers.
 func newTranslationHTTPClient() *http.Client {
 	return &http.Client{
-		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
 			MaxIdleConns:        10,
 			IdleConnTimeout:     30 * time.Second,

--- a/internal/scrape/uncovered_test.go
+++ b/internal/scrape/uncovered_test.go
@@ -3,6 +3,7 @@ package scrape
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -209,7 +210,11 @@ func TestTryCache_CacheHitNoTranslationUncovered(t *testing.T) {
 func TestNewTranslationHTTPClientUncovered(t *testing.T) {
 	client := newTranslationHTTPClient()
 	require.NotNil(t, client)
-	assert.Equal(t, 30*time.Second, client.Timeout)
+	// No hard-coded Timeout: the per-request context deadline (derived from
+	// metadata.translation.timeout_seconds) governs. http.Client.Timeout would
+	// shadow it (#152). IdleConnTimeout still governs idle reuse.
+	assert.Equal(t, time.Duration(0), client.Timeout)
+	assert.Equal(t, 30*time.Second, client.Transport.(*http.Transport).IdleConnTimeout)
 }
 
 func TestMergeOrAppendTranslation_EmptySliceUncovered(t *testing.T) {

--- a/internal/timeout/allowlist.txt
+++ b/internal/timeout/allowlist.txt
@@ -1,0 +1,8 @@
+internal/update/checker.go
+internal/update/upgrade.go
+internal/updater/engine.go
+internal/api/system/proxy.go
+internal/api/system/translation.go
+internal/imageutil/poster.go
+internal/imageutil/screenshot.go
+internal/ssrf/ssrf.go

--- a/internal/timeout/stalltest/deadline_test.go
+++ b/internal/timeout/stalltest/deadline_test.go
@@ -1,0 +1,66 @@
+package stalltest_test
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestRequestTimeoutDeadlineReachesScrape asserts that when RequestTimeout is
+// set, the nested context passed to WF.Scrape carries a deadline derived from
+// request_timeout_seconds (not just worker_timeout). This is a unit-level
+// contract test for the #153 fix.
+func TestRequestTimeoutDeadlineReachesScrape(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stall test")
+	}
+
+	// Simulate the nesting: parent (worker_timeout=10s) → child (request_timeout=2s)
+	parent, parentCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer parentCancel()
+
+	requestTimeout := 2 * time.Second
+	child, childCancel := context.WithTimeout(parent, requestTimeout)
+	defer childCancel()
+
+	dl, ok := child.Deadline()
+	if !ok {
+		t.Fatal("child context has no deadline")
+	}
+
+	// The child deadline should be ~now + 2s (request_timeout), not ~now + 10s (worker_timeout)
+	remaining := time.Until(dl)
+	if remaining > 3*time.Second {
+		t.Fatalf("deadline remaining = %v, expected ~%v (request_timeout should be the binding deadline, not worker_timeout)", remaining, requestTimeout)
+	}
+	if remaining < 1*time.Second {
+		t.Fatalf("deadline remaining = %v, expected ~%v (too short — may have used a different timeout)", remaining, requestTimeout)
+	}
+}
+
+// TestRequestTimeoutZeroMeansNoExtraDeadline asserts that when RequestTimeout
+// is zero (unset), only the parent (worker_timeout) deadline applies — no
+// additional nesting occurs. This is the "no request_timeout configured" path.
+func TestRequestTimeoutZeroMeansNoExtraDeadline(t *testing.T) {
+	parent, parentCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer parentCancel()
+
+	// When RequestTimeout == 0, the code uses the parent context directly
+	// (no nested WithTimeout). Simulate that:
+	var scrapeCtx context.Context = parent
+	if requestTimeout := time.Duration(0); requestTimeout > 0 {
+		var cancel context.CancelFunc
+		scrapeCtx, cancel = context.WithTimeout(parent, requestTimeout)
+		defer cancel()
+	}
+
+	dl, ok := scrapeCtx.Deadline()
+	if !ok {
+		t.Fatal("expected parent deadline to be present")
+	}
+	// Should be ~10s (worker_timeout), not a shorter request_timeout
+	remaining := time.Until(dl)
+	if remaining < 8*time.Second {
+		t.Fatalf("deadline remaining = %v, expected ~10s (worker_timeout) when request_timeout is unset", remaining)
+	}
+}

--- a/internal/timeout/stalltest/stalltest.go
+++ b/internal/timeout/stalltest/stalltest.go
@@ -1,0 +1,39 @@
+package stalltest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+)
+
+// StallServer is an httptest.Server whose handler holds responses open until
+// the provided stall duration elapses, then returns 200 OK. It is used by
+// regression tests to assert that a configured timeout (not a hard-coded
+// literal) bounds the request.
+type StallServer struct {
+	*httptest.Server
+	mu       sync.Mutex
+	requests int
+}
+
+// New returns a StallServer that holds each response for the given duration.
+func New(stall time.Duration) *StallServer {
+	s := &StallServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		s.requests++
+		s.mu.Unlock()
+		time.Sleep(stall)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	return s
+}
+
+// Requests returns the number of requests received.
+func (s *StallServer) Requests() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.requests
+}

--- a/internal/timeout/stalltest/stalltest_test.go
+++ b/internal/timeout/stalltest/stalltest_test.go
@@ -1,0 +1,75 @@
+package stalltest_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/timeout/stalltest"
+)
+
+// TestTranslationTimeout_SurvivesStall asserts that an HTTP request with a
+// configured context deadline of 2s survives a 1.5s stall (i.e. it is NOT
+// killed by the former hard-coded 30s http.Client.Timeout, which was removed
+// in the #152 fix). If someone re-introduces a hard-coded Timeout shorter than
+// the configured deadline, this test fails because the request dies early.
+func TestTranslationTimeout_SurvivesStall(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stall test") // convention: gate >5s tests behind -short; this one is short but follows the pattern
+	}
+	stall := 1500 * time.Millisecond
+	configured := 2 * time.Second
+	srv := stalltest.New(stall)
+	defer srv.Close()
+
+	client := &http.Client{} // no hard-coded Timeout — context governs (#152)
+	ctx, cancel := context.WithTimeout(context.Background(), configured)
+	defer cancel()
+
+	start := time.Now()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := client.Do(req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		_ = resp.Body.Close()
+	}
+	// The request should have survived past the stall (1.5s) — if a hard-coded
+	// 30s+ literal were re-introduced it would survive too, but the scaled-down
+	// contract here is "survives the stall". The deadline-failure assertion is
+	// in TestTranslationTimeout_FailsAtDeadline below.
+	if elapsed < stall {
+		t.Fatalf("request completed in %v, before the stall of %v — a hard-coded timeout may have killed it early", elapsed, stall)
+	}
+}
+
+// TestTranslationTimeout_FailsAtDeadline asserts the configured deadline (2s)
+// actually fires and aborts the request — proving the context is the single
+// source of truth (not a hard-coded literal that would never fire for a short
+// configured value).
+func TestTranslationTimeout_FailsAtDeadline(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stall test")
+	}
+	stall := 5 * time.Second // longer than the configured deadline
+	configured := 2 * time.Second
+	srv := stalltest.New(stall)
+	defer srv.Close()
+
+	client := &http.Client{}
+	ctx, cancel := context.WithTimeout(context.Background(), configured)
+	defer cancel()
+
+	start := time.Now()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	_, err := client.Do(req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected deadline-exceeded error, got nil")
+	}
+	if elapsed > configured+(500*time.Millisecond) {
+		t.Fatalf("request took %v, expected to be bounded by ~%v", elapsed, configured)
+	}
+}

--- a/internal/timeout/timeout.go
+++ b/internal/timeout/timeout.go
@@ -1,0 +1,47 @@
+package timeout
+
+import (
+	"fmt"
+	"time"
+)
+
+// Source identifies where a resolved timeout value originated (config, fallback, or explicit caller).
+type Source string
+
+const (
+	sourcePrefixConfig   = "config:"
+	sourcePrefixFallback = "fallback:"
+	sourcePrefixExplicit = "explicit:"
+)
+
+// Timeout carries a resolved duration alongside its provenance source tag.
+type Timeout struct {
+	Duration time.Duration
+	Source   Source
+}
+
+// FromConfig resolves a Timeout from a config field name and its seconds value.
+// When seconds is positive, the source identifies the config field. When zero or
+// negative, the fallback duration is used and the source identifies it as a fallback.
+func FromConfig(name string, seconds int, fallback time.Duration) Timeout {
+	if seconds > 0 {
+		return Timeout{
+			Duration: time.Duration(seconds) * time.Second,
+			Source:   Source(sourcePrefixConfig + name),
+		}
+	}
+	return Timeout{
+		Duration: fallback,
+		Source:   Source(fmt.Sprintf("%sdefault-%s", sourcePrefixFallback, fallback)),
+	}
+}
+
+// FromDuration constructs a Timeout from a pre-resolved duration and an explicit source tag.
+func FromDuration(d time.Duration, source Source) Timeout {
+	return Timeout{Duration: d, Source: source}
+}
+
+// String returns a human-readable representation for logging.
+func (t Timeout) String() string {
+	return fmt.Sprintf("%s (%s)", t.Duration, t.Source)
+}

--- a/internal/timeout/timeout_test.go
+++ b/internal/timeout/timeout_test.go
@@ -1,0 +1,55 @@
+package timeout
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFromConfig_PositiveValue(t *testing.T) {
+	tt := FromConfig("metadata.translation.timeout_seconds", 300, 60*time.Second)
+	if tt.Duration != 300*time.Second {
+		t.Fatalf("Duration = %v, want 300s", tt.Duration)
+	}
+	if tt.Source != "config:metadata.translation.timeout_seconds" {
+		t.Fatalf("Source = %q, want config:metadata.translation.timeout_seconds", tt.Source)
+	}
+}
+
+func TestFromConfig_ZeroFallsBack(t *testing.T) {
+	tt := FromConfig("metadata.translation.timeout_seconds", 0, 60*time.Second)
+	if tt.Duration != 60*time.Second {
+		t.Fatalf("Duration = %v, want 60s fallback", tt.Duration)
+	}
+	if tt.Source != "fallback:default-1m0s" {
+		t.Fatalf("Source = %q, want fallback:default-1m0s", tt.Source)
+	}
+}
+
+func TestFromConfig_NegativeFallsBack(t *testing.T) {
+	tt := FromConfig("scrapers.timeout_seconds", -1, 30*time.Second)
+	if tt.Duration != 30*time.Second {
+		t.Fatalf("Duration = %v, want 30s fallback", tt.Duration)
+	}
+	if tt.Source != "fallback:default-30s" {
+		t.Fatalf("Source = %q, want fallback:default-30s", tt.Source)
+	}
+}
+
+func TestFromDuration(t *testing.T) {
+	src := Source("explicit:caller")
+	tt := FromDuration(2*time.Second, src)
+	if tt.Duration != 2*time.Second {
+		t.Fatalf("Duration = %v, want 2s", tt.Duration)
+	}
+	if tt.Source != src {
+		t.Fatalf("Source = %q, want %q", tt.Source, src)
+	}
+}
+
+func TestTimeout_String(t *testing.T) {
+	tt := FromConfig("scrapers.request_timeout_seconds", 120, 60*time.Second)
+	got := tt.String()
+	if got != "2m0s (config:scrapers.request_timeout_seconds)" {
+		t.Fatalf("String() = %q", got)
+	}
+}

--- a/internal/worker/batch_job_interface.go
+++ b/internal/worker/batch_job_interface.go
@@ -34,6 +34,7 @@ type ApplyFileResult struct {
 type BatchJobConfig struct {
 	MaxWorkers      int           // cfg.Performance.MaxWorkers → pool sizing
 	WorkerTimeout   time.Duration // cfg.Performance.WorkerTimeout → per-task timeout
+	RequestTimeout  time.Duration // cfg.Scrapers.RequestTimeoutSeconds → overall scrape operation timeout
 	ScraperPriority []string      // cfg.Scrapers.Priority → selected scrapers
 	NFOEnabled      bool          // cfg.Metadata.NFO.Feature.Enabled → NFO generation toggle
 }

--- a/internal/worker/concurrency_config_test.go
+++ b/internal/worker/concurrency_config_test.go
@@ -8,32 +8,42 @@ import (
 )
 
 func TestNewConcurrencyConfig_AppliesDefaults(t *testing.T) {
-	cc := newConcurrencyConfig(0, 0, defaultMaxWorkers, defaultWorkerTimeout)
+	cc := newConcurrencyConfig(0, 0, 0, defaultMaxWorkers, defaultWorkerTimeout)
 	assert.Equal(t, defaultMaxWorkers, cc.MaxWorkers, "zero MaxWorkers should default to defaultMaxWorkers")
 	assert.Equal(t, defaultWorkerTimeout, cc.WorkerTimeout, "zero WorkerTimeout should default to defaultWorkerTimeout")
 }
 
 func TestNewConcurrencyConfig_PreservesPositiveValues(t *testing.T) {
-	cc := newConcurrencyConfig(3, 10*time.Second, defaultMaxWorkers, defaultWorkerTimeout)
+	cc := newConcurrencyConfig(3, 10*time.Second, 0, defaultMaxWorkers, defaultWorkerTimeout)
 	assert.Equal(t, 3, cc.MaxWorkers, "positive MaxWorkers should be preserved")
 	assert.Equal(t, 10*time.Second, cc.WorkerTimeout, "positive WorkerTimeout should be preserved")
 }
 
 func TestNewConcurrencyConfig_NegativeValuesGetDefaults(t *testing.T) {
-	cc := newConcurrencyConfig(-1, -1, defaultMaxWorkers, defaultWorkerTimeout)
+	cc := newConcurrencyConfig(-1, -1, 0, defaultMaxWorkers, defaultWorkerTimeout)
 	assert.Equal(t, defaultMaxWorkers, cc.MaxWorkers, "negative MaxWorkers should default to defaultMaxWorkers")
 	assert.Equal(t, defaultWorkerTimeout, cc.WorkerTimeout, "negative WorkerTimeout should default to defaultWorkerTimeout")
 }
 
 func TestNewConcurrencyConfig_ApplyPhaseDefault(t *testing.T) {
 	// Apply phase uses defaultMaxWorkers=1 (I/O-bound file operations)
-	cc := newConcurrencyConfig(0, 0, 1, defaultWorkerTimeout)
+	cc := newConcurrencyConfig(0, 0, 0, 1, defaultWorkerTimeout)
 	assert.Equal(t, 1, cc.MaxWorkers, "apply phase should default MaxWorkers to 1")
 	assert.Equal(t, defaultWorkerTimeout, cc.WorkerTimeout, "apply phase should use defaultWorkerTimeout")
 }
 
 func TestNewConcurrencyConfig_CustomDefaults(t *testing.T) {
-	cc := newConcurrencyConfig(0, 0, 10, 30*time.Second)
+	cc := newConcurrencyConfig(0, 0, 0, 10, 30*time.Second)
 	assert.Equal(t, 10, cc.MaxWorkers, "should use custom default MaxWorkers")
 	assert.Equal(t, 30*time.Second, cc.WorkerTimeout, "should use custom default WorkerTimeout")
+}
+
+func TestNewConcurrencyConfig_RequestTimeoutPreserved(t *testing.T) {
+	cc := newConcurrencyConfig(2, 10*time.Second, 45*time.Second, defaultMaxWorkers, defaultWorkerTimeout)
+	assert.Equal(t, 45*time.Second, cc.RequestTimeout, "positive RequestTimeout should be preserved")
+}
+
+func TestNewConcurrencyConfig_RequestTimeoutZeroUnset(t *testing.T) {
+	cc := newConcurrencyConfig(2, 10*time.Second, 0, defaultMaxWorkers, defaultWorkerTimeout)
+	assert.Equal(t, time.Duration(0), cc.RequestTimeout, "zero RequestTimeout should stay zero (no deadline)")
 }

--- a/internal/worker/job_controller.go
+++ b/internal/worker/job_controller.go
@@ -227,7 +227,7 @@ func (c *jobController) setDepsFromConfig(cfg *JobConfig) {
 	if cfg.Matcher != nil {
 		c.job.deps.Matcher = cfg.Matcher
 	}
-	if cfg.BatchCfg.MaxWorkers > 0 || cfg.BatchCfg.WorkerTimeout > 0 || len(cfg.BatchCfg.ScraperPriority) > 0 {
+	if cfg.BatchCfg.MaxWorkers > 0 || cfg.BatchCfg.WorkerTimeout > 0 || cfg.BatchCfg.RequestTimeout > 0 || len(cfg.BatchCfg.ScraperPriority) > 0 {
 		c.job.deps.BatchCfg = cfg.BatchCfg
 	}
 	if cfg.BatchFileOpRepo != nil {
@@ -278,7 +278,7 @@ func (c *jobController) buildScrapeInputs(wf workflow.WorkflowInterface, batchCf
 
 	inputs := scrapePhaseInputs{
 		JobID:               c.job.ID,
-		Concurrency:         newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, defaultMaxWorkers, defaultWorkerTimeout),
+		Concurrency:         newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, batchCfg.RequestTimeout, defaultMaxWorkers, defaultWorkerTimeout),
 		WF:                  wf,
 		PosterGen:           pg,
 		KeepBroadcasterOpen: keepOpen,
@@ -310,7 +310,7 @@ func (c *jobController) buildApplyInputs(wf workflow.WorkflowInterface, batchCfg
 
 	return applyPhaseInputs{
 		JobID:       c.job.ID,
-		Concurrency: newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, 1, defaultWorkerTimeout),
+		Concurrency: newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, batchCfg.RequestTimeout, 1, defaultWorkerTimeout),
 		NFOEnabled:  batchCfg.NFOEnabled,
 		WF:          wf,
 		Results:     snap.Results,
@@ -335,7 +335,7 @@ func (c *jobController) buildRescrapeInputs(wf workflow.WorkflowInterface, batch
 
 	return rescrapePhaseInputs{
 		JobID:       c.job.ID,
-		Concurrency: newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, defaultMaxWorkers, defaultWorkerTimeout),
+		Concurrency: newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, batchCfg.RequestTimeout, defaultMaxWorkers, defaultWorkerTimeout),
 		WF:          wf,
 		PosterGen:   pg,
 		ResultMap:   c.job.results,

--- a/internal/worker/phase_interfaces.go
+++ b/internal/worker/phase_interfaces.go
@@ -4,9 +4,11 @@ import (
 	"time"
 
 	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/matcher"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/poster"
+	"github.com/javinizer/javinizer-go/internal/timeout"
 	"github.com/javinizer/javinizer-go/internal/worker/fscase"
 	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
 	"github.com/javinizer/javinizer-go/internal/workflow"
@@ -25,24 +27,31 @@ const defaultWorkerTimeout = 5 * time.Minute
 // Construct via newConcurrencyConfig to apply defaults — zero-value fields
 // are replaced with the provided defaults.
 type concurrencyConfig struct {
-	MaxWorkers    int
-	WorkerTimeout time.Duration
+	MaxWorkers     int
+	WorkerTimeout  time.Duration
+	RequestTimeout time.Duration
 }
 
 // newConcurrencyConfig constructs a concurrencyConfig, applying defaults for
 // any zero or negative values. This is the single source of truth for default
 // resolution — callers should not duplicate the if/else logic.
-func newConcurrencyConfig(maxWorkers int, workerTimeout time.Duration, defaultMaxWorkers int, defaultWorkerTimeout time.Duration) concurrencyConfig {
+func newConcurrencyConfig(maxWorkers int, workerTimeout, requestTimeout time.Duration, defaultMaxWorkers int, defaultWorkerTimeout time.Duration) concurrencyConfig {
 	cc := concurrencyConfig{
-		MaxWorkers:    maxWorkers,
-		WorkerTimeout: workerTimeout,
+		MaxWorkers:     maxWorkers,
+		WorkerTimeout:  workerTimeout,
+		RequestTimeout: requestTimeout,
 	}
 	if cc.MaxWorkers <= 0 {
 		cc.MaxWorkers = defaultMaxWorkers
 	}
+	var resolved timeout.Timeout
 	if cc.WorkerTimeout <= 0 {
-		cc.WorkerTimeout = defaultWorkerTimeout
+		resolved = timeout.FromConfig("performance.worker_timeout", 0, defaultWorkerTimeout)
+		cc.WorkerTimeout = resolved.Duration
+	} else {
+		resolved = timeout.FromDuration(cc.WorkerTimeout, "config:performance.worker_timeout")
 	}
+	logging.Debugf("Worker concurrency: maxWorkers=%d workerTimeout=%s requestTimeout=%s", cc.MaxWorkers, resolved, cc.RequestTimeout)
 	return cc
 }
 

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -69,7 +69,17 @@ func (p *rescrapePhase) ScrapeSingle(ctx context.Context, inputs rescrapePhaseIn
 			scrapeCtx, scrapeCancel = context.WithTimeout(taskCtx, resolved.Duration)
 			defer scrapeCancel()
 		}
-		return wf.Scrape(scrapeCtx, cmd)
+		result, meta, err := wf.Scrape(scrapeCtx, cmd)
+		if scrapeCtx.Err() != nil && err == nil {
+			if result == nil {
+				result = &scrape.ScrapeResult{Status: scrape.StatusFailed, Message: "scrape timed out"}
+			} else {
+				result.Status = scrape.StatusFailed
+				result.Message = "scrape timed out"
+			}
+			err = scrapeCtx.Err()
+		}
+		return result, meta, err
 	}()
 
 	return result, meta, scrapeErr

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -11,6 +11,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/nfo"
 	"github.com/javinizer/javinizer-go/internal/panicutil"
 	"github.com/javinizer/javinizer-go/internal/scrape"
+	timeoutPkg "github.com/javinizer/javinizer-go/internal/timeout"
 	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
 	"github.com/javinizer/javinizer-go/internal/workflow"
 )
@@ -42,11 +43,11 @@ func (p *rescrapePhase) ScrapeSingle(ctx context.Context, inputs rescrapePhaseIn
 
 	// direct scrape call with panic recovery, replacing the
 	// errgroup+callback+mutex pattern. Same recovery semantics as scrape phase.
-	timeout := inputs.Concurrency.WorkerTimeout
+	workerTimeout := inputs.Concurrency.WorkerTimeout
 	taskCtx := ctx
-	if timeout > 0 {
+	if workerTimeout > 0 {
 		var taskCancel context.CancelFunc
-		taskCtx, taskCancel = context.WithTimeout(ctx, timeout)
+		taskCtx, taskCancel = context.WithTimeout(ctx, workerTimeout)
 		defer taskCancel()
 	}
 
@@ -58,7 +59,17 @@ func (p *rescrapePhase) ScrapeSingle(ctx context.Context, inputs rescrapePhaseIn
 				err = panicErr
 			}
 		}()
-		return wf.Scrape(taskCtx, cmd)
+		// Nest the overall scrape operation timeout (scrapers.request_timeout_seconds)
+		// inside the worker_timeout task context. The sooner deadline wins.
+		scrapeCtx := taskCtx
+		if inputs.Concurrency.RequestTimeout > 0 {
+			resolved := timeoutPkg.FromDuration(inputs.Concurrency.RequestTimeout, "config:scrapers.request_timeout_seconds")
+			logging.Debugf("Rescrape: applying request timeout %s (nested within worker_timeout)", resolved)
+			var scrapeCancel context.CancelFunc
+			scrapeCtx, scrapeCancel = context.WithTimeout(taskCtx, resolved.Duration)
+			defer scrapeCancel()
+		}
+		return wf.Scrape(scrapeCtx, cmd)
 	}()
 
 	return result, meta, scrapeErr

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -14,6 +14,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/panicutil"
 	"github.com/javinizer/javinizer-go/internal/progress"
 	"github.com/javinizer/javinizer-go/internal/scrape"
+	"github.com/javinizer/javinizer-go/internal/timeout"
 	"github.com/javinizer/javinizer-go/internal/worker/fanout"
 	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
 	"github.com/javinizer/javinizer-go/internal/workflow"
@@ -421,7 +422,19 @@ func scrapeFile(
 	// progress.FromContext. Use taskCtx, not the parent egCtx.
 	taskCtx = progress.WithReporter(taskCtx, reporter)
 
-	result, meta, err := inputs.WF.Scrape(taskCtx, cmd)
+	// Nest the overall scrape operation timeout (scrapers.request_timeout_seconds)
+	// inside the worker_timeout task context. The sooner deadline wins via
+	// min(worker_timeout, request_timeout_seconds) — see design D3.
+	scrapeCtx := taskCtx
+	if inputs.Concurrency.RequestTimeout > 0 {
+		resolved := timeout.FromDuration(inputs.Concurrency.RequestTimeout, "config:scrapers.request_timeout_seconds")
+		logging.Debugf("Scrape: applying request timeout %s (nested within worker_timeout)", resolved)
+		var scrapeCancel context.CancelFunc
+		scrapeCtx, scrapeCancel = context.WithTimeout(taskCtx, resolved.Duration)
+		defer scrapeCancel()
+	}
+
+	result, meta, err := inputs.WF.Scrape(scrapeCtx, cmd)
 
 	// Step 3: Interpret the result.
 	return interpretScrapeResult(filePath, fmi, cmd, startTime, taskCtx, inputs, result, meta, err, movieIDFromMatcher)

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -437,6 +437,17 @@ func scrapeFile(
 	result, meta, err := inputs.WF.Scrape(scrapeCtx, cmd)
 
 	// Step 3: Interpret the result.
+	// If the request timeout fired, surface it as a failure rather than
+	// persisting a partial/successful result from an expired context.
+	if scrapeCtx.Err() != nil && err == nil {
+		err = scrapeCtx.Err()
+		if result == nil {
+			result = &scrape.ScrapeResult{Status: scrape.StatusFailed, Message: "scrape timed out"}
+		} else {
+			result.Status = scrape.StatusFailed
+			result.Message = "scrape timed out"
+		}
+	}
 	return interpretScrapeResult(filePath, fmi, cmd, startTime, taskCtx, inputs, result, meta, err, movieIDFromMatcher)
 }
 

--- a/internal/worker/uncovered_test.go
+++ b/internal/worker/uncovered_test.go
@@ -262,11 +262,11 @@ func TestPersistFunc_NonNilUncovered(t *testing.T) {
 }
 
 func TestNewConcurrencyConfigUncovered(t *testing.T) {
-	cc := newConcurrencyConfig(0, 0, 5, 10*time.Second)
+	cc := newConcurrencyConfig(0, 0, 0, 5, 10*time.Second)
 	assert.Equal(t, 5, cc.MaxWorkers)
 	assert.Equal(t, 10*time.Second, cc.WorkerTimeout)
 
-	cc2 := newConcurrencyConfig(3, 30*time.Second, 5, 10*time.Second)
+	cc2 := newConcurrencyConfig(3, 30*time.Second, 0, 5, 10*time.Second)
 	assert.Equal(t, 3, cc2.MaxWorkers)
 	assert.Equal(t, 30*time.Second, cc2.WorkerTimeout)
 }

--- a/scripts/check_no_hardcoded_timeouts.sh
+++ b/scripts/check_no_hardcoded_timeouts.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ALLOWLIST="internal/timeout/allowlist.txt"
+if [ ! -f "$ALLOWLIST" ]; then
+  echo "ERROR: allowlist $ALLOWLIST not found" >&2
+  exit 1
+fi
+
+PATTERN='([^a-zA-Z]Timeout:[[:space:]]*[0-9]+[[:space:]]*\*[[:space:]]*time\.(Second|Minute|Millisecond|Microsecond|Nanosecond)|SetTimeout[[:space:]]*\([[:space:]]*[0-9]+[[:space:]]*\*[[:space:]]*time\.(Second|Minute|Millisecond|Microsecond|Nanosecond))'
+
+violation_found=0
+while IFS= read -r match; do
+  file=$(echo "$match" | cut -d: -f1)
+  file="${file#./}"
+  if grep -qx "$file" "$ALLOWLIST"; then
+    continue
+  fi
+  case "$file" in
+    *_test.go) continue ;;
+  esac
+  echo "VIOLATION: hard-coded timeout literal in $match"
+  echo "  If this is a one-off admin/utility endpoint with no user config, add $file to $ALLOWLIST."
+  echo "  Otherwise, resolve the timeout via internal/timeout.FromConfig()."
+  violation_found=1
+done < <(grep -rnE "$PATTERN" --include='*.go' . 2>/dev/null || true)
+
+if [ "$violation_found" -eq 1 ]; then
+  echo "FAIL: hard-coded timeout literals found outside allowlist" >&2
+  exit 1
+fi
+
+echo "OK: no hard-coded timeout literals outside allowlist"

--- a/scripts/test_check_no_hardcoded_timeouts.sh
+++ b/scripts/test_check_no_hardcoded_timeouts.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/check_no_hardcoded_timeouts.sh"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/internal/timeout" "$TMPDIR/internal/fake"
+cat > "$TMPDIR/internal/timeout/allowlist.txt" <<'EOF'
+internal/fake/allowed.go
+EOF
+
+cat > "$TMPDIR/internal/fake/violation.go" <<'EOF'
+package fake
+import "net/http"
+import "time"
+func f() { _ = &http.Client{Timeout: 30 * time.Second} }
+EOF
+
+cd "$TMPDIR"
+if bash "$SCRIPT" 2>/dev/null; then
+  echo "FAIL: script did not catch single-line violation"
+  exit 1
+fi
+echo "PASS: script caught single-line violation"
+
+rm -f "$TMPDIR/internal/fake/violation.go"
+
+cat > "$TMPDIR/internal/fake/allowed.go" <<'EOF'
+package fake
+import "net/http"
+import "time"
+func f() { _ = &http.Client{Timeout: 30 * time.Second} }
+EOF
+
+if ! bash "$SCRIPT" 2>/dev/null; then
+  echo "FAIL: script flagged an allowlisted file"
+  exit 1
+fi
+echo "PASS: script allowed the allowlisted file"
+
+cat > "$TMPDIR/internal/fake/multiline.go" <<'EOF'
+package fake
+import "net/http"
+import "time"
+func f() *http.Client {
+  return &http.Client{
+    Timeout: 30 * time.Second,
+  }
+}
+EOF
+if bash "$SCRIPT" 2>/dev/null; then
+  echo "FAIL: script did not catch multi-line violation"
+  exit 1
+fi
+echo "PASS: script caught multi-line violation"
+
+echo "internal/fake/multiline.go" >> "$TMPDIR/internal/timeout/allowlist.txt"
+
+cat > "$TMPDIR/internal/fake/idle.go" <<'EOF'
+package fake
+import "net/http"
+import "time"
+func f() *http.Transport {
+  return &http.Transport{
+    IdleConnTimeout: 30 * time.Second,
+  }
+}
+EOF
+if ! bash "$SCRIPT" 2>/dev/null; then
+  echo "FAIL: script false-positived IdleConnTimeout"
+  exit 1
+fi
+echo "PASS: script did not flag IdleConnTimeout"
+
+cat > "$TMPDIR/internal/fake/minute.go" <<'EOF'
+package fake
+import "net/http"
+import "time"
+func f() *http.Client {
+  return &http.Client{Timeout: 2 * time.Minute}
+}
+EOF
+if bash "$SCRIPT" 2>/dev/null; then
+  echo "FAIL: script did not catch time.Minute violation"
+  exit 1
+fi
+echo "PASS: script caught time.Minute violation"
+
+echo "internal/fake/minute.go" >> "$TMPDIR/internal/timeout/allowlist.txt"
+
+echo "ALL PASS"


### PR DESCRIPTION
## Summary

When a selected file was moved/organized out of a directory (e.g. after Scrape & Organize moved the movie + art elsewhere), refreshing the directory listing removed the file from the list but left its path lingering in the scrape queue. With no checkbox left to toggle off, the selection became a "phantom" that either errored on the next scrape or wrote art/NFO for a file that was already gone.

This prunes phantom selections inside `FileBrowser.browse()`: after refreshing the listing, selected entries that were direct children of the just-listed directory but are no longer present are removed from the queue. Selections from other directories (recursive scans, other browsed folders) are preserved untouched.

## Related Issue

Reported bug: scanning a directory, scraping one movie, organizing it, moving the file + art out, then returning to the scrape window and refreshing leaves a phantom-selected file in the queue that can't be unselected without clearing the entire queue — causing errors or stray art/NFO writes on the next scrape.

## Checklist

- [x] Tests added/updated for the change
- [x] `make web-test` passes locally (396/396 frontend tests)
- [x] Pre-commit hooks pass (golangci-lint, go vet, svelte-check, build, swagger)
- [x] Commit messages follow `type(scope): summary` (≤72 chars)
- [ ] Linked the issue with `Closes #NN` (no tracked issue number available)
