### PR TITLE
feat(scrape): add --output json mode for machine-readable per-scraper results

### DIFF
--- a/cmd/javinizer/commands/scrape/args_validator_test.go
+++ b/cmd/javinizer/commands/scrape/args_validator_test.go
@@ -1,0 +1,25 @@
+package scrape
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCommand_ArgsValidator(t *testing.T) {
+	cmd := NewCommand()
+	err := cmd.Args(cmd, []string{"TEST-001"})
+	require.NoError(t, err)
+	err = cmd.Args(cmd, []string{})
+	require.Error(t, err)
+	err = cmd.Args(cmd, []string{"TEST-001", "extra"})
+	require.Error(t, err)
+}
+
+func TestNewCommand_HasOutputFlag(t *testing.T) {
+	cmd := NewCommand()
+	flag := cmd.Flags().Lookup("output")
+	require.NotNil(t, flag)
+	assert.Equal(t, "text", flag.DefValue)
+}

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -219,7 +219,12 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 
 	// B1: Initialize logger to stderr-only before any code that might log,
 	// preventing stdout contamination of the JSON output.
-	loggingCfg := &logging.Config{Output: "stderr", Level: "warn"}
+	// Honor the --verbose flag like initConfig() does.
+	logLevel := "warn"
+	if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
+		logLevel = "debug"
+	}
+	loggingCfg := &logging.Config{Output: "stderr", Level: logLevel}
 	if err := logging.InitLogger(loggingCfg); err != nil {
 		_ = logging.SetOutput(os.Stderr)
 	}

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -256,7 +256,7 @@ func runScrape(cmd *cobra.Command, args []string, configFile string) error {
 	if outputFlag == jsonOutput {
 		return runScrapeJSON(cmd, args, configFile)
 	}
-	if outputFlag != "text" && outputFlag != "" {
+	if outputFlag != "text" {
 		return fmt.Errorf("invalid output value: must be 'text' or 'json'")
 	}
 	movie, results, err := Run(cmd.Context(), cmd, args, configFile, nil)
@@ -337,7 +337,10 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 		MaxAgeDays: cfg.Logging.MaxAgeDays,
 		Compress:   cfg.Logging.Compress,
 	}
-	_ = logging.InitLogger(loggingCfg)
+	if err := logging.InitLogger(loggingCfg); err != nil {
+		writeJSONError(cmd, unknownErrorEnvelope(fmt.Sprintf("failed to initialize logger: %v", err)))
+		return ErrJSONExit
+	}
 
 	deps, err := commandutil.NewQueryOnlyDependencies(cfg)
 	if err != nil {

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -21,6 +21,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const jsonOutput = "json"
+
 // NewCommand creates the scrape CLI subcommand that fetches metadata for a single movie ID.
 func NewCommand() *cobra.Command {
 	scrapeCmd := &cobra.Command{
@@ -28,11 +30,14 @@ func NewCommand() *cobra.Command {
 		Short: "Scrape metadata for a movie ID",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				output, _ := cmd.Flags().GetString("output")
-				if output == "json" {
+				if requestedJSONOutput(cmd) {
 					cmd.SilenceUsage = true
 					cmd.SilenceErrors = true
-					writeJSONError(cmd, unknownErrorEnvelope("exactly 1 argument (movie ID) is required"))
+					message := "exactly 1 argument (movie ID) is required"
+					if malformed := malformedValueFlag(os.Args[1:]); malformed != "" {
+						message = fmt.Sprintf("flag needs an argument: %s", malformed)
+					}
+					writeJSONError(cmd, unknownErrorEnvelope(message))
 					return ErrJSONExit
 				}
 				return fmt.Errorf("accepts 1 arg(s), received %d", len(args))
@@ -45,8 +50,7 @@ func NewCommand() *cobra.Command {
 		},
 	}
 	scrapeCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		output, _ := cmd.Flags().GetString("output")
-		if output == "json" {
+		if requestedJSONOutput(cmd) {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 			writeJSONError(cmd, unknownErrorEnvelope(err.Error()))
@@ -67,6 +71,45 @@ func NewCommand() *cobra.Command {
 	scrapeCmd.Flags().Bool("genre-replacement", false, "Enable genre replacement (overrides config)")
 	scrapeCmd.Flags().Bool("no-genre-replacement", false, "Disable genre replacement (overrides config)")
 	return scrapeCmd
+}
+
+func requestedJSONOutput(cmd *cobra.Command) bool {
+	output, _ := cmd.Flags().GetString("output")
+	if output == jsonOutput {
+		return true
+	}
+	return argsRequestJSONOutput(cmd.Flags().Args()) || argsRequestJSONOutput(os.Args[1:])
+}
+
+func malformedValueFlag(args []string) string {
+	requiresValue := map[string]struct{}{
+		"--scrapers":        {},
+		"-s":                {},
+		"--output":          {},
+		"--browser-timeout": {},
+		"--config":          {},
+	}
+	for i, arg := range args {
+		if _, ok := requiresValue[arg]; !ok {
+			continue
+		}
+		if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+			return arg
+		}
+	}
+	return ""
+}
+
+func argsRequestJSONOutput(args []string) bool {
+	for i, arg := range args {
+		if arg == "--output="+jsonOutput {
+			return true
+		}
+		if arg == "--output" && i+1 < len(args) && args[i+1] == jsonOutput {
+			return true
+		}
+	}
+	return false
 }
 
 // ApplyFlagOverrides applies CLI flag overrides to the config. Exported for testability.
@@ -210,7 +253,7 @@ func Run(ctx context.Context, cmd *cobra.Command, args []string, configFile stri
 
 func runScrape(cmd *cobra.Command, args []string, configFile string) error {
 	outputFlag, _ := cmd.Flags().GetString("output")
-	if outputFlag == "json" {
+	if outputFlag == jsonOutput {
 		return runScrapeJSON(cmd, args, configFile)
 	}
 	if outputFlag != "text" && outputFlag != "" {

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -44,6 +44,16 @@ func NewCommand() *cobra.Command {
 			return runScrape(cmd, args, configFile)
 		},
 	}
+	scrapeCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		output, _ := cmd.Flags().GetString("output")
+		if output == "json" {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			writeJSONError(cmd, unknownErrorEnvelope(err.Error()))
+			return ErrJSONExit
+		}
+		return err
+	})
 	scrapeCmd.Flags().StringSliceP("scrapers", "s", nil, "Comma-separated subset of enabled scrapers to use (e.g., 'r18dev,dmm'); scraper must be enabled in config.yaml")
 	scrapeCmd.Flags().BoolP("force", "f", false, "Force refresh metadata from scrapers (clear cache)")
 	scrapeCmd.Flags().String("output", "text", "Output format: 'text' (default) or 'json'. JSON mode requires --scrapers with exactly one scraper and is incompatible with --force. In JSON mode, stdout contains only the raw ScraperResult or error envelope; all logs go to stderr.")

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -30,6 +30,8 @@ func NewCommand() *cobra.Command {
 			if len(args) != 1 {
 				output, _ := cmd.Flags().GetString("output")
 				if output == "json" {
+					cmd.SilenceUsage = true
+					cmd.SilenceErrors = true
 					writeJSONError(cmd, unknownErrorEnvelope("exactly 1 argument (movie ID) is required"))
 					return ErrJSONExit
 				}

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/javinizer/javinizer-go/internal/commandutil"
 	"github.com/javinizer/javinizer-go/internal/config"
@@ -205,7 +207,8 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 	scrapersFlag, _ := cmd.Flags().GetStringSlice("scrapers")
 	forceRefresh, _ := cmd.Flags().GetBool("force")
 	if err := validateJSONMode(scrapersFlag, forceRefresh); err != nil {
-		return err
+		writeJSONError(cmd, unknownErrorEnvelope(err.Error()))
+		return ErrJSONExit
 	}
 
 	id := args[0]
@@ -219,7 +222,6 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 	// preventing stdout contamination of the JSON output.
 	loggingCfg := &logging.Config{Output: "stderr", Level: "warn"}
 	if err := logging.InitLogger(loggingCfg); err != nil {
-		// If logger init fails, force stderr output and continue.
 		_ = logging.SetOutput(os.Stderr)
 	}
 
@@ -235,16 +237,31 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 		return ErrJSONExit
 	}
 
+	// Apply configured umask (normally done by initConfig, which JSON mode skips)
+	if cfg.System.Umask != "" {
+		if mask, err := strconv.ParseUint(cfg.System.Umask, 8, 32); err == nil {
+			syscall.Umask(int(mask))
+		}
+	}
+
 	// Re-init logger with the user's config, but remove any stdout target
 	// to keep stdout clean for JSON output. Append stderr so diagnostics are
-	// still visible.
+	// still visible. Preserve format and rotation settings.
 	logOutput := removeStdoutFromLogOutput(cfg.Logging.Output)
 	if logOutput == "" {
 		logOutput = "stderr"
 	} else if !strings.Contains(logOutput, "stderr") {
 		logOutput = logOutput + ",stderr"
 	}
-	loggingCfg = &logging.Config{Output: logOutput, Level: cfg.Logging.Level}
+	loggingCfg = &logging.Config{
+		Output:     logOutput,
+		Level:      cfg.Logging.Level,
+		Format:     cfg.Logging.Format,
+		MaxSizeMB:  cfg.Logging.MaxSizeMB,
+		MaxBackups: cfg.Logging.MaxBackups,
+		MaxAgeDays: cfg.Logging.MaxAgeDays,
+		Compress:   cfg.Logging.Compress,
+	}
 	_ = logging.InitLogger(loggingCfg)
 
 	bs, err := commandutil.BootstrapScrapeOnly(cfg)

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -2,11 +2,15 @@ package scrape
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/javinizer/javinizer-go/internal/commandutil"
 	"github.com/javinizer/javinizer-go/internal/config"
 	"github.com/javinizer/javinizer-go/internal/formatter"
+	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/panicutil"
 	"github.com/javinizer/javinizer-go/internal/scrape"
@@ -29,12 +33,12 @@ func NewCommand() *cobra.Command {
 	}
 	scrapeCmd.Flags().StringSliceP("scrapers", "s", nil, "Comma-separated subset of enabled scrapers to use (e.g., 'r18dev,dmm'); scraper must be enabled in config.yaml")
 	scrapeCmd.Flags().BoolP("force", "f", false, "Force refresh metadata from scrapers (clear cache)")
+	scrapeCmd.Flags().String("output", "text", "Output format: 'text' (default) or 'json'. JSON mode requires --scrapers with exactly one scraper and is incompatible with --force. In JSON mode, stdout contains only the raw ScraperResult or error envelope; all logs go to stderr.")
 	scrapeCmd.Flags().Bool("scrape-actress", false, "Enable actress scraping (overrides config)")
 	scrapeCmd.Flags().Bool("no-scrape-actress", false, "Disable actress scraping (overrides config)")
 	scrapeCmd.Flags().Bool("browser", false, "Enable browser mode for DMM video pages (overrides config)")
 	scrapeCmd.Flags().Bool("no-browser", false, "Disable browser mode for DMM video pages (overrides config)")
 	scrapeCmd.Flags().Int("browser-timeout", 0, "Browser timeout in seconds (overrides config, 0=use config)")
-
 	scrapeCmd.Flags().Bool("actress-db", false, "Enable actress database lookup (overrides config)")
 	scrapeCmd.Flags().Bool("no-actress-db", false, "Disable actress database lookup (overrides config)")
 	scrapeCmd.Flags().Bool("genre-replacement", false, "Enable genre replacement (overrides config)")
@@ -45,8 +49,6 @@ func NewCommand() *cobra.Command {
 // ApplyFlagOverrides applies CLI flag overrides to the config. Exported for testability.
 func ApplyFlagOverrides(cmd *cobra.Command, cfg *config.Config) {
 	cfg.Scrapers.Normalize()
-
-	// DMM-specific CLI flags
 	if cmd.Flags().Changed("scrape-actress") || cmd.Flags().Changed("no-scrape-actress") || cmd.Flags().Changed("browser") || cmd.Flags().Changed("no-browser") {
 		if cfg.Scrapers.Overrides == nil {
 			cfg.Scrapers.Overrides = make(map[string]*models.ScraperSettings)
@@ -80,8 +82,6 @@ func ApplyFlagOverrides(cmd *cobra.Command, cfg *config.Config) {
 			cfg.Scrapers.Browser.Timeout = val
 		}
 	}
-
-	// Actress database flags
 	if cmd.Flags().Changed("actress-db") {
 		if val, _ := cmd.Flags().GetBool("actress-db"); val {
 			cfg.Metadata.ActressDatabase.Enabled = true
@@ -92,8 +92,6 @@ func ApplyFlagOverrides(cmd *cobra.Command, cfg *config.Config) {
 			cfg.Metadata.ActressDatabase.Enabled = false
 		}
 	}
-
-	// Genre replacement flags
 	if cmd.Flags().Changed("genre-replacement") {
 		if val, _ := cmd.Flags().GetBool("genre-replacement"); val {
 			cfg.Metadata.GenreReplacement.Enabled = true
@@ -116,12 +114,10 @@ func Run(ctx context.Context, cmd *cobra.Command, args []string, configFile stri
 	}()
 
 	id := args[0]
-
 	cfg, err := config.LoadOrCreate(configFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load config: %w", err)
 	}
-
 	config.ApplyEnvironmentOverrides(cfg)
 	ApplyFlagOverrides(cmd, cfg)
 	if _, err := config.Prepare(cfg); err != nil {
@@ -139,9 +135,6 @@ func Run(ctx context.Context, cmd *cobra.Command, args []string, configFile stri
 		wf = bs.Workflow
 		ownDeps = true
 	} else {
-		// Build the factory from the effective config (cfg), which has env/CLI
-		// overrides applied above — not deps.GetConfig(), which may hold a stale
-		// snapshot and would drop the overrides for injected-dependency callers.
 		fc, fcErr := workflow.NewFactoryConfigFromRepos(cfg, deps.ScraperRegistry, deps.DB.Repositories())
 		if fcErr != nil {
 			return nil, nil, fmt.Errorf("failed to create factory config: %w", fcErr)
@@ -161,7 +154,6 @@ func Run(ctx context.Context, cmd *cobra.Command, args []string, configFile stri
 
 	forceRefresh, _ := cmd.Flags().GetBool("force")
 	scrapersFlag, _ := cmd.Flags().GetStringSlice("scrapers")
-
 	scrapeCtx := ctx
 	if cfg.Scrapers.RequestTimeoutSeconds > 0 {
 		resolved := timeout.FromConfig("scrapers.request_timeout_seconds", cfg.Scrapers.RequestTimeoutSeconds, 0)
@@ -183,7 +175,6 @@ func Run(ctx context.Context, cmd *cobra.Command, args []string, configFile stri
 		}
 		return nil, nil, err
 	}
-
 	if result.Status == scrape.StatusFailed {
 		errMsg := "scrape failed"
 		if result.Message != "" {
@@ -191,16 +182,159 @@ func Run(ctx context.Context, cmd *cobra.Command, args []string, configFile stri
 		}
 		return nil, nil, fmt.Errorf("%s", errMsg)
 	}
-
 	return result.Movie, result.ScraperResults, nil
 }
 
-// runScrape is the Cobra handler that calls Run() and formats output.
 func runScrape(cmd *cobra.Command, args []string, configFile string) error {
+	outputFlag, _ := cmd.Flags().GetString("output")
+	if outputFlag == "json" {
+		return runScrapeJSON(cmd, args, configFile)
+	}
+	if outputFlag != "text" && outputFlag != "" {
+		return fmt.Errorf("invalid output value: must be 'text' or 'json'")
+	}
 	movie, results, err := Run(cmd.Context(), cmd, args, configFile, nil)
 	if err != nil {
 		return err
 	}
 	formatter.WriteMovie(cmd.OutOrStdout(), movie, results)
 	return nil
+}
+
+func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
+	scrapersFlag, _ := cmd.Flags().GetStringSlice("scrapers")
+	forceRefresh, _ := cmd.Flags().GetBool("force")
+	if err := validateJSONMode(scrapersFlag, forceRefresh); err != nil {
+		return err
+	}
+
+	id := args[0]
+
+	// B3: Respect JAVINIZER_CONFIG env var like initConfig() does.
+	if envConfig := os.Getenv("JAVINIZER_CONFIG"); envConfig != "" {
+		configFile = envConfig
+	}
+
+	// B1: Initialize logger to stderr-only before any code that might log,
+	// preventing stdout contamination of the JSON output.
+	loggingCfg := &logging.Config{Output: "stderr", Level: "warn"}
+	if err := logging.InitLogger(loggingCfg); err != nil {
+		// If logger init fails, force stderr output and continue.
+		_ = logging.SetOutput(os.Stderr)
+	}
+
+	cfg, err := config.LoadOrCreate(configFile)
+	if err != nil {
+		writeJSONError(cmd, unknownErrorEnvelope(fmt.Sprintf("failed to load config: %v", err)))
+		return ErrJSONExit
+	}
+	config.ApplyEnvironmentOverrides(cfg)
+	ApplyFlagOverrides(cmd, cfg)
+	if _, err := config.Prepare(cfg); err != nil {
+		writeJSONError(cmd, unknownErrorEnvelope(fmt.Sprintf("invalid configuration: %v", err)))
+		return ErrJSONExit
+	}
+
+	// Re-init logger with the user's config, but remove any stdout target
+	// to keep stdout clean for JSON output. Append stderr so diagnostics are
+	// still visible.
+	logOutput := removeStdoutFromLogOutput(cfg.Logging.Output)
+	if logOutput == "" {
+		logOutput = "stderr"
+	} else if !strings.Contains(logOutput, "stderr") {
+		logOutput = logOutput + ",stderr"
+	}
+	loggingCfg = &logging.Config{Output: logOutput, Level: cfg.Logging.Level}
+	_ = logging.InitLogger(loggingCfg)
+
+	bs, err := commandutil.BootstrapScrapeOnly(cfg)
+	if err != nil {
+		writeJSONError(cmd, unknownErrorEnvelope(fmt.Sprintf("failed to bootstrap: %v", err)))
+		return ErrJSONExit
+	}
+	defer func() { _ = bs.Close() }()
+
+	engine := scrape.NewQueryOnly(bs.ScraperRegistry)
+
+	scrapeCtx := cmd.Context()
+	if cfg.Scrapers.RequestTimeoutSeconds > 0 {
+		resolved := timeout.FromConfig("scrapers.request_timeout_seconds", cfg.Scrapers.RequestTimeoutSeconds, 0)
+		var cancel context.CancelFunc
+		scrapeCtx, cancel = context.WithTimeout(scrapeCtx, resolved.Duration)
+		defer cancel()
+	}
+
+	result, scraperErr := engine.QueryRaw(scrapeCtx, id, scrapersFlag[0])
+
+	if scrapeCtx.Err() != nil && scraperErr == nil {
+		scraperErr = &models.ScraperError{
+			Kind:      models.ScraperErrorKindUnavailable,
+			Message:   "context deadline exceeded",
+			Retryable: true,
+			Temporary: true,
+		}
+	}
+
+	if scraperErr != nil {
+		writeJSONError(cmd, jsonErrorWrapper{Error: scraperErrorToEnvelope(scraperErr)})
+		return ErrJSONExit
+	}
+
+	// F1: Handle nil result (scraper returned nil, nil)
+	if result == nil {
+		writeJSONError(cmd, unknownErrorEnvelope("scraper returned no result"))
+		return ErrJSONExit
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		writeJSONError(cmd, unknownErrorEnvelope(fmt.Sprintf("failed to marshal result: %v", err)))
+		return ErrJSONExit
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	return nil
+}
+
+// removeStdoutFromLogOutput parses a comma-separated log output string and
+// removes any "stdout" entries, returning the remaining outputs joined.
+func removeStdoutFromLogOutput(output string) string {
+	if output == "" {
+		return ""
+	}
+	parts := strings.Split(output, ",")
+	var filtered []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" && p != "stdout" {
+			filtered = append(filtered, p)
+		}
+	}
+	return strings.Join(filtered, ",")
+}
+
+func validateJSONMode(scrapersFlag []string, forceRefresh bool) error {
+	if len(scrapersFlag) != 1 {
+		return fmt.Errorf("json output requires --scrapers with exactly one scraper")
+	}
+	if strings.TrimSpace(scrapersFlag[0]) == "" {
+		return fmt.Errorf("json output requires --scrapers with a non-empty scraper name")
+	}
+	if forceRefresh {
+		return fmt.Errorf("json output is incompatible with --force")
+	}
+	return nil
+}
+
+// ErrJSONExit is a sentinel error that signals the JSON path already wrote
+// its error envelope to stdout; the caller should exit 1 without printing
+// anything else.
+// ErrJSONExit is a sentinel error that signals the JSON path already wrote
+// its error envelope to stdout; the caller should exit 1 without printing
+// anything else.
+var ErrJSONExit = fmt.Errorf("json error already emitted")
+
+// writeJSONError marshals and writes a JSON error envelope to the command's stdout.
+func writeJSONError(cmd *cobra.Command, wrap jsonErrorWrapper) {
+	data, _ := json.Marshal(wrap)
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(data))
 }

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -23,6 +23,12 @@ import (
 
 const jsonOutput = "json"
 
+var (
+	initJSONStderrLogger   = logging.InitLogger
+	bootstrapQueryOnlyDeps = commandutil.NewQueryOnlyDependencies
+	marshalScraperResult   = json.Marshal
+)
+
 // NewCommand creates the scrape CLI subcommand that fetches metadata for a single movie ID.
 func NewCommand() *cobra.Command {
 	scrapeCmd := &cobra.Command{
@@ -292,7 +298,7 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 		logLevel = "debug"
 	}
 	loggingCfg := &logging.Config{Output: "stderr", Level: logLevel}
-	if err := logging.InitLogger(loggingCfg); err != nil {
+	if err := initJSONStderrLogger(loggingCfg); err != nil {
 		_ = logging.SetOutput(os.Stderr)
 	}
 
@@ -342,7 +348,7 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 		return ErrJSONExit
 	}
 
-	deps, err := commandutil.NewQueryOnlyDependencies(cfg)
+	deps, err := bootstrapQueryOnlyDeps(cfg)
 	if err != nil {
 		writeJSONError(cmd, unknownErrorEnvelope(fmt.Sprintf("failed to bootstrap: %v", err)))
 		return ErrJSONExit
@@ -376,7 +382,7 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 		return ErrJSONExit
 	}
 
-	data, err := json.Marshal(result)
+	data, err := marshalScraperResult(result)
 	if err != nil {
 		writeJSONError(cmd, unknownErrorEnvelope(fmt.Sprintf("failed to marshal result: %v", err)))
 		return ErrJSONExit

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/javinizer/javinizer-go/internal/commandutil"
 	"github.com/javinizer/javinizer-go/internal/config"
@@ -240,7 +239,7 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 	// Apply configured umask (normally done by initConfig, which JSON mode skips)
 	if cfg.System.Umask != "" {
 		if mask, err := strconv.ParseUint(cfg.System.Umask, 8, 32); err == nil {
-			syscall.Umask(int(mask))
+			applyUmask(int(mask))
 		}
 	}
 

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -286,14 +286,14 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 	}
 	_ = logging.InitLogger(loggingCfg)
 
-	bs, err := commandutil.BootstrapScrapeOnly(cfg)
+	deps, err := commandutil.NewQueryOnlyDependencies(cfg)
 	if err != nil {
 		writeJSONError(cmd, unknownErrorEnvelope(fmt.Sprintf("failed to bootstrap: %v", err)))
 		return ErrJSONExit
 	}
-	defer func() { _ = bs.Close() }()
+	defer func() { _ = deps.Close() }()
 
-	engine := scrape.NewQueryOnly(bs.ScraperRegistry)
+	engine := scrape.NewQueryOnly(deps.ScraperRegistry)
 
 	scrapeCtx := cmd.Context()
 	if cfg.Scrapers.RequestTimeoutSeconds > 0 {

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -249,7 +249,7 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 	logOutput := removeStdoutFromLogOutput(cfg.Logging.Output)
 	if logOutput == "" {
 		logOutput = "stderr"
-	} else if !strings.Contains(logOutput, "stderr") {
+	} else if !hasOutputToken(logOutput, "stderr") {
 		logOutput = logOutput + ",stderr"
 	}
 	loggingCfg = &logging.Config{
@@ -309,6 +309,18 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 	}
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(data))
 	return nil
+}
+
+// hasOutputToken checks if a comma-separated output string contains an exact
+// token match (e.g. "stderr"), avoiding false positives on substrings like
+// "/var/log/javinizer-stderr.log".
+func hasOutputToken(output, token string) bool {
+	for _, part := range strings.Split(output, ",") {
+		if strings.TrimSpace(part) == token {
+			return true
+		}
+	}
+	return false
 }
 
 // removeStdoutFromLogOutput parses a comma-separated log output string and

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -361,13 +361,8 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 
 	result, scraperErr := engine.QueryRaw(scrapeCtx, id, scrapersFlag[0])
 
-	if scrapeCtx.Err() != nil && scraperErr == nil {
-		scraperErr = &models.ScraperError{
-			Kind:      models.ScraperErrorKindUnavailable,
-			Message:   "context deadline exceeded",
-			Retryable: true,
-			Temporary: true,
-		}
+	if ctxErr := scrapeCtx.Err(); ctxErr != nil {
+		scraperErr = contextErrorForJSON(ctxErr)
 	}
 
 	if scraperErr != nil {
@@ -388,6 +383,17 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 	}
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(data))
 	return nil
+}
+
+func contextErrorForJSON(err error) *models.ScraperError {
+	message := err.Error()
+	return &models.ScraperError{
+		Kind:      models.ScraperErrorKindUnavailable,
+		Message:   message,
+		Cause:     err,
+		Retryable: true,
+		Temporary: true,
+	}
 }
 
 // hasOutputToken checks if a comma-separated output string contains an exact

--- a/cmd/javinizer/commands/scrape/command.go
+++ b/cmd/javinizer/commands/scrape/command.go
@@ -26,7 +26,17 @@ func NewCommand() *cobra.Command {
 	scrapeCmd := &cobra.Command{
 		Use:   "scrape [id]",
 		Short: "Scrape metadata for a movie ID",
-		Args:  cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				output, _ := cmd.Flags().GetString("output")
+				if output == "json" {
+					writeJSONError(cmd, unknownErrorEnvelope("exactly 1 argument (movie ID) is required"))
+					return ErrJSONExit
+				}
+				return fmt.Errorf("accepts 1 arg(s), received %d", len(args))
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configFile, _ := cmd.Flags().GetString("config")
 			return runScrape(cmd, args, configFile)
@@ -203,6 +213,8 @@ func runScrape(cmd *cobra.Command, args []string, configFile string) error {
 }
 
 func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
 	scrapersFlag, _ := cmd.Flags().GetStringSlice("scrapers")
 	forceRefresh, _ := cmd.Flags().GetBool("force")
 	if err := validateJSONMode(scrapersFlag, forceRefresh); err != nil {
@@ -257,9 +269,13 @@ func runScrapeJSON(cmd *cobra.Command, args []string, configFile string) error {
 	} else if !hasOutputToken(logOutput, "stderr") {
 		logOutput = logOutput + ",stderr"
 	}
+	logLevel = cfg.Logging.Level
+	if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
+		logLevel = "debug"
+	}
 	loggingCfg = &logging.Config{
 		Output:     logOutput,
-		Level:      cfg.Logging.Level,
+		Level:      logLevel,
 		Format:     cfg.Logging.Format,
 		MaxSizeMB:  cfg.Logging.MaxSizeMB,
 		MaxBackups: cfg.Logging.MaxBackups,

--- a/cmd/javinizer/commands/scrape/coverage_test.go
+++ b/cmd/javinizer/commands/scrape/coverage_test.go
@@ -1,0 +1,48 @@
+package scrape
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasOutputToken(t *testing.T) {
+	assert.True(t, hasOutputToken("stderr", "stderr"))
+	assert.True(t, hasOutputToken("stdout,stderr", "stderr"))
+	assert.True(t, hasOutputToken("stderr,file.log", "stderr"))
+	assert.False(t, hasOutputToken("/var/log/javinizer-stderr.log", "stderr"))
+	assert.False(t, hasOutputToken("stdout,file.log", "stderr"))
+	assert.False(t, hasOutputToken("", "stderr"))
+}
+
+func TestRemoveStdoutFromLogOutput(t *testing.T) {
+	assert.Equal(t, "", removeStdoutFromLogOutput(""))
+	assert.Equal(t, "", removeStdoutFromLogOutput("stdout"))
+	assert.Equal(t, "file.log", removeStdoutFromLogOutput("stdout,file.log"))
+	assert.Equal(t, "file.log", removeStdoutFromLogOutput("file.log,stdout"))
+	assert.Equal(t, "file.log,stderr", removeStdoutFromLogOutput("stdout,file.log,stderr"))
+	assert.Equal(t, "file.log", removeStdoutFromLogOutput("file.log"))
+}
+
+func TestScraperErrorToEnvelope_NilError(t *testing.T) {
+	e := scraperErrorToEnvelope(nil)
+	assert.Equal(t, "unknown", e.Kind)
+}
+
+func TestScraperErrorToEnvelope_UsesErrorWhenMessageEmpty(t *testing.T) {
+	e := scraperErrorToEnvelope(&models.ScraperError{Scraper: "test", StatusCode: 500})
+	assert.NotEmpty(t, e.Message)
+}
+
+func TestUnknownErrorEnvelope(t *testing.T) {
+	wrap := unknownErrorEnvelope("something broke")
+	assert.Equal(t, "unknown", wrap.Error.Kind)
+	assert.Equal(t, "something broke", wrap.Error.Message)
+}
+
+func TestValidateJSONMode_EmptyScraperName(t *testing.T) {
+	err := validateJSONMode([]string{""}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-empty")
+}

--- a/cmd/javinizer/commands/scrape/coverage_test.go
+++ b/cmd/javinizer/commands/scrape/coverage_test.go
@@ -1,11 +1,21 @@
 package scrape
 
 import (
+	"context"
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestContextErrorForJSONOverridesTypedError(t *testing.T) {
+	err := contextErrorForJSON(context.DeadlineExceeded)
+	assert.Equal(t, models.ScraperErrorKindUnavailable, err.Kind)
+	assert.Equal(t, context.DeadlineExceeded.Error(), err.Message)
+	assert.ErrorIs(t, err.Cause, context.DeadlineExceeded)
+	assert.True(t, err.Retryable)
+	assert.True(t, err.Temporary)
+}
 
 func TestHasOutputToken(t *testing.T) {
 	assert.True(t, hasOutputToken("stderr", "stderr"))

--- a/cmd/javinizer/commands/scrape/coverage_test.go
+++ b/cmd/javinizer/commands/scrape/coverage_test.go
@@ -30,6 +30,11 @@ func TestScraperErrorToEnvelope_NilError(t *testing.T) {
 	assert.Equal(t, "unknown", e.Kind)
 }
 
+func TestScraperErrorToEnvelope_EmptyKindBecomesUnknown(t *testing.T) {
+	e := scraperErrorToEnvelope(&models.ScraperError{Message: "panic"})
+	assert.Equal(t, "unknown", e.Kind)
+}
+
 func TestScraperErrorToEnvelope_UsesErrorWhenMessageEmpty(t *testing.T) {
 	e := scraperErrorToEnvelope(&models.ScraperError{Scraper: "test", StatusCode: 500})
 	assert.NotEmpty(t, e.Message)

--- a/cmd/javinizer/commands/scrape/e2e_json_test.go
+++ b/cmd/javinizer/commands/scrape/e2e_json_test.go
@@ -17,7 +17,7 @@ func TestRunScrapeJSON_FullSuccessPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
 	dbPath := filepath.Join(tmpDir, "javinizer.db")
-	cfgContent := "config_version: 3\ndatabase:\n  dsn: \"" + dbPath + "\"\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + dbPath + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
 	os.WriteFile(cfgPath, []byte(cfgContent), 0644)
 	t.Setenv("JAVINIZER_CONFIG", cfgPath)
 
@@ -41,7 +41,7 @@ func TestRunScrapeJSON_TimeoutError(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
 	dbPath := filepath.Join(tmpDir, "javinizer.db")
-	cfgContent := "config_version: 3\ndatabase:\n  dsn: \"" + dbPath + "\"\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n  request_timeout_seconds: 1\n"
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + dbPath + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n  request_timeout_seconds: 1\n"
 	os.WriteFile(cfgPath, []byte(cfgContent), 0644)
 	t.Setenv("JAVINIZER_CONFIG", cfgPath)
 

--- a/cmd/javinizer/commands/scrape/e2e_json_test.go
+++ b/cmd/javinizer/commands/scrape/e2e_json_test.go
@@ -16,7 +16,9 @@ func TestRunScrapeJSON_FullSuccessPath(t *testing.T) {
 	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
-	dbPath := filepath.Join(tmpDir, "javinizer.db")
+	dbBlocker := filepath.Join(tmpDir, "database-blocker")
+	require.NoError(t, os.WriteFile(dbBlocker, []byte("not a directory"), 0o600))
+	dbPath := filepath.Join(dbBlocker, "javinizer.db")
 	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + dbPath + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
 	os.WriteFile(cfgPath, []byte(cfgContent), 0644)
 	t.Setenv("JAVINIZER_CONFIG", cfgPath)
@@ -34,6 +36,8 @@ func TestRunScrapeJSON_FullSuccessPath(t *testing.T) {
 	var result map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(output), &result), "output: %q", output)
 	assert.Equal(t, "e2emock", result["source"])
+	_, statErr := os.Stat(dbPath)
+	assert.Error(t, statErr)
 }
 
 func TestRunScrapeJSON_TimeoutError(t *testing.T) {

--- a/cmd/javinizer/commands/scrape/e2e_json_test.go
+++ b/cmd/javinizer/commands/scrape/e2e_json_test.go
@@ -1,0 +1,65 @@
+package scrape
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunScrapeJSON_FullSuccessPath(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	dbPath := filepath.Join(tmpDir, "javinizer.db")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: \"" + dbPath + "\"\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	os.WriteFile(cfgPath, []byte(cfgContent), 0644)
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := cmd.Execute()
+	require.NoError(t, err, "output: %s", buf.String())
+	output := strings.TrimSpace(buf.String())
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &result), "output: %q", output)
+	assert.Equal(t, "e2emock", result["source"])
+}
+
+func TestRunScrapeJSON_TimeoutError(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	dbPath := filepath.Join(tmpDir, "javinizer.db")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: \"" + dbPath + "\"\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n  request_timeout_seconds: 1\n"
+	os.WriteFile(cfgPath, []byte(cfgContent), 0644)
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"TEST-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := cmd.Execute()
+	output := strings.TrimSpace(buf.String())
+	require.NotEmpty(t, output)
+	if err != nil {
+		var wrap jsonErrorWrapper
+		require.NoError(t, json.Unmarshal([]byte(output), &wrap))
+	} else {
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+	}
+}

--- a/cmd/javinizer/commands/scrape/full_coverage_test.go
+++ b/cmd/javinizer/commands/scrape/full_coverage_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,6 +84,7 @@ func TestRunScrapeJSON_Umask(t *testing.T) {
 func TestRunScrapeJSON_ConfiguredLogOutput(t *testing.T) {
 	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
 	tmpDir := t.TempDir()
+	t.Cleanup(func() { logging.CloseLogger() })
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
 	logFile := filepath.ToSlash(filepath.Join(tmpDir, "javinizer.log"))
 	dbPath := filepath.ToSlash(filepath.Join(tmpDir, "javinizer.db"))
@@ -107,6 +109,7 @@ func TestRunScrapeJSON_ConfiguredLogOutput(t *testing.T) {
 func TestRunScrapeJSON_ConfiguredLogOutputWithStdout(t *testing.T) {
 	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
 	tmpDir := t.TempDir()
+	t.Cleanup(func() { logging.CloseLogger() })
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
 	logFile := filepath.ToSlash(filepath.Join(tmpDir, "javinizer.log"))
 	dbPath := filepath.ToSlash(filepath.Join(tmpDir, "javinizer.db"))

--- a/cmd/javinizer/commands/scrape/full_coverage_test.go
+++ b/cmd/javinizer/commands/scrape/full_coverage_test.go
@@ -84,8 +84,9 @@ func TestRunScrapeJSON_ConfiguredLogOutput(t *testing.T) {
 	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
-	logFile := filepath.Join(tmpDir, "javinizer.log")
-	cfgContent := "config_version: 3\nlogging:\n  output: " + logFile + "\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	logFile := filepath.ToSlash(filepath.Join(tmpDir, "javinizer.log"))
+	dbPath := filepath.ToSlash(filepath.Join(tmpDir, "javinizer.db"))
+	cfgContent := "config_version: 3\nlogging:\n  output: " + logFile + "\ndatabase:\n  dsn: " + dbPath + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
 	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
 	t.Setenv("JAVINIZER_CONFIG", cfgPath)
 
@@ -107,8 +108,9 @@ func TestRunScrapeJSON_ConfiguredLogOutputWithStdout(t *testing.T) {
 	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
-	logFile := filepath.Join(tmpDir, "javinizer.log")
-	cfgContent := "config_version: 3\nlogging:\n  output: stdout," + logFile + "\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	logFile := filepath.ToSlash(filepath.Join(tmpDir, "javinizer.log"))
+	dbPath := filepath.ToSlash(filepath.Join(tmpDir, "javinizer.db"))
+	cfgContent := "config_version: 3\nlogging:\n  output: stdout," + logFile + "\ndatabase:\n  dsn: " + dbPath + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
 	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
 	t.Setenv("JAVINIZER_CONFIG", cfgPath)
 

--- a/cmd/javinizer/commands/scrape/full_coverage_test.go
+++ b/cmd/javinizer/commands/scrape/full_coverage_test.go
@@ -1,0 +1,205 @@
+package scrape
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunScrapeJSON_Verbose(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+
+	cmd := NewCommand()
+	cmd.PersistentFlags().BoolP("verbose", "v", false, "")
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock", "-v"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := cmd.Execute()
+	require.NoError(t, err, "output: %s", buf.String())
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &result))
+	assert.Equal(t, "e2emock", result["source"])
+}
+
+func TestRunScrapeJSON_PrepareError(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority: []\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+}
+
+func TestRunScrapeJSON_Umask(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\nsystem:\n  umask: \"022\"\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := cmd.Execute()
+	require.NoError(t, err, "output: %s", buf.String())
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &result))
+	assert.Equal(t, "e2emock", result["source"])
+}
+
+func TestRunScrapeJSON_ConfiguredLogOutput(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	logFile := filepath.Join(tmpDir, "javinizer.log")
+	cfgContent := "config_version: 3\nlogging:\n  output: " + logFile + "\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := cmd.Execute()
+	require.NoError(t, err, "output: %s", buf.String())
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &result))
+	assert.Equal(t, "e2emock", result["source"])
+}
+
+func TestRunScrapeJSON_ConfiguredLogOutputWithStdout(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	logFile := filepath.Join(tmpDir, "javinizer.log")
+	cfgContent := "config_version: 3\nlogging:\n  output: stdout," + logFile + "\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := cmd.Execute()
+	require.NoError(t, err, "output: %s", buf.String())
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &result))
+	assert.Equal(t, "e2emock", result["source"])
+}
+
+func TestRunScrapeJSON_ContextTimeout(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n  request_timeout_seconds: 1\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := cmd.Execute()
+	output := strings.TrimSpace(buf.String())
+	require.NotEmpty(t, output)
+	if err != nil {
+		var wrap jsonErrorWrapper
+		require.NoError(t, json.Unmarshal([]byte(output), &wrap))
+		assert.Contains(t, []string{"unavailable", "unknown"}, wrap.Error.Kind)
+	} else {
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+		assert.Equal(t, "e2emock", result["source"])
+	}
+}
+
+func TestMalformedValueFlag_AllBranches(t *testing.T) {
+	assert.Equal(t, "--scrapers", malformedValueFlag([]string{"--scrapers"}))
+	assert.Equal(t, "--scrapers", malformedValueFlag([]string{"--scrapers", "--output"}))
+	assert.Equal(t, "", malformedValueFlag([]string{"--scrapers", "r18dev"}))
+	assert.Equal(t, "-s", malformedValueFlag([]string{"-s"}))
+	assert.Equal(t, "--browser-timeout", malformedValueFlag([]string{"--browser-timeout", "--output"}))
+	assert.Equal(t, "--config", malformedValueFlag([]string{"--config"}))
+}
+
+func TestRequestedJSONOutput_NotJSON(t *testing.T) {
+	cmd := NewCommand()
+	assert.False(t, requestedJSONOutput(cmd))
+}
+
+func TestContextErrorForJSON_Canceled(t *testing.T) {
+	err := contextErrorForJSON(context.Canceled)
+	assert.Equal(t, models.ScraperErrorKindUnavailable, err.Kind)
+	assert.Equal(t, context.Canceled.Error(), err.Message)
+	assert.True(t, err.Retryable)
+	assert.True(t, err.Temporary)
+}
+
+func TestRemoveStdoutFromLogOutput_EdgeCases(t *testing.T) {
+	assert.Equal(t, "", removeStdoutFromLogOutput("stdout,stdout"))
+	assert.Equal(t, "file.log,stderr", removeStdoutFromLogOutput(" stdout , file.log , stderr "))
+}
+
+func TestRunScrapeJSON_ScraperError(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"UNKNOWN-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.NotEmpty(t, wrap.Error.Message)
+}

--- a/cmd/javinizer/commands/scrape/json_cli_test.go
+++ b/cmd/javinizer/commands/scrape/json_cli_test.go
@@ -87,6 +87,30 @@ func TestRunScrapeJSON_ConfigErrorEmitsJSON(t *testing.T) {
 	assert.Equal(t, "unknown", wrap.Error.Kind)
 }
 
+func TestRunScrapeJSON_UnknownFlagEmitsJSON(t *testing.T) {
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"TEST-001", "--output", "json", "--unknown"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.Contains(t, wrap.Error.Message, "unknown flag")
+}
+
+func TestRunScrapeJSON_MissingFlagValueEmitsJSON(t *testing.T) {
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"TEST-001", "--output", "json", "--scrapers"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.Contains(t, wrap.Error.Message, "needs an argument")
+}
+
 func TestErrJSONExit_IsSentinel(t *testing.T) {
 	assert.Equal(t, "json error already emitted", ErrJSONExit.Error())
 }

--- a/cmd/javinizer/commands/scrape/json_cli_test.go
+++ b/cmd/javinizer/commands/scrape/json_cli_test.go
@@ -3,6 +3,7 @@ package scrape
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -67,7 +68,11 @@ func TestRunScrapeJSON_InvalidOutputValue(t *testing.T) {
 }
 
 func TestRunScrapeJSON_ConfigErrorEmitsJSON(t *testing.T) {
-	t.Setenv("JAVINIZER_CONFIG", "/nonexistent/deep/path/config.yaml")
+	// Use an invalid YAML config file to trigger a config load error on all platforms
+	tmpDir := t.TempDir()
+	cfgPath := tmpDir + "/bad.yaml"
+	os.WriteFile(cfgPath, []byte(":invalid: yaml: ["), 0644)
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
 	cmd := NewCommand()
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true

--- a/cmd/javinizer/commands/scrape/json_cli_test.go
+++ b/cmd/javinizer/commands/scrape/json_cli_test.go
@@ -111,6 +111,51 @@ func TestRunScrapeJSON_MissingFlagValueEmitsJSON(t *testing.T) {
 	assert.Contains(t, wrap.Error.Message, "needs an argument")
 }
 
+func TestRunScrapeJSON_UnknownFlagBeforeOutputEmitsJSON(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+	os.Args = []string{"javinizer", "scrape", "TEST-001", "--unknown", "--output", "json"}
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"TEST-001", "--unknown", "--output", "json"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.Contains(t, wrap.Error.Message, "unknown flag")
+}
+
+func TestRunScrapeJSON_MissingFlagValueBeforeOutputEmitsJSON(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+	os.Args = []string{"javinizer", "scrape", "TEST-001", "--scrapers", "--output", "json"}
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"TEST-001", "--scrapers", "--output", "json"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.Contains(t, wrap.Error.Message, "needs an argument")
+}
+
+func TestRunScrapeJSON_UnknownFlagBeforeOutputEqualsEmitsJSON(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+	os.Args = []string{"javinizer", "scrape", "TEST-001", "--unknown", "--output=json"}
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"TEST-001", "--unknown", "--output=json"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.Contains(t, wrap.Error.Message, "unknown flag")
+}
+
 func TestErrJSONExit_IsSentinel(t *testing.T) {
 	assert.Equal(t, "json error already emitted", ErrJSONExit.Error())
 }

--- a/cmd/javinizer/commands/scrape/json_cli_test.go
+++ b/cmd/javinizer/commands/scrape/json_cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -59,12 +60,40 @@ func TestRunScrapeJSON_ValidationEmptyScraperName(t *testing.T) {
 	assert.Contains(t, err.Error(), "non-empty")
 }
 
+func TestRunScrapeJSON_ExplicitEmptyOutputRejected(t *testing.T) {
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"TEST-001", "--output="})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output value")
+}
+
 func TestRunScrapeJSON_InvalidOutputValue(t *testing.T) {
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"TEST-001", "--output", "xml"})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid output value")
+}
+
+func TestRunScrapeJSON_LoggerErrorEmitsJSON(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\nlogging:\n  level: invalid\nscrapers:\n  priority:\n    - e2emock\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.Contains(t, wrap.Error.Message, "failed to initialize logger")
 }
 
 func TestRunScrapeJSON_ConfigErrorEmitsJSON(t *testing.T) {

--- a/cmd/javinizer/commands/scrape/json_cli_test.go
+++ b/cmd/javinizer/commands/scrape/json_cli_test.go
@@ -1,0 +1,129 @@
+package scrape
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunScrapeJSON_ValidationNoScrapers(t *testing.T) {
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"TEST-001", "--output", "json"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	require.Error(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "exactly one scraper")
+}
+
+func TestRunScrapeJSON_ValidationTwoScrapers(t *testing.T) {
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"TEST-001", "--output", "json", "--scrapers", "r18dev,dmm"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	require.Error(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "exactly one scraper")
+}
+
+func TestRunScrapeJSON_ValidationForce(t *testing.T) {
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"TEST-001", "--output", "json", "--scrapers", "r18dev", "--force"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	require.Error(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "--force")
+}
+
+func TestRunScrapeJSON_ValidationEmptyScraperName(t *testing.T) {
+	// Cobra's StringSlice with empty string gives []string{} (empty slice),
+	// which triggers the len != 1 check, not the empty-name check.
+	// Test validateJSONMode directly for the empty-name case.
+	err := validateJSONMode([]string{""}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-empty")
+}
+
+func TestRunScrapeJSON_InvalidOutputValue(t *testing.T) {
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"TEST-001", "--output", "xml"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output value")
+}
+
+func TestRunScrapeJSON_ConfigErrorEmitsJSON(t *testing.T) {
+	t.Setenv("JAVINIZER_CONFIG", "/nonexistent/deep/path/config.yaml")
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"TEST-001", "--output", "json", "--scrapers", "r18dev"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	output := strings.TrimSpace(buf.String())
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal([]byte(output), &wrap), "output was: %q", output)
+	assert.Equal(t, "unknown", wrap.Error.Kind)
+}
+
+func TestErrJSONExit_IsSentinel(t *testing.T) {
+	assert.Equal(t, "json error already emitted", ErrJSONExit.Error())
+}
+
+func TestWriteJSONError(t *testing.T) {
+	cmd := NewCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	writeJSONError(cmd, unknownErrorEnvelope("test error"))
+	output := buf.String()
+	assert.Contains(t, output, "test error")
+	assert.Contains(t, output, "unknown")
+}
+
+func TestRemoveStdoutFromLogOutput_AllPatterns(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{"", ""},
+		{"stdout", ""},
+		{"stderr", "stderr"},
+		{"stdout,stderr", "stderr"},
+		{"stdout,file.log", "file.log"},
+		{"stdout,file.log,stderr", "file.log,stderr"},
+		{"file.log,stdout,stderr", "file.log,stderr"},
+		{"file.log", "file.log"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expect, removeStdoutFromLogOutput(tt.input))
+	}
+}
+
+func TestHasOutputToken_AllPatterns(t *testing.T) {
+	assert.True(t, hasOutputToken("stderr", "stderr"))
+	assert.True(t, hasOutputToken("stdout,stderr", "stderr"))
+	assert.True(t, hasOutputToken("stderr,file.log", "stderr"))
+	assert.False(t, hasOutputToken("/var/log/javinizer-stderr.log", "stderr"))
+	assert.False(t, hasOutputToken("stdout,file.log", "stderr"))
+	assert.False(t, hasOutputToken("", "stderr"))
+}
+
+func TestApplyUmask_NoPanic(t *testing.T) {
+	assert.NotPanics(t, func() { applyUmask(0o077) })
+}

--- a/cmd/javinizer/commands/scrape/json_coverage_test.go
+++ b/cmd/javinizer/commands/scrape/json_coverage_test.go
@@ -17,7 +17,7 @@ func TestRunScrapeJSON_BootstrapError(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
 	dbPath := filepath.Join(tmpDir, "nonexistent", "deep", "db.sqlite")
-	cfgContent := "database:\n  dsn: \"" + dbPath + "\"\n  type: sqlite\nscrapers:\n  priority:\n    - r18dev\n"
+	cfgContent := "database:\n  dsn: " + dbPath + "\n  type: sqlite\nscrapers:\n  priority:\n    - r18dev\n"
 	os.WriteFile(cfgPath, []byte(cfgContent), 0644)
 	t.Setenv("JAVINIZER_CONFIG", cfgPath)
 

--- a/cmd/javinizer/commands/scrape/json_coverage_test.go
+++ b/cmd/javinizer/commands/scrape/json_coverage_test.go
@@ -1,0 +1,57 @@
+package scrape
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunScrapeJSON_BootstrapError(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	dbPath := filepath.Join(tmpDir, "nonexistent", "deep", "db.sqlite")
+	cfgContent := "database:\n  dsn: \"" + dbPath + "\"\n  type: sqlite\nscrapers:\n  priority:\n    - r18dev\n"
+	os.WriteFile(cfgPath, []byte(cfgContent), 0644)
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"TEST-001", "--output", "json", "--scrapers", "r18dev"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	output := strings.TrimSpace(buf.String())
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal([]byte(output), &wrap), "output was: %q", output)
+	assert.Equal(t, "unknown", wrap.Error.Kind)
+}
+
+func TestRunScrapeJSON_SuccessSerialization(t *testing.T) {
+	result := &models.ScraperResult{Source: "test", ID: "TEST-001", Title: "Test Movie"}
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "Test Movie")
+	assert.Contains(t, string(data), "TEST-001")
+}
+
+func TestRunScrapeJSON_UnknownScraperError(t *testing.T) {
+	// The unknown-scraper path is tested in internal/scrape via TestQueryRaw_UnknownScraper.
+	// Here we test the error envelope mapping.
+	envelope := scraperErrorToEnvelope(&models.ScraperError{
+		Scraper: "nonexistent",
+		Kind:    models.ScraperErrorKindUnknown,
+		Message: "scraper \"nonexistent\" is not registered or enabled",
+	})
+	assert.Equal(t, "unknown", envelope.Kind)
+	assert.Contains(t, envelope.Message, "not registered")
+}

--- a/cmd/javinizer/commands/scrape/json_dto.go
+++ b/cmd/javinizer/commands/scrape/json_dto.go
@@ -1,0 +1,49 @@
+package scrape
+
+import "github.com/javinizer/javinizer-go/internal/models"
+
+// jsonErrorEnvelope is the CLI-side wire DTO for scraper errors in JSON output mode.
+// It deliberately does NOT use the internal ScraperError struct (which has a Cause
+// error field that should not be serialized). Only the needed fields are mapped.
+type jsonErrorEnvelope struct {
+	Kind       string `json:"kind"`
+	Message    string `json:"message"`
+	StatusCode int    `json:"status_code"`
+	Retryable  bool   `json:"retryable"`
+	Temporary  bool   `json:"temporary"`
+}
+
+// jsonErrorWrapper wraps the envelope as {"error": {...}}.
+type jsonErrorWrapper struct {
+	Error jsonErrorEnvelope `json:"error"`
+}
+
+// scraperErrorToEnvelope maps a *models.ScraperError to the CLI-side JSON DTO.
+// Uses Error() for the message when Message is empty, since cause/status-generated
+// errors may have an empty Message field but a meaningful Error() string.
+func scraperErrorToEnvelope(err *models.ScraperError) jsonErrorEnvelope {
+	if err == nil {
+		return jsonErrorEnvelope{Kind: string(models.ScraperErrorKindUnknown)}
+	}
+	msg := err.Message
+	if msg == "" {
+		msg = err.Error()
+	}
+	return jsonErrorEnvelope{
+		Kind:       string(err.Kind),
+		Message:    msg,
+		StatusCode: err.StatusCode,
+		Retryable:  err.Retryable,
+		Temporary:  err.Temporary,
+	}
+}
+
+// unknownErrorEnvelope creates a generic unknown error envelope.
+func unknownErrorEnvelope(msg string) jsonErrorWrapper {
+	return jsonErrorWrapper{
+		Error: jsonErrorEnvelope{
+			Kind:    string(models.ScraperErrorKindUnknown),
+			Message: msg,
+		},
+	}
+}

--- a/cmd/javinizer/commands/scrape/json_dto.go
+++ b/cmd/javinizer/commands/scrape/json_dto.go
@@ -29,8 +29,12 @@ func scraperErrorToEnvelope(err *models.ScraperError) jsonErrorEnvelope {
 	if msg == "" {
 		msg = err.Error()
 	}
+	kind := err.Kind
+	if kind == "" {
+		kind = models.ScraperErrorKindUnknown
+	}
 	return jsonErrorEnvelope{
-		Kind:       string(err.Kind),
+		Kind:       string(kind),
 		Message:    msg,
 		StatusCode: err.StatusCode,
 		Retryable:  err.Retryable,

--- a/cmd/javinizer/commands/scrape/json_output_test.go
+++ b/cmd/javinizer/commands/scrape/json_output_test.go
@@ -1,0 +1,261 @@
+package scrape
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scrape"
+	"github.com/javinizer/javinizer-go/internal/scraperutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubScraper struct {
+	name    string
+	enabled bool
+	result  *models.ScraperResult
+	err     error
+	panic   interface{}
+}
+
+func (s *stubScraper) Name() string { return s.name }
+func (s *stubScraper) Search(_ context.Context, id string) (*models.ScraperResult, error) {
+	if s.panic != nil {
+		panic(s.panic)
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	r := *s.result
+	r.ID = id
+	return &r, nil
+}
+func (s *stubScraper) GetURL(_ context.Context, _ string) (string, error) { return "", nil }
+func (s *stubScraper) IsEnabled() bool                                    { return s.enabled }
+func (s *stubScraper) Close() error                                       { return nil }
+func (s *stubScraper) Config() *models.ScraperSettings {
+	return &models.ScraperSettings{Enabled: s.enabled}
+}
+
+func newTestEngine(t *testing.T, scraper models.Scraper) *scrape.Scraper {
+	reg := scraperutil.NewScraperRegistry()
+	reg.RegisterInstance(scraper)
+	return scrape.NewQueryOnly(reg)
+}
+
+func TestQueryRaw_ReturnsUnmergedResult(t *testing.T) {
+	expected := &models.ScraperResult{Source: "test", Title: "Test Movie"}
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, result: expected})
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	require.Nil(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "Test Movie", result.Title)
+	assert.Equal(t, "TEST-001", result.ID)
+}
+
+func TestQueryRaw_PreservesNotFoundError(t *testing.T) {
+	scraperErr := models.NewScraperNotFoundError("test", "not found")
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, err: scraperErr})
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	assert.Equal(t, models.ScraperErrorKindNotFound, err.Kind)
+	assert.Equal(t, 0, err.StatusCode)
+	assert.False(t, err.Retryable)
+	assert.False(t, err.Temporary)
+}
+
+func TestQueryRaw_PreservesBlockedError(t *testing.T) {
+	scraperErr := models.NewScraperStatusError("test", 403, "forbidden")
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, err: scraperErr})
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	assert.Equal(t, models.ScraperErrorKindBlocked, err.Kind)
+	assert.Equal(t, 403, err.StatusCode)
+	assert.False(t, err.Retryable)
+}
+
+func TestQueryRaw_PreservesTimeoutError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	time.Sleep(5 * time.Millisecond)
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, result: &models.ScraperResult{}})
+	result, err := engine.QueryRaw(ctx, "TEST-001", "test")
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	assert.Equal(t, models.ScraperErrorKindUnavailable, err.Kind)
+	assert.True(t, err.Retryable)
+	assert.True(t, err.Temporary)
+}
+
+func TestQueryRaw_PreservesPanic(t *testing.T) {
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, panic: "boom"})
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	assert.Equal(t, models.ScraperErrorKindUnknown, err.Kind)
+	assert.Contains(t, err.Message, "boom")
+}
+
+func TestQueryRaw_UnknownScraper(t *testing.T) {
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, result: &models.ScraperResult{}})
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "nonexistent")
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	assert.Equal(t, models.ScraperErrorKindUnknown, err.Kind)
+	assert.Contains(t, err.Message, "not registered")
+}
+
+func TestScraperErrorToEnvelope(t *testing.T) {
+	t.Run("nil returns unknown", func(t *testing.T) {
+		e := scraperErrorToEnvelope(nil)
+		assert.Equal(t, "unknown", e.Kind)
+	})
+	t.Run("not_found", func(t *testing.T) {
+		e := scraperErrorToEnvelope(models.NewScraperNotFoundError("test", "not found"))
+		assert.Equal(t, "not_found", e.Kind)
+		assert.Equal(t, 0, e.StatusCode)
+		assert.False(t, e.Retryable)
+	})
+	t.Run("blocked", func(t *testing.T) {
+		e := scraperErrorToEnvelope(models.NewScraperStatusError("test", 403, "forbidden"))
+		assert.Equal(t, "blocked", e.Kind)
+		assert.Equal(t, 403, e.StatusCode)
+	})
+	t.Run("uses Error() when Message empty", func(t *testing.T) {
+		e := scraperErrorToEnvelope(&models.ScraperError{Kind: models.ScraperErrorKindUnknown, StatusCode: 500, Scraper: "test"})
+		assert.NotEmpty(t, e.Message)
+	})
+}
+
+func TestValidation_InvalidOutput(t *testing.T) {
+	cmd := NewCommand()
+	cmd.SetArgs([]string{"TEST-001", "--output", "xml"})
+	var errMsg string
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		output, _ := cmd.Flags().GetString("output")
+		if output != "text" && output != "json" && output != "" {
+			return fmt.Errorf("invalid output value: must be 'text' or 'json'")
+		}
+		return nil
+	}
+	err := cmd.Execute()
+	require.Error(t, err)
+	errMsg = err.Error()
+	assert.Contains(t, errMsg, "invalid output value")
+}
+
+func TestValidation_JSONRequiresSingleScraper(t *testing.T) {
+	t.Run("no scrapers", func(t *testing.T) {
+		scrapersFlag := []string{}
+		err := validateJSONMode(scrapersFlag, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exactly one scraper")
+	})
+	t.Run("two scrapers", func(t *testing.T) {
+		scrapersFlag := []string{"r18dev", "dmm"}
+		err := validateJSONMode(scrapersFlag, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exactly one scraper")
+	})
+	t.Run("valid single scraper", func(t *testing.T) {
+		err := validateJSONMode([]string{"r18dev"}, false)
+		require.NoError(t, err)
+	})
+}
+
+func TestValidation_JSONRejectsForce(t *testing.T) {
+	err := validateJSONMode([]string{"r18dev"}, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--force")
+}
+
+func TestJSONOutput_Success(t *testing.T) {
+	expected := &models.ScraperResult{Source: "test", Title: "Test Movie", ID: "TEST-001"}
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, result: expected})
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	require.Nil(t, err)
+	require.NotNil(t, result)
+	data, marshalErr := json.Marshal(result)
+	require.NoError(t, marshalErr)
+	var parsed models.ScraperResult
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Equal(t, "Test Movie", parsed.Title)
+	assert.Equal(t, "test", parsed.Source)
+}
+
+func TestJSONOutput_NotFoundError(t *testing.T) {
+	scraperErr := models.NewScraperNotFoundError("test", "not found")
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, err: scraperErr})
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	envelope := scraperErrorToEnvelope(err)
+	assert.Equal(t, "not_found", envelope.Kind)
+	assert.Equal(t, 0, envelope.StatusCode)
+	assert.False(t, envelope.Retryable)
+}
+
+func TestJSONOutput_BlockedError(t *testing.T) {
+	scraperErr := models.NewScraperStatusError("test", 403, "forbidden")
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, err: scraperErr})
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	envelope := scraperErrorToEnvelope(err)
+	assert.Equal(t, "blocked", envelope.Kind)
+	assert.Equal(t, 403, envelope.StatusCode)
+}
+
+func TestJSONOutput_TimeoutError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	time.Sleep(5 * time.Millisecond)
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, result: &models.ScraperResult{}})
+	result, err := engine.QueryRaw(ctx, "TEST-001", "test")
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	envelope := scraperErrorToEnvelope(err)
+	assert.Equal(t, "unavailable", envelope.Kind)
+	assert.True(t, envelope.Retryable)
+	assert.True(t, envelope.Temporary)
+}
+
+func TestJSONOutput_PanicError(t *testing.T) {
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, panic: "boom"})
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	envelope := scraperErrorToEnvelope(err)
+	assert.Equal(t, "unknown", envelope.Kind)
+	assert.False(t, envelope.Retryable)
+	assert.False(t, envelope.Temporary)
+	assert.Contains(t, envelope.Message, "boom")
+}
+
+func TestJSONOutput_UnknownScraper(t *testing.T) {
+	engine := newTestEngine(t, &stubScraper{name: "test", enabled: true, result: &models.ScraperResult{}})
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "nonexistent")
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	envelope := scraperErrorToEnvelope(err)
+	assert.Equal(t, "unknown", envelope.Kind)
+	assert.Contains(t, envelope.Message, "not registered")
+}
+
+func TestJSONOutput_StdoutContainsOnlyJSON(t *testing.T) {
+	expected := &models.ScraperResult{Source: "test", Title: "Test"}
+	data, _ := json.Marshal(expected)
+	s := string(data)
+	assert.True(t, strings.HasPrefix(s, "{"))
+	assert.True(t, strings.HasSuffix(s, "}"))
+	var parsed models.ScraperResult
+	require.NoError(t, json.Unmarshal(data, &parsed))
+}

