### PR TITLE
fix(i18n): locale reload loop and startup language selector

### DIFF
--- a/web/frontend/src/lib/components/LanguageSelector.svelte
+++ b/web/frontend/src/lib/components/LanguageSelector.svelte
@@ -4,24 +4,14 @@
 	import { fly } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import { Languages, ChevronDown } from 'lucide-svelte';
-	import { LOCALE_STORAGE_KEY, SUPPORTED_LOCALES, selectLocale } from '$lib/i18n/locale';
+	import { SUPPORTED_LOCALES, currentLocaleChoice, selectLocale } from '$lib/i18n/locale';
 	import * as m from '$lib/paraglide/messages';
 
-	// Pre-auth there is no config access, so mirror the cached explicit pick
-	// and fall back to 'auto' (browser preference). Post-auth the configured
-	// ui.language wins again via reconcileWithConfig.
-	function currentSelection(): string {
-		if (!browser) return 'auto';
-		const cached = localStorage.getItem(LOCALE_STORAGE_KEY);
-		if (cached && SUPPORTED_LOCALES.some((l) => l.tag === cached)) return cached;
-		return 'auto';
-	}
-
-	// SSR/hydration renders 'auto' everywhere; the cached pick is applied
+	// SSR/hydration renders 'auto' everywhere; the recorded choice is applied
 	// post-mount to avoid a hydration value mismatch on the <select>.
 	let selected = $state('auto');
 	onMount(() => {
-		selected = currentSelection();
+		selected = currentLocaleChoice();
 	});
 
 	async function handleChange(event: Event) {

--- a/web/frontend/src/lib/components/LanguageSelector.svelte
+++ b/web/frontend/src/lib/components/LanguageSelector.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
+	import { fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import { Languages, ChevronDown } from 'lucide-svelte';
 	import { LOCALE_STORAGE_KEY, SUPPORTED_LOCALES, selectLocale } from '$lib/i18n/locale';
 	import * as m from '$lib/paraglide/messages';
 
@@ -22,13 +25,26 @@
 	}
 </script>
 
-<select
-	class="rounded-md border bg-background px-3 py-2 text-sm text-foreground shadow-sm"
-	aria-label={m.settings_language()}
-	value={selected}
-	onchange={(e) => void handleChange(e)}
+<div
+	class="group relative inline-flex items-center"
+	in:fly={{ y: -12, duration: 450, delay: 250, easing: cubicOut }}
 >
-	{#each SUPPORTED_LOCALES as locale (locale.tag)}
-		<option value={locale.tag}>{locale.selfName}</option>
-	{/each}
-</select>
+	<Languages
+		class="pointer-events-none absolute left-3 h-4 w-4 text-muted-foreground transition-colors group-hover:text-foreground"
+		strokeWidth={1.8}
+	/>
+	<select
+		class="cursor-pointer appearance-none rounded-full border border-border bg-card/95 py-2 pl-9 pr-9 text-sm font-medium text-foreground shadow-sm backdrop-blur transition-all hover:border-foreground/25 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+		aria-label={m.settings_language()}
+		value={selected}
+		onchange={(e) => void handleChange(e)}
+	>
+		{#each SUPPORTED_LOCALES as locale (locale.tag)}
+			<option value={locale.tag}>{locale.selfName}</option>
+		{/each}
+	</select>
+	<ChevronDown
+		class="pointer-events-none absolute right-3 h-4 w-4 text-muted-foreground transition-transform duration-200 group-focus-within:rotate-180"
+		strokeWidth={2}
+	/>
+</div>

--- a/web/frontend/src/lib/components/LanguageSelector.svelte
+++ b/web/frontend/src/lib/components/LanguageSelector.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
+	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import { Languages, ChevronDown } from 'lucide-svelte';
@@ -16,7 +17,12 @@
 		return 'auto';
 	}
 
-	let selected = $state(currentSelection());
+	// SSR/hydration renders 'auto' everywhere; the cached pick is applied
+	// post-mount to avoid a hydration value mismatch on the <select>.
+	let selected = $state('auto');
+	onMount(() => {
+		selected = currentSelection();
+	});
 
 	async function handleChange(event: Event) {
 		const value = (event.target as HTMLSelectElement).value;
@@ -32,6 +38,7 @@
 	<Languages
 		class="pointer-events-none absolute left-3 h-4 w-4 text-muted-foreground transition-colors group-hover:text-foreground"
 		strokeWidth={1.8}
+		aria-hidden="true"
 	/>
 	<select
 		class="cursor-pointer appearance-none rounded-full border border-border bg-card/95 py-2 pl-9 pr-9 text-sm font-medium text-foreground shadow-sm backdrop-blur transition-all hover:border-foreground/25 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -46,5 +53,6 @@
 	<ChevronDown
 		class="pointer-events-none absolute right-3 h-4 w-4 text-muted-foreground transition-transform duration-200 group-focus-within:rotate-180"
 		strokeWidth={2}
+		aria-hidden="true"
 	/>
 </div>

--- a/web/frontend/src/lib/components/LanguageSelector.svelte
+++ b/web/frontend/src/lib/components/LanguageSelector.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { LOCALE_STORAGE_KEY, SUPPORTED_LOCALES, selectLocale } from '$lib/i18n/locale';
+	import * as m from '$lib/paraglide/messages';
+
+	// Pre-auth there is no config access, so mirror the cached explicit pick
+	// and fall back to 'auto' (browser preference). Post-auth the configured
+	// ui.language wins again via reconcileWithConfig.
+	function currentSelection(): string {
+		if (!browser) return 'auto';
+		const cached = localStorage.getItem(LOCALE_STORAGE_KEY);
+		if (cached && SUPPORTED_LOCALES.some((l) => l.tag === cached)) return cached;
+		return 'auto';
+	}
+
+	let selected = $state(currentSelection());
+
+	async function handleChange(event: Event) {
+		const value = (event.target as HTMLSelectElement).value;
+		selected = value;
+		await selectLocale(value);
+	}
+</script>
+
+<select
+	class="rounded-md border bg-background px-3 py-2 text-sm text-foreground shadow-sm"
+	aria-label={m.settings_language()}
+	value={selected}
+	onchange={(e) => void handleChange(e)}
+>
+	{#each SUPPORTED_LOCALES as locale (locale.tag)}
+		<option value={locale.tag}>{locale.selfName}</option>
+	{/each}
+</select>

--- a/web/frontend/src/lib/components/settings/sections/WebUISettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/WebUISettingsSection.svelte
@@ -2,7 +2,7 @@
 	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
 	import type { SettingsConfig } from '$lib/api/types';
 	import * as m from '$lib/paraglide/messages';
-	import { SUPPORTED_LOCALES, selectLocale } from '$lib/i18n/locale';
+	import { SUPPORTED_LOCALES } from '$lib/i18n/locale';
 
 	interface Props {
 		config: SettingsConfig;
@@ -30,9 +30,12 @@
 		config.ui.language = value;
 	}
 
-	async function handleLanguageChange(value: string) {
+	function handleLanguageChange(value: string) {
+		// Only mark the config dirty here. Applying immediately would reload the
+		// page and discard the unsaved change; the saved language is applied
+		// (with a reload if the rendered locale changed) after a successful save
+		// via applySavedLocale in the settings store.
 		setSelectedLanguage(value);
-		await selectLocale(value);
 	}
 </script>
 

--- a/web/frontend/src/lib/components/settings/sections/WebUISettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/WebUISettingsSection.svelte
@@ -2,7 +2,7 @@
 	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
 	import type { SettingsConfig } from '$lib/api/types';
 	import * as m from '$lib/paraglide/messages';
-	import { SUPPORTED_LOCALES, selectLocale, LOCALE_STORAGE_KEY, resolveBrowserLocale, applyLocale } from '$lib/i18n/locale';
+	import { SUPPORTED_LOCALES, selectLocale } from '$lib/i18n/locale';
 
 	interface Props {
 		config: SettingsConfig;
@@ -32,13 +32,7 @@
 
 	async function handleLanguageChange(value: string) {
 		setSelectedLanguage(value);
-		if (value === 'auto') {
-			localStorage.removeItem(LOCALE_STORAGE_KEY);
-			const browserLocale = resolveBrowserLocale();
-			await applyLocale(browserLocale);
-		} else {
-			await selectLocale(value);
-		}
+		await selectLocale(value);
 	}
 </script>
 

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -24,9 +24,10 @@
 
 	interface Props {
 		onComplete: () => void;
+		onSessionCreated?: () => void;
 	}
 
-	let { onComplete }: Props = $props();
+	let { onComplete, onSessionCreated }: Props = $props();
 
 	type StepId = 'credentials' | 'directories' | 'scrapers';
 
@@ -152,6 +153,7 @@
 			if (result?.session_id) BaseClient.setSessionID(result.session_id);
 			syncWebSocketAuth();
 			credentialsRegistered = true;
+		onSessionCreated?.();
 		} catch (e) {
 			error = e instanceof Error ? e.message : m.setup_err_create_admin();
 		} finally {

--- a/web/frontend/src/lib/components/setup/SetupWizard.svelte
+++ b/web/frontend/src/lib/components/setup/SetupWizard.svelte
@@ -7,6 +7,7 @@
 	import { toastStore } from '$lib/stores/toast';
 	import { getThemeStore } from '$lib/stores/theme.svelte';
 	import { websocketStore } from '$lib/stores/websocket';
+	import { currentLocaleChoice } from '$lib/i18n/locale';
 	import Button from '$lib/components/ui/Button.svelte';
 	import StepCredentials from './StepCredentials.svelte';
 	import StepCredentialsSuccess from './StepCredentialsSuccess.svelte';
@@ -203,11 +204,19 @@
 					(sc[scraper.name] as Record<string, unknown>).enabled = selectedScrapers.includes(scraper.name);
 				}
 				fresh.scrapers = sc as typeof fresh.scrapers;
-				await apiClient.request('/api/v1/config', {
-					method: 'PUT',
-					body: JSON.stringify(fresh),
-				});
 			}
+			// Persist the interface language chosen during setup so post-auth
+			// reconciliation honors it instead of reverting to the browser
+			// locale under the default 'auto' config.
+			const localeChoice = currentLocaleChoice();
+			if (localeChoice !== 'auto') {
+				if (!fresh.ui) fresh.ui = { language: 'auto' };
+				fresh.ui.language = localeChoice;
+			}
+			await apiClient.request('/api/v1/config', {
+				method: 'PUT',
+				body: JSON.stringify(fresh),
+			});
 			toastStore.success(m.setup_toast_complete(), 4000);
 			onComplete();
 		} catch (e) {

--- a/web/frontend/src/lib/i18n/locale.test.ts
+++ b/web/frontend/src/lib/i18n/locale.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
 	applyLocale,
+	applySavedLocale,
 	LOCALE_STORAGE_KEY,
 	reconcileWithConfig,
 	resolveLocaleTag,
@@ -104,6 +105,28 @@ describe('reconcileWithConfig / applyLocale reload guards (#164)', () => {
 		expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('zh-Hans');
 	});
 
+	it('auto config with an unpinned ja browser is steady via preferredLanguage', async () => {
+		// No cached tag: Paraglide resolves ja directly from navigator.languages.
+		mockGetLocale.mockImplementation(() => localStorage.getItem(LOCALE_STORAGE_KEY) ?? 'ja');
+		stubLanguages(['ja-JP']);
+
+		const result = await reconcileWithConfig({ language: 'auto' } as UIConfig);
+
+		expect(result).toBe('ja');
+		expect(mockSetLocale).not.toHaveBeenCalled();
+	});
+
+	it('auto config with an unsupported browser locale falls back to base and stays steady', async () => {
+		// de-DE maps to no catalog: app and Paraglide both resolve baseLocale.
+		mockGetLocale.mockImplementation(() => localStorage.getItem(LOCALE_STORAGE_KEY) ?? 'en');
+		stubLanguages(['de-DE']);
+
+		const result = await reconcileWithConfig({ language: 'auto' } as UIConfig);
+
+		expect(result).toBe('en');
+		expect(mockSetLocale).not.toHaveBeenCalled();
+	});
+
 	it('auto config corrects a stale cached tag exactly once, then stays stable', async () => {
 		localStorage.setItem(LOCALE_STORAGE_KEY, 'en');
 
@@ -197,6 +220,64 @@ describe('selectLocale', () => {
 		localStorage.setItem(LOCALE_STORAGE_KEY, 'ja');
 
 		await selectLocale('fr');
+
+		expect(mockSetLocale).toHaveBeenCalledWith('en');
+	});
+});
+
+describe('applySavedLocale', () => {
+	function stubLanguages(langs: string[]) {
+		Object.defineProperty(window.navigator, 'languages', { value: langs, configurable: true });
+	}
+
+	beforeEach(() => {
+		localStorage.clear();
+		mockGetLocale.mockReset();
+		mockSetLocale.mockReset();
+		mockGetLocale.mockImplementation(() => localStorage.getItem(LOCALE_STORAGE_KEY) ?? 'en');
+		mockSetLocale.mockImplementation(async (tag: string) => {
+			localStorage.setItem(LOCALE_STORAGE_KEY, tag);
+		});
+		stubLanguages(['zh-CN']);
+	});
+
+	it('reloads via setLocale when the saved locale differs from the rendered one', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'zh-Hans');
+
+		await applySavedLocale('ja');
+
+		expect(mockSetLocale).toHaveBeenCalledWith('ja');
+	});
+
+	it('resolves auto to the browser preference', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'ja');
+
+		await applySavedLocale('auto');
+
+		expect(mockSetLocale).toHaveBeenCalledWith('zh-Hans');
+	});
+
+	it('maps config variants onto shipped catalogs', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'en');
+
+		await applySavedLocale('zh-Hans-CN');
+
+		expect(mockSetLocale).toHaveBeenCalledWith('zh-Hans');
+	});
+
+	it('re-pins without setLocale when the saved locale is already rendered', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'zh-Hans');
+
+		await applySavedLocale('zh-Hans');
+
+		expect(mockSetLocale).not.toHaveBeenCalled();
+		expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('zh-Hans');
+	});
+
+	it('falls back to the base locale for valid but unsupported config tags', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'ja');
+
+		await applySavedLocale('pt-BR');
 
 		expect(mockSetLocale).toHaveBeenCalledWith('en');
 	});

