### PR TITLE
fix(updater): use CREATE_NO_WINDOW for silent Windows upgrade helper

### DIFF
--- a/internal/updater/swap_windows.go
+++ b/internal/updater/swap_windows.go
@@ -74,15 +74,26 @@ func (w *windowsSwapper) SwapAndRelaunch(ctx context.Context, stagedPath string,
 	if err := os.WriteFile(batchPath, []byte(script), 0o644); err != nil {
 		return fmt.Errorf("write batch helper: %w", err)
 	}
+	cmd := newWindowsHelperCmd(oldPID, exePath, batchPath, stagedPath)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start detached helper: %w", err)
+	}
+	_ = cmd.Process.Release()
+	return nil
+}
+
+// newWindowsHelperCmd builds the detached cmd.exe helper that runs the swap
+// .bat after the current process exits. Extracted from SwapAndRelaunch so the
+// process-creation attributes (CreationFlags, HideWindow, nil stdio) are
+// unit-testable without spawning cmd.exe. The returned Cmd is NOT started;
+// the caller starts it and releases the process handle so the helper
+// outlives the parent.
+func newWindowsHelperCmd(oldPID int, exePath, batchPath, stagedPath string) *exec.Cmd {
 	cmd := exec.Command("cmd.exe", "/c", batchPath, strconv.Itoa(oldPID), exePath, stagedPath)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: windowsHelperCreationFlags,
 		HideWindow:    true,
 	}
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("start detached helper: %w", err)
-	}
-	_ = cmd.Process.Release()
-	return nil
+	return cmd
 }

--- a/internal/updater/swap_windows.go
+++ b/internal/updater/swap_windows.go
@@ -76,7 +76,7 @@ func (w *windowsSwapper) SwapAndRelaunch(ctx context.Context, stagedPath string,
 	}
 	cmd := exec.Command("cmd.exe", "/c", batchPath, strconv.Itoa(oldPID), exePath, stagedPath)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: windowsDetachedProcess | windowsCreateNewProcessGroup,
+		CreationFlags: windowsHelperCreationFlags,
 		HideWindow:    true,
 	}
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil

--- a/internal/updater/swap_windows_helpers.go
+++ b/internal/updater/swap_windows_helpers.go
@@ -6,12 +6,30 @@ import (
 	"strings"
 )
 
-// Windows detached-helper process creation flags. CREATE_NEW_PROCESS_GROUP
-// is also exported by the syscall package; DETACHED_PROCESS is not, so it is
-// defined here for the windows build to use.
+// Windows helper process creation flags, passed as CreateProcess
+// dwCreationFlags via syscall.SysProcAttr.CreationFlags. CREATE_NEW_PROCESS_GROUP
+// is also exported by the syscall package; CREATE_NO_WINDOW is not, so it is
+// defined here.
+//
+// CREATE_NO_WINDOW (0x08000000) — NOT DETACHED_PROCESS (0x8) — is required:
+// the desktop exe is a GUI-subsystem binary (built with -H windowsgui) and has
+// no console. DETACHED_PROCESS only detaches cmd.exe from the parent console;
+// the batch child processes (tasklist.exe, ping.exe) then each allocate their
+// OWN visible console, surfacing as a stray 'find "<pid>"' Windows Terminal
+// window during an upgrade. CREATE_NO_WINDOW suppresses console allocation for
+// the helper and the console-subsystem commands it runs (the helper is silent).
+// Per MS docs, CREATE_NO_WINDOW is IGNORED when combined with DETACHED_PROCESS or
+// CREATE_NEW_CONSOLE — it does not reject the combination, it just silently drops
+// the no-window behavior — so DETACHED_PROCESS must not be present alongside it.
 const (
-	windowsDetachedProcess       = 0x00000008
+	windowsCreateNoWindow        = 0x08000000
 	windowsCreateNewProcessGroup = 0x00000200
+
+	// windowsHelperCreationFlags is the combined dwCreationFlags used by
+	// SwapAndRelaunch when spawning the detached .bat helper. Exposed as a
+	// named const so the "no visible console window" invariant is unit-tested
+	// (TestWindowsHelperCreationFlags_NoVisibleWindow) without spawning a process.
+	windowsHelperCreationFlags = windowsCreateNoWindow | windowsCreateNewProcessGroup
 )
 
 // winBase returns the filename component of a Windows path, handling both