--- a/cmd/javinizer/commands/scrape/patch_coverage_test.go
+++ b/cmd/javinizer/commands/scrape/patch_coverage_test.go
@@ -1,0 +1,188 @@
+package scrape
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/commandutil"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunScrape_FlagErrorNonJSON(t *testing.T) {
+	origArgs := os.Args
+	t.Cleanup(func() { os.Args = origArgs })
+	os.Args = []string{"javinizer", "scrape", "TEST-001", "--bogus-flag"}
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"TEST-001", "--bogus-flag"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.NotEqual(t, ErrJSONExit, err)
+	assert.Contains(t, err.Error(), "unknown flag")
+}
+
+func TestRunScrapeJSON_StderrLoggerFallback(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	orig := initJSONStderrLogger
+	t.Cleanup(func() { initJSONStderrLogger = orig })
+	initJSONStderrLogger = func(*logging.Config) error { return errors.New("logger boom") }
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	require.NoError(t, err, "output: %s", buf.String())
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &result))
+	assert.Equal(t, "e2emock", result["source"])
+}
+
+func TestRunScrapeJSON_PrepareFailure(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n  browser:\n    enabled: true\n    timeout: 30\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock", "--browser-timeout", "99999"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.Contains(t, wrap.Error.Message, "invalid configuration")
+}
+
+func TestRunScrapeJSON_LogOutputStdoutFallback(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	t.Cleanup(func() { logging.CloseLogger() })
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	dbPath := filepath.ToSlash(filepath.Join(tmpDir, "javinizer.db"))
+	cfgContent := "config_version: 3\nlogging:\n  output: stdout\ndatabase:\n  dsn: " + dbPath + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	require.NoError(t, err, "output: %s", buf.String())
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &result))
+	assert.Equal(t, "e2emock", result["source"])
+}
+
+func TestRunScrapeJSON_BootstrapFailure(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	orig := bootstrapQueryOnlyDeps
+	t.Cleanup(func() { bootstrapQueryOnlyDeps = orig })
+	bootstrapQueryOnlyDeps = func(cfg *config.Config) (*commandutil.CoreDeps, error) {
+		return nil, errors.New("bootstrap boom")
+	}
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.Contains(t, wrap.Error.Message, "failed to bootstrap")
+}
+
+func TestRunScrapeJSON_ContextErrorAfterQuery(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n  request_timeout_seconds: 60\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := cmd.ExecuteContext(ctx)
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.Equal(t, "unavailable", wrap.Error.Kind)
+}
+
+func TestRunScrapeJSON_NilResult(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"NIL-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.Contains(t, wrap.Error.Message, "scraper returned no result")
+}
+
+func TestRunScrapeJSON_MarshalFailure(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	orig := marshalScraperResult
+	t.Cleanup(func() { marshalScraperResult = orig })
+	marshalScraperResult = func(any) ([]byte, error) { return nil, errors.New("marshal boom") }
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "config_version: 3\ndatabase:\n  dsn: " + filepath.Join(tmpDir, "javinizer.db") + "\n  type: sqlite\nscrapers:\n  priority:\n    - e2emock\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("JAVINIZER_CONFIG", cfgPath)
+	cmd := NewCommand()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"GOOD-001", "--output", "json", "--scrapers", "e2emock"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	err := cmd.Execute()
+	assert.Equal(t, ErrJSONExit, err)
+	var wrap jsonErrorWrapper
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &wrap))
+	assert.Contains(t, wrap.Error.Message, "failed to marshal result")
+}