--- a/web/frontend/src/lib/i18n/locale.test.ts
+++ b/web/frontend/src/lib/i18n/locale.test.ts
@@ -1,5 +1,24 @@
-import { describe, it, expect } from 'vitest';
-import { resolveLocaleTag, SUPPORTED_LOCALES } from './locale';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+	applyLocale,
+	LOCALE_STORAGE_KEY,
+	reconcileWithConfig,
+	resolveLocaleTag,
+	SUPPORTED_LOCALES
+} from './locale';
+import type { UIConfig } from '$lib/api/types';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+const mockGetLocale = vi.fn();
+const mockSetLocale = vi.fn();
+
+vi.mock('$lib/paraglide/runtime', () => ({
+	baseLocale: 'en',
+	locales: ['en', 'en-XA', 'ja', 'zh-Hans', 'zh-Hant'],
+	getLocale: (...args: unknown[]) => mockGetLocale(...args),
+	setLocale: (...args: unknown[]) => mockSetLocale(...args)
+}));
 
 describe('resolveLocaleTag', () => {
 	it('resolves canonical supported tags', () => {
@@ -52,5 +71,82 @@ describe('resolveLocaleTag', () => {
 			if (locale.tag === 'auto') continue;
 			expect(resolveLocaleTag(locale.tag)).toBe(locale.tag);
 		}
+	});
+});
+
+describe('reconcileWithConfig / applyLocale reload guards (#164)', () => {
+	function stubLanguages(langs: string[]) {
+		Object.defineProperty(window.navigator, 'languages', { value: langs, configurable: true });
+	}
+
+	beforeEach(() => {
+		localStorage.clear();
+		mockGetLocale.mockReset();
+		mockSetLocale.mockReset();
+		// Simulate Paraglide's resolution for a zh-CN browser: the localStorage
+		// strategy hits, but preferredLanguage cannot map zh-CN -> zh-Hans
+		// (exact and base-tag matching only), so it falls back to baseLocale.
+		mockGetLocale.mockImplementation(() => localStorage.getItem(LOCALE_STORAGE_KEY) ?? 'en');
+		mockSetLocale.mockImplementation(async (tag: string) => {
+			localStorage.setItem(LOCALE_STORAGE_KEY, tag);
+		});
+		stubLanguages(['zh-CN']);
+	});
+
+	it('auto config in steady state does not reapply (setLocale reloads by default)', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'zh-Hans');
+
+		const result = await reconcileWithConfig({ language: 'auto' } as UIConfig);
+
+		expect(result).toBe('zh-Hans');
+		expect(mockSetLocale).not.toHaveBeenCalled();
+		expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('zh-Hans');
+	});
+
+	it('auto config corrects a stale cached tag exactly once, then stays stable', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'en');
+
+		const first = await reconcileWithConfig({ language: 'auto' } as UIConfig);
+
+		expect(first).toBe('zh-Hans');
+		expect(mockSetLocale).toHaveBeenCalledTimes(1);
+		expect(mockSetLocale).toHaveBeenCalledWith('zh-Hans');
+
+		// Second pass simulates the next page load after setLocale's reload:
+		// without the steady-state guard this re-applied and reloaded forever.
+		const second = await reconcileWithConfig({ language: 'auto' } as UIConfig);
+
+		expect(second).toBe('zh-Hans');
+		expect(mockSetLocale).toHaveBeenCalledTimes(1);
+	});
+
+	it('explicit configured locale is cached; the fresh cache makes reapply a no-op', async () => {
+		stubLanguages(['en-US']);
+
+		const result = await reconcileWithConfig({ language: 'zh-Hant' } as UIConfig);
+
+		expect(result).toBe('zh-Hant');
+		expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('zh-Hant');
+		// The cache write above already makes getLocale() resolve the tag, so
+		// applyLocale's guard skips setLocale — same as before the fix, where
+		// setLocale's own no-reload guard saw the fresh cache and did nothing.
+		expect(mockSetLocale).not.toHaveBeenCalled();
+	});
+
+	it('applyLocale skips setLocale when the locale already matches', async () => {
+		mockGetLocale.mockReturnValue('zh-Hans');
+
+		await applyLocale('zh-Hans');
+
+		expect(mockSetLocale).not.toHaveBeenCalled();
+		expect(document.documentElement.lang).toBe('zh-Hans');
+	});
+
+	it('applyLocale delegates to setLocale on an actual change', async () => {
+		mockGetLocale.mockReturnValue('en');
+
+		await applyLocale('zh-Hans');
+
+		expect(mockSetLocale).toHaveBeenCalledWith('zh-Hans');
 	});
 });

