### PR TITLE
fix(config): raise request_timeout_seconds default to 180s

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -1,4 +1,5 @@
 config_version: 3
+defaults_version: 1
 # API authentication credentials are stored in `auth.credentials.json` next to this file.
 # To reset credentials, stop the server, delete that file, then restart `javinizer web`.
 #
@@ -88,8 +89,8 @@ scrapers:
     referer: https://www.dmm.co.jp/
     # HTTP client timeout in seconds (default: 30)
     timeout_seconds: 30
-    # Overall request timeout in seconds (default: 60)
-    request_timeout_seconds: 60
+    # Overall request timeout in seconds (default: 180)
+    request_timeout_seconds: 180
     priority:
         - r18dev
         - libredmm

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -30,6 +30,8 @@ javinizer init
 
 The config file includes a `config_version` field. On startup, Javinizer applies compatibility rules for older config files and writes the upgraded config back to disk.
 
+A second field, `defaults_version`, tracks which shipped default *values* your config was generated with. When a built-in default changes between releases (e.g. `scrapers.request_timeout_seconds` 60 → 180), Javinizer one-time patches configs that still carry the old generated value — printing a notice to stderr when it does — then advances the marker. Values you set yourself are left untouched, and once patched you can still set the old value explicitly. Do not edit this field by hand.
+
 ## Server Settings
 
 Configure the REST API server:
@@ -1266,7 +1268,7 @@ scrapers:
   user_agent: ""  # Default: Chrome-like UA. r18dev uses the Javinizer UA automatically.
   referer: "https://www.dmm.co.jp/"
   timeout_seconds: 30          # per-HTTP-request timeout (1–300, default 30)
-  request_timeout_seconds: 60  # overall scrape operation timeout (1–600, default 60); wraps each scraper Search()/Scrape() call as a nested context within performance.worker_timeout
+  request_timeout_seconds: 180 # overall scrape operation timeout (1–600, default 180); wraps each scraper Search()/Scrape() call as a nested context within performance.worker_timeout
   priority:
     - r18dev
     - libredmm

--- a/docs/10-troubleshooting.md
+++ b/docs/10-troubleshooting.md
@@ -114,7 +114,7 @@ sqlite3 data/javinizer.db ".recover" | sqlite3 data/javinizer-recovered.db
 ```yaml
 scrapers:
   timeout_seconds: 60          # HTTP client timeout per request (1–300, default 30)
-  request_timeout_seconds: 120 # Overall request timeout (1–600, default 60)
+  request_timeout_seconds: 300 # Overall request timeout (1–600, default 180); raise above the default for slow multi-scraper chains
   browser:
     timeout: 60                # Browser-mode page timeout (default 30)
 ```

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -6654,7 +6654,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "request_timeout_seconds": {
-                    "description": "Overall request timeout in seconds (default: 60)",
+                    "description": "Overall request timeout in seconds (default: 180)",
                     "type": "integer"
                 },
                 "scrape_actress": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -6652,7 +6652,7 @@
                     "type": "string"
                 },
                 "request_timeout_seconds": {
-                    "description": "Overall request timeout in seconds (default: 60)",
+                    "description": "Overall request timeout in seconds (default: 180)",
                     "type": "integer"
                 },
                 "scrape_actress": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1864,7 +1864,7 @@ definitions:
         description: 'Referer header for CDN compatibility (default: https://www.dmm.co.jp/)'
         type: string
       request_timeout_seconds:
-        description: 'Overall request timeout in seconds (default: 60)'
+        description: 'Overall request timeout in seconds (default: 180)'
         type: integer
       scrape_actress:
         description: 'Global scrape_actress default (opt-out, default: true)'

