### PR TITLE
feat(review): add bidirectional favorite-genre shuttle in movie editor

### DIFF
--- a/web/frontend/messages/en-XA.json
+++ b/web/frontend/messages/en-XA.json
@@ -811,6 +811,8 @@
   "movie_genre_favorites_label": "[ Fåvörítës ]",
   "movie_genre_favorite_add_title": "[ Ädd {name} ]",
   "movie_genre_favorite_already_added_title": "[ {name} ålrëådy åddëd ]",
+  "movie_genre_add_to_favorites_title": "[ Ädd {name} tö fåvörítës ]",
+  "movie_genre_remove_from_favorites_title": "[ Rëmövë {name} fröm fåvörítës ]",
   "movie_rating_display": "[ {score}/10 ]",
   "movie_rating_vote_one": "[ ({votes} vötë) ]",
   "movie_rating_votes": "[ ({votes} vötës) ]",

--- a/web/frontend/messages/en.json
+++ b/web/frontend/messages/en.json
@@ -1108,6 +1108,8 @@
   "movie_genre_favorites_label": "Favorites",
   "movie_genre_favorite_add_title": "Add {name}",
   "movie_genre_favorite_already_added_title": "{name} already added",
+  "movie_genre_add_to_favorites_title": "Add {name} to favorites",
+  "movie_genre_remove_from_favorites_title": "Remove {name} from favorites",
   "movie_rating_display": "{score}/10",
   "movie_rating_vote_one": "({votes} vote)",
   "movie_rating_votes": "({votes} votes)",

--- a/web/frontend/messages/ja.json
+++ b/web/frontend/messages/ja.json
@@ -1108,6 +1108,8 @@
   "movie_genre_favorites_label": "お気に入り",
   "movie_genre_favorite_add_title": "{name} を追加",
   "movie_genre_favorite_already_added_title": "{name} は既に追加済み",
+  "movie_genre_add_to_favorites_title": "{name} をお気に入りに追加",
+  "movie_genre_remove_from_favorites_title": "{name} をお気に入りから削除",
   "movie_rating_display": "{score}/10",
   "movie_rating_vote_one": "({votes} 票)",
   "movie_rating_votes": "({votes} 票)",

--- a/web/frontend/messages/zh-Hans.json
+++ b/web/frontend/messages/zh-Hans.json
@@ -1108,6 +1108,8 @@
   "movie_genre_favorites_label": "收藏",
   "movie_genre_favorite_add_title": "添加 {name}",
   "movie_genre_favorite_already_added_title": "{name} 已添加",
+  "movie_genre_add_to_favorites_title": "将 {name} 添加到收藏",
+  "movie_genre_remove_from_favorites_title": "将 {name} 从收藏移除",
   "movie_rating_display": "{score}/10",
   "movie_rating_vote_one": "（{votes} 票）",
   "movie_rating_votes": "（{votes} 票）",

--- a/web/frontend/messages/zh-Hant.json
+++ b/web/frontend/messages/zh-Hant.json
@@ -1108,6 +1108,8 @@
   "movie_genre_favorites_label": "收藏",
   "movie_genre_favorite_add_title": "新增 {name}",
   "movie_genre_favorite_already_added_title": "{name} 已新增",
+  "movie_genre_add_to_favorites_title": "將 {name} 加入收藏",
+  "movie_genre_remove_from_favorites_title": "將 {name} 從收藏移除",
   "movie_rating_display": "{score}/10",
   "movie_rating_vote_one": "（{votes} 票）",
   "movie_rating_votes": "（{votes} 票）",

--- a/web/frontend/src/lib/components/MovieEditor.svelte
+++ b/web/frontend/src/lib/components/MovieEditor.svelte
@@ -195,6 +195,15 @@
 		}
 		return unique.sort((a, b) => a.localeCompare(b));
 	});