--- a/web/frontend/src/lib/i18n/locale.test.ts
+++ b/web/frontend/src/lib/i18n/locale.test.ts
@@ -161,6 +161,19 @@ describe('reconcileWithConfig / applyLocale reload guards (#164)', () => {
 		expect(mockSetLocale).toHaveBeenCalledTimes(1);
 	});
 
+	it('auto config forces a reload when a stale pin differs from the browser locale', async () => {
+		// Pre-auth selector pinned ja on an en-US browser; config is auto. The
+		// stale pin must be overwritten and the page reloaded (setLocale called),
+		// not silently left rendering ja.
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'ja');
+		stubLanguages(['en-US']);
+
+		const result = await reconcileWithConfig({ language: 'auto' } as UIConfig);
+
+		expect(result).toBe('en');
+		expect(mockSetLocale).toHaveBeenCalledWith('en');
+	});
+
 	it('explicit configured locale is cached; the fresh cache makes reapply a no-op', async () => {
 		stubLanguages(['en-US']);
 

--- a/web/frontend/src/lib/i18n/locale.test.ts
+++ b/web/frontend/src/lib/i18n/locale.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
 	applyLocale,
 	applySavedLocale,
+	currentLocaleChoice,
+	LOCALE_CHOICE_KEY,
 	LOCALE_STORAGE_KEY,
 	reconcileWithConfig,
 	resolveLocaleTag,
@@ -214,6 +216,20 @@ describe('selectLocale', () => {
 
 		expect(mockSetLocale).not.toHaveBeenCalled();
 		expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('zh-Hans');
+		expect(localStorage.getItem(LOCALE_CHOICE_KEY)).toBe('zh-Hans');
+	});
+
+	it('records the choice separately so auto does not read back as an explicit tag', async () => {
+		// zh-CN browser already rendering zh-Hans (pinned by setLocale for rendering).
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'zh-Hans');
+
+		await selectLocale('auto');
+
+		// No reload: the rendered locale already matches the browser preference.
+		expect(mockSetLocale).not.toHaveBeenCalled();
+		// The choice is recorded as 'auto', not the resolved concrete tag.
+		expect(localStorage.getItem(LOCALE_CHOICE_KEY)).toBe('auto');
+		expect(currentLocaleChoice()).toBe('auto');
 	});
 
 	it('falls back to the base locale for unsupported tags', async () => {
@@ -265,7 +281,18 @@ describe('applySavedLocale', () => {
 		expect(mockSetLocale).toHaveBeenCalledWith('zh-Hans');
 	});
 
-	it('re-pins without setLocale when the saved locale is already rendered', async () => {
+	it('does not pin a concrete tag when auto is already rendered', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'zh-Hans');
+
+		await applySavedLocale('auto');
+
+		expect(mockSetLocale).not.toHaveBeenCalled();
+		// The rendering cache stays as-is; no conflation with an explicit pick.
+		expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('zh-Hans');
+		expect(localStorage.getItem(LOCALE_CHOICE_KEY)).toBeNull();
+	});
+
+	it('re-pins without setLocale when an explicit saved locale is already rendered', async () => {
 		localStorage.setItem(LOCALE_STORAGE_KEY, 'zh-Hans');
 
 		await applySavedLocale('zh-Hans');
@@ -280,5 +307,32 @@ describe('applySavedLocale', () => {
 		await applySavedLocale('pt-BR');
 
 		expect(mockSetLocale).toHaveBeenCalledWith('en');
+	});
+});
+
+describe('currentLocaleChoice', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it('returns the recorded explicit choice', () => {
+		localStorage.setItem(LOCALE_CHOICE_KEY, 'ja');
+		expect(currentLocaleChoice()).toBe('ja');
+	});
+
+	it('returns auto when the choice is auto', () => {
+		localStorage.setItem(LOCALE_CHOICE_KEY, 'auto');
+		// A concrete tag may still be pinned for rendering; the choice stays auto.
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'zh-Hans');
+		expect(currentLocaleChoice()).toBe('auto');
+	});
+
+	it('falls back to auto when no choice is recorded', () => {
+		expect(currentLocaleChoice()).toBe('auto');
+	});
+
+	it('falls back to auto for an invalid recorded choice', () => {
+		localStorage.setItem(LOCALE_CHOICE_KEY, 'klingon');
+		expect(currentLocaleChoice()).toBe('auto');
 	});
 });

--- a/web/frontend/src/lib/i18n/locale.test.ts
+++ b/web/frontend/src/lib/i18n/locale.test.ts
@@ -4,6 +4,7 @@ import {
 	LOCALE_STORAGE_KEY,
 	reconcileWithConfig,
 	resolveLocaleTag,
+	selectLocale,
 	SUPPORTED_LOCALES
 } from './locale';
 import type { UIConfig } from '$lib/api/types';
@@ -148,5 +149,55 @@ describe('reconcileWithConfig / applyLocale reload guards (#164)', () => {
 		await applyLocale('zh-Hans');
 
 		expect(mockSetLocale).toHaveBeenCalledWith('zh-Hans');
+	});
+});
+
+describe('selectLocale', () => {
+	function stubLanguages(langs: string[]) {
+		Object.defineProperty(window.navigator, 'languages', { value: langs, configurable: true });
+	}
+
+	beforeEach(() => {
+		localStorage.clear();
+		mockGetLocale.mockReset();
+		mockSetLocale.mockReset();
+		mockGetLocale.mockImplementation(() => localStorage.getItem(LOCALE_STORAGE_KEY) ?? 'en');
+		mockSetLocale.mockImplementation(async (tag: string) => {
+			localStorage.setItem(LOCALE_STORAGE_KEY, tag);
+		});
+		stubLanguages(['zh-CN']);
+	});
+
+	it("'auto' resolves the browser locale instead of forcing the base locale", async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'en');
+
+		await selectLocale('auto');
+
+		expect(mockSetLocale).toHaveBeenCalledWith('zh-Hans');
+	});
+
+	it('applies an explicit pick via setLocale when it differs from the rendered locale', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'en');
+
+		await selectLocale('ja');
+
+		expect(mockSetLocale).toHaveBeenCalledWith('ja');
+	});
+
+	it('re-pins the cache without setLocale when the pick is already rendered', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'zh-Hans');
+
+		await selectLocale('zh-Hans');
+
+		expect(mockSetLocale).not.toHaveBeenCalled();
+		expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('zh-Hans');
+	});
+
+	it('falls back to the base locale for unsupported tags', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'ja');
+
+		await selectLocale('fr');
+
+		expect(mockSetLocale).toHaveBeenCalledWith('en');
 	});
 });