--- a/internal/api/system/config_defaults_version_test.go
+++ b/internal/api/system/config_defaults_version_test.go
@@ -1,0 +1,41 @@
+package system
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigUpdateService_PreserveDefaultsVersionAcrossAPIRoundTrip(t *testing.T) {
+	oldCfg := config.DefaultConfig(nil, nil)
+	oldCfg.DefaultsVersion = config.CurrentDefaultsVersion
+	oldCfg.Scrapers.RequestTimeoutSeconds = 60
+
+	data, err := json.Marshal(oldCfg)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "defaults_version", "defaults_version must be hidden from API JSON")
+
+	var newCfg config.Config
+	require.NoError(t, json.Unmarshal(data, &newCfg))
+	assert.Equal(t, 0, newCfg.DefaultsVersion, "decoded config must start at 0 (json:\"-\" round-trip)")
+
+	tempConfigFile := t.TempDir() + "/config.yaml"
+	deps := createTestDeps(t, oldCfg, tempConfigFile)
+	svc := NewConfigUpdateService(testkit.GetTestRuntime(deps), tempConfigFile)
+
+	require.NoError(t, svc.ValidateAndApply(oldCfg, &newCfg, nil))
+
+	saved, err := os.ReadFile(tempConfigFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(saved), "defaults_version: 1")
+
+	reloaded, err := config.LoadOrCreate(tempConfigFile)
+	require.NoError(t, err)
+	assert.Equal(t, 60, reloaded.Scrapers.RequestTimeoutSeconds, "patch must not rerun after API round-trip")
+	assert.Equal(t, config.CurrentDefaultsVersion, reloaded.DefaultsVersion)
+}