+	const favoritedNameByKey = $derived.by(() => {
+		const map = new Map<string, string>();
+		for (const g of favoriteGenres) {
+			const trimmed = g.trim();
+			if (!trimmed) continue;
+			map.set(trimmed.toLowerCase(), trimmed);
+		}
+		return map;
+	});
 	const presentGenreNames = $derived.by(() => {
 		const set = new Set<string>();
 		editedMovie.genres?.forEach(g => set.add(normalizeGenreName(g.name)));
@@ -515,12 +524,13 @@
 							<span class="leading-none">{genre.name}</span>
 							{#if onAddFavorite && onRemoveFavorite}
 								{@const isFavorited = favoritedGenreNames.has(normalizeGenreName(genre.name))}
+								{@const storedFavoriteName = favoritedNameByKey.get(normalizeGenreName(genre.name)) ?? genre.name}
 								{@const favoriteLabel = isFavorited
 									? m.movie_genre_remove_from_favorites_title({ name: genre.name })
 									: m.movie_genre_add_to_favorites_title({ name: genre.name })}
 								<button
 									type="button"
-									onclick={() => isFavorited ? onRemoveFavorite?.(genre.name) : onAddFavorite?.(genre.name)}
+									onclick={() => isFavorited ? onRemoveFavorite?.(storedFavoriteName) : onAddFavorite?.(genre.name)}
 									class="ml-0.5 p-0.5 rounded-full hover:bg-primary/20 transition-all opacity-70 hover:opacity-100"
 									aria-label={favoriteLabel}
 									title={favoriteLabel}

--- a/web/frontend/src/lib/components/MovieEditor.svelte
+++ b/web/frontend/src/lib/components/MovieEditor.svelte
@@ -18,9 +18,10 @@
 		favoritedGenreNames?: Set<string>;
 		onAddFavorite?: (genre: string) => void;
 		onRemoveFavorite?: (genre: string) => void;
+		favoriteMutationPending?: boolean;
 	}
 
-	let { movie, originalMovie, onUpdate, fieldSources, showFieldSources = false, jobId, resultId, nfoDifferences, favoriteGenres = [], favoritedGenreNames = new Set<string>(), onAddFavorite, onRemoveFavorite }: Props = $props();
+	let { movie, originalMovie, onUpdate, fieldSources, showFieldSources = false, jobId, resultId, nfoDifferences, favoriteGenres = [], favoritedGenreNames = new Set<string>(), onAddFavorite, onRemoveFavorite, favoriteMutationPending = false }: Props = $props();
 
 	// Create a local editable copy - initialized by effect
 	let editedMovie = $state<Movie>({} as Movie);
@@ -530,8 +531,9 @@
 									: m.movie_genre_add_to_favorites_title({ name: genre.name })}
 								<button
 									type="button"
+									disabled={favoriteMutationPending}
 									onclick={() => isFavorited ? onRemoveFavorite?.(storedFavoriteName) : onAddFavorite?.(genre.name)}
-									class="ml-0.5 p-0.5 rounded-full hover:bg-primary/20 transition-all opacity-70 hover:opacity-100"
+									class="ml-0.5 p-0.5 rounded-full hover:bg-primary/20 transition-all opacity-70 hover:opacity-100 disabled:opacity-50 disabled:cursor-not-allowed"
 									aria-label={favoriteLabel}
 									title={favoriteLabel}
 								>

--- a/web/frontend/src/lib/components/MovieEditor.svelte
+++ b/web/frontend/src/lib/components/MovieEditor.svelte
@@ -2,7 +2,7 @@
 	import * as m from '$lib/paraglide/messages';
 	import type { Movie, Genre, FieldDifference } from '$lib/api/types';
 	import { apiClient } from '$lib/api/client';
-	import { CircleAlert, LoaderCircle, X, Plus, Check } from 'lucide-svelte';
+	import { CircleAlert, LoaderCircle, X, Plus, Check, Star } from 'lucide-svelte';
 	import NfoDiffBadge from './NfoDiffBadge.svelte';
 
 	interface Props {
@@ -15,9 +15,12 @@
 		resultId?: string;
 		nfoDifferences?: FieldDifference[];
 		favoriteGenres?: string[];
+		favoritedGenreNames?: Set<string>;
+		onAddFavorite?: (genre: string) => void;
+		onRemoveFavorite?: (genre: string) => void;
 	}
 
-	let { movie, originalMovie, onUpdate, fieldSources, showFieldSources = false, jobId, resultId, nfoDifferences, favoriteGenres = [] }: Props = $props();
+	let { movie, originalMovie, onUpdate, fieldSources, showFieldSources = false, jobId, resultId, nfoDifferences, favoriteGenres = [], favoritedGenreNames = new Set<string>(), onAddFavorite, onRemoveFavorite }: Props = $props();
 
 	// Create a local editable copy - initialized by effect
 	let editedMovie = $state<Movie>({} as Movie);
@@ -510,6 +513,25 @@
 					{#each editedMovie.genres as genre}
 						<span class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-linear-to-br from-primary/10 to-primary/5 text-primary rounded-full text-sm font-medium hover:from-primary/15 hover:to-primary/10 transition-all shadow-sm border border-primary/10">
 							<span class="leading-none">{genre.name}</span>
+							{#if onAddFavorite && onRemoveFavorite}
+								{@const isFavorited = favoritedGenreNames.has(normalizeGenreName(genre.name))}
+								{@const favoriteLabel = isFavorited
+									? m.movie_genre_remove_from_favorites_title({ name: genre.name })
+									: m.movie_genre_add_to_favorites_title({ name: genre.name })}
+								<button
+									type="button"
+									onclick={() => isFavorited ? onRemoveFavorite?.(genre.name) : onAddFavorite?.(genre.name)}
+									class="ml-0.5 p-0.5 rounded-full hover:bg-primary/20 transition-all opacity-70 hover:opacity-100"
+									aria-label={favoriteLabel}
+									title={favoriteLabel}
+								>
+									{#if isFavorited}
+										<Star class="h-3.5 w-3.5 fill-current" />
+									{:else}
+										<Star class="h-3.5 w-3.5" />
+									{/if}
+								</button>
+							{/if}
 							<button
 								type="button"
 								onclick={() => removeGenre(genre.name)}

--- a/web/frontend/src/routes/review/[jobId]/components/MovieMetadataCard.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/MovieMetadataCard.svelte
@@ -5,6 +5,9 @@
 	import MovieEditor from '$lib/components/MovieEditor.svelte';
 	import NfoDiffSummary from './NfoDiffSummary.svelte';
 	import { createFavoriteGenresQuery } from '$lib/query/queries';
+	import { createMutation, useQueryClient } from '@tanstack/svelte-query';
+	import { apiClient } from '$lib/api/client';
+	import { toastStore } from '$lib/stores/toast';
 	import { LoaderCircle, RotateCcw, TableProperties } from 'lucide-svelte';
 	import * as m from '$lib/paraglide/messages';
 
@@ -38,6 +41,40 @@
 	let favoriteGenres = $derived<string[]>(
 		favoritesQuery.isError ? [] : (favoritesQuery.data?.favorites ?? [])
 	);
+	const favoritedGenreNames = $derived.by(() => {
+		const set = new Set<string>();
+		for (const g of favoriteGenres) set.add(g.trim().toLowerCase());
+		return set;
+	});
+
+	const queryClient = useQueryClient();
+	const addFavoriteMutation = createMutation(() => ({
+		mutationFn: (genre: string) => apiClient.addFavoriteGenre({ genre }),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: ['genre-favorites'] });
+			void queryClient.invalidateQueries({ queryKey: ['config'] });
+		},
+		onError: (err: Error) => {
+			toastStore.error(err.message || m.genres_add_favorite_failed(), 4000);
+		},
+	}));
+	const removeFavoriteMutation = createMutation(() => ({
+		mutationFn: (genre: string) => apiClient.deleteFavoriteGenre(genre),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: ['genre-favorites'] });
+			void queryClient.invalidateQueries({ queryKey: ['config'] });
+		},
+		onError: (err: Error) => {
+			toastStore.error(err.message || m.genres_remove_favorite_failed(), 4000);
+		},
+	}));
+
+	function handleAddFavorite(genre: string) {
+		addFavoriteMutation.mutate(genre);
+	}
+	function handleRemoveFavorite(genre: string) {
+		removeFavoriteMutation.mutate(genre);
+	}
 </script>
 
 <Card class="p-6">