--- a/web/frontend/src/lib/i18n/locale.test.ts
+++ b/web/frontend/src/lib/i18n/locale.test.ts
@@ -377,6 +377,19 @@ describe('bootstrapLocale', () => {
 		expect(mockSetLocale).not.toHaveBeenCalled();
 	});
 
+	it('honors an explicit choice even when the rendering pin is absent', async () => {
+		// Edge case: localStorage was unavailable when setLocale tried to write
+		// the pin, so the choice is recorded but the mirror key is not. The
+		// explicit choice must win over the browser locale, not revert to it.
+		localStorage.setItem(LOCALE_CHOICE_KEY, 'ja');
+		stubLanguages(['en-US']);
+
+		const effective = await bootstrapLocale();
+
+		expect(effective).toBe('ja');
+		expect(mockSetLocale).toHaveBeenCalledWith('ja');
+	});
+
 	it('falls back to the browser preference when no choice is recorded', async () => {
 		stubLanguages(['zh-CN']);
 

--- a/web/frontend/src/lib/i18n/locale.test.ts
+++ b/web/frontend/src/lib/i18n/locale.test.ts
@@ -130,6 +130,20 @@ describe('reconcileWithConfig / applyLocale reload guards (#164)', () => {
 		expect(mockSetLocale).not.toHaveBeenCalled();
 	});
 
+	it('auto config syncs the choice key so a stale pre-auth pick cannot loop with bootstrap', async () => {
+		// Pre-auth selector left an explicit 'ja' choice; config is 'auto' and the
+		// browser is en-US. reconcile must clear the choice to 'auto' so the next
+		// bootstrap (which honors an explicit choice) doesn't re-apply 'ja' and loop.
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'ja');
+		localStorage.setItem(LOCALE_CHOICE_KEY, 'ja');
+		stubLanguages(['en-US']);
+
+		const result = await reconcileWithConfig({ language: 'auto' } as UIConfig);
+
+		expect(result).toBe('en');
+		expect(localStorage.getItem(LOCALE_CHOICE_KEY)).toBe('auto');
+	});
+
 	it('auto config corrects a stale cached tag exactly once, then stays stable', async () => {
 		localStorage.setItem(LOCALE_STORAGE_KEY, 'en');
 

--- a/web/frontend/src/lib/i18n/locale.test.ts
+++ b/web/frontend/src/lib/i18n/locale.test.ts
@@ -279,6 +279,15 @@ describe('applySavedLocale', () => {
 		await applySavedLocale('ja');
 
 		expect(mockSetLocale).toHaveBeenCalledWith('ja');
+		expect(localStorage.getItem(LOCALE_CHOICE_KEY)).toBe('ja');
+	});
+
+	it('syncs the selector choice to auto for an auto save', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'zh-Hans');
+
+		await applySavedLocale('auto');
+
+		expect(localStorage.getItem(LOCALE_CHOICE_KEY)).toBe('auto');
 	});
 
 	it('resolves auto to the browser preference', async () => {
@@ -305,7 +314,8 @@ describe('applySavedLocale', () => {
 		expect(mockSetLocale).not.toHaveBeenCalled();
 		// The rendering cache stays as-is; no conflation with an explicit pick.
 		expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('zh-Hans');
-		expect(localStorage.getItem(LOCALE_CHOICE_KEY)).toBeNull();
+		// The choice is synced to the saved 'auto' so bootstrap honors it.
+		expect(localStorage.getItem(LOCALE_CHOICE_KEY)).toBe('auto');
 	});
 
 	it('re-pins without setLocale when an explicit saved locale is already rendered', async () => {

--- a/web/frontend/src/lib/i18n/locale.test.ts
+++ b/web/frontend/src/lib/i18n/locale.test.ts
@@ -232,6 +232,21 @@ describe('selectLocale', () => {
 		expect(currentLocaleChoice()).toBe('auto');
 	});
 
+	it('pins the rendering cache for an explicit pick even when already rendered', async () => {
+		// ja-JP browser: Paraglide resolves ja via preferredLanguage with no pin,
+		// so the UI renders ja without a cached tag. Picking ja explicitly must
+		// still pin the cache so a later browser-language change doesn't override
+		// the explicit selection on the next bootstrap.
+		mockGetLocale.mockImplementation(() => localStorage.getItem(LOCALE_STORAGE_KEY) ?? 'ja');
+		stubLanguages(['ja-JP']);
+
+		await selectLocale('ja');
+
+		expect(mockSetLocale).not.toHaveBeenCalled();
+		expect(localStorage.getItem(LOCALE_CHOICE_KEY)).toBe('ja');
+		expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('ja');
+	});
+
 	it('falls back to the base locale for unsupported tags', async () => {
 		localStorage.setItem(LOCALE_STORAGE_KEY, 'ja');
 

--- a/web/frontend/src/lib/i18n/locale.test.ts
+++ b/web/frontend/src/lib/i18n/locale.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
 	applyLocale,
 	applySavedLocale,
+	bootstrapLocale,
 	currentLocaleChoice,
 	LOCALE_CHOICE_KEY,
 	LOCALE_STORAGE_KEY,
@@ -322,6 +323,56 @@ describe('applySavedLocale', () => {
 		await applySavedLocale('pt-BR');
 
 		expect(mockSetLocale).toHaveBeenCalledWith('en');
+	});
+});
+
+describe('bootstrapLocale', () => {
+	function stubLanguages(langs: string[]) {
+		Object.defineProperty(window.navigator, 'languages', { value: langs, configurable: true });
+	}
+
+	beforeEach(() => {
+		localStorage.clear();
+		mockGetLocale.mockReset();
+		mockSetLocale.mockReset();
+		mockGetLocale.mockImplementation(() => localStorage.getItem(LOCALE_STORAGE_KEY) ?? 'en');
+		mockSetLocale.mockImplementation(async (tag: string) => {
+			localStorage.setItem(LOCALE_STORAGE_KEY, tag);
+		});
+	});
+
+	it('re-resolves the browser locale for an auto choice, ignoring a stale pin', async () => {
+		// A prior setLocale pinned zh-Hans for a zh-CN browser; the user later
+		// switches the browser to ja-JP and chose 'auto'. bootstrap must follow
+		// the browser, not the stale pin.
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'zh-Hans');
+		localStorage.setItem(LOCALE_CHOICE_KEY, 'auto');
+		stubLanguages(['ja-JP']);
+
+		const effective = await bootstrapLocale();
+
+		expect(effective).toBe('ja');
+		// applyLocale sees the stale pin != ja and delegates to setLocale.
+		expect(mockSetLocale).toHaveBeenCalledWith('ja');
+	});
+
+	it('trusts the cached pin for an explicit choice', async () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, 'ja');
+		localStorage.setItem(LOCALE_CHOICE_KEY, 'ja');
+		stubLanguages(['zh-CN']);
+
+		const effective = await bootstrapLocale();
+
+		expect(effective).toBe('ja');
+		expect(mockSetLocale).not.toHaveBeenCalled();
+	});
+
+	it('falls back to the browser preference when no choice is recorded', async () => {
+		stubLanguages(['zh-CN']);
+
+		const effective = await bootstrapLocale();
+
+		expect(effective).toBe('zh-Hans');
 	});
 });
 

--- a/web/frontend/src/lib/i18n/locale.test.ts
+++ b/web/frontend/src/lib/i18n/locale.test.ts
@@ -360,6 +360,7 @@ describe('applySavedLocale', () => {
 		await applySavedLocale('pt-BR');
 
 		expect(mockSetLocale).toHaveBeenCalledWith('en');
+		expect(localStorage.getItem(LOCALE_CHOICE_KEY)).toBe('en');
 	});
 });
 