--- a/cmd/javinizer/commands/scrape/umask_unix.go
+++ b/cmd/javinizer/commands/scrape/umask_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package scrape
+
+import "syscall"
+
+func applyUmask(mask int) {
+	syscall.Umask(mask)
+}

--- a/cmd/javinizer/commands/scrape/umask_windows.go
+++ b/cmd/javinizer/commands/scrape/umask_windows.go
@@ -1,0 +1,6 @@
+//go:build windows
+
+package scrape
+
+func applyUmask(mask int) {
+}

--- a/cmd/javinizer/err_json_exit_test.go
+++ b/cmd/javinizer/err_json_exit_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/cmd/javinizer/commands/scrape"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun_ErrJSONExitSuppressed(t *testing.T) {
+	// Verify that ErrJSONExit is properly suppressed (returns 1 without writeCrashLog)
+	oldExecuteFn := executeFn
+	defer func() { executeFn = oldExecuteFn }()
+	executeFn = func() error { return scrape.ErrJSONExit }
+
+	exitCode := run()
+	assert.Equal(t, 1, exitCode)
+}
+
+func TestRun_ErrJSONExitNotWriteCrashLog(t *testing.T) {
+	// Verify that a non-ErrJSONExit error does get writeCrashLog (returns 1)
+	oldExecuteFn := executeFn
+	defer func() { executeFn = oldExecuteFn }()
+	executeFn = func() error { return errors.New("regular error") }
+
+	exitCode := run()
+	assert.Equal(t, 1, exitCode)
+}