@@ -91,6 +128,9 @@
 			resultId={currentResult.result_id}
 			nfoDifferences={nfoDifferences}
 			favoriteGenres={favoriteGenres}
+			favoritedGenreNames={favoritedGenreNames}
+			onAddFavorite={handleAddFavorite}
+			onRemoveFavorite={handleRemoveFavorite}
 		/>
 
 		{#if nfoDifferences && nfoDifferences.length > 0}

--- a/web/frontend/src/routes/review/[jobId]/components/MovieMetadataCard.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/MovieMetadataCard.svelte
@@ -75,6 +75,7 @@
 	function handleRemoveFavorite(genre: string) {
 		removeFavoriteMutation.mutate(genre);
 	}
+	let favoriteMutationPending = $derived(addFavoriteMutation.isPending || removeFavoriteMutation.isPending);
 </script>
 
 <Card class="p-6">
@@ -131,6 +132,7 @@
 			favoritedGenreNames={favoritedGenreNames}
 			onAddFavorite={handleAddFavorite}
 			onRemoveFavorite={handleRemoveFavorite}
+			favoriteMutationPending={favoriteMutationPending}
 		/>
 
 		{#if nfoDifferences && nfoDifferences.length > 0}


### PR DESCRIPTION
## Summary

Closes #121. Completes the favorite-genres quick-apply workflow by adding the **reverse direction** of the shuttle: a Star affordance on each movie genre chip that adds the genre to `webui.favorites.genre` (or removes it if already favorited).

PR #168 shipped the forward direction (click a favorite → add to movie). This adds the other half — click a movie's genre → favorite it for later — so the palette is built up from the review page, not just curated on the Genres settings page.

## Changes

- **`MovieMetadataCard.svelte`** (container) — adds `addFavoriteGenre` + `deleteFavoriteGenre` mutations (mirrors the Genres page pattern), invalidates `['genre-favorites']` + `['config']` on success, surfaces errors via toast. Passes `favoritedGenreNames` (a `Set<string>`), `onAddFavorite`, and `onRemoveFavorite` as props to `MovieEditor`.
- **`MovieEditor.svelte`** (presentational leaf) — adds a Star affordance on each movie genre chip, next to the existing X remove button. Outline Star = click to favorite; filled Star = already favorited, click to unfavorite. `aria-label` + `title` mirror the localized add/remove strings. Rendered only when both callbacks are provided (graceful no-op otherwise).
- **i18n** — 2 new Paraglide keys (`movie_genre_add_to_favorites_title`, `movie_genre_remove_from_favorites_title`) across all 5 locales (en, ja, zh-Hans, zh-Hant, en-XA).

## Scope decisions vs #121

- **Per-movie mutation API** (`PUT /api/v1/movies/{id}/genres`) — **not built**; the existing `PATCH /api/v1/batch/{id}/results/{resultId}` (`updateBatchMovie`) seam already persists genre edits on review save.
- **Undo/removed pane** — **Option B** (rely on existing Reset/cancel-to-discard). The existing Reset button covers full revert; a per-chip undo stack adds complexity for marginal value.
- **Tag equivalents** — out of scope per #121.
- **Pre-existing `apiClient` import in `MovieEditor.svelte`** — used only for the display-title preview feature (`apiClient.previewDisplayTitle`, line 78), which predates this PR and PR #168. Lifting it to the container is a separate refactor (~30 lines of preview state/effect) out of scope here. No new `apiClient` calls were added to `MovieEditor` by this PR — all new favorites mutations live in `MovieMetadataCard`.

## Verification

- `svelte-check`: 0 errors (1 pre-existing warning in `LocaleReconciler.svelte`)
- `vitest`: 464/464 pass
- Pre-commit hook: all 7 checks pass (gofmt, vet, `go test -short`, build, swagger, svelte-check)

## Design constraints honored (from PR #168 review + council runs)

- New mutations live in the container; `MovieEditor` receives the new favorite callbacks as props (no new `apiClient` calls added to the leaf).
- Locale-independent `toLowerCase()` for comparison keys.
- `aria-label` + `title` mirroring; `Star` icon as non-color cue for favorited state.
- `favoritedGenreNames` derived depends on `favoriteGenres` (recomputes on mutation via query invalidation).
- `['genre-favorites']` invalidated on every favorite mutation.
- No code comments (AGENTS.md).