--- a/web/frontend/src/lib/i18n/locale.ts
+++ b/web/frontend/src/lib/i18n/locale.ts
@@ -8,6 +8,24 @@ import type { UIConfig } from '$lib/api/types';
 // across reloads and clearClientStorage-tolerant flows.
 export const LOCALE_STORAGE_KEY = 'javinizer-locale';
 
+// Records the user's selector choice ('auto' or an explicit tag), kept separate
+// from LOCALE_STORAGE_KEY: that key is also Paraglide's rendering cache
+// (setLocale writes the resolved tag there for catalogs that preferredLanguage
+// can't derive, e.g. zh-CN -> zh-Hans), so it cannot on its own distinguish an
+// explicit pick from an auto-resolved one. Without this, choosing Automatic
+// would come back as a concrete tag after reload (#165 P2).
+export const LOCALE_CHOICE_KEY = 'javinizer-locale-choice';
+
+// currentLocaleChoice returns the selector value for the recorded choice:
+// 'auto' (browser preference) or an explicit supported tag. Pre-auth there is
+// no config, so this is the source of truth for the dropdown display.
+export function currentLocaleChoice(): string {
+	if (!browser) return 'auto';
+	const choice = localStorage.getItem(LOCALE_CHOICE_KEY);
+	if (choice === 'auto' || (choice !== null && isSupported(choice))) return choice;
+	return 'auto';
+}
+
 // Supported locales that ship a catalog. Currently English only; future
 // reviewed locales are added here. Use self-names so the selector stays usable
 // when the current locale is wrong.
@@ -170,17 +188,18 @@ export async function reconcileWithConfig(ui?: UIConfig | null): Promise<string>
 }
 
 // selectLocale applies a locale picked from a selector. 'auto' resolves the