--- a/cmd/javinizer/main.go
+++ b/cmd/javinizer/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime/debug"
 	"time"
 
+	"github.com/javinizer/javinizer-go/cmd/javinizer/commands/scrape"
 	"github.com/javinizer/javinizer-go/internal/desktop"
 )
 
@@ -40,6 +42,9 @@ func run() (exitCode int) {
 		}
 	}()
 	if err := executeFn(); err != nil {
+		if errors.Is(err, scrape.ErrJSONExit) {
+			return 1
+		}
 		writeCrashLog(err.Error())
 		return 1
 	}

--- a/cmd/javinizer/root.go
+++ b/cmd/javinizer/root.go
@@ -87,6 +87,7 @@ func init() {
 
 	// Global flags
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "configs/config.yaml", "config file path")
+	rootCmd.SilenceErrors = true
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "enable debug logging")
 
 	// Desktop builds (injected via -X internal/desktop.BuildDesktop=1) run with

--- a/cmd/javinizer/root.go
+++ b/cmd/javinizer/root.go
@@ -166,7 +166,17 @@ func shouldSkipConfigInit(cmd *cobra.Command) bool {
 
 	// `javinizer --version` should stay lightweight and side-effect free.
 	versionFlag := cmd.Flags().Lookup("version")
-	return versionFlag != nil && versionFlag.Changed
+	if versionFlag != nil && versionFlag.Changed {
+		return true
+	}
+	// `javinizer scrape --output json` handles config init itself so it can
+	// emit JSON error envelopes instead of os.Exit(1) on config failures.
+	if cmd.Name() == "scrape" {
+		if outputFlag := cmd.Flags().Lookup("output"); outputFlag != nil && outputFlag.Changed && outputFlag.Value.String() == "json" {
+			return true
+		}
+	}
+	return false
 }
 
 // isTUICommand reports whether cmd (or any ancestor) is the tui subcommand.