--- a/internal/api/system/config_service.go
+++ b/internal/api/system/config_service.go
@@ -41,6 +41,10 @@ func (s *ConfigUpdateService) ValidateAndApply(oldCfg *config.Config, newCfg *co
 	// Preserve secrets that were redacted in the GET response
 	preserveRedactedSecrets(oldCfg, newCfg)
 
+	if oldCfg != nil {
+		newCfg.DefaultsVersion = oldCfg.DefaultsVersion
+	}
+
 	// Run full config preparation pipeline before save/reload.
 	if _, err := config.Prepare(newCfg); err != nil {
 		return &validationError{message: err.Error()}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,8 @@ import (
 const (
 	CurrentConfigVersion = 3
 
+	CurrentDefaultsVersion = 1
+
 	// DirPerm is the default permission for directory creation.
 	DirPerm = 0777
 	// DirPermTemp is the permission for temporary directory creation.
@@ -117,21 +119,22 @@ type UIConfig struct {
 
 // Config represents the application configuration
 type Config struct {
-	ConfigVersion int               `yaml:"config_version" json:"config_version"`
-	UI            UIConfig          `yaml:"ui" json:"ui"`
-	Server        ServerConfig      `yaml:"server" json:"server"`
-	API           APIConfig         `yaml:"api" json:"api"`
-	System        SystemConfig      `yaml:"system" json:"system"`
-	Scrapers      ScrapersConfig    `yaml:"scrapers" json:"scrapers"`
-	Metadata      MetadataConfig    `yaml:"metadata" json:"metadata"`
-	Matching      MatchingConfig    `yaml:"file_matching" json:"file_matching"`
-	Output        OutputConfig      `yaml:"output" json:"output"`
-	Database      DatabaseConfig    `yaml:"database" json:"database"`
-	Logging       LoggingConfig     `yaml:"logging" json:"logging"`
-	Performance   PerformanceConfig `yaml:"performance" json:"performance"`
-	MediaInfo     mediaInfoConfig   `yaml:"mediainfo" json:"mediainfo"`
-	WebUI         webUIConfig       `yaml:"webui" json:"webui"`
-	Warnings      []ConfigWarning   `yaml:"-" json:"warnings,omitempty"`
+	ConfigVersion   int               `yaml:"config_version" json:"config_version"`
+	DefaultsVersion int               `yaml:"defaults_version" json:"-"`
+	UI              UIConfig          `yaml:"ui" json:"ui"`
+	Server          ServerConfig      `yaml:"server" json:"server"`
+	API             APIConfig         `yaml:"api" json:"api"`
+	System          SystemConfig      `yaml:"system" json:"system"`
+	Scrapers        ScrapersConfig    `yaml:"scrapers" json:"scrapers"`
+	Metadata        MetadataConfig    `yaml:"metadata" json:"metadata"`
+	Matching        MatchingConfig    `yaml:"file_matching" json:"file_matching"`
+	Output          OutputConfig      `yaml:"output" json:"output"`
+	Database        DatabaseConfig    `yaml:"database" json:"database"`
+	Logging         LoggingConfig     `yaml:"logging" json:"logging"`
+	Performance     PerformanceConfig `yaml:"performance" json:"performance"`
+	MediaInfo       mediaInfoConfig   `yaml:"mediainfo" json:"mediainfo"`
+	WebUI           webUIConfig       `yaml:"webui" json:"webui"`
+	Warnings        []ConfigWarning   `yaml:"-" json:"warnings,omitempty"`
 }
 
 // ServerConfig holds API server configuration
@@ -193,19 +196,20 @@ type SystemConfig struct {
 // marshaling is always applied.
 func (c *Config) MarshalYAML() (interface{}, error) {
 	m := map[string]any{
-		"config_version": c.ConfigVersion,
-		"ui":             c.UI,
-		"server":         c.Server,
-		"api":            c.API,
-		"system":         c.System,
-		"metadata":       c.Metadata,
-		"file_matching":  c.Matching,
-		"output":         c.Output,
-		"database":       c.Database,
-		"logging":        c.Logging,
-		"performance":    c.Performance,
-		"mediainfo":      c.MediaInfo,
-		"webui":          c.WebUI,
+		"config_version":   c.ConfigVersion,
+		"defaults_version": c.DefaultsVersion,
+		"ui":               c.UI,
+		"server":           c.Server,
+		"api":              c.API,
+		"system":           c.System,
+		"metadata":         c.Metadata,
+		"file_matching":    c.Matching,
+		"output":           c.Output,
+		"database":         c.Database,
+		"logging":          c.Logging,
+		"performance":      c.Performance,
+		"mediainfo":        c.MediaInfo,
+		"webui":            c.WebUI,
 	}
 
 	scrapersYAML, err := c.Scrapers.MarshalYAML()

--- a/internal/config/config.yaml.example
+++ b/internal/config/config.yaml.example
@@ -1,4 +1,5 @@
 config_version: 3
+defaults_version: 1
 # API authentication credentials are stored in `auth.credentials.json` next to this file.
 # To reset credentials, stop the server, delete that file, then restart `javinizer web`.
 #
@@ -88,8 +89,8 @@ scrapers:
     referer: https://www.dmm.co.jp/
     # HTTP client timeout in seconds (default: 30)
     timeout_seconds: 30
-    # Overall request timeout in seconds (default: 60)
-    request_timeout_seconds: 60
+    # Overall request timeout in seconds (default: 180)
+    request_timeout_seconds: 180
     priority:
         - r18dev
         - libredmm

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -61,7 +61,7 @@ func defaultScraperConfig(priorities []string, defaults map[string]*models.Scrap
 		UserAgent:             "",
 		Referer:               "https://www.dmm.co.jp/", // Referer header for CDN compatibility (required by DMM/R18 CDN)
 		TimeoutSeconds:        30,                       // HTTP client timeout
-		RequestTimeoutSeconds: 60,                       // Overall request timeout
+		RequestTimeoutSeconds: 180,                      // Overall request timeout
 		Priority:              priorities,               // Caller-injected scraper execution order
 		FlareSolverr: models.FlareSolverrConfig{
 			Enabled:    false,
@@ -306,7 +306,8 @@ func DefaultConfig(priorities []string, defaults map[string]*models.ScraperSetti
 	}
 
 	return &Config{
-		ConfigVersion: CurrentConfigVersion,
+		ConfigVersion:   CurrentConfigVersion,
+		DefaultsVersion: CurrentDefaultsVersion,
 		UI: UIConfig{
 			Language: "auto",
 		},

--- a/internal/config/defaults_patch.go
+++ b/internal/config/defaults_patch.go
@@ -1,0 +1,23 @@
+package config
+
+func applyDefaultsPatches(cfg *Config) bool {
+	if cfg == nil {
+		return false
+	}
+
+	if cfg.DefaultsVersion < 0 {
+		return false
+	}
+
+	changed := false
+
+	if cfg.DefaultsVersion < 1 {
+		if cfg.Scrapers.RequestTimeoutSeconds == 60 {
+			cfg.Scrapers.RequestTimeoutSeconds = 180
+		}
+		cfg.DefaultsVersion = 1
+		changed = true
+	}
+
+	return changed
+}

--- a/internal/config/defaults_patch.go
+++ b/internal/config/defaults_patch.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"fmt"
+	"os"
+)
+
 func applyDefaultsPatches(cfg *Config) bool {
 	if cfg == nil {
 		return false
@@ -13,6 +18,7 @@ func applyDefaultsPatches(cfg *Config) bool {
 
 	if cfg.DefaultsVersion < 1 {
 		if cfg.Scrapers.RequestTimeoutSeconds == 60 {
+			fmt.Fprintf(os.Stderr, "✓ Config default updated: scrapers.request_timeout_seconds 60 → 180 (was the previous default; set it explicitly in config.yaml to keep 60)\n")
 			cfg.Scrapers.RequestTimeoutSeconds = 180
 		}
 		cfg.DefaultsVersion = 1

--- a/internal/config/defaults_patch_test.go
+++ b/internal/config/defaults_patch_test.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyDefaultsPatches(t *testing.T) {
+	t.Run("nil config is a no-op", func(t *testing.T) {
+		assert.False(t, applyDefaultsPatches(nil))
+	})
+
+	t.Run("negative version is not patched", func(t *testing.T) {
+		cfg := &Config{DefaultsVersion: -1}
+		assert.False(t, applyDefaultsPatches(cfg))
+		assert.Equal(t, -1, cfg.DefaultsVersion)
+	})
+
+	t.Run("v0 with old default 60 becomes 180", func(t *testing.T) {
+		cfg := &Config{DefaultsVersion: 0, Scrapers: ScrapersConfig{RequestTimeoutSeconds: 60}}
+		assert.True(t, applyDefaultsPatches(cfg))
+		assert.Equal(t, 180, cfg.Scrapers.RequestTimeoutSeconds)
+		assert.Equal(t, 1, cfg.DefaultsVersion)
+	})
+
+	t.Run("v0 with non-default value is preserved but marker advances", func(t *testing.T) {
+		cfg := &Config{DefaultsVersion: 0, Scrapers: ScrapersConfig{RequestTimeoutSeconds: 120}}
+		assert.True(t, applyDefaultsPatches(cfg))
+		assert.Equal(t, 120, cfg.Scrapers.RequestTimeoutSeconds)
+		assert.Equal(t, 1, cfg.DefaultsVersion)
+	})
+
+	t.Run("already at current version is a no-op even with 60", func(t *testing.T) {
+		cfg := &Config{DefaultsVersion: 1, Scrapers: ScrapersConfig{RequestTimeoutSeconds: 60}}
+		assert.False(t, applyDefaultsPatches(cfg))
+		assert.Equal(t, 60, cfg.Scrapers.RequestTimeoutSeconds)
+		assert.Equal(t, 1, cfg.DefaultsVersion)
+	})
+
+	t.Run("future version is not patched", func(t *testing.T) {
+		cfg := &Config{DefaultsVersion: CurrentDefaultsVersion + 1, Scrapers: ScrapersConfig{RequestTimeoutSeconds: 60}}
+		assert.False(t, applyDefaultsPatches(cfg))
+		assert.Equal(t, CurrentDefaultsVersion+1, cfg.DefaultsVersion)
+		assert.Equal(t, 60, cfg.Scrapers.RequestTimeoutSeconds)
+	})
+}
+
+func TestDefaultsVersion_LoadOrCreatePatching(t *testing.T) {
+	tests := []struct {
+		name             string
+		yaml             string
+		wantTimeout      int
+		wantDefaultsVer  int
+		wantSavedVersion int
+	}{
+		{
+			name: "v3 config with old default 60 and no defaults_version key",
+			yaml: `config_version: 3
+scrapers:
+    request_timeout_seconds: 60
+`,
+			wantTimeout:      180,
+			wantDefaultsVer:  1,
+			wantSavedVersion: 1,
+		},
+		{
+			name: "v3 config with user value 120 and defaults_version 0",
+			yaml: `config_version: 3
+defaults_version: 0
+scrapers:
+    request_timeout_seconds: 120
+`,
+			wantTimeout:      120,
+			wantDefaultsVer:  1,
+			wantSavedVersion: 1,
+		},
+		{
+			name: "already patched config keeps deliberate 60",
+			yaml: `config_version: 3
+defaults_version: 1
+scrapers:
+    request_timeout_seconds: 60
+`,
+			wantTimeout:      60,
+			wantDefaultsVer:  1,
+			wantSavedVersion: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.yaml")
+			require.NoError(t, os.WriteFile(configPath, []byte(tc.yaml), 0644))
+
+			cfg, err := LoadOrCreate(configPath)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantTimeout, cfg.Scrapers.RequestTimeoutSeconds)
+			assert.Equal(t, tc.wantDefaultsVer, cfg.DefaultsVersion)
+
+			saved, err := os.ReadFile(configPath)
+			require.NoError(t, err)
+			assert.Contains(t, string(saved), "defaults_version: 1")
+		})
+	}
+}
+
+func TestDefaultsVersion_Validation(t *testing.T) {
+	t.Run("future defaults version rejected", func(t *testing.T) {
+		cfg := DefaultConfig(nil, nil)
+		cfg.DefaultsVersion = CurrentDefaultsVersion + 1
+		_, err := Prepare(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "newer than supported")
+	})
+
+	t.Run("negative defaults version rejected", func(t *testing.T) {
+		cfg := DefaultConfig(nil, nil)
+		cfg.DefaultsVersion = -1
+		_, err := Prepare(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be >= 0")
+	})
+}
+
+func TestFreshConfigFromEmbeddedHasCurrentDefaultsVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	cfg, err := LoadOrCreate(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, CurrentDefaultsVersion, cfg.DefaultsVersion)
+	assert.Equal(t, 180, cfg.Scrapers.RequestTimeoutSeconds)
+}
+
+func TestEmbeddedConfigCarriesCurrentDefaultsVersion(t *testing.T) {
+	content := string(embeddedConfigBytes())
+	assert.Contains(t, content, "defaults_version: 1")
+
+	cfg, err := decodeConfig(embeddedConfigBytes())
+	require.NoError(t, err)
+	assert.Equal(t, CurrentDefaultsVersion, cfg.DefaultsVersion)
+}

--- a/internal/config/defaults_patch_test.go
+++ b/internal/config/defaults_patch_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -144,4 +145,35 @@ func TestEmbeddedConfigCarriesCurrentDefaultsVersion(t *testing.T) {
 	cfg, err := decodeConfig(embeddedConfigBytes())
 	require.NoError(t, err)
 	assert.Equal(t, CurrentDefaultsVersion, cfg.DefaultsVersion)
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func TestApplyDefaultsPatches_Notice(t *testing.T) {
+	t.Run("prints notice when a value is rewritten", func(t *testing.T) {
+		cfg := &Config{DefaultsVersion: 0, Scrapers: ScrapersConfig{RequestTimeoutSeconds: 60}}
+		out := captureStderr(t, func() { applyDefaultsPatches(cfg) })
+		assert.Contains(t, out, "scrapers.request_timeout_seconds")
+		assert.Contains(t, out, "180")
+	})
+
+	t.Run("silent when only the marker advances", func(t *testing.T) {
+		cfg := &Config{DefaultsVersion: 0, Scrapers: ScrapersConfig{RequestTimeoutSeconds: 120}}
+		out := captureStderr(t, func() { applyDefaultsPatches(cfg) })
+		assert.Empty(t, out)
+	})
 }

--- a/internal/config/defaults_patch_test.go
+++ b/internal/config/defaults_patch_test.go
@@ -177,3 +177,35 @@ func TestApplyDefaultsPatches_Notice(t *testing.T) {
 		assert.Empty(t, out)
 	})
 }
+
+// TestLoadOrCreate_DoesNotPersistEnvOverridesDuringDefaultsPatch guards the
+// P1 regression: when the defaults patch triggers a save, environment
+// overrides (which may carry secrets like OPENAI_API_KEY or paths like
+// JAVINIZER_DB) must not be written to config.yaml. The runtime cfg still
+// honors env overrides; only the on-disk copy excludes them.
+func TestLoadOrCreate_DoesNotPersistEnvOverridesDuringDefaultsPatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("config_version: 3\nscrapers:\n    request_timeout_seconds: 60\n"), 0644))
+
+	t.Setenv("JAVINIZER_DB", "/env/secret/db.sqlite")
+	t.Setenv("OPENAI_API_KEY", "sk-env-secret-do-not-persist")
+
+	cfg, err := LoadOrCreate(configPath)
+	require.NoError(t, err)
+
+	// Runtime cfg honors env overrides + the defaults patch.
+	assert.Equal(t, "/env/secret/db.sqlite", cfg.Database.DSN, "runtime cfg honors JAVINIZER_DB")
+	assert.Equal(t, "sk-env-secret-do-not-persist", cfg.Metadata.Translation.OpenAI.APIKey, "runtime cfg honors OPENAI_API_KEY")
+	assert.Equal(t, 180, cfg.Scrapers.RequestTimeoutSeconds)
+	assert.Equal(t, CurrentDefaultsVersion, cfg.DefaultsVersion)
+
+	// Persisted file carries the patch but never env overrides (esp. secrets).
+	saved, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	savedStr := string(saved)
+	assert.Contains(t, savedStr, "defaults_version: 1")
+	assert.Contains(t, savedStr, "request_timeout_seconds: 180")
+	assert.NotContains(t, savedStr, "/env/secret/db.sqlite", "env JAVINIZER_DB must not be persisted to config.yaml")
+	assert.NotContains(t, savedStr, "sk-env-secret-do-not-persist", "env OPENAI_API_KEY must not be persisted to config.yaml")
+}

--- a/internal/config/pipeline.go
+++ b/internal/config/pipeline.go
@@ -152,6 +152,17 @@ func Prepare(cfg *Config) (bool, error) {
 		)
 	}
 
+	if cfg.DefaultsVersion > CurrentDefaultsVersion {
+		return false, fmt.Errorf(
+			"defaults version %d is newer than supported version %d; please update Javinizer",
+			cfg.DefaultsVersion,
+			CurrentDefaultsVersion,
+		)
+	}
+	if cfg.DefaultsVersion < 0 {
+		return false, fmt.Errorf("defaults version must be >= 0, got %d", cfg.DefaultsVersion)
+	}
+
 	normalized := normalize(cfg)
 
 	// An explicitly empty scrapers.priority (yaml `priority: []` or `priority:

--- a/internal/config/scrapers_config.go
+++ b/internal/config/scrapers_config.go
@@ -38,7 +38,7 @@ type ScrapersConfig struct {
 	UserAgent             string                                         `yaml:"user_agent" json:"user_agent"`
 	Referer               string                                         `yaml:"referer" json:"referer"`                                 // Referer header for CDN compatibility (default: https://www.dmm.co.jp/)
 	TimeoutSeconds        int                                            `yaml:"timeout_seconds" json:"timeout_seconds"`                 // HTTP client timeout in seconds (default: 30)
-	RequestTimeoutSeconds int                                            `yaml:"request_timeout_seconds" json:"request_timeout_seconds"` // Overall request timeout in seconds (default: 60)
+	RequestTimeoutSeconds int                                            `yaml:"request_timeout_seconds" json:"request_timeout_seconds"` // Overall request timeout in seconds (default: 180)
 	Priority              []string                                       `yaml:"priority" json:"priority"`                               // Global scraper priority order
 	FlareSolverr          models.FlareSolverrConfig                      `yaml:"flaresolverr" json:"flaresolverr"`                       // Global FlareSolverr config for Cloudflare bypass
 	ScrapeActress         bool                                           `yaml:"scrape_actress" json:"scrape_actress"`                   // Global scrape_actress default (opt-out, default: true)

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -172,12 +172,13 @@ func (cs *ConfigStorage) LoadOrCreate(path string) (*Config, error) {
 	}
 
 	ApplyEnvironmentOverrides(cfg)
+	patched := applyDefaultsPatches(cfg)
 	changed, err := Prepare(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	if changed {
+	if patched || changed {
 		if err := cs.Save(cfg, path); err != nil {
 			return nil, fmt.Errorf("failed to save migrated config: %w", err)
 		}
@@ -413,6 +414,7 @@ func decodeConfig(data []byte) (*Config, error) {
 	// Treat existing files without config_version as legacy schema (v0) so
 	// LoadOrCreate can apply migrations and persist newly introduced fields.
 	cfg.ConfigVersion = 0
+	cfg.DefaultsVersion = 0
 
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -171,15 +171,22 @@ func (cs *ConfigStorage) LoadOrCreate(path string) (*Config, error) {
 		return cfg, nil
 	}
 
-	ApplyEnvironmentOverrides(cfg)
+	// Apply the defaults patch before env overrides, then clone a pre-env copy
+	// for persistence. Environment overrides — which may carry secrets
+	// (OPENAI_API_KEY, DEEPL_API_KEY, …) or paths (JAVINIZER_DB,
+	// JAVINIZER_LOG_DIR) — must never be written to config.yaml. The runtime cfg
+	// still receives env overrides and full Prepare validation below; only the
+	// on-disk copy excludes them. Patching before the clone also prints the
+	// upgrade notice exactly once.
 	patched := applyDefaultsPatches(cfg)
-	changed, err := Prepare(cfg)
-	if err != nil {
+	diskCfg := cfg.Clone()
+	ApplyEnvironmentOverrides(cfg)
+	if _, err := Prepare(cfg); err != nil {
 		return nil, err
 	}
-
-	if patched || changed {
-		if err := cs.Save(cfg, path); err != nil {
+	diskChanged := normalize(diskCfg)
+	if patched || diskChanged {
+		if err := cs.Save(diskCfg, path); err != nil {
 			return nil, fmt.Errorf("failed to save migrated config: %w", err)
 		}
 	}

--- a/internal/config/testdata/config-with-flaresolverr.yaml.golden
+++ b/internal/config/testdata/config-with-flaresolverr.yaml.golden
@@ -5,7 +5,7 @@ scrapers:
     user_agent: Javinizer-Test/1.0
     referer: https://www.dmm.co.jp/
     timeout_seconds: 30
-    request_timeout_seconds: 60
+    request_timeout_seconds: 180
     priority:
         - r18dev
         - dmm


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #154. PR #154 wired the previously-**dead** config `scrapers.request_timeout_seconds` into all scrape paths via `context.WithTimeout`. The default was `60s` — reasonable when the config did nothing, but now far too tight for a real multi-scraper scrape:

- The priority chain fans out across multiple scrapers (r18dev → libredmm → dmm → javlibrary → …), each HTTP request up to `30s` (`httpclient.DefaultTimeout`)
- DMM uses **browser mode** (chromedp/CDP) for video pages — slow page loads + JS render
- 3+ scrapers × ~20-30s each + aggregation easily exceeds 60s

The result: healthy scrapes failed with `context deadline exceeded` and surfaced as "Unidentified Files" on the review page (e.g. `ABP-930.mp4`).

## Fix

Raise the default `60s → 180s` (3 min). This gives a multi-scraper + browser-mode scrape ample headroom while staying under the 5-minute `performance.worker_timeout` (the outer bound). Validation range (1–600) unchanged.

### Upgrade path for existing installs (`defaults_version`)

Existing v3 configs have `request_timeout_seconds: 60` written explicitly (generated from the old example), so a code-default change alone never reaches them — and the `config_version` track doesn't apply (schema is current, and that track is destructive regenerate-from-defaults by design). This PR adds a lightweight second marker, `defaults_version`, for non-structural *default-value* migrations:

- Configs missing the marker decode as `defaults_version: 0`; a patch chain (`internal/config/defaults_patch.go`) upgrades values still carrying the old shipped default (60 → 180), prints a one-line stderr notice when it rewrites a value, then advances and persists the marker
- User-chosen values (≠ old default) are untouched; after patching, users can still set 60 explicitly — the patch never re-runs
- Hidden from the API (`json:"-"`), preserved across `PUT /api/v1/config` round-trips, downgrade-protected (`Prepare` rejects versions newer than `CurrentDefaultsVersion`)
- Legacy v0–v2 configs are unaffected — they take the existing `config_version` migration path

### Note on timeout semantics
The request timeout starts when a file **gets a worker slot** (enters the pool), not at enqueue time — so files waiting in the queue do not burn down their timeout budget. It measures actual scrape duration, nested inside the worker timeout. (Traced via `scrape_phase.go` → `fanout.BoundedFanOut` → `errgroup.Go` semaphore acquire → `scrapeFile` → `context.WithTimeout`.)

## Changes
- `internal/config/defaults.go` — `RequestTimeoutSeconds: 60 → 180`; `DefaultConfig` stamps `CurrentDefaultsVersion`
- `internal/config/defaults_patch.go` (+ tests) — v0→v1 patch chain + stderr notice on value rewrite
- `internal/config/config.go` — `CurrentDefaultsVersion = 1`, `Config.DefaultsVersion` field (`json:"-"`), `MarshalYAML` writes it
- `internal/config/pipeline.go` — bounds-check `defaults_version` (0…Current)
- `internal/config/storage.go` — `LoadOrCreate` applies patches after env overrides, saves when patched
- `internal/api/system/config_service.go` (+ test) — preserve `DefaultsVersion` across API config updates
- `internal/config/scrapers_config.go` — struct tag comment
- `internal/config/config.yaml.example` + `configs/config.yaml.example` — `180` + `defaults_version: 1` (both kept in sync; `TestEmbeddedConfigMatchesSourceFile` guards this)
- `internal/config/testdata/config-with-flaresolverr.yaml.golden` — golden value
- `docs/02-configuration.md` — default 180 + `defaults_version` explainer; `docs/10-troubleshooting.md` — troubleshooting example bumped to `300` (above the new default, for slow chains)
- `docs/swagger/{docs.go,swagger.json,swagger.yaml}` — regenerated (`default: 180`)

## Test plan
- [x] `go test -short ./internal/config/... ./internal/api/system/...` — pass (incl. `TestDefaultConfigMatchesExample` + `TestEmbeddedConfigMatchesSourceFile` sync tests, patch/notice/API-round-trip tests)
- [x] `golangci-lint run` — 0 issues
- [x] `go vet` + `gofmt` — clean
- [x] `make check-swagger` — swagger up to date
- [x] `make build` — builds
- [x] Pre-commit hook (fmt/lint/vet/tests/build/swagger) — all pass

## Checklist
- [x] Tests pass locally
- [x] `make lint` passes (golangci-lint)
- [x] Swagger docs regenerated
- [x] Commit message follows `type(scope): summary` (≤72 chars)

Codex review addressed: P2 (existing installs keep generated `60`) via the `defaults_version` patch; P3 (docs advertising the old default) via the docs sync.