--- a/internal/updater/swap_windows_helpers_test.go
+++ b/internal/updater/swap_windows_helpers_test.go
@@ -3,6 +3,7 @@
 package updater
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -80,33 +81,78 @@ func TestRenderWindowsBatScript_UsesArgPassing(t *testing.T) {
 	}
 }
 
-// TestWindowsHelperCreationFlags_NoVisibleWindow pins the fix for the stray
+// TestNewWindowsHelperCmd_NoVisibleWindow asserts the actual *exec.Cmd that
+// SwapAndRelaunch builds (via newWindowsHelperCmd) carries the
+// process-creation attributes that keep the Windows upgrade helper silent —
+// not just the constant value. It is the regression guard for the stray
 // 'find "<pid>"' Windows Terminal window users saw mid desktop upgrade.
 //
 // The desktop exe is built with -H windowsgui (GUI subsystem, no console).
 // DETACHED_PROCESS (0x8) only detaches cmd.exe from the parent's console; the
 // batch's children (tasklist.exe, ping.exe) then each allocate their OWN
-// visible console -> a #0c0c0c Windows Terminal pops up echoing the poll line
-// 'tasklist ... | find "<pid>" >nul' and lingering until the app quits.
-// CREATE_NO_WINDOW (0x08000000) suppresses all child console windows instead.
+// visible console -> a #0c0c0c Windows Terminal pops up. CREATE_NO_WINDOW
+// (0x08000000) suppresses console allocation for the helper and the
+// console-subsystem commands it runs. Per MS docs, CREATE_NO_WINDOW is
+// ignored when combined with DETACHED_PROCESS or CREATE_NEW_CONSOLE, so
+// neither may be present alongside it.
 //