--- a/cmd/javinizer/should_skip_test.go
+++ b/cmd/javinizer/should_skip_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/cmd/javinizer/commands/scrape"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldSkipConfigInit_ScrapeJSONOutput(t *testing.T) {
+	cmd := scrape.NewCommand()
+	require.NoError(t, cmd.Flags().Set("output", "json"))
+	assert.True(t, shouldSkipConfigInit(cmd))
+}
+
+func TestShouldSkipConfigInit_ScrapeDefaultOutput(t *testing.T) {
+	cmd := scrape.NewCommand()
+	assert.False(t, shouldSkipConfigInit(cmd))
+}
+
+func TestShouldSkipConfigInit_ScrapeTextOutput(t *testing.T) {
+	cmd := scrape.NewCommand()
+	require.NoError(t, cmd.Flags().Set("output", "text"))
+	assert.False(t, shouldSkipConfigInit(cmd))
+}

--- a/cmd/javinizer/silence_errors_test.go
+++ b/cmd/javinizer/silence_errors_test.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRootCommand_SilenceErrors(t *testing.T) {
+	assert.True(t, rootCmd.SilenceErrors, "rootCmd should have SilenceErrors set to prevent Cobra from printing JSON sentinel errors")
+}

--- a/docs/15-cli-json-output.md
+++ b/docs/15-cli-json-output.md
@@ -1,0 +1,58 @@
+# CLI JSON Output Mode
+
+The `javinizer scrape` command supports machine-readable JSON output via the `--output json` flag. This is designed for automated tooling (e.g., [javinizer-go-tracker](https://github.com/javinizer/javinizer-go-tracker)) that needs raw per-scraper results without aggregation, caching, or database persistence.
+
+## Usage
+
+```bash
+javinizer scrape ABF-153 --scrapers r18dev --output json
+```
+
+**Requirements:**
+- `--scrapers` must specify exactly one scraper
+- `--force` is not allowed (it would trigger a database write)
+- `--config` must point to a valid config file with the named scraper enabled
+
+## Output Schema
+
+### Success (exit 0)
+
+Stdout contains a single JSON object matching `models.ScraperResult`:
+
+```json
+{
+  "source": "r18dev",
+  "source_url": "https://...",
+  "id": "ABF-153",
+  "title": "...",
+  "actresses": [...],
+  "genres": [...],
+  "poster_url": "...",
+  "screenshot_urls": [...]
+}
+```
+
+### Error (exit 1)
+
+Stdout contains an error envelope:
+
+```json
+{
+  "error": {
+    "kind": "not_found",
+    "message": "movie not found",
+    "status_code": 0,
+    "retryable": false,
+    "temporary": false
+  }
+}
+```
+
+**Error kinds:**
+- `not_found` — scraper returned no results (status_code: 0)
+- `blocked` — HTTP 403/451, Cloudflare challenge, or access denied
+- `rate_limited` — HTTP 429
+- `unavailable` — HTTP 5xx, timeout, or context cancellation (retryable, temporary)
+- `unknown` — panic, config error, unknown scraper, or other unexpected failure
+
+All diagnostic logs go to stderr; stdout contains only the JSON document.

--- a/internal/commandutil/dependencies.go
+++ b/internal/commandutil/dependencies.go
@@ -105,6 +105,43 @@ func NewDependencies(cfg *config.Config) (*CoreDeps, error) {
 	return NewDependenciesWithOptions(cfg, nil)
 }
 
+// NewQueryOnlyDependencies initializes scrapers without opening the application database.
+func NewQueryOnlyDependencies(cfg *config.Config) (*CoreDeps, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+
+	reg := scraperutil.NewScraperRegistry()
+	if os.Getenv("JAVINIZER_E2E_SCRAPERS") == "true" {
+		e2emock.Register(reg)
+		e2emock.ApplyToConfig(cfg)
+	} else {
+		scraper.RegisterAll(reg)
+	}
+
+	if err := cfg.Scrapers.Finalize(reg); err != nil {
+		return nil, fmt.Errorf("failed to finalize scraper config: %w", err)
+	}
+	cfg.RecomputeWarnings()
+
+	r18DumpLookup, r18DumpCloser, dumpErr := OpenR18DevDumpLookup(cfg)
+	if dumpErr != nil {
+		logging.Warnf("%v", dumpErr)
+	}
+
+	registry, err := scraper.NewDefaultScraperRegistryFrom(reg, scraper.ScraperRegistryConfigFromApp(cfg), newMemoryContentIDRepository(), r18DumpLookup)
+	if err != nil {
+		if r18DumpCloser != nil {
+			_ = r18DumpCloser.Close()
+		}
+		return nil, fmt.Errorf("failed to initialize scraper registry: %w", err)
+	}
+
+	deps := &CoreDeps{ScraperRegistry: registry, Logger: logging.GlobalLogger(), r18DumpCloser: r18DumpCloser}
+	deps.config.Store(cfg)
+	return deps, nil
+}
+
 // NewDependenciesWithOptions creates a new CoreDeps instance with optional dependency injection.
 // If opts is nil or opts fields are nil, real implementations are created.
 // If opts fields are non-nil, injected dependencies are used (for testing).

--- a/internal/commandutil/dependencies.go
+++ b/internal/commandutil/dependencies.go
@@ -105,6 +105,13 @@ func NewDependencies(cfg *config.Config) (*CoreDeps, error) {
 	return NewDependenciesWithOptions(cfg, nil)
 }
 
+var (
+	finalizeScrapersConfig = func(c *config.ScrapersConfig, reg *scraperutil.ScraperRegistry) error {
+		return c.Finalize(reg)
+	}
+	newScraperRegistryFrom = scraper.NewDefaultScraperRegistryFrom
+)
+
 // NewQueryOnlyDependencies initializes scrapers without opening the application database.
 func NewQueryOnlyDependencies(cfg *config.Config) (*CoreDeps, error) {
 	if cfg == nil {
@@ -119,7 +126,7 @@ func NewQueryOnlyDependencies(cfg *config.Config) (*CoreDeps, error) {
 		scraper.RegisterAll(reg)
 	}
 
-	if err := cfg.Scrapers.Finalize(reg); err != nil {
+	if err := finalizeScrapersConfig(&cfg.Scrapers, reg); err != nil {
 		return nil, fmt.Errorf("failed to finalize scraper config: %w", err)
 	}
 	cfg.RecomputeWarnings()
@@ -129,7 +136,7 @@ func NewQueryOnlyDependencies(cfg *config.Config) (*CoreDeps, error) {
 		logging.Warnf("%v", dumpErr)
 	}
 
-	registry, err := scraper.NewDefaultScraperRegistryFrom(reg, scraper.ScraperRegistryConfigFromApp(cfg), newMemoryContentIDRepository(), r18DumpLookup)
+	registry, err := newScraperRegistryFrom(reg, scraper.ScraperRegistryConfigFromApp(cfg), newMemoryContentIDRepository(), r18DumpLookup)
 	if err != nil {
 		if r18DumpCloser != nil {
 			_ = r18DumpCloser.Close()

--- a/internal/commandutil/memory_content_id_repository.go
+++ b/internal/commandutil/memory_content_id_repository.go
@@ -64,7 +64,10 @@ func (r *memoryContentIDRepository) GetAllPaginated(ctx context.Context, limit, 
 	return all[offset:end], nil
 }
 
-func (r *memoryContentIDRepository) GetAll(_ context.Context) ([]models.ContentIDMapping, error) {
+func (r *memoryContentIDRepository) GetAll(ctx context.Context) ([]models.ContentIDMapping, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	keys := make([]string, 0, len(r.mappings))

--- a/internal/commandutil/memory_content_id_repository.go
+++ b/internal/commandutil/memory_content_id_repository.go
@@ -1,0 +1,84 @@
+package commandutil
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+type memoryContentIDRepository struct {
+	mu       sync.RWMutex
+	mappings map[string]models.ContentIDMapping
+}
+
+func newMemoryContentIDRepository() models.ContentIDMappingRepositoryInterface {
+	return &memoryContentIDRepository{mappings: make(map[string]models.ContentIDMapping)}
+}
+
+func (r *memoryContentIDRepository) FindBySearchID(_ context.Context, searchID string) (*models.ContentIDMapping, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	mapping, ok := r.mappings[strings.ToUpper(searchID)]
+	if !ok {
+		return nil, fmt.Errorf("content ID mapping not found")
+	}
+	copied := mapping
+	return &copied, nil
+}
+
+func (r *memoryContentIDRepository) Create(_ context.Context, mapping *models.ContentIDMapping) error {
+	if mapping == nil {
+		return fmt.Errorf("content ID mapping cannot be nil")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	copied := *mapping
+	copied.SearchID = strings.ToUpper(copied.SearchID)
+	r.mappings[copied.SearchID] = copied
+	return nil
+}
+
+func (r *memoryContentIDRepository) Delete(_ context.Context, searchID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.mappings, strings.ToUpper(searchID))
+	return nil
+}
+
+func (r *memoryContentIDRepository) GetAllPaginated(ctx context.Context, limit, offset int) ([]models.ContentIDMapping, error) {
+	all, err := r.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if offset >= len(all) {
+		return []models.ContentIDMapping{}, nil
+	}
+	end := len(all)
+	if limit > 0 && offset+limit < end {
+		end = offset + limit
+	}
+	return all[offset:end], nil
+}
+
+func (r *memoryContentIDRepository) GetAll(_ context.Context) ([]models.ContentIDMapping, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	keys := make([]string, 0, len(r.mappings))
+	for key := range r.mappings {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]models.ContentIDMapping, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, r.mappings[key])
+	}
+	return result, nil
+}
+
+func (r *memoryContentIDRepository) GetAllChunked(ctx context.Context, _ int) ([]models.ContentIDMapping, error) {
+	return r.GetAll(ctx)
+}

--- a/internal/commandutil/memory_content_id_repository_test.go
+++ b/internal/commandutil/memory_content_id_repository_test.go
@@ -1,0 +1,81 @@
+package commandutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryContentIDRepository_CreateAndFind(t *testing.T) {
+	repo := newMemoryContentIDRepository()
+	ctx := context.Background()
+
+	err := repo.Create(ctx, &models.ContentIDMapping{SearchID: "MDB-087", ContentID: "61mdb087", Source: "dmm"})
+	require.NoError(t, err)
+
+	found, err := repo.FindBySearchID(ctx, "mdb-087")
+	require.NoError(t, err)
+	assert.Equal(t, "61mdb087", found.ContentID)
+	assert.Equal(t, "MDB-087", found.SearchID)
+}
+
+func TestMemoryContentIDRepository_FindNotFound(t *testing.T) {
+	repo := newMemoryContentIDRepository()
+	_, err := repo.FindBySearchID(context.Background(), "NOPE")
+	assert.Error(t, err)
+}
+
+func TestMemoryContentIDRepository_CreateNil(t *testing.T) {
+	repo := newMemoryContentIDRepository()
+	err := repo.Create(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+func TestMemoryContentIDRepository_Delete(t *testing.T) {
+	repo := newMemoryContentIDRepository()
+	ctx := context.Background()
+	require.NoError(t, repo.Create(ctx, &models.ContentIDMapping{SearchID: "ABC-123", ContentID: "abc123", Source: "dmm"}))
+	require.NoError(t, repo.Delete(ctx, "abc-123"))
+	_, err := repo.FindBySearchID(ctx, "ABC-123")
+	assert.Error(t, err)
+}
+
+func TestMemoryContentIDRepository_GetAll(t *testing.T) {
+	repo := newMemoryContentIDRepository()
+	ctx := context.Background()
+	require.NoError(t, repo.Create(ctx, &models.ContentIDMapping{SearchID: "BBB-001", ContentID: "bbb1", Source: "dmm"}))
+	require.NoError(t, repo.Create(ctx, &models.ContentIDMapping{SearchID: "AAA-001", ContentID: "aaa1", Source: "dmm"}))
+	all, err := repo.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+	assert.Equal(t, "AAA-001", all[0].SearchID)
+	assert.Equal(t, "BBB-001", all[1].SearchID)
+}
+
+func TestMemoryContentIDRepository_GetAllPaginated(t *testing.T) {
+	repo := newMemoryContentIDRepository()
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		require.NoError(t, repo.Create(ctx, &models.ContentIDMapping{SearchID: string(rune('A'+i)) + "-001", ContentID: "c", Source: "dmm"}))
+	}
+	page, err := repo.GetAllPaginated(ctx, 2, 1)
+	require.NoError(t, err)
+	assert.Len(t, page, 2)
+
+	overflow, err := repo.GetAllPaginated(ctx, 10, 100)
+	require.NoError(t, err)
+	assert.Empty(t, overflow)
+}
+
+func TestMemoryContentIDRepository_GetAllChunked(t *testing.T) {
+	repo := newMemoryContentIDRepository()
+	ctx := context.Background()
+	require.NoError(t, repo.Create(ctx, &models.ContentIDMapping{SearchID: "X-1", ContentID: "c1", Source: "dmm"}))
+	require.NoError(t, repo.Create(ctx, &models.ContentIDMapping{SearchID: "X-2", ContentID: "c2", Source: "dmm"}))
+	all, err := repo.GetAllChunked(ctx, 100)
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+}

--- a/internal/commandutil/patch_coverage_test.go
+++ b/internal/commandutil/patch_coverage_test.go
@@ -1,0 +1,90 @@
+package commandutil
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scraper"
+	"github.com/javinizer/javinizer-go/internal/scraperutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewQueryOnlyDependencies_FinalizeError(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	orig := finalizeScrapersConfig
+	t.Cleanup(func() { finalizeScrapersConfig = orig })
+	finalizeScrapersConfig = func(c *config.ScrapersConfig, reg *scraperutil.ScraperRegistry) error {
+		return errors.New("finalize boom")
+	}
+	tmpDir := t.TempDir()
+	cfg := &config.Config{Database: config.DatabaseConfig{Type: "sqlite", DSN: filepath.Join(tmpDir, "javinizer.db")}}
+	deps, err := NewQueryOnlyDependencies(cfg)
+	require.Error(t, err)
+	assert.Nil(t, deps)
+	assert.Contains(t, err.Error(), "failed to finalize scraper config")
+}
+
+func TestNewQueryOnlyDependencies_DumpLookupWarning(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	corruptDump := filepath.Join(tmpDir, "corrupt.db")
+	require.NoError(t, os.WriteFile(corruptDump, []byte("not a sqlite database"), 0o600))
+	cfg := &config.Config{Database: config.DatabaseConfig{Type: "sqlite", DSN: filepath.Join(tmpDir, "javinizer.db")}}
+	cfg.Metadata.R18DevDump.Enabled = true
+	cfg.Metadata.R18DevDump.Path = corruptDump
+	cfg.Scrapers.Priority = []string{"e2emock"}
+	deps, err := NewQueryOnlyDependencies(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, deps)
+	assert.NoError(t, deps.Close())
+}
+
+func TestNewQueryOnlyDependencies_RegistryInitError(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	orig := newScraperRegistryFrom
+	t.Cleanup(func() { newScraperRegistryFrom = orig })
+	newScraperRegistryFrom = func(reg *scraperutil.ScraperRegistry, cfg scraper.ScraperRegistryConfig, contentIDRepo models.ContentIDMappingRepositoryInterface, r18DevDump models.R18DevDumpLookup) (*scraperutil.ScraperRegistry, error) {
+		return nil, errors.New("registry boom")
+	}
+	tmpDir := t.TempDir()
+	cfg := &config.Config{Database: config.DatabaseConfig{Type: "sqlite", DSN: filepath.Join(tmpDir, "javinizer.db")}}
+	cfg.Scrapers.Priority = []string{"e2emock"}
+	deps, err := NewQueryOnlyDependencies(cfg)
+	require.Error(t, err)
+	assert.Nil(t, deps)
+	assert.Contains(t, err.Error(), "failed to initialize scraper registry")
+}
+
+func TestNewQueryOnlyDependencies_RegistryInitError_ClosesDump(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	orig := newScraperRegistryFrom
+	t.Cleanup(func() { newScraperRegistryFrom = orig })
+	newScraperRegistryFrom = func(reg *scraperutil.ScraperRegistry, cfg scraper.ScraperRegistryConfig, contentIDRepo models.ContentIDMappingRepositoryInterface, r18DevDump models.R18DevDumpLookup) (*scraperutil.ScraperRegistry, error) {
+		return nil, errors.New("registry boom")
+	}
+	dumpPath := seedDumpDB(t)
+	tmpDir := t.TempDir()
+	cfg := &config.Config{Database: config.DatabaseConfig{Type: "sqlite", DSN: filepath.Join(tmpDir, "javinizer.db")}}
+	cfg.Metadata.R18DevDump.Enabled = true
+	cfg.Metadata.R18DevDump.Path = dumpPath
+	cfg.Scrapers.Priority = []string{"e2emock"}
+	deps, err := NewQueryOnlyDependencies(cfg)
+	require.Error(t, err)
+	assert.Nil(t, deps)
+	assert.Contains(t, err.Error(), "failed to initialize scraper registry")
+}
+
+func TestMemoryContentIDRepository_GetAllPaginated_CancelledContext(t *testing.T) {
+	repo := newMemoryContentIDRepository()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := repo.GetAllPaginated(ctx, 1, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/internal/commandutil/query_only_deps_test.go
+++ b/internal/commandutil/query_only_deps_test.go
@@ -1,0 +1,77 @@
+package commandutil
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewQueryOnlyDependencies_Success(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "javinizer.db")
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{Type: "sqlite", DSN: dbPath},
+	}
+	cfg.Metadata.R18DevDump.Path = filepath.Join(tmpDir, "nonexistent_dump.db")
+
+	deps, err := NewQueryOnlyDependencies(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, deps)
+	assert.NotNil(t, deps.ScraperRegistry)
+	assert.NotNil(t, deps.GetConfig())
+	assert.NoError(t, deps.Close())
+
+	_, statErr := os.Stat(dbPath)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestNewQueryOnlyDependencies_NilConfig(t *testing.T) {
+	deps, err := NewQueryOnlyDependencies(nil)
+	require.Error(t, err)
+	assert.Nil(t, deps)
+	assert.Contains(t, err.Error(), "config cannot be nil")
+}
+
+func TestNewQueryOnlyDependencies_RealScrapers(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{Type: "sqlite", DSN: filepath.Join(tmpDir, "javinizer.db")},
+	}
+	cfg.Metadata.R18DevDump.Path = filepath.Join(tmpDir, "nonexistent_dump.db")
+
+	deps, err := NewQueryOnlyDependencies(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, deps)
+	assert.NotNil(t, deps.ScraperRegistry)
+	assert.NoError(t, deps.Close())
+
+	_, statErr := os.Stat(filepath.Join(tmpDir, "javinizer.db"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestNewQueryOnlyDependencies_E2EInstanceWorks(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{Type: "sqlite", DSN: filepath.Join(tmpDir, "javinizer.db")},
+	}
+	cfg.Metadata.R18DevDump.Path = filepath.Join(tmpDir, "nonexistent_dump.db")
+
+	deps, err := NewQueryOnlyDependencies(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, deps)
+
+	instance, ok := deps.ScraperRegistry.GetInstance("e2emock")
+	assert.True(t, ok)
+	assert.NotNil(t, instance)
+	assert.Equal(t, "e2emock", instance.Name())
+
+	_ = context.Background()
+	assert.NoError(t, deps.Close())
+}

--- a/internal/scrape/patch_coverage_test.go
+++ b/internal/scrape/patch_coverage_test.go
@@ -1,0 +1,85 @@
+package scrape
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scraperutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mappedRetryScraper struct {
+	name string
+}
+
+func (m *mappedRetryScraper) Name() string    { return m.name }
+func (m *mappedRetryScraper) IsEnabled() bool { return true }
+func (m *mappedRetryScraper) Close() error    { return nil }
+func (m *mappedRetryScraper) Config() *models.ScraperSettings {
+	return &models.ScraperSettings{Enabled: true}
+}
+func (m *mappedRetryScraper) GetURL(_ context.Context, _ string) (string, error) { return "", nil }
+func (m *mappedRetryScraper) ResolveSearchQuery(input string) (string, bool) {
+	return "MAPPED-" + input, true
+}
+func (m *mappedRetryScraper) Search(_ context.Context, query string) (*models.ScraperResult, error) {
+	if strings.HasPrefix(query, "MAPPED-") {
+		return nil, errors.New("mapped query failed")
+	}
+	return nil, context.DeadlineExceeded
+}
+
+func TestQuerySingle_MappedQueryRetryContextError(t *testing.T) {
+	scraper := &mappedRetryScraper{name: "mapped"}
+	outcome := querySingle(context.Background(), "TEST-001", scraper)
+	require.NotNil(t, outcome.failure)
+	assert.Equal(t, "mapped", outcome.failure.Scraper)
+	assert.Equal(t, models.ScraperErrorKindUnavailable, outcome.failure.Kind)
+	assert.True(t, outcome.failure.Retryable)
+	assert.True(t, outcome.failure.Temporary)
+}
+
+func TestClassifyScraperError_EmptyMessageFallback(t *testing.T) {
+	origErr := &models.ScraperError{Scraper: "orig", Cause: errors.New("root cause")}
+	result := classifyScraperError("test", origErr, "")
+	assert.Equal(t, "test", result.Scraper)
+	assert.Equal(t, origErr.Kind, result.Kind)
+	assert.NotEmpty(t, result.Message)
+	assert.Equal(t, "orig scraper error", result.Message)
+}
+
+func TestQueryRaw_NilContext(t *testing.T) {
+	reg := scraperutil.NewScraperRegistry()
+	reg.RegisterInstance(&stubScrapeWithResult{name: "test", enabled: true, result: &models.ScraperResult{Source: "test", Title: "Hello"}})
+	engine := NewQueryOnly(reg)
+	result, err := engine.QueryRaw(nil, "TEST-001", "test")
+	require.Nil(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "Hello", result.Title)
+}
+
+func TestQueryRaw_UnknownScraperName(t *testing.T) {
+	reg := scraperutil.NewScraperRegistry()
+	reg.RegisterInstance(&stubScrapeWithResult{name: "test", enabled: true, result: &models.ScraperResult{Source: "test"}})
+	engine := NewQueryOnly(reg)
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "nonexistent")
+	assert.Nil(t, result)
+	require.NotNil(t, err)
+	assert.Equal(t, models.ScraperErrorKindUnknown, err.Kind)
+	assert.Contains(t, err.Message, "not registered")
+}
+
+func TestQueryRaw_ScraperReturnsError(t *testing.T) {
+	reg := scraperutil.NewScraperRegistry()
+	reg.RegisterInstance(&mockScraper{name: "errscraper", enabled: true, err: errors.New("boom")})
+	engine := NewQueryOnly(reg)
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "errscraper")
+	assert.Nil(t, result)
+	require.NotNil(t, err)
+	assert.Equal(t, models.ScraperErrorKindUnknown, err.Kind)
+	assert.Equal(t, "boom", err.Message)
+}

--- a/internal/scrape/query.go
+++ b/internal/scrape/query.go
@@ -154,8 +154,8 @@ func querySingle(ctx context.Context, movieID string, scraper models.Scraper) (o
 
 	scraperResult, err := safeSearch(ctx, scraper, scraperQuery)
 	if err != nil {
-		if errors.Is(err, ctx.Err()) {
-			outcome = queryOutcome{failure: &models.ScraperError{Scraper: scraper.Name(), Cause: err}}
+		if isContextError(ctx, err) {
+			outcome = queryOutcome{failure: classifyContextError(scraper.Name(), err)}
 			return
 		}
 
@@ -165,16 +165,77 @@ func querySingle(ctx context.Context, movieID string, scraper models.Scraper) (o
 				outcome = queryOutcome{result: retryResult}
 				return
 			}
-			outcome = queryOutcome{failure: &models.ScraperError{Scraper: scraper.Name(), Message: fmt.Sprintf("%v (mapped query: %v)", retryErr, err)}}
+			if isContextError(ctx, retryErr) {
+				outcome = queryOutcome{failure: classifyContextError(scraper.Name(), retryErr)}
+				return
+			}
+			outcome = queryOutcome{failure: classifyScraperError(scraper.Name(), retryErr, fmt.Sprintf("%v (mapped query: %v)", retryErr, err))}
 			return
 		}
 
-		outcome = queryOutcome{failure: &models.ScraperError{Scraper: scraper.Name(), Cause: err}}
+		outcome = queryOutcome{failure: classifyScraperError(scraper.Name(), err, "")}
 		return
 	}
 
 	outcome = queryOutcome{result: scraperResult}
 	return
+}
+
+// isContextError checks if the error is a context cancellation/deadline error,
+// either via errors.Is(err, ctx.Err()) or by checking the sentinel errors directly.
+// This catches cases where the scraper returns context.DeadlineExceeded from its
+// own request context while the parent ctx.Err() is nil.
+func isContextError(ctx context.Context, err error) bool {
+	if errors.Is(err, ctx.Err()) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	return false
+}
+
+// classifyContextError constructs a typed ScraperError for context cancellation/deadline
+// errors. AsScraperError() cannot extract typed fields from raw context errors because
+// they are not ScraperError instances, so this function explicitly sets Kind=unavailable,
+// Retryable=true, Temporary=true.
+func classifyContextError(scraperName string, err error) *models.ScraperError {
+	return &models.ScraperError{
+		Scraper:   scraperName,
+		Kind:      models.ScraperErrorKindUnavailable,
+		Message:   err.Error(),
+		Retryable: true,
+		Temporary: true,
+		Cause:     err,
+	}
+}
+
+// classifyScraperError wraps a scraper error, preserving typed fields (Kind,
+// StatusCode, Retryable, Temporary) via AsScraperError when available. If the
+// error is not a ScraperError, it falls back to a generic unknown classification.
+// The fallbackMsg is used as the Message when the error has no typed fields.
+func classifyScraperError(scraperName string, err error, fallbackMsg string) *models.ScraperError {
+	if se, ok := models.AsScraperError(err); ok {
+		copied := *se
+		copied.Scraper = scraperName
+		if copied.Message == "" {
+			copied.Message = err.Error()
+		}
+		return &copied
+	}
+	msg := fallbackMsg
+	if msg == "" {
+		msg = err.Error()
+	}
+	return &models.ScraperError{
+		Scraper: scraperName,
+		Kind:    models.ScraperErrorKindUnknown,
+		Message: msg,
+		Cause:   err,
+	}
 }
 
 func safeSearch(ctx context.Context, scraper models.Scraper, id string) (result *models.ScraperResult, err error) {

--- a/internal/scrape/query_coverage_test.go
+++ b/internal/scrape/query_coverage_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/scraperutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsContextError(t *testing.T) {
@@ -51,17 +52,6 @@ func TestClassifyScraperError_FallbackMsg(t *testing.T) {
 	assert.Equal(t, "custom fallback", err.Message)
 }
 
-func TestQueryRaw_DisabledScraper(t *testing.T) {
-	reg := scraperutil.NewScraperRegistry()
-	reg.RegisterInstance(&stubScrape{name: "test", enabled: false})
-	engine := NewQueryOnly(reg)
-	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
-	assert.Nil(t, result)
-	assert.NotNil(t, err)
-	assert.Equal(t, models.ScraperErrorKindUnknown, err.Kind)
-	assert.Contains(t, err.Message, "not enabled")
-}
-
 type stubScrape struct {
 	name    string
 	enabled bool
@@ -76,4 +66,54 @@ func (s *stubScrape) IsEnabled() bool                                    { retur
 func (s *stubScrape) Close() error                                       { return nil }
 func (s *stubScrape) Config() *models.ScraperSettings {
 	return &models.ScraperSettings{Enabled: s.enabled}
+}
+
+type stubScrapeWithResult struct {
+	name    string
+	enabled bool
+	result  *models.ScraperResult
+}
+
+func (s *stubScrapeWithResult) Name() string { return s.name }
+func (s *stubScrapeWithResult) Search(_ context.Context, id string) (*models.ScraperResult, error) {
+	r := *s.result
+	r.ID = id
+	return &r, nil
+}
+func (s *stubScrapeWithResult) GetURL(_ context.Context, _ string) (string, error) { return "", nil }
+func (s *stubScrapeWithResult) IsEnabled() bool                                    { return s.enabled }
+func (s *stubScrapeWithResult) Close() error                                       { return nil }
+func (s *stubScrapeWithResult) Config() *models.ScraperSettings {
+	return &models.ScraperSettings{Enabled: s.enabled}
+}
+
+func TestQueryRaw_SuccessWithResult(t *testing.T) {
+	reg := scraperutil.NewScraperRegistry()
+	reg.RegisterInstance(&stubScrapeWithResult{name: "test", enabled: true, result: &models.ScraperResult{Source: "test", Title: "Hello"}})
+	engine := NewQueryOnly(reg)
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	require.Nil(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "Hello", result.Title)
+	assert.Equal(t, "TEST-001", result.ID)
+}
+
+func TestQueryRaw_NilResult(t *testing.T) {
+	reg := scraperutil.NewScraperRegistry()
+	reg.RegisterInstance(&stubScrape{name: "test", enabled: true})
+	engine := NewQueryOnly(reg)
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	require.Nil(t, err)
+	assert.Nil(t, result)
+}
+
+func TestQueryRaw_DisabledScraper(t *testing.T) {
+	reg := scraperutil.NewScraperRegistry()
+	reg.RegisterInstance(&stubScrape{name: "test", enabled: false})
+	engine := NewQueryOnly(reg)
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	assert.Nil(t, result)
+	assert.NotNil(t, err)
+	assert.Equal(t, models.ScraperErrorKindUnknown, err.Kind)
+	assert.Contains(t, err.Message, "not enabled")
 }

--- a/internal/scrape/query_coverage_test.go
+++ b/internal/scrape/query_coverage_test.go
@@ -1,0 +1,79 @@
+package scrape
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scraperutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsContextError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.True(t, isContextError(ctx, context.Canceled))
+	assert.True(t, isContextError(ctx, context.DeadlineExceeded))
+	assert.True(t, isContextError(ctx, fmt.Errorf("wrapped: %w", context.DeadlineExceeded)))
+	assert.False(t, isContextError(context.Background(), errors.New("regular error")))
+}
+
+func TestClassifyContextError(t *testing.T) {
+	err := classifyContextError("test", context.DeadlineExceeded)
+	assert.Equal(t, "test", err.Scraper)
+	assert.Equal(t, models.ScraperErrorKindUnavailable, err.Kind)
+	assert.True(t, err.Retryable)
+	assert.True(t, err.Temporary)
+	assert.Contains(t, err.Message, "deadline")
+}
+
+func TestClassifyScraperError_WithTypedError(t *testing.T) {
+	original := models.NewScraperNotFoundError("orig", "not found")
+	err := classifyScraperError("test", original, "")
+	assert.Equal(t, "test", err.Scraper)
+	assert.Equal(t, models.ScraperErrorKindNotFound, err.Kind)
+	assert.Equal(t, 0, err.StatusCode)
+	assert.False(t, err.Retryable)
+	assert.Equal(t, "orig", original.Scraper)
+}
+
+func TestClassifyScraperError_WithGenericError(t *testing.T) {
+	err := classifyScraperError("test", errors.New("network failed"), "")
+	assert.Equal(t, "test", err.Scraper)
+	assert.Equal(t, models.ScraperErrorKindUnknown, err.Kind)
+	assert.Equal(t, "network failed", err.Message)
+}
+
+func TestClassifyScraperError_FallbackMsg(t *testing.T) {
+	err := classifyScraperError("test", errors.New("retry failed"), "custom fallback")
+	assert.Equal(t, "custom fallback", err.Message)
+}
+
+func TestQueryRaw_DisabledScraper(t *testing.T) {
+	reg := scraperutil.NewScraperRegistry()
+	reg.RegisterInstance(&stubScrape{name: "test", enabled: false})
+	engine := NewQueryOnly(reg)
+	result, err := engine.QueryRaw(context.Background(), "TEST-001", "test")
+	assert.Nil(t, result)
+	assert.NotNil(t, err)
+	assert.Equal(t, models.ScraperErrorKindUnknown, err.Kind)
+	assert.Contains(t, err.Message, "not enabled")
+}
+
+type stubScrape struct {
+	name    string
+	enabled bool
+}
+
+func (s *stubScrape) Name() string { return s.name }
+func (s *stubScrape) Search(_ context.Context, _ string) (*models.ScraperResult, error) {
+	return nil, nil
+}
+func (s *stubScrape) GetURL(_ context.Context, _ string) (string, error) { return "", nil }
+func (s *stubScrape) IsEnabled() bool                                    { return s.enabled }
+func (s *stubScrape) Close() error                                       { return nil }
+func (s *stubScrape) Config() *models.ScraperSettings {
+	return &models.ScraperSettings{Enabled: s.enabled}
+}

--- a/internal/scrape/query_coverage_test.go
+++ b/internal/scrape/query_coverage_test.go
@@ -107,6 +107,16 @@ func TestQueryRaw_NilResult(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestIsContextError_WrappedDeadlineExceeded(t *testing.T) {
+	wrapped := fmt.Errorf("request failed: %w", context.DeadlineExceeded)
+	assert.True(t, isContextError(context.Background(), wrapped))
+}
+
+func TestIsContextError_WrappedCanceled(t *testing.T) {
+	wrapped := fmt.Errorf("cancelled: %w", context.Canceled)
+	assert.True(t, isContextError(context.Background(), wrapped))
+}
+
 func TestQueryRaw_DisabledScraper(t *testing.T) {
 	reg := scraperutil.NewScraperRegistry()
 	reg.RegisterInstance(&stubScrape{name: "test", enabled: false})

--- a/internal/scrape/scrape.go
+++ b/internal/scrape/scrape.go
@@ -167,8 +167,9 @@ func (s *Scraper) QueryRaw(ctx context.Context, movieID, scraperName string) (*m
 			Message: fmt.Sprintf("scraper %q is not enabled", scraperName),
 		}
 	}
-	resolvedID := s.resolveContentID(ctx, movieID, []string{scraperName})
-	outcome := querySingle(ctx, resolvedID, scraper)
+	// Skip content-ID resolution in raw mode — it reads/writes the DB cache,
+	// which contradicts the no-persistence contract.
+	outcome := querySingle(ctx, movieID, scraper)
 	if outcome.failure != nil {
 		return nil, outcome.failure
 	}

--- a/internal/scrape/scrape.go
+++ b/internal/scrape/scrape.go
@@ -143,6 +143,41 @@ type ScraperInterface interface {
 
 var _ ScraperInterface = (*Scraper)(nil)
 
+// QueryRaw queries a single scraper by name and returns the unmerged result
+// without calling Aggregate() or postProcessScraped(). It is the exported seam
+// for machine-readable CLI output (--output json). The movieID is resolved via
+// resolveScrapeInput before querying. The returned ScraperError preserves typed
+// fields (Kind, StatusCode, Retryable, Temporary) via the querySingle() fix.
+func (s *Scraper) QueryRaw(ctx context.Context, movieID, scraperName string) (*models.ScraperResult, *models.ScraperError) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	scraper, exists := s.registry.GetInstance(scraperName)
+	if !exists || scraper == nil {
+		return nil, &models.ScraperError{
+			Scraper: scraperName,
+			Kind:    models.ScraperErrorKindUnknown,
+			Message: fmt.Sprintf("scraper %q is not registered or enabled", scraperName),
+		}
+	}
+	resolvedID := s.resolveContentID(ctx, movieID, []string{scraperName})
+	outcome := querySingle(ctx, resolvedID, scraper)
+	if outcome.failure != nil {
+		return nil, outcome.failure
+	}
+	return outcome.result, nil
+}
+
+// NewQueryOnly constructs a Scraper engine with only the registry populated,
+// suitable for QueryRaw() calls that bypass aggregation, cache, and persistence.
+// All other dependencies are nil — QueryRaw only needs the registry.
+func NewQueryOnly(registry ScraperInstanceResolver) *Scraper {
+	return &Scraper{
+		registry: registry,
+		cfg:      &Config{},
+	}
+}
+
 // New constructs a Scraper engine from its registry, aggregator, repositories, HTTP client, config, translator, and filesystem dependencies.
 func New(
 	registry ScraperInstanceResolver,

--- a/internal/scrape/scrape.go
+++ b/internal/scrape/scrape.go
@@ -160,6 +160,13 @@ func (s *Scraper) QueryRaw(ctx context.Context, movieID, scraperName string) (*m
 			Message: fmt.Sprintf("scraper %q is not registered or enabled", scraperName),
 		}
 	}
+	if !scraper.IsEnabled() {
+		return nil, &models.ScraperError{
+			Scraper: scraperName,
+			Kind:    models.ScraperErrorKindUnknown,
+			Message: fmt.Sprintf("scraper %q is not enabled", scraperName),
+		}
+	}
 	resolvedID := s.resolveContentID(ctx, movieID, []string{scraperName})
 	outcome := querySingle(ctx, resolvedID, scraper)
 	if outcome.failure != nil {

--- a/internal/scraper/e2emock/e2emock.go
+++ b/internal/scraper/e2emock/e2emock.go
@@ -124,6 +124,8 @@ func (s *Scraper) Search(_ context.Context, id string) (*models.ScraperResult, e
 		return successResult(id), nil
 	case strings.HasPrefix(upper, "MULTI-"):
 		return successResult(id), nil
+	case strings.HasPrefix(upper, "NIL-"):
+		return nil, nil
 	case strings.HasPrefix(upper, "FAIL-"):
 		return nil, fmt.Errorf("e2emock: movie %s not found — simulating a 404 from the source", id)
 	case strings.HasPrefix(upper, "ALIAS-"):

--- a/internal/scraper/e2emock/e2emock_test.go
+++ b/internal/scraper/e2emock/e2emock_test.go
@@ -148,3 +148,14 @@ func TestScraper_Search_FailErrorNotCollapsedToNoResult(t *testing.T) {
 		t.Errorf("error %q must carry the e2emock: substring", err.Error())
 	}
 }
+
+func TestScraper_Search_NilResult(t *testing.T) {
+	s := &Scraper{}
+	res, err := s.Search(context.Background(), "NIL-001")
+	if err != nil {
+		t.Fatalf("unexpected error for NIL-* id: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("expected nil result for NIL-* id, got %+v", res)
+	}
+}

--- a/test/e2e/cli/flags_test.go
+++ b/test/e2e/cli/flags_test.go
@@ -38,6 +38,7 @@ var commandFlags = map[string][]flagSpec{
 	"scrape": {
 		{"scrapers", "s"},
 		{"force", "f"},
+		{"output", ""},
 		{"scrape-actress", ""},
 		{"no-scrape-actress", ""},
 		{"browser", ""},


### PR DESCRIPTION
## Summary

Adds a `--output json` flag to `javinizer scrape` that returns the raw, unmerged `ScraperResult` from a single scraper as JSON to stdout. This eliminates the need for the javinizer-go-tracker project to inject a 500-line probe binary and compile against internal packages — the tracker can now use release binaries directly.

### What changed

- **`QueryRaw()` method** on the `Scraper` engine (`internal/scrape/scrape.go`) — queries a single scraper by name without calling `Aggregate()` or `postProcessScraped()`. Uses a new `NewQueryOnly()` constructor that only needs the registry.
- **`querySingle()` fixes** (`internal/scrape/query.go`) — preserves typed error fields (`Kind`, `StatusCode`, `Retryable`, `Temporary`) via `AsScraperError()` with copy-before-mutate. New `isContextError()` catches `DeadlineExceeded`/`Canceled` via `errors.Is` (not just `ctx.Err()`). Applied in both primary and mapped-query retry paths.
- **JSON error DTO** (`cmd/javinizer/commands/scrape/json_dto.go`) — `jsonErrorEnvelope` with snake_case tags: `kind`, `message`, `status_code`, `retryable`, `temporary`. `Cause` excluded. Falls back to `Error()` when `Message` is empty.
- **`runScrapeJSON()`** — inits logger to stderr-only via `removeStdoutFromLogOutput()` (parses multi-output configs and strips `stdout`), respects `JAVINIZER_CONFIG` env var, calls `QueryRaw`, writes JSON to stdout. All diagnostics go to stderr.
- **`shouldSkipConfigInit`** — skips `initConfig()` when `--output json` so config errors emit JSON envelopes instead of `os.Exit(1)`.
- **`ErrJSONExit` sentinel** — `main.go` suppresses it (exit 1, no extra output to stderr).
- **`validateJSONMode()`** — requires exactly one scraper, rejects `--force`, rejects empty scraper names.
- **18 tests** covering success, not_found, blocked, timeout, panic, unknown scraper, validation (no scrapers, 2 scrapers, --force, invalid output, empty name), and stdout-only-JSON.
- **`docs/15-cli-json-output.md`** — usage documentation with success/error schema examples.

### Usage

```bash
# Success
javinizer scrape ABF-153 --scrapers r18dev --output json
# → {"source":"r18dev","id":"ABF-153","title":"...",...}

# Error
javinizer scrape NOTFOUND-999 --scrapers r18dev --output json
# → {"error":{"kind":"not_found","message":"...","status_code":0,"retryable":false,"temporary":false}}
```

### Review

Reviewed by `gpt-5.6-sol` (medium thinking) across 3 rounds (128 tool calls total). All blockers and fixes addressed:
- stdout contamination from lazy logger init → `removeStdoutFromLogOutput()` + stderr-only init
- context errors not reliably classified → `isContextError()` checks both sentinel errors + `ctx.Err()`
- `JAVINIZER_CONFIG` env var ignored → added `os.Getenv` check
- `emitJSONError` called `os.Exit` → replaced with `ErrJSONExit` sentinel + `writeJSONError`
- typed-error preservation mutated original error → copy before mutate
- validation accepted empty scraper names → explicit rejection
- nil result from `(nil, nil)` return → nil check added

## Checklist

- [x] Tests added/updated for the change
- [x] `make test-short` passes locally
- [x] `make lint` passes (golangci-lint)
- [x] Commit messages follow `type(scope): summary` (≤72 chars)
- [x] If adding a `*_timeout_seconds` or `*_timeout` config field, confirmed it is read by a runtime code path outside the config package