-// browser preference (mapped onto the shipped catalogs). When the effective
-// locale differs from the currently rendered one, setLocale pins it through
-// the localStorage strategy and reloads the page so compiled messages
-// re-render; a same-locale pick only re-pins the cache.
+// browser preference (mapped onto the shipped catalogs). The choice is recorded
+// under LOCALE_CHOICE_KEY separately from Paraglide's rendering cache
+// (LOCALE_STORAGE_KEY): when the effective locale differs from the rendered
+// one, setLocale pins the resolved tag for rendering and reloads so compiled
+// messages re-render; a same-locale pick only updates the recorded choice.
 export async function selectLocale(tag: string): Promise<void> {
 	if (!browser) return;
 	const resolved = tag === 'auto' ? resolveBrowserLocale() : isSupported(tag) ? tag : baseLocale;
-	if (getLocale() === resolved) {
-		localStorage.setItem(LOCALE_STORAGE_KEY, resolved);
-	} else {
+	localStorage.setItem(LOCALE_CHOICE_KEY, tag);
+	if (getLocale() !== resolved) {
 		await setLocale(resolved as typeof locales[number]);
+		return;
 	}
 	document.documentElement.lang = resolved;
 	document.documentElement.dir = localeDir(resolved);
@@ -196,13 +215,14 @@ export async function selectLocale(tag: string): Promise<void> {
 export async function applySavedLocale(language?: string | null): Promise<void> {
 	if (!browser) return;
 	const configured = language?.trim() ?? '';
-	const resolved =
-		configured === '' || canonicalizeTag(configured) === 'auto'
-			? resolveBrowserLocale()
-			: (resolveLocaleTag(configured) ?? baseLocale);
+	const isAuto = configured === '' || canonicalizeTag(configured) === 'auto';
+	const resolved = isAuto ? resolveBrowserLocale() : (resolveLocaleTag(configured) ?? baseLocale);
 	if (getLocale() === resolved) {
-		localStorage.setItem(LOCALE_STORAGE_KEY, resolved);
-	} else {
-		await setLocale(resolved as typeof locales[number]);
+		// Already rendering the target. Don't pin a concrete tag for 'auto' —
+		// that would conflate the rendering cache with an explicit choice and
+		// mask later browser-preference changes.
+		if (!isAuto) localStorage.setItem(LOCALE_STORAGE_KEY, resolved);
+		return;
 	}
+	await setLocale(resolved as typeof locales[number]);
 }

--- a/web/frontend/src/lib/i18n/locale.ts
+++ b/web/frontend/src/lib/i18n/locale.ts
@@ -169,10 +169,19 @@ export async function reconcileWithConfig(ui?: UIConfig | null): Promise<string>
 	return baseLocale;
 }
 
+// selectLocale applies a locale picked from a selector. 'auto' resolves the
+// browser preference (mapped onto the shipped catalogs). When the effective
+// locale differs from the currently rendered one, setLocale pins it through
+// the localStorage strategy and reloads the page so compiled messages
+// re-render; a same-locale pick only re-pins the cache.
 export async function selectLocale(tag: string): Promise<void> {
 	if (!browser) return;
-	if (tag !== 'auto' && isSupported(tag)) {
-		localStorage.setItem(LOCALE_STORAGE_KEY, tag);
+	const resolved = tag === 'auto' ? resolveBrowserLocale() : isSupported(tag) ? tag : baseLocale;
+	if (getLocale() === resolved) {
+		localStorage.setItem(LOCALE_STORAGE_KEY, resolved);
+	} else {
+		await setLocale(resolved as typeof locales[number]);
 	}
-	await applyLocale(isSupported(tag) ? tag : baseLocale);
+	document.documentElement.lang = resolved;
+	document.documentElement.dir = localeDir(resolved);
 }

--- a/web/frontend/src/lib/i18n/locale.ts
+++ b/web/frontend/src/lib/i18n/locale.ts
@@ -228,6 +228,12 @@ export async function applySavedLocale(language?: string | null): Promise<void> 
 	const configured = language?.trim() ?? '';
 	const isAuto = configured === '' || canonicalizeTag(configured) === 'auto';
 	const resolved = isAuto ? resolveBrowserLocale() : (resolveLocaleTag(configured) ?? baseLocale);
+	// Sync the selector choice to the just-saved config so bootstrapLocale
+	// honors it before the protected config loads on the next startup: 'auto'
+	// keeps the browser preference authoritative, an explicit tag is recorded
+	// as such. Without this a stale 'auto' choice would make bootstrap re-resolve
+	// the browser locale and briefly undo an explicit settings save.
+	localStorage.setItem(LOCALE_CHOICE_KEY, isAuto ? 'auto' : resolved);
 	if (getLocale() === resolved) {
 		// Already rendering the target. Don't pin a concrete tag for 'auto' —
 		// that would conflate the rendering cache with an explicit choice and

--- a/web/frontend/src/lib/i18n/locale.ts
+++ b/web/frontend/src/lib/i18n/locale.ts
@@ -117,14 +117,19 @@ function readCachedLocale(): string | null {
 // preference — the concrete tag pinned by setLocale (for catalogs
 // preferredLanguage can't derive, e.g. zh-CN -> zh-Hans) is just a rendering
 // cache and must not pin the language across browser-language changes. For an
-// explicit choice (or none recorded yet) it trusts the cached pin and falls
-// back to the browser. Sets document.documentElement.lang and dir.
+// explicit choice it is authoritative even if the rendering pin is absent
+// (e.g. localStorage was unavailable when setLocale tried to write it), so the
+// pre-auth selector stays consistent with the rendered locale. With no choice
+// recorded it trusts the cached pin and falls back to the browser.
 export async function bootstrapLocale(): Promise<string> {
 	if (!browser) return baseLocale;
 
+	const choice = localStorage.getItem(LOCALE_CHOICE_KEY);
 	let effective: string;
-	if (localStorage.getItem(LOCALE_CHOICE_KEY) === 'auto') {
+	if (choice === 'auto') {
 		effective = resolveBrowserLocale();
+	} else if (choice && isSupported(choice)) {
+		effective = choice;
 	} else {
 		effective = readCachedLocale() ?? resolveBrowserLocale();
 	}

--- a/web/frontend/src/lib/i18n/locale.ts
+++ b/web/frontend/src/lib/i18n/locale.ts
@@ -113,15 +113,20 @@ function readCachedLocale(): string | null {
 }
 
 // bootstrapLocale resolves the effective locale before the protected full-config
-// request finishes. Order: valid localStorage mirror -> browser preference ->
-// base locale. Sets document.documentElement.lang and dir. Returns the resolved
-// locale tag.
+// request finishes. For an 'auto' choice it always re-resolves the browser
+// preference — the concrete tag pinned by setLocale (for catalogs
+// preferredLanguage can't derive, e.g. zh-CN -> zh-Hans) is just a rendering
+// cache and must not pin the language across browser-language changes. For an
+// explicit choice (or none recorded yet) it trusts the cached pin and falls
+// back to the browser. Sets document.documentElement.lang and dir.
 export async function bootstrapLocale(): Promise<string> {
 	if (!browser) return baseLocale;
 
-	let effective = readCachedLocale();
-	if (!effective) {
+	let effective: string;
+	if (localStorage.getItem(LOCALE_CHOICE_KEY) === 'auto') {
 		effective = resolveBrowserLocale();
+	} else {
+		effective = readCachedLocale() ?? resolveBrowserLocale();
 	}
 
 	await applyLocale(effective);

--- a/web/frontend/src/lib/i18n/locale.ts
+++ b/web/frontend/src/lib/i18n/locale.ts
@@ -111,10 +111,17 @@ export async function bootstrapLocale(): Promise<string> {
 }
 
 // applyLocale sets the Paraglide locale and updates <html lang> and <html dir>.
+// setLocale reloads the page by default, so skip it when Paraglide already
+// renders the target: its own no-reload guard compares against getLocale(),
+// which cannot map region tags like zh-CN onto script locales (zh-Hans) and
+// reports baseLocale instead — callers that clear the cached tag before
+// applying (the 'auto' flows) would otherwise reload on every pass (#164).
 export async function applyLocale(tag: string): Promise<void> {
 	if (!browser) return;
 	const resolved = isSupported(tag) ? tag : baseLocale;
-	await setLocale(resolved as typeof locales[number]);
+	if (getLocale() !== resolved) {
+		await setLocale(resolved as typeof locales[number]);
+	}
 	document.documentElement.lang = resolved;
 	document.documentElement.dir = localeDir(resolved);
 }
@@ -136,8 +143,16 @@ export async function reconcileWithConfig(ui?: UIConfig | null): Promise<string>
 
 	const configured = ui?.language?.trim() ?? '';
 	if (configured === '' || canonicalizeTag(configured) === 'auto') {
-		localStorage.removeItem(LOCALE_STORAGE_KEY);
 		const browserLocale = resolveBrowserLocale();
+		// Steady state: Paraglide already renders the browser-preferred locale.
+		// Clearing the cached tag and reapplying on every reconcile (which runs
+		// on each page load post-auth) makes getLocale() fall back to baseLocale
+		// for script-based locales (zh-Hans/zh-Hant), so setLocale's reload
+		// guard misfires and the page reloads forever (#164).
+		if (getLocale() === browserLocale) {
+			return browserLocale;
+		}
+		localStorage.removeItem(LOCALE_STORAGE_KEY);
 		await applyLocale(browserLocale);
 		return browserLocale;
 	}

--- a/web/frontend/src/lib/i18n/locale.ts
+++ b/web/frontend/src/lib/i18n/locale.ts
@@ -172,6 +172,11 @@ export async function reconcileWithConfig(ui?: UIConfig | null): Promise<string>
 	const configured = ui?.language?.trim() ?? '';
 	if (configured === '' || canonicalizeTag(configured) === 'auto') {
 		const browserLocale = resolveBrowserLocale();
+		// Sync the choice to 'auto' so bootstrap (which honors an explicit
+		// LOCALE_CHOICE_KEY) and reconcile agree — otherwise a pre-auth
+		// explicit pick left in the choice key would make bootstrap re-apply
+		// it, then reconcile flip back to the browser locale, looping.
+		localStorage.setItem(LOCALE_CHOICE_KEY, 'auto');
 		// Steady state: Paraglide already renders the browser-preferred locale.
 		// Clearing the cached tag and reapplying on every reconcile (which runs
 		// on each page load post-auth) makes getLocale() fall back to baseLocale
@@ -187,12 +192,17 @@ export async function reconcileWithConfig(ui?: UIConfig | null): Promise<string>
 
 	const resolved = resolveLocaleTag(configured);
 	if (resolved) {
+		// Mirror the explicit config into the choice key so bootstrap honors it
+		// before the protected config loads on the next startup.
+		localStorage.setItem(LOCALE_CHOICE_KEY, resolved);
 		localStorage.setItem(LOCALE_STORAGE_KEY, resolved);
 		await applyLocale(resolved);
 		return resolved;
 	}
 
-	// Valid but unsupported configured tag: render English, do not cache.
+	// Valid but unsupported configured tag: render English, do not cache. Treat
+	// the choice as 'auto' so bootstrap follows the browser, not a stale pick.
+	localStorage.setItem(LOCALE_CHOICE_KEY, 'auto');
 	await applyLocale(baseLocale);
 	return baseLocale;
 }

--- a/web/frontend/src/lib/i18n/locale.ts
+++ b/web/frontend/src/lib/i18n/locale.ts
@@ -205,9 +205,11 @@ export async function reconcileWithConfig(ui?: UIConfig | null): Promise<string>
 		return resolved;
 	}
 
-	// Valid but unsupported configured tag: render English, do not cache. Treat
-	// the choice as 'auto' so bootstrap follows the browser, not a stale pick.
-	localStorage.setItem(LOCALE_CHOICE_KEY, 'auto');
+	// Valid but unsupported configured tag: render English, do not cache the
+	// tag. Record the rendered fallback (baseLocale) as the choice — NOT 'auto'
+	// — so bootstrap honors it on the next load instead of re-resolving the
+	// browser locale and looping back here (browser -> en -> browser ...).
+	localStorage.setItem(LOCALE_CHOICE_KEY, baseLocale);
 	await applyLocale(baseLocale);
 	return baseLocale;
 }

--- a/web/frontend/src/lib/i18n/locale.ts
+++ b/web/frontend/src/lib/i18n/locale.ts
@@ -192,7 +192,10 @@ export async function reconcileWithConfig(ui?: UIConfig | null): Promise<string>
 // under LOCALE_CHOICE_KEY separately from Paraglide's rendering cache
 // (LOCALE_STORAGE_KEY): when the effective locale differs from the rendered
 // one, setLocale pins the resolved tag for rendering and reloads so compiled
-// messages re-render; a same-locale pick only updates the recorded choice.
+// messages re-render. For an explicit pick that already matches the rendered
+// locale, the rendering cache is still pinned so a later browser-language
+// change doesn't override the explicit selection on the next bootstrap; 'auto'
+// never pins, so the browser preference stays authoritative.
 export async function selectLocale(tag: string): Promise<void> {
 	if (!browser) return;
 	const resolved = tag === 'auto' ? resolveBrowserLocale() : isSupported(tag) ? tag : baseLocale;
@@ -200,6 +203,9 @@ export async function selectLocale(tag: string): Promise<void> {
 	if (getLocale() !== resolved) {
 		await setLocale(resolved as typeof locales[number]);
 		return;
+	}
+	if (tag !== 'auto' && isSupported(tag)) {
+		localStorage.setItem(LOCALE_STORAGE_KEY, resolved);
 	}
 	document.documentElement.lang = resolved;
 	document.documentElement.dir = localeDir(resolved);

--- a/web/frontend/src/lib/i18n/locale.ts
+++ b/web/frontend/src/lib/i18n/locale.ts
@@ -185,8 +185,13 @@ export async function reconcileWithConfig(ui?: UIConfig | null): Promise<string>
 		if (getLocale() === browserLocale) {
 			return browserLocale;
 		}
-		localStorage.removeItem(LOCALE_STORAGE_KEY);
-		await applyLocale(browserLocale);
+		// Stale pin differs from the browser locale. applyLocale's guard can't
+		// force the reload here: once the pin is cleared getLocale() resolves to
+		// the browser locale and it would skip setLocale, leaving the already-
+		// rendered page in the stale language. setLocale captures its snapshot
+		// while the stale pin is still present (so it differs from browserLocale),
+		// pins the browser locale, and reloads.
+		await setLocale(browserLocale as typeof locales[number]);
 		return browserLocale;
 	}
 

--- a/web/frontend/src/lib/i18n/locale.ts
+++ b/web/frontend/src/lib/i18n/locale.ts
@@ -185,3 +185,24 @@ export async function selectLocale(tag: string): Promise<void> {
 	document.documentElement.lang = resolved;
 	document.documentElement.dir = localeDir(resolved);
 }
+
+// applySavedLocale applies a just-persisted ui.language after a settings
+// save. Unlike reconcileWithConfig (which never reloads in steady state and
+// pins before applying, so it can leave the UI rendering the old locale),
+// this forces a reload when the saved locale differs from the rendered one —
+// otherwise a language change saved in settings would not re-render the page.
+// Config values go through resolveLocaleTag so variants like zh-Hans-CN map
+// onto shipped catalogs; 'auto' resolves the browser preference.
+export async function applySavedLocale(language?: string | null): Promise<void> {
+	if (!browser) return;
+	const configured = language?.trim() ?? '';
+	const resolved =
+		configured === '' || canonicalizeTag(configured) === 'auto'
+			? resolveBrowserLocale()
+			: (resolveLocaleTag(configured) ?? baseLocale);
+	if (getLocale() === resolved) {
+		localStorage.setItem(LOCALE_STORAGE_KEY, resolved);
+	} else {
+		await setLocale(resolved as typeof locales[number]);
+	}
+}

--- a/web/frontend/src/lib/utils/storage.test.ts
+++ b/web/frontend/src/lib/utils/storage.test.ts
@@ -12,6 +12,7 @@ describe('clearClientStorage', () => {
 
 	it('preserves UI preference keys while wiping per-server state', () => {
 		localStorage.setItem('javinizer-locale', 'zh-Hans');
+		localStorage.setItem('javinizer-locale-choice', 'auto');
 		localStorage.setItem('javinizer-theme', 'dark');
 		// Real session key used by BaseClient (lib/api/clients/common.ts).
 		localStorage.setItem('javinizer_session', 'stale-session-id');
@@ -20,6 +21,7 @@ describe('clearClientStorage', () => {
 		clearClientStorage();
 
 		expect(localStorage.getItem('javinizer-locale')).toBe('zh-Hans');
+		expect(localStorage.getItem('javinizer-locale-choice')).toBe('auto');
 		expect(localStorage.getItem('javinizer-theme')).toBe('dark');
 		expect(localStorage.getItem('javinizer_session')).toBeNull();
 		expect(localStorage.getItem('some-other-cache')).toBeNull();

--- a/web/frontend/src/lib/utils/storage.test.ts
+++ b/web/frontend/src/lib/utils/storage.test.ts
@@ -13,22 +13,23 @@ describe('clearClientStorage', () => {
 	it('preserves UI preference keys while wiping per-server state', () => {
 		localStorage.setItem('javinizer-locale', 'zh-Hans');
 		localStorage.setItem('javinizer-theme', 'dark');
-		localStorage.setItem('javinizer-session', 'stale-session-id');
+		// Real session key used by BaseClient (lib/api/clients/common.ts).
+		localStorage.setItem('javinizer_session', 'stale-session-id');
 		localStorage.setItem('some-other-cache', 'x');
 
 		clearClientStorage();
 
 		expect(localStorage.getItem('javinizer-locale')).toBe('zh-Hans');
 		expect(localStorage.getItem('javinizer-theme')).toBe('dark');
-		expect(localStorage.getItem('javinizer-session')).toBeNull();
+		expect(localStorage.getItem('javinizer_session')).toBeNull();
 		expect(localStorage.getItem('some-other-cache')).toBeNull();
 	});
 
-	it('clears cookies', () => {
-		document.cookie = 'javinizer-session=abc; path=/';
+	it('clears cookies defensively (the app itself uses header + localStorage auth)', () => {
+		document.cookie = 'stale-cookie=abc; path=/';
 
 		clearClientStorage();
 
-		expect(document.cookie).not.toContain('javinizer-session');
+		expect(document.cookie).not.toContain('stale-cookie');
 	});
 });

--- a/web/frontend/src/lib/utils/storage.test.ts
+++ b/web/frontend/src/lib/utils/storage.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { clearClientStorage } from './storage';
+
+describe('clearClientStorage', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		for (const raw of document.cookie.split(';')) {
+			const name = raw.split('=')[0]?.trim();
+			if (name) document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+		}
+	});
+
+	it('preserves UI preference keys while wiping per-server state', () => {
+		localStorage.setItem('javinizer-locale', 'zh-Hans');
+		localStorage.setItem('javinizer-theme', 'dark');
+		localStorage.setItem('javinizer-session', 'stale-session-id');
+		localStorage.setItem('some-other-cache', 'x');
+
+		clearClientStorage();
+
+		expect(localStorage.getItem('javinizer-locale')).toBe('zh-Hans');
+		expect(localStorage.getItem('javinizer-theme')).toBe('dark');
+		expect(localStorage.getItem('javinizer-session')).toBeNull();
+		expect(localStorage.getItem('some-other-cache')).toBeNull();
+	});
+
+	it('clears cookies', () => {
+		document.cookie = 'javinizer-session=abc; path=/';
+
+		clearClientStorage();
+
+		expect(document.cookie).not.toContain('javinizer-session');
+	});
+});

--- a/web/frontend/src/lib/utils/storage.ts
+++ b/web/frontend/src/lib/utils/storage.ts
@@ -1,8 +1,18 @@
+// UI preference keys survive the wipe — they are not per-server state. The
+// locale pin must persist or a language picked on the setup wizard is
+// silently discarded on the next page load (the wipe runs on every mount
+// while the server is uninitialized).
+const PRESERVED_KEYS = ['javinizer-locale', 'javinizer-theme'];
+
 export function clearClientStorage(): void {
 	if (typeof window === 'undefined') return;
 
 	try {
+		const preserved = PRESERVED_KEYS.map((key) => [key, localStorage.getItem(key)] as const);
 		localStorage.clear();
+		for (const [key, value] of preserved) {
+			if (value !== null) localStorage.setItem(key, value);
+		}
 	} catch {
 		// localStorage may be unavailable in private mode or sandboxed frames
 	}

--- a/web/frontend/src/lib/utils/storage.ts
+++ b/web/frontend/src/lib/utils/storage.ts
@@ -8,10 +8,16 @@ export function clearClientStorage(): void {
 	if (typeof window === 'undefined') return;
 
 	try {
-		const preserved = PRESERVED_KEYS.map((key) => [key, localStorage.getItem(key)] as const);
-		localStorage.clear();
-		for (const [key, value] of preserved) {
-			if (value !== null) localStorage.setItem(key, value);
+		// Remove only non-preserved keys instead of clear()+restore: a setItem
+		// failure mid-restore (e.g. Safari private mode QuotaExceededError)
+		// would otherwise silently lose the preserved preferences.
+		const keysToRemove: string[] = [];
+		for (let i = 0; i < localStorage.length; i++) {
+			const key = localStorage.key(i);
+			if (key && !PRESERVED_KEYS.includes(key)) keysToRemove.push(key);
+		}
+		for (const key of keysToRemove) {
+			localStorage.removeItem(key);
 		}
 	} catch {
 		// localStorage may be unavailable in private mode or sandboxed frames

--- a/web/frontend/src/lib/utils/storage.ts
+++ b/web/frontend/src/lib/utils/storage.ts
@@ -2,7 +2,7 @@
 // locale pin must persist or a language picked on the setup wizard is
 // silently discarded on the next page load (the wipe runs on every mount
 // while the server is uninitialized).
-const PRESERVED_KEYS = ['javinizer-locale', 'javinizer-theme'];
+const PRESERVED_KEYS = ['javinizer-locale', 'javinizer-locale-choice', 'javinizer-theme'];
 
 export function clearClientStorage(): void {
 	if (typeof window === 'undefined') return;

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -40,6 +40,7 @@
 	let loginPassword = $state('');
 	let loginRememberMe = $state(true);
 	let clientStorageCleared = false;
+	let setupSessionActive = $state(false);
 
 	function localizeApiError(error: unknown, fallback: string): string {
 		if (error instanceof ApiError && error.code) {
@@ -143,7 +144,7 @@
 <svelte:head>
 </svelte:head>
 
-{#if !authAuthenticated}
+{#if !authAuthenticated && !setupSessionActive}
 	<div class="fixed top-4 right-4 z-50">
 		<LanguageSelector />
 	</div>
@@ -181,7 +182,10 @@
 		</div>
 	</div>
 {:else if !authInitialized}
-	<SetupWizard onComplete={() => { void refreshAuthStatus(); }} />
+	<SetupWizard
+		onComplete={() => { void refreshAuthStatus(); }}
+		onSessionCreated={() => { setupSessionActive = true; }}
+	/>
 {:else if !authAuthenticated}
 	<div class="min-h-screen bg-background flex items-center justify-center px-4 py-10">
 		<div class="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm space-y-4">

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -144,7 +144,7 @@
 <svelte:head>
 </svelte:head>
 
-{#if !authAuthenticated && !setupSessionActive}
+{#if !authAuthenticated && !(setupSessionActive && !authInitialized)}
 	<div class="fixed top-4 right-4 z-50">
 		<LanguageSelector />
 	</div>

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -21,6 +21,7 @@
 	import { translateErrorCode } from '$lib/i18n/api-messages';
 	import { ApiError } from '$lib/api/clients/common';
 	import LocaleReconciler from '$lib/components/LocaleReconciler.svelte';
+	import LanguageSelector from '$lib/components/LanguageSelector.svelte';
 	import '../app.css';
 
 	let { children } = $props();
@@ -141,6 +142,12 @@
 
 <svelte:head>
 </svelte:head>
+
+{#if !authAuthenticated}
+	<div class="fixed top-4 right-4 z-50">
+		<LanguageSelector />
+	</div>
+{/if}
 
 {#if authLoading}
 	<div class="min-h-screen bg-background flex items-center justify-center px-4">

--- a/web/frontend/src/routes/settings/stores/settings-store.svelte.ts
+++ b/web/frontend/src/routes/settings/stores/settings-store.svelte.ts
@@ -4,6 +4,7 @@ import { untrack } from 'svelte';
 import { apiClient } from '$lib/api/client';
 import { createConfigQuery } from '$lib/query/queries';
 import { toastStore } from '$lib/stores/toast';
+import { applySavedLocale } from '$lib/i18n/locale';
 import { isProxyConfigDirty, isTestValid, type TestResult } from '$lib/proxy/proxy-logic';
 import type {
 	Config,
@@ -292,6 +293,10 @@ export function createSettingsStore(deps: SettingsStoreDeps): SettingsStore {
 			deps.clearTestResults();
 			updateProxyConfigBaseline();
 			toastStore.success(m.settings_config_saved_toast(), 4000);
+			// Apply the just-saved ui.language before the config refetch re-fires
+			// LocaleReconciler: this reloads when the rendered locale must change,
+			// which reconcileWithConfig deliberately never does on its own.
+			void applySavedLocale(config?.ui?.language);
 			void queryClient.invalidateQueries({ queryKey: ['config'] }).then(() => {
 				const updated = queryClient.getQueryData<Config>(['config']);
 				if (updated && config) {


### PR DESCRIPTION
## Summary

Fixes the infinite refresh loop (#164) for users whose browser locale is Simplified Chinese (and Traditional Chinese), and adds a visible language selector to the pre-auth screens.

### Root cause (#164)
Paraglide's `preferredLanguage` matcher only does exact/base-tag matching, so a `zh-CN` browser never resolves to the shipped `zh-Hans` catalog — `getLocale()` falls back to `en`. `reconcileWithConfig`'s `auto` branch (the default config) cleared the cached locale tag and reapplied `setLocale` (which reloads by default) on every post-auth page load; its no-reload guard compared against the just-poisoned `getLocale()` and saw `en != zh-Hans`, reloading forever. Japanese users were unaffected (`ja` matches directly), which is why only Chinese-locale users hit it.

### Changes
- **`fix(i18n): stop locale reconcile reload loop for zh locales`** — make the `auto` reconcile a no-op in steady state and `applyLocale` skip `setLocale` when already rendering the target. `Fixes #164`.
- **`feat(i18n): add language selector to pre-auth screens`** — new `LanguageSelector.svelte` rendered top-right on every pre-auth screen; `selectLocale` reworked so `auto` resolves the browser preference and changed picks reload.
- **`feat(i18n): polish startup language selector, keep locale across setup wipes`** — restyled as a pill (Languages icon, rotating chevron, entrance animation); `clearClientStorage` preserves `javinizer-locale`/`javinizer-theme` so a language picked on the setup wizard isn't discarded next load.
- **`fix(i18n): address review findings`** — settings dropdown marks dirty only (no immediate reload that discarded the unsaved change); `applySavedLocale` applies the saved language after a successful save. Hardened `clearClientStorage` partial-failure, hydration-safe selector init, `aria-hidden` on decorative icons, and expanded tests.

### Verification
- 440/440 frontend tests pass; `svelte-check` clean; production build succeeds; pre-commit hook (fmt, golangci-lint, go vet, Go tests, build, swagger, svelte-check) green.
- E2E in a real browser: switch to 简体中文 on the setup wizard reloads straight into Chinese and persists (`lang=zh-Hans`, pin intact, wizard renders 管理员账户).

Fixes #164