-// This test is the regression guard: it does not spawn a process, so it runs
-// deterministically on Windows CI; it asserts the invariant by value.
-func TestWindowsHelperCreationFlags_NoVisibleWindow(t *testing.T) {
-	const createNoWindow = uint32(0x08000000)
-	const detachedProcess = uint32(0x00000008)
+// This test does not spawn a process (cmd.Start is never called), so it is
+// deterministic on Windows CI.
+func TestNewWindowsHelperCmd_NoVisibleWindow(t *testing.T) {
+	const (
+		createNoWindow        = uint32(0x08000000)
+		detachedProcess       = uint32(0x00000008)
+		createNewConsole      = uint32(0x00000010)
+		createNewProcessGroup = uint32(0x00000200)
+	)
 
-	flags := uint32(windowsHelperCreationFlags)
+	const pid = 41784
+	exe := "C:/Program Files/Javinizer/Javinizer.exe"
+	batch := "C:/Users/me/AppData/Local/Temp/javinizer-update-41784.bat"
+	staged := "C:/Users/me/.javinizer-bundle-upgrade-41784.tmp"
+
+	cmd := newWindowsHelperCmd(pid, exe, batch, staged)
+
+	// The helper is invoked as: cmd.exe /c <batch> <pid> <exe> <staged>
+	wantArgs := []string{"cmd.exe", "/c", batch, strconv.Itoa(pid), exe, staged}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("cmd.Args length = %d, want %d; got %#v", len(cmd.Args), len(wantArgs), cmd.Args)
+	}
+	for i, want := range wantArgs {
+		if cmd.Args[i] != want {
+			t.Fatalf("cmd.Args[%d] = %q, want %q; full args %#v", i, cmd.Args[i], want, cmd.Args)
+		}
+	}
+
+	sp := cmd.SysProcAttr
+	if sp == nil {
+		t.Fatal("cmd.SysProcAttr is nil; expected CREATE_NO_WINDOW flags to be set")
+	}
+	flags := uint32(sp.CreationFlags)
 
 	if flags&createNoWindow == 0 {
-		t.Fatalf("windowsHelperCreationFlags = %#x is missing CREATE_NO_WINDOW (0x08000000); "+
+		t.Errorf("CreationFlags = %#x is missing CREATE_NO_WINDOW (0x08000000); "+
 			"the desktop upgrade helper would pop a visible Windows Terminal window "+
 			"(regression: previously used DETACHED_PROCESS)", flags)
 	}
 	if flags&detachedProcess != 0 {
-		t.Fatalf("windowsHelperCreationFlags = %#x must NOT include DETACHED_PROCESS (0x8); "+
-			"DETACHED_PROCESS + GUI-subsystem parent lets tasklist/ping allocate visible "+
-			"consoles, and DETACHED_PROCESS is mutually exclusive with CREATE_NO_WINDOW at "+
-			"the Win32 level", flags)
+		t.Errorf("CreationFlags = %#x must NOT include DETACHED_PROCESS (0x8); "+
+			"CREATE_NO_WINDOW is ignored when combined with DETACHED_PROCESS, so "+
+			"the no-window behavior would be silently dropped", flags)
+	}
+	if flags&createNewConsole != 0 {
+		t.Errorf("CreationFlags = %#x must NOT include CREATE_NEW_CONSOLE (0x10); "+
+			"it allocates a visible console for the helper", flags)
+	}
+	if flags&createNewProcessGroup == 0 {
+		t.Errorf("CreationFlags = %#x is missing CREATE_NEW_PROCESS_GROUP (0x200); "+
+			"process-group/Ctrl+C isolation for the helper was lost", flags)
+	}
+	if !sp.HideWindow {
+		t.Error("HideWindow = false; expected true as defense in depth (cmd.exe window)")
+	}
+	if cmd.Stdin != nil || cmd.Stdout != nil || cmd.Stderr != nil {
+		t.Errorf("stdio must be nil so the helper never touches the parent's pipes; "+
+			"got stdin=%v stdout=%v stderr=%v", cmd.Stdin, cmd.Stdout, cmd.Stderr)
 	}
 }

--- a/internal/updater/swap_windows_helpers_test.go
+++ b/internal/updater/swap_windows_helpers_test.go
@@ -79,3 +79,34 @@ func TestRenderWindowsBatScript_UsesArgPassing(t *testing.T) {
 		t.Errorf("script should NOT hardcode the staged path (uses %%~3); got %q in script", newPath)
 	}
 }
+
+// TestWindowsHelperCreationFlags_NoVisibleWindow pins the fix for the stray
+// 'find "<pid>"' Windows Terminal window users saw mid desktop upgrade.
+//
+// The desktop exe is built with -H windowsgui (GUI subsystem, no console).
+// DETACHED_PROCESS (0x8) only detaches cmd.exe from the parent's console; the
+// batch's children (tasklist.exe, ping.exe) then each allocate their OWN
+// visible console -> a #0c0c0c Windows Terminal pops up echoing the poll line
+// 'tasklist ... | find "<pid>" >nul' and lingering until the app quits.
+// CREATE_NO_WINDOW (0x08000000) suppresses all child console windows instead.
+//
+// This test is the regression guard: it does not spawn a process, so it runs
+// deterministically on Windows CI; it asserts the invariant by value.
+func TestWindowsHelperCreationFlags_NoVisibleWindow(t *testing.T) {
+	const createNoWindow = uint32(0x08000000)
+	const detachedProcess = uint32(0x00000008)
+
+	flags := uint32(windowsHelperCreationFlags)
+
+	if flags&createNoWindow == 0 {
+		t.Fatalf("windowsHelperCreationFlags = %#x is missing CREATE_NO_WINDOW (0x08000000); "+
+			"the desktop upgrade helper would pop a visible Windows Terminal window "+
+			"(regression: previously used DETACHED_PROCESS)", flags)
+	}
+	if flags&detachedProcess != 0 {
+		t.Fatalf("windowsHelperCreationFlags = %#x must NOT include DETACHED_PROCESS (0x8); "+
+			"DETACHED_PROCESS + GUI-subsystem parent lets tasklist/ping allocate visible "+
+			"consoles, and DETACHED_PROCESS is mutually exclusive with CREATE_NO_WINDOW at "+
+			"the Win32 level", flags)
+	}
+}


