### PR TITLE
fix(httpclient): sync scraper ProxyEnabled with resolved proxy mode

### DIFF
--- a/internal/httpclient/factory_coverage_test.go
+++ b/internal/httpclient/factory_coverage_test.go
@@ -104,7 +104,27 @@ func TestInitScraperClient_WithProxyEnabled(t *testing.T) {
 	globalProxy := &models.ProxyConfig{Enabled: false}
 	result := InitScraperClient(settings, globalProxy, models.FlareSolverrConfig{})
 	require.NotNil(t, result)
-	assert.True(t, result.ProxyEnabled)
+	// Circuit breaker: global proxy disabled means Direct mode for ALL scrapers,
+	// regardless of any per-scraper override, so the flag must report no proxy.
+	assert.False(t, result.ProxyEnabled)
+}
+
+func TestInitScraperClient_ScraperOptsOutOfGlobalProxy(t *testing.T) {
+	settings := &models.ScraperSettings{
+		Enabled:    true,
+		Timeout:    30,
+		RetryCount: 3,
+		Proxy:      &models.ProxyConfig{Enabled: false},
+	}
+	globalProxy := &models.ProxyConfig{
+		Enabled:        true,
+		Profiles:       map[string]models.ProxyProfile{"default": {URL: "http://proxy:8080"}},
+		DefaultProfile: "default",
+	}
+	result := InitScraperClient(settings, globalProxy, models.FlareSolverrConfig{})
+	require.NotNil(t, result)
+	// Scraper explicitly opted out of a globally-enabled proxy → Direct mode (no proxy).
+	assert.False(t, result.ProxyEnabled)
 }
 
 func TestInitScraperClient_GlobalProxyEnabled(t *testing.T) {

--- a/internal/httpclient/scraper_client.go
+++ b/internal/httpclient/scraper_client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scraperconfig"
 )
 
 // ScraperHTTPClientOption configures a scraper HTTP client at construction.
@@ -92,10 +93,7 @@ func InitScraperClient(settings *models.ScraperSettings, globalProxy *models.Pro
 		globalProxyVal = *globalProxy
 	}
 
-	proxyEnabled := globalProxyVal.Enabled
-	if settings.Proxy != nil && settings.Proxy.Enabled {
-		proxyEnabled = true
-	}
+	proxyEnabled := scraperconfig.ResolveScraperProxyMode(globalProxyVal, settings.Proxy) != scraperconfig.ScraperProxyModeDirect
 
 	proxyConfig := models.ResolveScraperProxy(globalProxyVal, settings.Proxy)
 

--- a/internal/httpclient/scraper_client_test.go
+++ b/internal/httpclient/scraper_client_test.go
@@ -91,7 +91,10 @@ func TestInitScraperClient_WithProxy(t *testing.T) {
 	result := InitScraperClient(settings, nil, models.FlareSolverrConfig{})
 	assert.NotNil(t, result)
 	assert.NotNil(t, result.Client)
-	assert.True(t, result.ProxyEnabled)
+	// No global proxy configured: the resolver's circuit breaker forces Direct
+	// mode for every scraper, so the flag must report no proxy even when the
+	// scraper carries its own enabled proxy override.
+	assert.False(t, result.ProxyEnabled)
 }
 
 func TestInitScraperClient_WithGlobalProxy(t *testing.T) {


### PR DESCRIPTION
## Problem

`InitScraperClient` computes a `proxyEnabled` flag that is returned as `ScraperClientResult.ProxyEnabled` and drives the `"Using proxy …"` log line. The previous computation only ever flipped the flag to `true`:

```go
proxyEnabled := globalProxyVal.Enabled
if settings.Proxy != nil && settings.Proxy.Enabled {
    proxyEnabled = true
}
```

This was out of sync with the authoritative resolver `ResolveScraperProxyMode` (`internal/scraperconfig/config.go`) in two cases:

1. **Opt-out not respected** — a scraper that explicitly sets `proxy.Enabled = false` to opt out of a *globally-enabled* proxy still reported `ProxyEnabled = true` (and logged `"Using proxy"`), even though the actual client used Direct / no-proxy mode.
2. **Circuit-breaker mismatch** — `ResolveScraperProxyMode` forces Direct mode for *all* scrapers when the global proxy is disabled. The old flag computation reported `true` whenever a per-scraper override was enabled, even with the global proxy off, so it logged `"Using proxy"` while the client actually used Direct.

## Fix

Delegate `proxyEnabled` to the authoritative resolver so the flag (and log line) matches the actual client behavior:

```go
proxyEnabled := scraperconfig.ResolveScraperProxyMode(globalProxyVal, settings.Proxy) != scraperconfig.ScraperProxyModeDirect
```

`Direct` mode (no proxy) now correctly maps to `ProxyEnabled = false` for both the opt-out case and the global-disabled circuit-breaker case.

## Test changes

- `TestInitScraperClient_WithProxyEnabled` — previously encoded the buggy expectation (global disabled + scraper enabled → `true`). Updated to assert `false`, since the circuit breaker forces Direct mode for all scrapers when global is off.
- `TestInitScraperClient_ScraperOptsOutOfGlobalProxy` (new) — regression guard for the reported bug: global proxy enabled + scraper `proxy.Enabled = false` → `ProxyEnabled = false` (scraper opted out → Direct).
- `TestInitScraperClient_WithProxy` — global proxy is `nil` (disabled), so the circuit breaker forces Direct mode; assertion updated to `false` to match the resolver.
- `TestInitScraperClient_WithGlobalProxy` / `TestInitScraperClient_GlobalProxyEnabled` — unchanged; both still report `true` (global enabled, scraper inherits).

## Verification

- `gofmt -l` clean
- `go vet ./internal/httpclient/ ./internal/scraperconfig/`
- `go test -race ./internal/httpclient/ ./internal/scraperconfig/`
- `go test -short ./internal/httpclient/`
- `go build ./...`
- pre-commit hook (gofmt, golangci-lint, go vet, `go test -short`, build) passed