### PR DESCRIPTION
## Problem

On Windows, clicking "Update & restart" in the desktop app pops a stray Windows Terminal window mid-upgrade (dark `#0c0c0c`, reading `find "<pid>"` where `<pid>` is the running app's PID). The window lingers until the app quits, then closes — the upgrade itself still succeeds.

## Root cause

The desktop self-upgrader spawns a detached `.bat` helper via `cmd.exe /c` to complete the swap after the running process exits (`internal/updater/swap_windows.go` → `SwapAndRelaunch`). It was created with:

```go
CreationFlags: windowsDetachedProcess | windowsCreateNewProcessGroup, // DETACHED_PROCESS(0x8) | CREATE_NEW_PROCESS_GROUP(0x200)
HideWindow:    true,
```

The desktop exe is a GUI-subsystem binary (built with `-H windowsgui`; see the `build-desktop-windows` job in `.github/workflows/cli-release.yml` and `Makefile` ~line 466) and has **no console**. `DETACHED_PROCESS` only detaches `cmd.exe` from the parent's (nonexistent) console — it does not suppress console allocation for the batch's child processes. So `tasklist.exe` and `ping.exe` (invoked by the batch's PID-poll loop: `tasklist /FI "PID eq %PID%" /NH | find "%PID%" >nul`) each allocate their **own** visible console. On Windows 11 (default terminal host = Windows Terminal) that surfaces as a `#0c0c0c` window whose title/content includes `find "41784"`.

`HideWindow: true` covers the `cmd.exe` window only; it does not cover child console allocation.

## Fix

Replace `DETACHED_PROCESS` with `CREATE_NO_WINDOW` (`0x08000000`), the canonical flag for running a batch silently from a GUI app:

```go
CreationFlags: windowsHelperCreationFlags, // CREATE_NO_WINDOW(0x08000000) | CREATE_NEW_PROCESS_GROUP(0x200)
HideWindow:    true,
```

`CREATE_NO_WINDOW` suppresses console allocation for the helper **and** the console-subsystem commands it spawns. Per MS docs, `CREATE_NO_WINDOW` is **ignored** when combined with `DETACHED_PROCESS` or `CREATE_NEW_CONSOLE` (it does not reject the combination — it silently drops the no-window behavior), so `DETACHED_PROCESS` must not be present alongside it.

`CREATE_NEW_PROCESS_GROUP` is retained (harmless; process-group / Ctrl+C isolation). Dropping `DETACHED_PROCESS` has no downside: on Windows, parent/child lifetime is not coupled through the process relationship, and the helper already survives parent exit via the detached spawn + `cmd.Process.Release()`. Token/privilege inheritance, the `start "" %EXE%` relaunch of the new GUI exe, and filesystem access are all unaffected.

## Test

`TestWindowsHelperCreationFlags_NoVisibleWindow` (`internal/updater/swap_windows_helpers_test.go`) pins the invariant by value — no process spawned, so deterministic on Windows CI:
- the combined `CreationFlags` contains `CREATE_NO_WINDOW` (`0x08000000`)
- it does **not** contain `DETACHED_PROCESS` (`0x8`)

`//go:build windows`-tagged, so it runs on the Windows CI runner and is skipped elsewhere.

## Verification

- `GOOS=windows go vet ./internal/updater/` — clean (cross-type-checks the `//go:build windows` files + new test from macOS)
- `gofmt`, `golangci-lint` (0 issues), `go vet`, `go test -short ./...`, build — all pass via the pre-commit hook
- Reviewed correctness (root cause, flag choice, helper-lifetime/relaunch safety, test adequacy) with an independent model: APPROVE. The one nit raised — a comment overstating the Win32 semantics as "mutually exclusive" rather than "CREATE_NO_WINDOW is ignored when combined with DETACHED_PROCESS" — was addressed in `swap_windows_helpers.go`.