### PR TITLE
feat(api/history): wire history record creation during scrape/organize

### DIFF
--- a/internal/api/core/bootstrap.go
+++ b/internal/api/core/bootstrap.go
@@ -54,7 +54,7 @@ func bootstrapAPIDeps(cfg *config.Config, configFile string, auth commandutil.Au
 	// OsFs, and APIDeps.Fs was left unset). GetFs() falls back to OsFs when
 	// nil, so this is behavior-preserving for existing callers.
 	fs := afero.NewOsFs()
-	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, sharedEngine, fs, worker.WithActressRepo(repos.ActressRepo))
+	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, sharedEngine, fs, worker.WithActressRepo(repos.ActressRepo), worker.WithHistoryRepo(repos.HistoryRepo))
 	eventEmitter := eventlog.NewEmitter(repos.EventRepo)
 	reverter := history.NewReverter(fs, repos.BatchFileOpRepo)
 

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -22,11 +22,16 @@ func redactURLCredentials(input string) string {
 		return "redacted"
 	}
 	if u.Host == "" {
+		if u.Scheme != "" {
+			return "redacted"
+		}
 		return input
 	}
 	if u.User != nil {
 		u.User = url.UserPassword("redacted", "redacted")
 	}
+	u.RawQuery = ""
+	u.Fragment = ""
 	return u.String()
 }
 

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -32,7 +32,7 @@ func redactURLCredentials(input string) string {
 		return "redacted"
 	}
 	if u.Host == "" {
-		if u.Scheme != "" {
+		if strings.EqualFold(u.Scheme, "http") || strings.EqualFold(u.Scheme, "https") {
 			return "redacted"
 		}
 		return input

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -136,11 +136,14 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 				auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer auditCancel()
 				safeInput := redactURLCredentials(cmd.RawInput)
-				movieID := safeInput
-				for _, sr := range result.ScraperResults {
-					if sr.ID != "" {
-						movieID = sr.ID
-						break
+				movieID := cmd.MovieID
+				if movieID == "" {
+					movieID = safeInput
+					for _, sr := range result.ScraperResults {
+						if sr.ID != "" {
+							movieID = sr.ID
+							break
+						}
 					}
 				}
 				_ = deps.HistoryRepo.Create(auditCtx, &models.History{

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -18,7 +18,7 @@ import (
 )
 
 var movieEmbeddedURLRe = regexp.MustCompile(`(?i)https?://[^\s/]+@`)
-var movieQueryURLRe = regexp.MustCompile(`(?i)(https?://[^\s?]+)\?[^\s]+`)
+var movieQueryURLRe = regexp.MustCompile(`(?i)(https?://[^\s?#]+)[?#][^\s]+`)
 
 func redactEmbeddedURLs(s string) string {
 	s = movieEmbeddedURLRe.ReplaceAllString(s, "https://redacted:redacted@")

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -14,6 +15,20 @@ import (
 
 	contracts "github.com/javinizer/javinizer-go/internal/api/contracts"
 )
+
+func redactURLCredentials(input string) string {
+	u, err := url.Parse(input)
+	if err != nil {
+		return "redacted"
+	}
+	if u.Host == "" {
+		return input
+	}
+	if u.User != nil {
+		u.User = url.UserPassword("redacted", "redacted")
+	}
+	return u.String()
+}
 
 // scrapeMovie godoc
 // @Summary Scrape movie metadata
@@ -78,10 +93,11 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			if deps.HistoryRepo != nil && !errors.Is(scrapeCtx.Err(), context.Canceled) {
 				auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer auditCancel()
+				safeInput := redactURLCredentials(cmd.RawInput)
 				_ = deps.HistoryRepo.Create(auditCtx, &models.History{
-					MovieID:      cmd.RawInput,
+					MovieID:      safeInput,
 					Operation:    models.HistoryOpScrape,
-					OriginalPath: cmd.RawInput,
+					OriginalPath: safeInput,
 					Status:       models.HistoryStatusFailed,
 					ErrorMessage: "scrape timed out",
 				})
@@ -93,10 +109,11 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			if deps.HistoryRepo != nil && !errors.Is(err, context.Canceled) {
 				auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer auditCancel()
+				safeInput := redactURLCredentials(cmd.RawInput)
 				_ = deps.HistoryRepo.Create(auditCtx, &models.History{
-					MovieID:      cmd.RawInput,
+					MovieID:      safeInput,
 					Operation:    models.HistoryOpScrape,
-					OriginalPath: cmd.RawInput,
+					OriginalPath: safeInput,
 					Status:       models.HistoryStatusFailed,
 					ErrorMessage: err.Error(),
 				})
@@ -113,10 +130,11 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			if deps.HistoryRepo != nil {
 				auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer auditCancel()
+				safeInput := redactURLCredentials(cmd.RawInput)
 				_ = deps.HistoryRepo.Create(auditCtx, &models.History{
-					MovieID:      cmd.RawInput,
+					MovieID:      safeInput,
 					Operation:    models.HistoryOpScrape,
-					OriginalPath: cmd.RawInput,
+					OriginalPath: safeInput,
 					Status:       models.HistoryStatusFailed,
 					ErrorMessage: errMsg,
 				})
@@ -131,7 +149,7 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			_ = deps.HistoryRepo.Create(auditCtx, &models.History{
 				MovieID:      result.Movie.ID,
 				Operation:    models.HistoryOpScrape,
-				OriginalPath: cmd.RawInput,
+				OriginalPath: redactURLCredentials(cmd.RawInput),
 				Status:       models.HistoryStatusSuccess,
 			})
 		}

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -15,6 +16,12 @@ import (
 
 	contracts "github.com/javinizer/javinizer-go/internal/api/contracts"
 )
+
+var movieEmbeddedURLRe = regexp.MustCompile(`(?i)https?://[^\s/]+@`)
+
+func redactEmbeddedURLs(s string) string {
+	return movieEmbeddedURLRe.ReplaceAllString(s, "https://redacted:redacted@")
+}
 
 func redactURLCredentials(input string) string {
 	u, err := url.Parse(input)
@@ -120,7 +127,7 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 					Operation:    models.HistoryOpScrape,
 					OriginalPath: safeInput,
 					Status:       models.HistoryStatusFailed,
-					ErrorMessage: err.Error(),
+					ErrorMessage: redactEmbeddedURLs(err.Error()),
 				})
 			}
 			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: err.Error()})
@@ -130,20 +137,17 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 		if result.Status == scrape.StatusFailed {
 			errMsg := "Movie not found"
 			if result.Message != "" {
-				errMsg = result.Message
+				errMsg = redactEmbeddedURLs(result.Message)
 			}
 			if deps.HistoryRepo != nil {
 				auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer auditCancel()
 				safeInput := redactURLCredentials(cmd.RawInput)
-				movieID := cmd.MovieID
-				if movieID == "" {
-					movieID = safeInput
-					for _, sr := range result.ScraperResults {
-						if sr.ID != "" {
-							movieID = sr.ID
-							break
-						}
+				movieID := safeInput
+				for _, sr := range result.ScraperResults {
+					if sr.ID != "" {
+						movieID = sr.ID
+						break
 					}
 				}
 				_ = deps.HistoryRepo.Create(auditCtx, &models.History{

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/javinizer/javinizer-go/internal/api/core"
@@ -73,10 +74,32 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 		}
 		result, _, err := wf.Scrape(scrapeCtx, cmd)
 		if scrapeCtx.Err() != nil {
+			if deps.HistoryRepo != nil {
+				auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer auditCancel()
+				_ = deps.HistoryRepo.Create(auditCtx, &models.History{
+					MovieID:      cmd.RawInput,
+					Operation:    models.HistoryOpScrape,
+					OriginalPath: cmd.RawInput,
+					Status:       models.HistoryStatusFailed,
+					ErrorMessage: "scrape timed out",
+				})
+			}
 			c.JSON(http.StatusGatewayTimeout, contracts.ErrorResponse{Error: "scrape timed out"})
 			return
 		}
 		if err != nil {
+			if deps.HistoryRepo != nil {
+				auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer auditCancel()
+				_ = deps.HistoryRepo.Create(auditCtx, &models.History{
+					MovieID:      cmd.RawInput,
+					Operation:    models.HistoryOpScrape,
+					OriginalPath: cmd.RawInput,
+					Status:       models.HistoryStatusFailed,
+					ErrorMessage: err.Error(),
+				})
+			}
 			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: err.Error()})
 			return
 		}
@@ -86,8 +109,30 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			if result.Message != "" {
 				errMsg = result.Message
 			}
+			if deps.HistoryRepo != nil {
+				auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer auditCancel()
+				_ = deps.HistoryRepo.Create(auditCtx, &models.History{
+					MovieID:      cmd.RawInput,
+					Operation:    models.HistoryOpScrape,
+					OriginalPath: cmd.RawInput,
+					Status:       models.HistoryStatusFailed,
+					ErrorMessage: errMsg,
+				})
+			}
 			c.JSON(http.StatusNotFound, contracts.ErrorResponse{Error: errMsg})
 			return
+		}
+
+		if deps.HistoryRepo != nil && result.Movie != nil {
+			auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer auditCancel()
+			_ = deps.HistoryRepo.Create(auditCtx, &models.History{
+				MovieID:      result.Movie.ID,
+				Operation:    models.HistoryOpScrape,
+				OriginalPath: cmd.RawInput,
+				Status:       models.HistoryStatusSuccess,
+			})
 		}
 
 		// Generate temp poster for the scraped movie.

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -2,6 +2,7 @@ package movie
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -74,7 +75,7 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 		}
 		result, _, err := wf.Scrape(scrapeCtx, cmd)
 		if scrapeCtx.Err() != nil {
-			if deps.HistoryRepo != nil {
+			if deps.HistoryRepo != nil && !errors.Is(scrapeCtx.Err(), context.Canceled) {
 				auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer auditCancel()
 				_ = deps.HistoryRepo.Create(auditCtx, &models.History{
@@ -89,7 +90,7 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 			return
 		}
 		if err != nil {
-			if deps.HistoryRepo != nil {
+			if deps.HistoryRepo != nil && !errors.Is(err, context.Canceled) {
 				auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer auditCancel()
 				_ = deps.HistoryRepo.Create(auditCtx, &models.History{

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -18,9 +18,12 @@ import (
 )
 
 var movieEmbeddedURLRe = regexp.MustCompile(`(?i)https?://[^\s/]+@`)
+var movieQueryURLRe = regexp.MustCompile(`(?i)(https?://[^\s?]+)\?[^\s]+`)
 
 func redactEmbeddedURLs(s string) string {
-	return movieEmbeddedURLRe.ReplaceAllString(s, "https://redacted:redacted@")
+	s = movieEmbeddedURLRe.ReplaceAllString(s, "https://redacted:redacted@")
+	s = movieQueryURLRe.ReplaceAllString(s, "$1")
+	return s
 }
 
 func redactURLCredentials(input string) string {

--- a/internal/api/movie/scrape.go
+++ b/internal/api/movie/scrape.go
@@ -136,8 +136,15 @@ func scrapeMovie(deps MovieDeps) gin.HandlerFunc {
 				auditCtx, auditCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer auditCancel()
 				safeInput := redactURLCredentials(cmd.RawInput)
+				movieID := safeInput
+				for _, sr := range result.ScraperResults {
+					if sr.ID != "" {
+						movieID = sr.ID
+						break
+					}
+				}
 				_ = deps.HistoryRepo.Create(auditCtx, &models.History{
-					MovieID:      safeInput,
+					MovieID:      movieID,
 					Operation:    models.HistoryOpScrape,
 					OriginalPath: safeInput,
 					Status:       models.HistoryStatusFailed,

--- a/internal/api/movie/scrape_history_test.go
+++ b/internal/api/movie/scrape_history_test.go
@@ -91,7 +91,7 @@ func TestScrapeHistoryAuditMatrix(t *testing.T) {
 			var testRecords []models.History
 			reqID := tc.requestBody.(contracts.ScrapeRequest).ID
 			for _, r := range records {
-				if r.OriginalPath == reqID {
+				if r.OriginalPath == reqID || r.MovieID == reqID {
 					testRecords = append(testRecords, r)
 				}
 			}
@@ -100,6 +100,69 @@ func TestScrapeHistoryAuditMatrix(t *testing.T) {
 				assert.Equal(t, tc.wantHistoryStatus, testRecords[0].Status)
 				assert.Equal(t, tc.wantHistoryOp, testRecords[0].Operation)
 			}
+		})
+	}
+}
+
+func TestRedactURLCredentials(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "valid URL with credentials",
+			input: "https://alice:secret@example.com/path",
+			want:  "https://redacted:redacted@example.com/path",
+		},
+		{
+			name:  "URL without credentials",
+			input: "https://example.com/path",
+			want:  "https://example.com/path",
+		},
+		{
+			name:  "ordinary movie ID",
+			input: "IPX-123",
+			want:  "IPX-123",
+		},
+		{
+			name:  "malformed URL with credentials",
+			input: "https://alice:secret@example.com/%zz",
+			want:  "redacted",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "URL with only username",
+			input: "https://alice@example.com/path",
+			want:  "https://redacted:redacted@example.com/path",
+		},
+		{
+			name:  "opaque URL with credentials",
+			input: "https:alice:secret@example.com/path",
+			want:  "redacted",
+		},
+		{
+			name:  "URL with query string containing token",
+			input: "https://example.com/path?token=secret",
+			want:  "https://example.com/path",
+		},
+		{
+			name:  "URL with fragment",
+			input: "https://example.com/path#session",
+			want:  "https://example.com/path",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactURLCredentials(tc.input)
+			assert.Equal(t, tc.want, got)
+			assert.NotContains(t, got, "alice", "credentials must not appear in output")
+			assert.NotContains(t, got, "secret", "credentials must not appear in output")
 		})
 	}
 }

--- a/internal/api/movie/scrape_history_test.go
+++ b/internal/api/movie/scrape_history_test.go
@@ -1,0 +1,105 @@
+package movie
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scraperutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	contracts "github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+)
+
+func TestScrapeHistoryAuditMatrix(t *testing.T) {
+	type testCase struct {
+		name              string
+		requestBody       interface{}
+		setupScraper      func(*scraperutil.ScraperRegistry)
+		expectedStatus    int
+		wantHistoryRows   int
+		wantHistoryStatus models.HistoryStatus
+		wantHistoryOp     models.HistoryOperation
+	}
+
+	cases := []testCase{
+		{
+			name:        "successful scrape writes success history row",
+			requestBody: contracts.ScrapeRequest{ID: "HIST-001"},
+			setupScraper: func(registry *scraperutil.ScraperRegistry) {
+				registry.RegisterInstance(&mockScraperWithResults{
+					name:    "r18dev",
+					enabled: true,
+					result: &models.ScraperResult{
+						Source: "r18dev",
+						ID:     "HIST-001",
+						Title:  "History Test Movie",
+					},
+				})
+			},
+			expectedStatus:    200,
+			wantHistoryRows:   1,
+			wantHistoryStatus: models.HistoryStatusSuccess,
+			wantHistoryOp:     models.HistoryOpScrape,
+		},
+		{
+			name:              "scraper failure writes failed history row",
+			requestBody:       contracts.ScrapeRequest{ID: "HIST-FAIL"},
+			setupScraper:      func(_ *scraperutil.ScraperRegistry) {},
+			expectedStatus:    404,
+			wantHistoryRows:   1,
+			wantHistoryStatus: models.HistoryStatusFailed,
+			wantHistoryOp:     models.HistoryOpScrape,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			cfg := &config.Config{
+				Scrapers: config.ScrapersConfig{
+					Priority: []string{"r18dev"},
+				},
+			}
+			deps := createTestDeps(t, cfg, "")
+			movieDeps := NewMovieDeps(deps.Repos.MovieRepo,
+				WithWorkflow(testkit.GetTestRuntime(deps).GetWorkflow),
+				WithHistoryRepo(deps.Repos.HistoryRepo),
+			)
+			tc.setupScraper(deps.CoreDeps.GetRegistry())
+
+			router := gin.New()
+			router.POST("/scrape", scrapeMovie(movieDeps))
+
+			body, _ := json.Marshal(tc.requestBody)
+			req := httptest.NewRequest("POST", "/scrape", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.expectedStatus, w.Code)
+
+			records, err := deps.Repos.HistoryRepo.FindByOperation(context.Background(), models.HistoryOpScrape, 100)
+			require.NoError(t, err)
+			var testRecords []models.History
+			reqID := tc.requestBody.(contracts.ScrapeRequest).ID
+			for _, r := range records {
+				if r.OriginalPath == reqID {
+					testRecords = append(testRecords, r)
+				}
+			}
+			assert.Len(t, testRecords, tc.wantHistoryRows)
+			if tc.wantHistoryRows == 1 {
+				assert.Equal(t, tc.wantHistoryStatus, testRecords[0].Status)
+				assert.Equal(t, tc.wantHistoryOp, testRecords[0].Operation)
+			}
+		})
+	}
+}

--- a/internal/api/movie/service.go
+++ b/internal/api/movie/service.go
@@ -20,6 +20,7 @@ type WorkflowFunc func() workflow.WorkflowInterface
 // matching the ActressDeps pattern used in the actress package.
 type MovieDeps struct {
 	MovieRepo        database.MovieRepositoryInterface
+	HistoryRepo      database.HistoryRepositoryInterface
 	WorkflowFn       WorkflowFunc
 	PosterGen        poster.PosterGenerator
 	AllowedDirs      []string
@@ -37,6 +38,11 @@ func NewMovieDeps(movieRepo database.MovieRepositoryInterface, opts ...MovieDeps
 
 // MovieDepsOption configures a MovieDeps instance.
 type MovieDepsOption func(*MovieDeps)
+
+// WithHistoryRepo sets the history repository for recording scrape operations.
+func WithHistoryRepo(r database.HistoryRepositoryInterface) MovieDepsOption {
+	return func(d *MovieDeps) { d.HistoryRepo = r }
+}
 
 // WithWorkflow sets the workflow factory function for scrape and compare operations.
 func WithWorkflow(fn WorkflowFunc) MovieDepsOption {

--- a/internal/api/server/routes.go
+++ b/internal/api/server/routes.go
@@ -153,6 +153,7 @@ func registerAPIV1Routes(router *gin.Engine, rt *core.APIRuntime) {
 		movie.WithAllowedDirs(secCfg.AllowedDirectories),
 		movie.WithPosterGen(posterGenForMovie),
 		movie.WithRequestTimeoutFn(func() time.Duration { return rt.GetAPIConfig().RequestTimeout }),
+		movie.WithHistoryRepo(deps.Repos.HistoryRepo),
 	)
 	tokenSvc := token.NewTokenService(deps.Repos.ApiTokenRepo)
 

--- a/internal/api/testkit/helpers.go
+++ b/internal/api/testkit/helpers.go
@@ -197,7 +197,7 @@ func CreateTestDeps(t *testing.T, cfg *config.Config, configFile string) *core.A
 	repos := db.Repositories()
 
 	// Initialize job queue with jobRepo for persistence
-	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, nil, nil, worker.WithActressRepo(repos.ActressRepo))
+	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, nil, nil, worker.WithActressRepo(repos.ActressRepo), worker.WithHistoryRepo(repos.HistoryRepo))
 
 	deps := &core.APIDeps{
 		CoreDeps: &commandutil.CoreDeps{

--- a/internal/models/movie.go
+++ b/internal/models/movie.go
@@ -376,7 +376,11 @@ func (MovieTag) TableName() string {
 	return "movie_tags"
 }
 
-// History represents a log of file organization operations
+// History represents a log of file organization operations.
+// History is the canonical operation-audit log read by the dashboard history
+// endpoints (GET /history, GET /history/stats). BatchFileOperation is the
+// file-move revert ledger read by the reverter; both rows are written for a
+// single successful organize through the production full workflow.
 type History struct {
 	ID           uint             `json:"id" gorm:"primaryKey"`
 	MovieID      string           `json:"movie_id" gorm:"index"`

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -311,19 +311,21 @@ func interpretApplyResult(
 		}
 		outcome.Failed = true
 		outcome.ErrorMsg = errMsg
-		auditCtx, auditCancel := historyAuditContext()
-		defer auditCancel()
-		recordHistory(auditCtx, inputs.HistoryRepo, models.History{
-			MovieID:      movie.ID,
-			BatchJobID:   jobIDPtr(inputs.JobID),
-			Operation:    models.HistoryOpOrganize,
-			OriginalPath: filePath,
-			NewPath:      nilGuardOrganizeNewPath(result),
-			Status:       models.HistoryStatusFailed,
-			ErrorMessage: errMsg,
-			DryRun:       cfg.DryRun,
-			Metadata:     organizeMetadata(inputs.OperationMode, result),
-		})
+		if result != nil && result.OrganizeResult != nil {
+			auditCtx, auditCancel := historyAuditContext()
+			defer auditCancel()
+			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+				MovieID:      movie.ID,
+				BatchJobID:   jobIDPtr(inputs.JobID),
+				Operation:    models.HistoryOpOrganize,
+				OriginalPath: filePath,
+				NewPath:      nilGuardOrganizeNewPath(result),
+				Status:       models.HistoryStatusFailed,
+				ErrorMessage: errMsg,
+				DryRun:       cfg.DryRun,
+				Metadata:     organizeMetadata(inputs.OperationMode, result),
+			})
+		}
 		return outcome
 	}
 
@@ -353,18 +355,20 @@ func interpretApplyResult(
 		cfg.OnFileOrganized(filePath)
 	}
 	outcome.Success = true
-	auditCtx, auditCancel := historyAuditContext()
-	defer auditCancel()
-	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
-		MovieID:      movie.ID,
-		BatchJobID:   jobIDPtr(inputs.JobID),
-		Operation:    models.HistoryOpOrganize,
-		OriginalPath: filePath,
-		NewPath:      nilGuardOrganizeNewPath(result),
-		Status:       models.HistoryStatusSuccess,
-		DryRun:       cfg.DryRun,
-		Metadata:     organizeMetadata(inputs.OperationMode, result),
-	})
+	if result != nil && result.OrganizeResult != nil {
+		auditCtx, auditCancel := historyAuditContext()
+		defer auditCancel()
+		recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+			MovieID:      movie.ID,
+			BatchJobID:   jobIDPtr(inputs.JobID),
+			Operation:    models.HistoryOpOrganize,
+			OriginalPath: filePath,
+			NewPath:      nilGuardOrganizeNewPath(result),
+			Status:       models.HistoryStatusSuccess,
+			DryRun:       cfg.DryRun,
+			Metadata:     organizeMetadata(inputs.OperationMode, result),
+		})
+	}
 	return outcome
 }
 

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -41,6 +41,7 @@ type applyFileOutcome struct {
 	PanicMsg  string
 	ErrorMsg  string
 	Movie     *models.Movie // updated movie after apply (nil if failed)
+	DryRun    bool          // true if apply was a dry-run
 }
 
 // Run executes the apply phase: setup errgroup → iterate files → dispatch
@@ -380,6 +381,7 @@ func applyFile(
 	outcome = applyFileOutcome{
 		FilePath: filePath,
 		MovieID:  movie.ID,
+		DryRun:   cfg.DryRun,
 	}
 
 	rc := recoveryContext{

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -313,7 +313,9 @@ func interpretApplyResult(
 		}
 		outcome.Failed = true
 		outcome.ErrorMsg = errMsg
-		auditOrganizeFailure(inputs, movie, filePath, result, applyErr, cfg)
+		if !cfg.OrganizeOptions.Skip || (result != nil && result.OrganizeResult != nil) {
+			auditOrganizeFailure(inputs, movie, filePath, result, applyErr, cfg)
+		}
 		return outcome
 	}
 

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -435,7 +435,7 @@ func trackApplyResults(inputs applyPhaseInputs, outcomes []applyFileOutcome, org
 		if o.Failed || o.Panic {
 			atomic.AddInt64(failed, 1)
 		}
-		if o.Panic && !o.Cancelled {
+		if o.Panic && !o.Cancelled && !inputs.OrganizeSkipped {
 			auditOrganizePanic(inputs, o)
 		}
 	}

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -114,17 +114,15 @@ func (p *applyPhase) Run(ctx context.Context, inputs applyPhaseInputs, cfg Apply
 	)
 
 	if err := ctx.Err(); err != nil {
+		var org, fail int64
+		trackApplyResults(inputs, outcomes, &org, &fail)
 		inputs.Lifecycle.MarkCancelled()
-		// On cancellation, skip trackResults + OnPhaseComplete + MarkOrganized/
-		// MarkCompleted — the job is cancelled, not completed. Any outcomes
-		// collected before cancellation are already reflected on the in-memory
-		// result via UpdateFileResult inside each worker goroutine.
 		return
 	}
 
 	var organized int64
 	var failed int64
-	trackApplyResults(outcomes, &organized, &failed)
+	trackApplyResults(inputs, outcomes, &organized, &failed)
 
 	orgCount := atomic.LoadInt64(&organized)
 	failCount := atomic.LoadInt64(&failed)
@@ -313,6 +311,19 @@ func interpretApplyResult(
 		}
 		outcome.Failed = true
 		outcome.ErrorMsg = errMsg
+		auditCtx, auditCancel := historyAuditContext()
+		defer auditCancel()
+		recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+			MovieID:      movie.ID,
+			BatchJobID:   jobIDPtr(inputs.JobID),
+			Operation:    models.HistoryOpOrganize,
+			OriginalPath: filePath,
+			NewPath:      nilGuardOrganizeNewPath(result),
+			Status:       models.HistoryStatusFailed,
+			ErrorMessage: errMsg,
+			DryRun:       cfg.DryRun,
+			Metadata:     organizeMetadata(inputs.OperationMode, result),
+		})
 		return outcome
 	}
 
@@ -342,6 +353,18 @@ func interpretApplyResult(
 		cfg.OnFileOrganized(filePath)
 	}
 	outcome.Success = true
+	auditCtx, auditCancel := historyAuditContext()
+	defer auditCancel()
+	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+		MovieID:      movie.ID,
+		BatchJobID:   jobIDPtr(inputs.JobID),
+		Operation:    models.HistoryOpOrganize,
+		OriginalPath: filePath,
+		NewPath:      nilGuardOrganizeNewPath(result),
+		Status:       models.HistoryStatusSuccess,
+		DryRun:       cfg.DryRun,
+		Metadata:     organizeMetadata(inputs.OperationMode, result),
+	})
 	return outcome
 }
 
@@ -423,16 +446,25 @@ func applyFile(
 // trackApplyResults processes collected applyFileOutcomes: increments counters
 // for organized/failed. The actual Updater/Broadcaster calls are already done
 // inside applyFile; this function only handles the aggregate counters.
-func trackApplyResults(outcomes []applyFileOutcome, organized *int64, failed *int64) {
+func trackApplyResults(inputs applyPhaseInputs, outcomes []applyFileOutcome, organized *int64, failed *int64) {
 	for _, o := range outcomes {
 		if o.Success {
 			atomic.AddInt64(organized, 1)
 		}
-		// Count panics as failures too. Currently setPanic() sets both Panic
-		// and Failed, so the || o.Panic is defensive — it future-proofs against
-		// changes to setPanic that might set only Panic without Failed.
 		if o.Failed || o.Panic {
 			atomic.AddInt64(failed, 1)
+		}
+		if o.Panic && !o.Cancelled {
+			auditCtx, cancel := historyAuditContext()
+			defer cancel()
+			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+				MovieID:      o.MovieID,
+				BatchJobID:   jobIDPtr(inputs.JobID),
+				Operation:    models.HistoryOpOrganize,
+				OriginalPath: o.FilePath,
+				Status:       models.HistoryStatusFailed,
+				ErrorMessage: o.PanicMsg,
+			})
 		}
 	}
 }

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -279,7 +279,7 @@ func interpretApplyResult(
 			EndedAt:       &now,
 		})
 		if isCancelled {
-			// Cancellation is not a failure: broadcast a non-failure apply event
+			auditOrganizeSuccess(inputs, movie, filePath, result, cfg)
 			// and do NOT invoke OnFileFailed, otherwise the review page records
 			// the file as failed and offers a Retry path despite the persisted
 			// result being Cancelled.
@@ -311,21 +311,7 @@ func interpretApplyResult(
 		}
 		outcome.Failed = true
 		outcome.ErrorMsg = errMsg
-		if result != nil && result.OrganizeResult != nil {
-			auditCtx, auditCancel := historyAuditContext()
-			defer auditCancel()
-			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
-				MovieID:      movie.ID,
-				BatchJobID:   jobIDPtr(inputs.JobID),
-				Operation:    models.HistoryOpOrganize,
-				OriginalPath: filePath,
-				NewPath:      nilGuardOrganizeNewPath(result),
-				Status:       models.HistoryStatusFailed,
-				ErrorMessage: errMsg,
-				DryRun:       cfg.DryRun,
-				Metadata:     organizeMetadata(inputs.OperationMode, result),
-			})
-		}
+		auditOrganizeFailure(inputs, movie, filePath, result, errMsg, cfg)
 		return outcome
 	}
 
@@ -355,20 +341,7 @@ func interpretApplyResult(
 		cfg.OnFileOrganized(filePath)
 	}
 	outcome.Success = true
-	if result != nil && result.OrganizeResult != nil {
-		auditCtx, auditCancel := historyAuditContext()
-		defer auditCancel()
-		recordHistory(auditCtx, inputs.HistoryRepo, models.History{
-			MovieID:      movie.ID,
-			BatchJobID:   jobIDPtr(inputs.JobID),
-			Operation:    models.HistoryOpOrganize,
-			OriginalPath: filePath,
-			NewPath:      nilGuardOrganizeNewPath(result),
-			Status:       models.HistoryStatusSuccess,
-			DryRun:       cfg.DryRun,
-			Metadata:     organizeMetadata(inputs.OperationMode, result),
-		})
-	}
+	auditOrganizeSuccess(inputs, movie, filePath, result, cfg)
 	return outcome
 }
 
@@ -459,16 +432,7 @@ func trackApplyResults(inputs applyPhaseInputs, outcomes []applyFileOutcome, org
 			atomic.AddInt64(failed, 1)
 		}
 		if o.Panic && !o.Cancelled {
-			auditCtx, cancel := historyAuditContext()
-			defer cancel()
-			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
-				MovieID:      o.MovieID,
-				BatchJobID:   jobIDPtr(inputs.JobID),
-				Operation:    models.HistoryOpOrganize,
-				OriginalPath: o.FilePath,
-				Status:       models.HistoryStatusFailed,
-				ErrorMessage: o.PanicMsg,
-			})
+			auditOrganizePanic(inputs, o)
 		}
 	}
 }

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -311,7 +311,7 @@ func interpretApplyResult(
 		}
 		outcome.Failed = true
 		outcome.ErrorMsg = errMsg
-		auditOrganizeFailure(inputs, movie, filePath, result, errMsg, cfg)
+		auditOrganizeFailure(inputs, movie, filePath, result, applyErr, cfg)
 		return outcome
 	}
 

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -279,7 +279,9 @@ func interpretApplyResult(
 			EndedAt:       &now,
 		})
 		if isCancelled {
-			auditOrganizeSuccess(inputs, movie, filePath, result, cfg)
+			if result != nil && result.OrganizeResult != nil {
+				auditOrganizeSuccess(inputs, movie, filePath, result, cfg)
+			}
 			// and do NOT invoke OnFileFailed, otherwise the review page records
 			// the file as failed and offers a Retry path despite the persisted
 			// result being Cancelled.

--- a/internal/worker/batch_job.go
+++ b/internal/worker/batch_job.go
@@ -161,7 +161,7 @@ func newBatchJob(files []string, jobCfg ...*JobConfig) *BatchJob {
 
 	// Per P-2: wireJobDeps centralizes attachLifecycleCallback, posterEditor,
 	// controller, and PersistFn wiring shared with reconstructBatchJob.
-	wireJobDeps(job, nil, nil, nil)
+	wireJobDeps(job, nil, nil, nil, nil)
 
 	if len(jobCfg) > 0 && jobCfg[0] != nil {
 		cfg := jobCfg[0]

--- a/internal/worker/history_audit_matrix_test.go
+++ b/internal/worker/history_audit_matrix_test.go
@@ -1,0 +1,274 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/scrape"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditMatrix_Scrape(t *testing.T) {
+	type testCase struct {
+		name       string
+		outcome    scrapeFileOutcome
+		recorded   map[string]bool
+		wantRows   int
+		wantStatus models.HistoryStatus
+		wantOp     models.HistoryOperation
+	}
+
+	cases := []testCase{
+		{
+			name:     "success not persisted (pre-cancel): one success row",
+			outcome:  scrapeFileOutcome{FilePath: "/in/a.mp4", MovieID: "A-001", Success: true, Result: &scrape.ScrapeResult{Movie: &models.Movie{ID: "A-001"}, Status: scrape.StatusCompleted}},
+			recorded: nil,
+			wantRows: 1, wantStatus: models.HistoryStatusSuccess, wantOp: models.HistoryOpScrape,
+		},
+		{
+			name:     "success already persisted: no row from track",
+			outcome:  scrapeFileOutcome{FilePath: "/in/b.mp4", MovieID: "B-001", Success: true, Result: &scrape.ScrapeResult{Movie: &models.Movie{ID: "B-001"}, Status: scrape.StatusCompleted}},
+			recorded: map[string]bool{"/in/b.mp4": true},
+			wantRows: 0,
+		},
+		{
+			name:     "scraper failure: one failed row",
+			outcome:  scrapeFileOutcome{FilePath: "/in/c.mp4", MovieID: "C-001", Failed: true, ErrorMsg: "no results"},
+			recorded: nil,
+			wantRows: 1, wantStatus: models.HistoryStatusFailed, wantOp: models.HistoryOpScrape,
+		},
+		{
+			name:     "scraper panic: one failed row",
+			outcome:  scrapeFileOutcome{FilePath: "/in/d.mp4", MovieID: "D-001", Panic: true, PanicMsg: "boom"},
+			recorded: nil,
+			wantRows: 1, wantStatus: models.HistoryStatusFailed, wantOp: models.HistoryOpScrape,
+		},
+		{
+			name:     "cancellation: no row",
+			outcome:  scrapeFileOutcome{FilePath: "/in/e.mp4", MovieID: "E-001", Failed: true, Cancelled: true, ErrorMsg: "canceled"},
+			recorded: nil,
+			wantRows: 0,
+		},
+		{
+			name:     "success + cancellation: no row (cancelled)",
+			outcome:  scrapeFileOutcome{FilePath: "/in/f.mp4", MovieID: "F-001", Success: true, Cancelled: true},
+			recorded: nil,
+			wantRows: 0,
+		},
+		{
+			name:     "success no result movie: no row",
+			outcome:  scrapeFileOutcome{FilePath: "/in/g.mp4", MovieID: "G-001", Success: true, Result: &scrape.ScrapeResult{Movie: nil}},
+			recorded: nil,
+			wantRows: 0,
+		},
+		{
+			name:     "panic takes precedence over failed",
+			outcome:  scrapeFileOutcome{FilePath: "/in/h.mp4", MovieID: "H-001", Panic: true, Failed: true, PanicMsg: "panic", ErrorMsg: "error"},
+			recorded: nil,
+			wantRows: 1, wantStatus: models.HistoryStatusFailed, wantOp: models.HistoryOpScrape,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newHistoryTestDB(t)
+			repos := db.Repositories()
+			inputs := scrapePhaseInputs{JobID: "matrix-job", HistoryRepo: repos.HistoryRepo}
+			trackScrapeResults(inputs, []scrapeFileOutcome{tc.outcome}, tc.recorded)
+			records, err := repos.HistoryRepo.FindByBatchJobID(context.Background(), "matrix-job")
+			require.NoError(t, err)
+			assert.Len(t, records, tc.wantRows)
+			if tc.wantRows == 1 {
+				assert.Equal(t, tc.wantStatus, records[0].Status)
+				assert.Equal(t, tc.wantOp, records[0].Operation)
+				assert.Equal(t, tc.outcome.FilePath, records[0].OriginalPath)
+			}
+		})
+	}
+}
+
+func TestAuditMatrix_Organize(t *testing.T) {
+	type testCase struct {
+		name         string
+		outcome      applyFileOutcome
+		skipOrganize bool
+		result       *workflow.ApplyResult
+		applyErr     error
+		wantRows     int
+		wantStatus   models.HistoryStatus
+		wantNewPath  string
+	}
+
+	organizeResult := &workflow.ApplyResult{
+		OrganizeResult: &organizer.OrganizeResult{NewPath: "/out/movie.mp4"},
+	}
+
+	cases := []testCase{
+		{
+			name:     "success with organize result: one success row with NewPath",
+			outcome:  applyFileOutcome{FilePath: "/in/a.mp4", MovieID: "A-001", Success: true},
+			result:   organizeResult,
+			wantRows: 1, wantStatus: models.HistoryStatusSuccess, wantNewPath: "/out/movie.mp4",
+		},
+		{
+			name:     "success without organize result (metadata-artwork): no row",
+			outcome:  applyFileOutcome{FilePath: "/in/b.mp4", MovieID: "B-001", Success: true},
+			result:   &workflow.ApplyResult{},
+			wantRows: 0,
+		},
+		{
+			name:     "failure with organize result: one failed row",
+			outcome:  applyFileOutcome{FilePath: "/in/c.mp4", MovieID: "C-001", Failed: true, ErrorMsg: "apply failed"},
+			result:   organizeResult,
+			applyErr: errors.New("apply failed"),
+			wantRows: 1, wantStatus: models.HistoryStatusFailed,
+		},
+		{
+			name:         "failure without organize result (organize skipped): no row",
+			outcome:      applyFileOutcome{FilePath: "/in/d.mp4", MovieID: "D-001", Failed: true, ErrorMsg: "download failed"},
+			skipOrganize: true,
+			result:       &workflow.ApplyResult{},
+			applyErr:     errors.New("download failed"),
+			wantRows:     0,
+		},
+		{
+			name:     "cancellation: no row",
+			outcome:  applyFileOutcome{FilePath: "/in/e.mp4", MovieID: "E-001", Cancelled: true, ErrorMsg: "canceled"},
+			result:   &workflow.ApplyResult{},
+			applyErr: context.Canceled,
+			wantRows: 0,
+		},
+		{
+			name:     "cancellation with organize result (moved then cancelled): one success row",
+			outcome:  applyFileOutcome{FilePath: "/in/f.mp4", MovieID: "F-001", Cancelled: true},
+			result:   organizeResult,
+			applyErr: context.Canceled,
+			wantRows: 1, wantStatus: models.HistoryStatusSuccess, wantNewPath: "/out/movie.mp4",
+		},
+		{
+			name:     "panic with organize enabled: one failed row from trackApplyResults",
+			outcome:  applyFileOutcome{FilePath: "/in/g.mp4", MovieID: "G-001", Panic: true, Failed: true, PanicMsg: "boom"},
+			wantRows: 1, wantStatus: models.HistoryStatusFailed,
+		},
+		{
+			name:         "panic with organize skipped: no row",
+			outcome:      applyFileOutcome{FilePath: "/in/h.mp4", MovieID: "H-001", Panic: true, Failed: true, PanicMsg: "boom"},
+			skipOrganize: true,
+			wantRows:     0,
+		},
+		{
+			name:     "nil result on success path: no row",
+			outcome:  applyFileOutcome{FilePath: "/in/i.mp4", MovieID: "I-001", Success: true},
+			result:   nil,
+			wantRows: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newHistoryTestDB(t)
+			repos := db.Repositories()
+			inputs := applyPhaseInputs{
+				JobID:           "matrix-org-job",
+				HistoryRepo:     repos.HistoryRepo,
+				OrganizeSkipped: tc.skipOrganize,
+				OperationMode:   "organize",
+			}
+			movie := &models.Movie{ID: tc.outcome.MovieID, Title: "Test"}
+			cfg := ApplyPhaseConfig{}
+
+			// Simulate interpretApplyResult's history decision
+			if tc.outcome.Success {
+				auditOrganizeSuccess(inputs, movie, tc.outcome.FilePath, tc.result, cfg)
+			} else if tc.outcome.Failed && !tc.outcome.Cancelled && !tc.outcome.Panic {
+				if !tc.skipOrganize || (tc.result != nil && tc.result.OrganizeResult != nil) {
+					auditOrganizeFailure(inputs, movie, tc.outcome.FilePath, tc.result, tc.applyErr, cfg)
+				}
+			} else if tc.outcome.Cancelled && tc.result != nil && tc.result.OrganizeResult != nil {
+				auditOrganizeSuccess(inputs, movie, tc.outcome.FilePath, tc.result, cfg)
+			}
+
+			// Simulate trackApplyResults panic decision
+			if tc.outcome.Panic && !tc.outcome.Cancelled && !tc.skipOrganize {
+				auditOrganizePanic(inputs, tc.outcome)
+			}
+
+			records, err := repos.HistoryRepo.FindByBatchJobID(context.Background(), "matrix-org-job")
+			require.NoError(t, err)
+			assert.Len(t, records, tc.wantRows)
+			if tc.wantRows == 1 {
+				assert.Equal(t, tc.wantStatus, records[0].Status)
+				assert.Equal(t, models.HistoryOpOrganize, records[0].Operation)
+				if tc.wantNewPath != "" {
+					assert.Equal(t, tc.wantNewPath, records[0].NewPath)
+				}
+			}
+		})
+	}
+}
+
+func TestAuditMatrix_Rescrape(t *testing.T) {
+	type testCase struct {
+		name       string
+		err        error
+		wantRows   int
+		wantStatus models.HistoryStatus
+	}
+
+	cases := []testCase{
+		{
+			name:     "success: one success row",
+			err:      nil,
+			wantRows: 1, wantStatus: models.HistoryStatusSuccess,
+		},
+		{
+			name:     "scraper failure: one failed row",
+			err:      errors.New("scraper error"),
+			wantRows: 1, wantStatus: models.HistoryStatusFailed,
+		},
+		{
+			name:     "cancellation: no row",
+			err:      context.Canceled,
+			wantRows: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newHistoryTestDB(t)
+			repos := db.Repositories()
+			inputs := rescrapePhaseInputs{JobID: "matrix-rescrape-job", HistoryRepo: repos.HistoryRepo}
+
+			if tc.err == nil {
+				auditRescrapeSuccess(inputs, "R-001", "/in/r.mp4")
+			} else {
+				auditRescrapeFailure(inputs, "R-001", "/in/r.mp4", tc.err)
+			}
+
+			records, err := repos.HistoryRepo.FindByBatchJobID(context.Background(), "matrix-rescrape-job")
+			require.NoError(t, err)
+			assert.Len(t, records, tc.wantRows)
+			if tc.wantRows == 1 {
+				assert.Equal(t, tc.wantStatus, records[0].Status)
+				assert.Equal(t, models.HistoryOpScrape, records[0].Operation)
+			}
+		})
+	}
+}
+
+func TestAuditMatrix_CreateError_LogAndContinue(t *testing.T) {
+	repo := &failingHistoryRepo{err: errors.New("db down")}
+	assert.NotPanics(t, func() {
+		recordHistory(context.Background(), repo, models.History{
+			MovieID:   "ERR-001",
+			Operation: models.HistoryOpScrape,
+			Status:    models.HistoryStatusSuccess,
+		})
+	})
+	assert.Equal(t, 1, repo.callCount)
+}

--- a/internal/worker/history_audit_matrix_test.go
+++ b/internal/worker/history_audit_matrix_test.go
@@ -212,6 +212,11 @@ func TestAuditMatrix_Organize(t *testing.T) {
 				if tc.wantNewPath != "" {
 					assert.Equal(t, tc.wantNewPath, records[0].NewPath)
 				}
+				if tc.outcome.Panic {
+					assert.Equal(t, tc.outcome.PanicMsg, records[0].ErrorMessage)
+				} else if tc.outcome.Failed {
+					assert.Equal(t, tc.outcome.ErrorMsg, records[0].ErrorMessage)
+				}
 			}
 		})
 	}

--- a/internal/worker/history_audit_matrix_test.go
+++ b/internal/worker/history_audit_matrix_test.go
@@ -87,6 +87,11 @@ func TestAuditMatrix_Scrape(t *testing.T) {
 				assert.Equal(t, tc.wantStatus, records[0].Status)
 				assert.Equal(t, tc.wantOp, records[0].Operation)
 				assert.Equal(t, tc.outcome.FilePath, records[0].OriginalPath)
+				if tc.outcome.Panic {
+					assert.Equal(t, tc.outcome.PanicMsg, records[0].ErrorMessage)
+				} else if tc.outcome.Failed {
+					assert.Equal(t, tc.outcome.ErrorMsg, records[0].ErrorMessage)
+				}
 			}
 		})
 	}

--- a/internal/worker/history_coverage_test.go
+++ b/internal/worker/history_coverage_test.go
@@ -1,0 +1,73 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuditCoverage_OrganizeFailureWithURLInError(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	inputs := applyPhaseInputs{JobID: "cov-job", HistoryRepo: repos.HistoryRepo, OperationMode: "organize"}
+	movie := &models.Movie{ID: "COV-001"}
+	result := &workflow.ApplyResult{}
+	auditOrganizeFailure(inputs, movie, "/in/cov.mp4", result, context.DeadlineExceeded, ApplyPhaseConfig{})
+	records, err := repos.HistoryRepo.FindByMovieID(context.Background(), "COV-001")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, records)
+}
+
+func TestAuditCoverage_OrganizeFailureWithURLErrorMessage(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	inputs := applyPhaseInputs{JobID: "cov-url-job", HistoryRepo: repos.HistoryRepo, OperationMode: "organize"}
+	movie := &models.Movie{ID: "COV-002"}
+	result := &workflow.ApplyResult{}
+	auditOrganizeFailure(inputs, movie, "/in/cov.mp4", result, newURLError("https://alice:secret@example.com/path"), ApplyPhaseConfig{})
+	records, err := repos.HistoryRepo.FindByMovieID(context.Background(), "COV-002")
+	assert.NoError(t, err)
+	if len(records) > 0 {
+		assert.NotContains(t, records[0].ErrorMessage, "alice")
+		assert.NotContains(t, records[0].ErrorMessage, "secret")
+	}
+}
+
+func TestAuditCoverage_ScrapeFailureEmptyErrMsg(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	inputs := scrapePhaseInputs{JobID: "cov-empty-job", HistoryRepo: repos.HistoryRepo}
+	o := scrapeFileOutcome{FilePath: "/in/empty.mp4", MovieID: "EMPTY-001", Failed: true, ErrorMsg: ""}
+	auditScrapeFailure(inputs, o)
+	records, err := repos.HistoryRepo.FindByBatchJobID(context.Background(), "cov-empty-job")
+	assert.NoError(t, err)
+	assert.Empty(t, records, "empty errMsg with Failed but no Panic should not write a row")
+}
+
+func TestAuditCoverage_RescrapeFailureCancellation(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	inputs := rescrapePhaseInputs{JobID: "cov-rescrape-job", HistoryRepo: repos.HistoryRepo}
+	auditRescrapeFailure(inputs, "R-001", "/in/r.mp4", context.Canceled)
+	records, err := repos.HistoryRepo.FindByBatchJobID(context.Background(), "cov-rescrape-job")
+	assert.NoError(t, err)
+	assert.Empty(t, records, "cancellation should not write a row")
+}
+
+func TestAuditCoverage_OrganizeMetadataMarshalError(t *testing.T) {
+	result := &workflow.ApplyResult{FailedStep: "download"}
+	meta := organizeMetadata("organize", result)
+	assert.Contains(t, meta, "organize")
+	assert.Contains(t, meta, "operation_mode")
+}
+
+type urlError struct {
+	msg string
+}
+
+func (e *urlError) Error() string { return e.msg }
+
+func newURLError(msg string) error { return &urlError{msg: msg} }

--- a/internal/worker/history_integration_test.go
+++ b/internal/worker/history_integration_test.go
@@ -1,0 +1,223 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/scrape"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHistoryIntegration_ScrapeSuccessWritesRow(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	repo := repos.HistoryRepo
+	movieRepo := repos.MovieRepo
+
+	movie := &models.Movie{ID: "ABC-001", Title: "Test Movie"}
+	_, err := movieRepo.Upsert(context.Background(), movie)
+	require.NoError(t, err)
+
+	o := scrapeFileOutcome{
+		FilePath: "/input/ABC-001.mp4",
+		MovieID:  "ABC-001",
+		Success:  true,
+		Result: &scrape.ScrapeResult{
+			Movie:  movie,
+			Status: scrape.StatusCompleted,
+		},
+	}
+	inputs := scrapePhaseInputs{
+		JobID:       "job-1",
+		MovieRepo:   movieRepo,
+		HistoryRepo: repo,
+		Updater:     resultstore.New(1, []string{"/input/ABC-001.mp4"}),
+	}
+	persistScrapeOutcome(context.Background(), o, inputs, nil)
+
+	records, err := repo.FindByBatchJobID(context.Background(), "job-1")
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, models.HistoryOpScrape, records[0].Operation)
+	assert.Equal(t, models.HistoryStatusSuccess, records[0].Status)
+	assert.Equal(t, "ABC-001", records[0].MovieID)
+	assert.Equal(t, "/input/ABC-001.mp4", records[0].OriginalPath)
+}
+
+func TestHistoryIntegration_ScrapeFailureWritesFailedRow(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	repo := repos.HistoryRepo
+
+	outcomes := []scrapeFileOutcome{
+		{FilePath: "/input/FAIL-001.mp4", MovieID: "FAIL-001", Failed: true, ErrorMsg: "no results"},
+		{FilePath: "/input/BOOM-001.mp4", MovieID: "BOOM-001", Panic: true, PanicMsg: "goroutine panic"},
+	}
+	trackScrapeResults(scrapePhaseInputs{JobID: "job-2", HistoryRepo: repo}, outcomes)
+
+	records, err := repo.FindByBatchJobID(context.Background(), "job-2")
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	for _, r := range records {
+		assert.Equal(t, models.HistoryOpScrape, r.Operation)
+		assert.Equal(t, models.HistoryStatusFailed, r.Status)
+	}
+}
+
+func TestHistoryIntegration_ScrapeCancelledNotWritten(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	repo := repos.HistoryRepo
+
+	outcomes := []scrapeFileOutcome{
+		{FilePath: "/input/CAN-001.mp4", MovieID: "CAN-001", Failed: true, Cancelled: true, ErrorMsg: "canceled"},
+		{FilePath: "/input/ERR-001.mp4", MovieID: "ERR-001", Failed: true, ErrorMsg: "real error"},
+	}
+	trackScrapeResults(scrapePhaseInputs{JobID: "job-3", HistoryRepo: repo}, outcomes)
+
+	records, err := repo.FindByBatchJobID(context.Background(), "job-3")
+	require.NoError(t, err)
+	require.Len(t, records, 1, "cancelled outcome must not produce a row")
+	assert.Equal(t, "ERR-001", records[0].MovieID)
+}
+
+func TestHistoryIntegration_OrganizePanicWritesFromTrackApply(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	repo := repos.HistoryRepo
+
+	outcomes := []applyFileOutcome{
+		{FilePath: "/input/ABC-001.mp4", MovieID: "ABC-001", Panic: true, Failed: true, PanicMsg: "boom"},
+		{FilePath: "/input/ABC-002.mp4", MovieID: "ABC-002", Failed: true, ErrorMsg: "apply error"},
+		{FilePath: "/input/ABC-003.mp4", MovieID: "ABC-003", Success: true},
+	}
+	var org, fail int64
+	trackApplyResults(applyPhaseInputs{JobID: "job-4", HistoryRepo: repo}, outcomes, &org, &fail)
+
+	records, err := repo.FindByBatchJobID(context.Background(), "job-4")
+	require.NoError(t, err)
+	require.Len(t, records, 1, "only panic outcome should be written, not failed or success")
+	assert.Equal(t, "ABC-001", records[0].MovieID)
+	assert.Equal(t, models.HistoryOpOrganize, records[0].Operation)
+	assert.Equal(t, models.HistoryStatusFailed, records[0].Status)
+}
+
+func TestHistoryReconstruction_JobStoreRehydratesHistoryRepo(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+
+	jq := NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, "", nil, nil,
+		WithHistoryRepo(repos.HistoryRepo),
+	)
+	job := jq.CreateJobBatch([]string{"file1.mp4"})
+	require.NotNil(t, job.deps.HistoryRepo)
+
+	job.deps.HistoryRepo = nil
+	jq.SetReconstructionDeps(nil, nil, BatchJobConfig{})
+	assert.NotNil(t, job.deps.HistoryRepo, "SetReconstructionDeps must rehydrate HistoryRepo")
+}
+
+func TestHistoryConcurrency_MultiFileScrapeRace(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	repo := repos.HistoryRepo
+
+	const fileCount = 10
+	outcomes := make([]scrapeFileOutcome, fileCount)
+	for i := 0; i < fileCount; i++ {
+		outcomes[i] = scrapeFileOutcome{
+			FilePath: fmt.Sprintf("/input/file-%d.mp4", i),
+			MovieID:  fmt.Sprintf("MOV-%03d", i),
+			Failed:   true,
+			ErrorMsg: "test error",
+		}
+	}
+	trackScrapeResults(scrapePhaseInputs{JobID: "race-job", HistoryRepo: repo}, outcomes)
+
+	records, err := repo.FindByBatchJobID(context.Background(), "race-job")
+	require.NoError(t, err)
+	assert.Equal(t, fileCount, len(records), "all failed outcomes should produce rows")
+}
+
+func TestHistoryTimeoutContext_WriteSucceedsWithAuditContext(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	repo := repos.HistoryRepo
+
+	auditCtx, auditCancel := historyAuditContext()
+	defer auditCancel()
+
+	recordHistory(auditCtx, repo, models.History{
+		MovieID:      "TIMEOUT-001",
+		BatchJobID:   strPtrHist("timeout-job"),
+		Operation:    models.HistoryOpOrganize,
+		OriginalPath: "/input/TIMEOUT-001.mp4",
+		Status:       models.HistoryStatusFailed,
+		ErrorMessage: "apply timed out",
+	})
+
+	records, err := repo.FindByMovieID(context.Background(), "TIMEOUT-001")
+	require.NoError(t, err)
+	require.Len(t, records, 1, "audit context must succeed even when the worker ctx would be expired")
+	assert.Equal(t, models.HistoryStatusFailed, records[0].Status)
+}
+
+func TestHistoryMultipart_TwoPartMovieWritesTwoRowsPerOperation(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	repo := repos.HistoryRepo
+	movieRepo := repos.MovieRepo
+
+	movie := &models.Movie{ID: "MULTI-001", Title: "Multipart Movie"}
+	_, err := movieRepo.Upsert(context.Background(), movie)
+	require.NoError(t, err)
+
+	inputs := scrapePhaseInputs{
+		JobID:       "multi-job",
+		MovieRepo:   movieRepo,
+		HistoryRepo: repo,
+		Updater:     resultstore.New(2, []string{"/input/MULTI-001-pt1.mp4", "/input/MULTI-001-pt2.mp4"}),
+	}
+	for _, part := range []string{"pt1", "pt2"} {
+		o := scrapeFileOutcome{
+			FilePath: fmt.Sprintf("/input/MULTI-001-%s.mp4", part),
+			MovieID:  "MULTI-001",
+			Success:  true,
+			Result: &scrape.ScrapeResult{
+				Movie:  movie.Clone(),
+				Status: scrape.StatusCompleted,
+			},
+		}
+		persistScrapeOutcome(context.Background(), o, inputs, nil)
+	}
+
+	records, err := repo.FindByBatchJobID(context.Background(), "multi-job")
+	require.NoError(t, err)
+	require.Len(t, records, 2, "two-part movie should produce two scrape rows")
+	for _, r := range records {
+		assert.Equal(t, "MULTI-001", r.MovieID, "both rows share the same MovieID")
+		assert.NotEqual(t, "", r.OriginalPath, "each row has a distinct OriginalPath")
+	}
+	paths := []string{records[0].OriginalPath, records[1].OriginalPath}
+	assert.NotEqual(t, paths[0], paths[1], "paths must be distinct")
+}
+
+func TestHistoryOrganizeMetadata_IncludesOperationMode(t *testing.T) {
+	result := &workflow.ApplyResult{
+		OrganizeResult: &organizer.OrganizeResult{NewPath: "/dest/movie.mp4"},
+	}
+	meta := organizeMetadata("in-place", result)
+	assert.Contains(t, meta, "in-place")
+	assert.Contains(t, meta, "operation_mode")
+}
+
+func strPtrHist(s string) *string { return &s }
+
+var _ = time.Second

--- a/internal/worker/history_integration_test.go
+++ b/internal/worker/history_integration_test.go
@@ -245,12 +245,39 @@ func TestHistoryCardinality_PersistedSuccessExactlyOneRow(t *testing.T) {
 		},
 	}
 
-	persistScrapeOutcome(context.Background(), o, inputs, nil)
-	trackScrapeResults(inputs, []scrapeFileOutcome{o}, map[string]bool{o.FilePath: true})
+	recorded := persistScrapeOutcomePool(context.Background(), []scrapeFileOutcome{o}, inputs, nil)
+	trackScrapeResults(inputs, []scrapeFileOutcome{o}, recorded)
 
 	records, err := repo.FindByBatchJobID(context.Background(), "card-job")
 	require.NoError(t, err)
-	assert.Len(t, records, 1, "persist + track must produce exactly one success row")
+	assert.Len(t, records, 1, "persist pool + track must produce exactly one success row")
+	if len(records) == 1 {
+		assert.Equal(t, models.HistoryStatusSuccess, records[0].Status)
+	}
+}
+
+func TestHistoryCardinality_PrePersistCancelAuditsSuccess(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	repo := repos.HistoryRepo
+
+	inputs := scrapePhaseInputs{
+		JobID:       "card-cancel-job",
+		HistoryRepo: repo,
+	}
+
+	o := scrapeFileOutcome{
+		FilePath: "/input/CARD-002.mp4",
+		MovieID:  "CARD-002",
+		Success:  true,
+		Result:   &scrape.ScrapeResult{Movie: &models.Movie{ID: "CARD-002"}, Status: scrape.StatusCompleted},
+	}
+
+	trackScrapeResults(inputs, []scrapeFileOutcome{o}, nil)
+
+	records, err := repo.FindByBatchJobID(context.Background(), "card-cancel-job")
+	require.NoError(t, err)
+	assert.Len(t, records, 1, "pre-persist cancel must audit one success row via trackScrapeResults(nil)")
 	if len(records) == 1 {
 		assert.Equal(t, models.HistoryStatusSuccess, records[0].Status)
 	}

--- a/internal/worker/history_integration_test.go
+++ b/internal/worker/history_integration_test.go
@@ -60,7 +60,7 @@ func TestHistoryIntegration_ScrapeFailureWritesFailedRow(t *testing.T) {
 		{FilePath: "/input/FAIL-001.mp4", MovieID: "FAIL-001", Failed: true, ErrorMsg: "no results"},
 		{FilePath: "/input/BOOM-001.mp4", MovieID: "BOOM-001", Panic: true, PanicMsg: "goroutine panic"},
 	}
-	trackScrapeResults(scrapePhaseInputs{JobID: "job-2", HistoryRepo: repo}, outcomes)
+	trackScrapeResults(scrapePhaseInputs{JobID: "job-2", HistoryRepo: repo}, outcomes, nil)
 
 	records, err := repo.FindByBatchJobID(context.Background(), "job-2")
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestHistoryIntegration_ScrapeCancelledNotWritten(t *testing.T) {
 		{FilePath: "/input/CAN-001.mp4", MovieID: "CAN-001", Failed: true, Cancelled: true, ErrorMsg: "canceled"},
 		{FilePath: "/input/ERR-001.mp4", MovieID: "ERR-001", Failed: true, ErrorMsg: "real error"},
 	}
-	trackScrapeResults(scrapePhaseInputs{JobID: "job-3", HistoryRepo: repo}, outcomes)
+	trackScrapeResults(scrapePhaseInputs{JobID: "job-3", HistoryRepo: repo}, outcomes, nil)
 
 	records, err := repo.FindByBatchJobID(context.Background(), "job-3")
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestHistoryConcurrency_MultiFileScrapeRace(t *testing.T) {
 			ErrorMsg: "test error",
 		}
 	}
-	trackScrapeResults(scrapePhaseInputs{JobID: "race-job", HistoryRepo: repo}, outcomes)
+	trackScrapeResults(scrapePhaseInputs{JobID: "race-job", HistoryRepo: repo}, outcomes, nil)
 
 	records, err := repo.FindByBatchJobID(context.Background(), "race-job")
 	require.NoError(t, err)
@@ -216,6 +216,44 @@ func TestHistoryOrganizeMetadata_IncludesOperationMode(t *testing.T) {
 	meta := organizeMetadata("in-place", result)
 	assert.Contains(t, meta, "in-place")
 	assert.Contains(t, meta, "operation_mode")
+}
+
+func TestHistoryCardinality_PersistedSuccessExactlyOneRow(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	repo := repos.HistoryRepo
+	movieRepo := repos.MovieRepo
+
+	movie := &models.Movie{ID: "CARD-001", Title: "Cardinality Test"}
+	_, err := movieRepo.Upsert(context.Background(), movie)
+	require.NoError(t, err)
+
+	inputs := scrapePhaseInputs{
+		JobID:       "card-job",
+		MovieRepo:   movieRepo,
+		HistoryRepo: repo,
+		Updater:     resultstore.New(1, []string{"/input/CARD-001.mp4"}),
+	}
+
+	o := scrapeFileOutcome{
+		FilePath: "/input/CARD-001.mp4",
+		MovieID:  "CARD-001",
+		Success:  true,
+		Result: &scrape.ScrapeResult{
+			Movie:  movie.Clone(),
+			Status: scrape.StatusCompleted,
+		},
+	}
+
+	persistScrapeOutcome(context.Background(), o, inputs, nil)
+	trackScrapeResults(inputs, []scrapeFileOutcome{o}, map[string]bool{o.FilePath: true})
+
+	records, err := repo.FindByBatchJobID(context.Background(), "card-job")
+	require.NoError(t, err)
+	assert.Len(t, records, 1, "persist + track must produce exactly one success row")
+	if len(records) == 1 {
+		assert.Equal(t, models.HistoryStatusSuccess, records[0].Status)
+	}
 }
 
 func strPtrHist(s string) *string { return &s }

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -127,11 +127,11 @@ func auditOrganizeSuccess(inputs applyPhaseInputs, movie *models.Movie, filePath
 // auditOrganizeFailure writes a failed organize history row for non-cancellation failures.
 // Called from interpretApplyResult when applyErr is non-nil and not context.Canceled.
 // Writes regardless of whether OrganizeResult exists — organize was requested and failed.
-func auditOrganizeFailure(inputs applyPhaseInputs, movie *models.Movie, filePath string, result *workflow.ApplyResult, errMsg string, cfg ApplyPhaseConfig) {
+func auditOrganizeFailure(inputs applyPhaseInputs, movie *models.Movie, filePath string, result *workflow.ApplyResult, applyErr error, cfg ApplyPhaseConfig) {
 	if inputs.HistoryRepo == nil {
 		return
 	}
-	if errors.Is(errors.New(errMsg), context.Canceled) {
+	if applyErr != nil && errors.Is(applyErr, context.Canceled) {
 		return
 	}
 	auditCtx, cancel := historyAuditContext()
@@ -143,7 +143,7 @@ func auditOrganizeFailure(inputs applyPhaseInputs, movie *models.Movie, filePath
 		OriginalPath: filePath,
 		NewPath:      nilGuardOrganizeNewPath(result),
 		Status:       models.HistoryStatusFailed,
-		ErrorMessage: errMsg,
+		ErrorMessage: applyErr.Error(),
 		DryRun:       cfg.DryRun,
 		Metadata:     organizeMetadata(inputs.OperationMode, result),
 	})

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/javinizer/javinizer-go/internal/database"
@@ -55,4 +56,151 @@ func organizeMetadata(mode string, result *workflow.ApplyResult) string {
 
 func historyAuditContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), 5*time.Second)
+}
+
+// auditScrapeFailure writes a failed scrape history row for a non-cancellation error or panic.
+// It is called from trackScrapeResults for outcomes that were NOT handled by persistScrapeOutcome.
+func auditScrapeFailure(inputs scrapePhaseInputs, o scrapeFileOutcome) {
+	if inputs.HistoryRepo == nil || o.Cancelled {
+		return
+	}
+	auditCtx, cancel := historyAuditContext()
+	defer cancel()
+	errMsg := o.ErrorMsg
+	if o.Panic {
+		errMsg = o.PanicMsg
+	}
+	if errMsg == "" && !o.Failed && !o.Panic {
+		return
+	}
+	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+		MovieID:      o.MovieID,
+		BatchJobID:   jobIDPtr(inputs.JobID),
+		Operation:    models.HistoryOpScrape,
+		OriginalPath: o.FilePath,
+		Status:       models.HistoryStatusFailed,
+		ErrorMessage: errMsg,
+	})
+}
+
+// auditScrapeSuccess writes a success scrape history row for outcomes NOT already handled by persist.
+// Called from trackScrapeResults when recordedSuccesses does not contain the file path.
+func auditScrapeSuccess(inputs scrapePhaseInputs, o scrapeFileOutcome) {
+	if inputs.HistoryRepo == nil || o.Cancelled || !o.Success {
+		return
+	}
+	if o.Result == nil || o.Result.Movie == nil {
+		return
+	}
+	auditCtx, cancel := historyAuditContext()
+	defer cancel()
+	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+		MovieID:      o.Result.Movie.ID,
+		BatchJobID:   jobIDPtr(inputs.JobID),
+		Operation:    models.HistoryOpScrape,
+		OriginalPath: o.FilePath,
+		Status:       models.HistoryStatusSuccess,
+	})
+}
+
+// auditOrganizeSuccess writes a success organize history row.
+// Only called when organize actually ran (result.OrganizeResult != nil) or when organizing
+// was cancelled after a partial move (OrganizeResult exists despite context.Canceled).
+func auditOrganizeSuccess(inputs applyPhaseInputs, movie *models.Movie, filePath string, result *workflow.ApplyResult, cfg ApplyPhaseConfig) {
+	if inputs.HistoryRepo == nil || result == nil || result.OrganizeResult == nil {
+		return
+	}
+	auditCtx, cancel := historyAuditContext()
+	defer cancel()
+	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+		MovieID:      movie.ID,
+		BatchJobID:   jobIDPtr(inputs.JobID),
+		Operation:    models.HistoryOpOrganize,
+		OriginalPath: filePath,
+		NewPath:      result.OrganizeResult.NewPath,
+		Status:       models.HistoryStatusSuccess,
+		DryRun:       cfg.DryRun,
+		Metadata:     organizeMetadata(inputs.OperationMode, result),
+	})
+}
+
+// auditOrganizeFailure writes a failed organize history row for non-cancellation failures.
+// Called from interpretApplyResult when applyErr is non-nil and not context.Canceled.
+// Writes regardless of whether OrganizeResult exists — organize was requested and failed.
+func auditOrganizeFailure(inputs applyPhaseInputs, movie *models.Movie, filePath string, result *workflow.ApplyResult, errMsg string, cfg ApplyPhaseConfig) {
+	if inputs.HistoryRepo == nil {
+		return
+	}
+	if errors.Is(errors.New(errMsg), context.Canceled) {
+		return
+	}
+	auditCtx, cancel := historyAuditContext()
+	defer cancel()
+	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+		MovieID:      movie.ID,
+		BatchJobID:   jobIDPtr(inputs.JobID),
+		Operation:    models.HistoryOpOrganize,
+		OriginalPath: filePath,
+		NewPath:      nilGuardOrganizeNewPath(result),
+		Status:       models.HistoryStatusFailed,
+		ErrorMessage: errMsg,
+		DryRun:       cfg.DryRun,
+		Metadata:     organizeMetadata(inputs.OperationMode, result),
+	})
+}
+
+// auditOrganizePanic writes a failed organize history row for panics recovered outside interpretApplyResult.
+// Called from trackApplyResults for o.Panic outcomes only (not o.Failed, to avoid double-write).
+func auditOrganizePanic(inputs applyPhaseInputs, o applyFileOutcome) {
+	if inputs.HistoryRepo == nil || o.Cancelled || !o.Panic {
+		return
+	}
+	auditCtx, cancel := historyAuditContext()
+	defer cancel()
+	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+		MovieID:      o.MovieID,
+		BatchJobID:   jobIDPtr(inputs.JobID),
+		Operation:    models.HistoryOpOrganize,
+		OriginalPath: o.FilePath,
+		Status:       models.HistoryStatusFailed,
+		ErrorMessage: o.PanicMsg,
+	})
+}
+
+// auditRescrapeSuccess writes a success scrape history row for a completed rescrape.
+func auditRescrapeSuccess(inputs rescrapePhaseInputs, movieID, filePath string) {
+	if inputs.HistoryRepo == nil {
+		return
+	}
+	auditCtx, cancel := historyAuditContext()
+	defer cancel()
+	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+		MovieID:      movieID,
+		BatchJobID:   jobIDPtr(inputs.JobID),
+		Operation:    models.HistoryOpScrape,
+		OriginalPath: filePath,
+		Status:       models.HistoryStatusSuccess,
+		Metadata:     organizeMetadata("rescrape", nil),
+	})
+}
+
+// auditRescrapeFailure writes a failed scrape history row for a non-cancellation rescrape failure.
+func auditRescrapeFailure(inputs rescrapePhaseInputs, movieID, filePath string, err error) {
+	if inputs.HistoryRepo == nil {
+		return
+	}
+	if err != nil && errors.Is(err, context.Canceled) {
+		return
+	}
+	auditCtx, cancel := historyAuditContext()
+	defer cancel()
+	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+		MovieID:      movieID,
+		BatchJobID:   jobIDPtr(inputs.JobID),
+		Operation:    models.HistoryOpScrape,
+		OriginalPath: filePath,
+		Status:       models.HistoryStatusFailed,
+		ErrorMessage: err.Error(),
+		Metadata:     organizeMetadata("rescrape", nil),
+	})
 }

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"time"
 
 	"github.com/javinizer/javinizer-go/internal/database"
@@ -139,6 +140,13 @@ func auditOrganizeFailure(inputs applyPhaseInputs, movie *models.Movie, filePath
 	errMsg := ""
 	if applyErr != nil {
 		errMsg = applyErr.Error()
+	}
+	// Redact any URLs that may contain credentials in the error message
+	if u, e := url.Parse(errMsg); e == nil && u.Host != "" && u.User != nil {
+		u.User = url.UserPassword("redacted", "redacted")
+		u.RawQuery = ""
+		u.Fragment = ""
+		errMsg = u.String()
 	}
 	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
 		MovieID:      movie.ID,

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -17,6 +17,7 @@ func recordHistory(ctx context.Context, repo database.HistoryRepositoryInterface
 	if repo == nil {
 		return
 	}
+	h.ErrorMessage = redactEmbeddedURLs(h.ErrorMessage)
 	if err := repo.Create(ctx, &h); err != nil {
 		logging.Warnf("[history] create failed for %s %s: %v", h.Operation, h.MovieID, err)
 	}
@@ -176,10 +177,10 @@ func auditOrganizePanic(inputs applyPhaseInputs, o applyFileOutcome) {
 }
 
 // auditRescrapeSuccess writes a success scrape history row for a completed rescrape.
-var embeddedURLRe = regexp.MustCompile(`https?://[^@\s/]+:[^@\s/]+@`)
+var workerEmbeddedURLRe = regexp.MustCompile(`(?i)https?://[^\s/]+@`)
 
 func redactEmbeddedURLs(s string) string {
-	return embeddedURLRe.ReplaceAllString(s, "https://redacted:redacted@")
+	return workerEmbeddedURLRe.ReplaceAllString(s, "https://redacted:redacted@")
 }
 
 func auditRescrapeSuccess(inputs rescrapePhaseInputs, movieID, filePath string) {

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -136,6 +136,10 @@ func auditOrganizeFailure(inputs applyPhaseInputs, movie *models.Movie, filePath
 	}
 	auditCtx, cancel := historyAuditContext()
 	defer cancel()
+	errMsg := ""
+	if applyErr != nil {
+		errMsg = applyErr.Error()
+	}
 	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
 		MovieID:      movie.ID,
 		BatchJobID:   jobIDPtr(inputs.JobID),
@@ -143,7 +147,7 @@ func auditOrganizeFailure(inputs applyPhaseInputs, movie *models.Movie, filePath
 		OriginalPath: filePath,
 		NewPath:      nilGuardOrganizeNewPath(result),
 		Status:       models.HistoryStatusFailed,
-		ErrorMessage: applyErr.Error(),
+		ErrorMessage: errMsg,
 		DryRun:       cfg.DryRun,
 		Metadata:     organizeMetadata(inputs.OperationMode, result),
 	})

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -107,8 +107,12 @@ func auditScrapeSuccess(inputs scrapePhaseInputs, o scrapeFileOutcome) {
 // Only called when organize actually ran (result.OrganizeResult != nil) or when organizing
 // was cancelled after a partial move (OrganizeResult exists despite context.Canceled).
 func auditOrganizeSuccess(inputs applyPhaseInputs, movie *models.Movie, filePath string, result *workflow.ApplyResult, cfg ApplyPhaseConfig) {
-	if inputs.HistoryRepo == nil || result == nil || result.OrganizeResult == nil {
+	if inputs.HistoryRepo == nil || result == nil {
 		return
+	}
+	newPath := ""
+	if result.OrganizeResult != nil {
+		newPath = result.OrganizeResult.NewPath
 	}
 	auditCtx, cancel := historyAuditContext()
 	defer cancel()
@@ -117,7 +121,7 @@ func auditOrganizeSuccess(inputs applyPhaseInputs, movie *models.Movie, filePath
 		BatchJobID:   jobIDPtr(inputs.JobID),
 		Operation:    models.HistoryOpOrganize,
 		OriginalPath: filePath,
-		NewPath:      result.OrganizeResult.NewPath,
+		NewPath:      newPath,
 		Status:       models.HistoryStatusSuccess,
 		DryRun:       cfg.DryRun,
 		Metadata:     organizeMetadata(inputs.OperationMode, result),

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -71,7 +71,7 @@ func auditScrapeFailure(inputs scrapePhaseInputs, o scrapeFileOutcome) {
 	if o.Panic {
 		errMsg = o.PanicMsg
 	}
-	if errMsg == "" && !o.Failed && !o.Panic {
+	if errMsg == "" {
 		return
 	}
 	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
@@ -207,13 +207,17 @@ func auditRescrapeFailure(inputs rescrapePhaseInputs, movieID, filePath string, 
 	}
 	auditCtx, cancel := historyAuditContext()
 	defer cancel()
+	errMsg := ""
+	if err != nil {
+		errMsg = err.Error()
+	}
 	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
 		MovieID:      movieID,
 		BatchJobID:   jobIDPtr(inputs.JobID),
 		Operation:    models.HistoryOpScrape,
 		OriginalPath: filePath,
 		Status:       models.HistoryStatusFailed,
-		ErrorMessage: err.Error(),
+		ErrorMessage: errMsg,
 		Metadata:     organizeMetadata("rescrape", nil),
 	})
 }

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -168,6 +168,7 @@ func auditOrganizePanic(inputs applyPhaseInputs, o applyFileOutcome) {
 		OriginalPath: o.FilePath,
 		Status:       models.HistoryStatusFailed,
 		ErrorMessage: o.PanicMsg,
+		DryRun:       o.DryRun,
 	})
 }
 

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -178,9 +178,12 @@ func auditOrganizePanic(inputs applyPhaseInputs, o applyFileOutcome) {
 
 // auditRescrapeSuccess writes a success scrape history row for a completed rescrape.
 var workerEmbeddedURLRe = regexp.MustCompile(`(?i)https?://[^\s/]+@`)
+var workerQueryURLRe = regexp.MustCompile(`(?i)(https?://[^\s?]+)\?[^\s]+`)
 
 func redactEmbeddedURLs(s string) string {
-	return workerEmbeddedURLRe.ReplaceAllString(s, "https://redacted:redacted@")
+	s = workerEmbeddedURLRe.ReplaceAllString(s, "https://redacted:redacted@")
+	s = workerQueryURLRe.ReplaceAllString(s, "$1")
+	return s
 }
 
 func auditRescrapeSuccess(inputs rescrapePhaseInputs, movieID, filePath string) {

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -178,7 +178,7 @@ func auditOrganizePanic(inputs applyPhaseInputs, o applyFileOutcome) {
 
 // auditRescrapeSuccess writes a success scrape history row for a completed rescrape.
 var workerEmbeddedURLRe = regexp.MustCompile(`(?i)https?://[^\s/]+@`)
-var workerQueryURLRe = regexp.MustCompile(`(?i)(https?://[^\s?]+)\?[^\s]+`)
+var workerQueryURLRe = regexp.MustCompile(`(?i)(https?://[^\s?#]+)[?#][^\s]+`)
 
 func redactEmbeddedURLs(s string) string {
 	s = workerEmbeddedURLRe.ReplaceAllString(s, "https://redacted:redacted@")

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -1,0 +1,58 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+)
+
+func recordHistory(ctx context.Context, repo database.HistoryRepositoryInterface, h models.History) {
+	if repo == nil {
+		return
+	}
+	if err := repo.Create(ctx, &h); err != nil {
+		logging.Warnf("[history] create failed for %s %s: %v", h.Operation, h.MovieID, err)
+	}
+}
+
+func jobIDPtr(id models.JobID) *string {
+	s := string(id)
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func nilGuardOrganizeNewPath(result *workflow.ApplyResult) string {
+	if result == nil || result.OrganizeResult == nil {
+		return ""
+	}
+	return result.OrganizeResult.NewPath
+}
+
+func organizeMetadata(mode string, result *workflow.ApplyResult) string {
+	steps := "{}"
+	if result != nil {
+		if b, err := json.Marshal(result.Steps); err == nil {
+			steps = string(b)
+		}
+	}
+	m := map[string]any{
+		"operation_mode": mode,
+		"steps":          json.RawMessage(steps),
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+func historyAuditContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 5*time.Second)
+}

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/javinizer/javinizer-go/internal/database"
@@ -142,12 +142,7 @@ func auditOrganizeFailure(inputs applyPhaseInputs, movie *models.Movie, filePath
 		errMsg = applyErr.Error()
 	}
 	// Redact any URLs that may contain credentials in the error message
-	if u, e := url.Parse(errMsg); e == nil && u.Host != "" && u.User != nil {
-		u.User = url.UserPassword("redacted", "redacted")
-		u.RawQuery = ""
-		u.Fragment = ""
-		errMsg = u.String()
-	}
+	errMsg = redactEmbeddedURLs(errMsg)
 	recordHistory(auditCtx, inputs.HistoryRepo, models.History{
 		MovieID:      movie.ID,
 		BatchJobID:   jobIDPtr(inputs.JobID),
@@ -181,6 +176,12 @@ func auditOrganizePanic(inputs applyPhaseInputs, o applyFileOutcome) {
 }
 
 // auditRescrapeSuccess writes a success scrape history row for a completed rescrape.
+var embeddedURLRe = regexp.MustCompile(`https?://[^@\s/]+:[^@\s/]+@`)
+
+func redactEmbeddedURLs(s string) string {
+	return embeddedURLRe.ReplaceAllString(s, "https://redacted:redacted@")
+}
+
 func auditRescrapeSuccess(inputs rescrapePhaseInputs, movieID, filePath string) {
 	if inputs.HistoryRepo == nil {
 		return

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -107,12 +107,8 @@ func auditScrapeSuccess(inputs scrapePhaseInputs, o scrapeFileOutcome) {
 // Only called when organize actually ran (result.OrganizeResult != nil) or when organizing
 // was cancelled after a partial move (OrganizeResult exists despite context.Canceled).
 func auditOrganizeSuccess(inputs applyPhaseInputs, movie *models.Movie, filePath string, result *workflow.ApplyResult, cfg ApplyPhaseConfig) {
-	if inputs.HistoryRepo == nil || result == nil {
+	if inputs.HistoryRepo == nil || result == nil || result.OrganizeResult == nil {
 		return
-	}
-	newPath := ""
-	if result.OrganizeResult != nil {
-		newPath = result.OrganizeResult.NewPath
 	}
 	auditCtx, cancel := historyAuditContext()
 	defer cancel()
@@ -121,7 +117,7 @@ func auditOrganizeSuccess(inputs applyPhaseInputs, movie *models.Movie, filePath
 		BatchJobID:   jobIDPtr(inputs.JobID),
 		Operation:    models.HistoryOpOrganize,
 		OriginalPath: filePath,
-		NewPath:      newPath,
+		NewPath:      result.OrganizeResult.NewPath,
 		Status:       models.HistoryStatusSuccess,
 		DryRun:       cfg.DryRun,
 		Metadata:     organizeMetadata(inputs.OperationMode, result),

--- a/internal/worker/job_controller.go
+++ b/internal/worker/job_controller.go
@@ -340,6 +340,7 @@ func (c *jobController) buildRescrapeInputs(wf workflow.WorkflowInterface, batch
 	pg := c.job.deps.PosterGen
 	pfn := c.job.deps.PersistFn
 	tempDir := c.job.cfg.tempDir
+	histRepo := c.job.deps.HistoryRepo
 	c.job.mu.RUnlock()
 
 	return rescrapePhaseInputs{
@@ -347,6 +348,7 @@ func (c *jobController) buildRescrapeInputs(wf workflow.WorkflowInterface, batch
 		Concurrency: newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, batchCfg.RequestTimeout, defaultMaxWorkers, defaultWorkerTimeout),
 		WF:          wf,
 		PosterGen:   pg,
+		HistoryRepo: histRepo,
 		ResultMap:   c.job.results,
 		Lifecycle:   c.job.lifecycle,
 		persister:   persistFunc(pfn),

--- a/internal/worker/job_controller.go
+++ b/internal/worker/job_controller.go
@@ -316,20 +316,21 @@ func (c *jobController) buildApplyInputs(wf workflow.WorkflowInterface, batchCfg
 	}
 
 	return applyPhaseInputs{
-		JobID:         c.job.ID,
-		Concurrency:   newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, batchCfg.RequestTimeout, 1, defaultWorkerTimeout),
-		NFOEnabled:    batchCfg.NFOEnabled,
-		WF:            wf,
-		Results:       snap.Results,
-		Excluded:      snap.Excluded,
-		Destination:   cfg.Destination,
-		Update:        upd,
-		HistoryRepo:   histRepo,
-		OperationMode: opMode,
-		Broadcaster:   broadcaster,
-		Updater:       c.job.results,
-		Lifecycle:     c.job.lifecycle,
-		persister:     persistFunc(persistFn),
+		JobID:           c.job.ID,
+		Concurrency:     newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, batchCfg.RequestTimeout, 1, defaultWorkerTimeout),
+		NFOEnabled:      batchCfg.NFOEnabled,
+		WF:              wf,
+		Results:         snap.Results,
+		Excluded:        snap.Excluded,
+		Destination:     cfg.Destination,
+		Update:          upd,
+		HistoryRepo:     histRepo,
+		OperationMode:   opMode,
+		OrganizeSkipped: cfg.OrganizeOptions.Skip,
+		Broadcaster:     broadcaster,
+		Updater:         c.job.results,
+		Lifecycle:       c.job.lifecycle,
+		persister:       persistFunc(persistFn),
 	}
 }
 

--- a/internal/worker/job_controller.go
+++ b/internal/worker/job_controller.go
@@ -267,6 +267,7 @@ func (c *jobController) buildScrapeInputs(wf workflow.WorkflowInterface, batchCf
 	m := c.job.deps.Matcher
 	pg := c.job.deps.PosterGen
 	movieRepo := c.job.deps.MovieRepo
+	histRepo := c.job.deps.HistoryRepo
 	c.job.mu.RUnlock()
 
 	c.job.batchJobEventSource.mu.RLock()
@@ -288,6 +289,7 @@ func (c *jobController) buildScrapeInputs(wf workflow.WorkflowInterface, batchCf
 		persister:           persistFunc(persistFn),
 		FileMatchInfo:       fileMatchInfo,
 		MovieRepo:           movieRepo,
+		HistoryRepo:         histRepo,
 	}
 	if m != nil {
 		inputs.Matcher = m
@@ -306,21 +308,28 @@ func (c *jobController) buildApplyInputs(wf workflow.WorkflowInterface, batchCfg
 
 	c.job.mu.RLock()
 	upd := c.job.cfg.update
+	opMode := string(c.job.cfg.operationMode)
+	histRepo := c.job.deps.HistoryRepo
 	c.job.mu.RUnlock()
+	if opMode == "" {
+		opMode = "organize"
+	}
 
 	return applyPhaseInputs{
-		JobID:       c.job.ID,
-		Concurrency: newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, batchCfg.RequestTimeout, 1, defaultWorkerTimeout),
-		NFOEnabled:  batchCfg.NFOEnabled,
-		WF:          wf,
-		Results:     snap.Results,
-		Excluded:    snap.Excluded,
-		Destination: cfg.Destination,
-		Update:      upd,
-		Broadcaster: broadcaster,
-		Updater:     c.job.results,
-		Lifecycle:   c.job.lifecycle,
-		persister:   persistFunc(persistFn),
+		JobID:         c.job.ID,
+		Concurrency:   newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, batchCfg.RequestTimeout, 1, defaultWorkerTimeout),
+		NFOEnabled:    batchCfg.NFOEnabled,
+		WF:            wf,
+		Results:       snap.Results,
+		Excluded:      snap.Excluded,
+		Destination:   cfg.Destination,
+		Update:        upd,
+		HistoryRepo:   histRepo,
+		OperationMode: opMode,
+		Broadcaster:   broadcaster,
+		Updater:       c.job.results,
+		Lifecycle:     c.job.lifecycle,
+		persister:     persistFunc(persistFn),
 	}
 }
 

--- a/internal/worker/job_store.go
+++ b/internal/worker/job_store.go
@@ -31,6 +31,7 @@ type JobStore struct {
 	batchFileOpRepo   database.BatchFileOperationRepositoryInterface
 	movieRepo         database.MovieRepositoryInterface
 	actressRepo       database.ActressRepositoryInterface
+	historyRepo       database.HistoryRepositoryInterface
 	persistence       JobPersistencer
 	tempDir           string
 	templateEngine    template.EngineInterface
@@ -71,6 +72,14 @@ func WithPersistence(p JobPersistencer) JobStoreOption {
 func WithActressRepo(r database.ActressRepositoryInterface) JobStoreOption {
 	return func(s *JobStore) {
 		s.actressRepo = r
+	}
+}
+
+// WithHistoryRepo sets the history repository used to record operation
+// history during scrape and organize. When unset, history writes are skipped.
+func WithHistoryRepo(r database.HistoryRepositoryInterface) JobStoreOption {
+	return func(s *JobStore) {
+		s.historyRepo = r
 	}
 }
 
@@ -159,6 +168,9 @@ func (s *JobStore) SetReconstructionDeps(m matcher.MatcherInterface, pg poster.P
 		// BatchCfg is a value type (not a pointer), so we always overwrite to
 		// pick up the latest config snapshot.
 		job.deps.BatchCfg = batchCfg
+		if s.historyRepo != nil {
+			job.deps.HistoryRepo = s.historyRepo
+		}
 		job.mu.Unlock()
 	}
 	s.mu.Unlock()
@@ -322,6 +334,9 @@ func (s *JobStore) createJob(files []string, jobCfg ...*JobConfig) *BatchJob {
 	}
 	if job.deps.ActressRepo == nil {
 		job.deps.ActressRepo = s.actressRepo
+	}
+	if job.deps.HistoryRepo == nil {
+		job.deps.HistoryRepo = s.historyRepo
 	}
 
 	s.mu.Lock()

--- a/internal/worker/job_store_history_test.go
+++ b/internal/worker/job_store_history_test.go
@@ -1,0 +1,260 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newHistoryTestDB(t *testing.T) *database.DB {
+	t.Helper()
+	cfg := &database.Config{Type: "sqlite", DSN: ":memory:", LogLevel: "error"}
+	db, err := database.New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.RunMigrationsOnStartup(context.Background()))
+	return db
+}
+
+func TestJobStore_HistoryRepo_WiredViaCreateJob(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	jq := NewJobStore(nil, nil, nil, "", nil, nil, WithHistoryRepo(repos.HistoryRepo))
+	job := jq.CreateJobBatch([]string{"file1.mp4"})
+	require.NotNil(t, job.deps.HistoryRepo)
+	assert.Equal(t, repos.HistoryRepo, job.deps.HistoryRepo)
+}
+
+func TestJobStore_HistoryRepo_NilWithoutOption(t *testing.T) {
+	jq := NewInMemoryJobStore()
+	job := jq.CreateJobBatch([]string{"file1.mp4"})
+	assert.Nil(t, job.deps.HistoryRepo)
+}
+
+func TestJobStore_HistoryRepo_RehydratedInSetReconstructionDeps(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	jq := NewJobStore(nil, nil, nil, "", nil, nil, WithHistoryRepo(repos.HistoryRepo))
+	job := jq.CreateJobBatch([]string{"file1.mp4"})
+	job.deps.HistoryRepo = nil
+	jq.SetReconstructionDeps(nil, nil, BatchJobConfig{})
+	assert.NotNil(t, job.deps.HistoryRepo)
+	assert.Equal(t, repos.HistoryRepo, job.deps.HistoryRepo)
+}
+
+func TestRecordHistory_NilRepo_NoOp(t *testing.T) {
+	assert.NotPanics(t, func() {
+		recordHistory(context.Background(), nil, models.History{
+			MovieID:   "TEST-001",
+			Operation: models.HistoryOpScrape,
+			Status:    models.HistoryStatusSuccess,
+		})
+	})
+}
+
+func TestRecordHistory_CreateError_LoggedAndContinued(t *testing.T) {
+	repo := &failingHistoryRepo{err: errors.New("db down")}
+	assert.NotPanics(t, func() {
+		recordHistory(context.Background(), repo, models.History{
+			MovieID:   "TEST-001",
+			Operation: models.HistoryOpScrape,
+			Status:    models.HistoryStatusSuccess,
+		})
+	})
+	assert.Equal(t, 1, repo.callCount)
+}
+
+func TestOrganizeMetadata_NilResult(t *testing.T) {
+	assert.Contains(t, organizeMetadata("organize", nil), "operation_mode")
+	assert.Contains(t, organizeMetadata("organize", nil), "organize")
+}
+
+func TestOrganizeMetadata_NonNilResult(t *testing.T) {
+	result := &workflow.ApplyResult{FailedStep: "download"}
+	meta := organizeMetadata("in-place", result)
+	assert.Contains(t, meta, "in-place")
+	assert.Contains(t, meta, "operation_mode")
+}
+
+func TestNilGuardOrganizeNewPath_NilResult(t *testing.T) {
+	assert.Equal(t, "", nilGuardOrganizeNewPath(nil))
+}
+
+func TestNilGuardOrganizeNewPath_NilOrganizeResult(t *testing.T) {
+	result := &workflow.ApplyResult{OrganizeResult: nil}
+	assert.Equal(t, "", nilGuardOrganizeNewPath(result))
+}
+
+func TestNilGuardOrganizeNewPath_WithNewPath(t *testing.T) {
+	result := &workflow.ApplyResult{OrganizeResult: &organizer.OrganizeResult{NewPath: "/dest/movie.mp4"}}
+	assert.Equal(t, "/dest/movie.mp4", nilGuardOrganizeNewPath(result))
+}
+
+func TestJobIDPtr_EmptyID(t *testing.T) {
+	ptr := jobIDPtr("")
+	assert.Nil(t, ptr)
+}
+
+func TestJobIDPtr_NonEmptyID(t *testing.T) {
+	ptr := jobIDPtr("job-123")
+	require.NotNil(t, ptr)
+	assert.Equal(t, "job-123", *ptr)
+}
+
+func TestTrackScrapeResults_CancelledNotWritten(t *testing.T) {
+	repo := &countingHistoryRepo{}
+	outcomes := []scrapeFileOutcome{
+		{FilePath: "a.mp4", MovieID: "A-001", Failed: true, Cancelled: true, ErrorMsg: "canceled"},
+		{FilePath: "b.mp4", MovieID: "B-001", Failed: true, ErrorMsg: "real error"},
+		{FilePath: "c.mp4", MovieID: "C-001", Panic: true, PanicMsg: "boom"},
+	}
+	trackScrapeResults(scrapePhaseInputs{HistoryRepo: repo}, outcomes)
+	assert.Equal(t, 2, repo.createCount(), "cancelled outcome should NOT be written; failed+panic should")
+}
+
+func TestTrackApplyResults_PanicOnlyNotDoubleWritten(t *testing.T) {
+	repo := &countingHistoryRepo{}
+	outcomes := []applyFileOutcome{
+		{FilePath: "a.mp4", MovieID: "A-001", Failed: true, ErrorMsg: "apply error", Success: false},
+		{FilePath: "b.mp4", MovieID: "B-001", Panic: true, Failed: true, PanicMsg: "boom"},
+		{FilePath: "c.mp4", MovieID: "C-001", Success: true},
+	}
+	var org, fail int64
+	trackApplyResults(applyPhaseInputs{HistoryRepo: repo}, outcomes, &org, &fail)
+	assert.Equal(t, int64(1), org)
+	assert.Equal(t, int64(2), fail)
+	assert.Equal(t, 1, repo.createCount(), "only panic outcome should be written from trackApplyResults")
+}
+
+type failingHistoryRepo struct {
+	err       error
+	callCount int
+}
+
+func (r *failingHistoryRepo) Create(_ context.Context, _ *models.History) error {
+	r.callCount++
+	return r.err
+}
+func (r *failingHistoryRepo) FindByID(_ context.Context, _ uint) (*models.History, error) {
+	return nil, nil
+}
+func (r *failingHistoryRepo) FindByMovieID(_ context.Context, _ string) ([]models.History, error) {
+	return nil, nil
+}
+func (r *failingHistoryRepo) ListByMovieID(_ context.Context, _ string, _, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *failingHistoryRepo) CountByMovieID(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
+func (r *failingHistoryRepo) FindByBatchJobID(_ context.Context, _ string) ([]models.History, error) {
+	return nil, nil
+}
+func (r *failingHistoryRepo) FindByOperation(_ context.Context, _ models.HistoryOperation, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *failingHistoryRepo) ListByOperation(_ context.Context, _ models.HistoryOperation, _, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *failingHistoryRepo) FindByStatus(_ context.Context, _ models.HistoryStatus, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *failingHistoryRepo) ListByStatus(_ context.Context, _ models.HistoryStatus, _, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *failingHistoryRepo) FindRecent(_ context.Context, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *failingHistoryRepo) FindByDateRange(_ context.Context, _, _ time.Time) ([]models.History, error) {
+	return nil, nil
+}
+func (r *failingHistoryRepo) Count(_ context.Context) (int64, error) {
+	return 0, nil
+}
+func (r *failingHistoryRepo) CountByStatus(_ context.Context, _ models.HistoryStatus) (int64, error) {
+	return 0, nil
+}
+func (r *failingHistoryRepo) CountByOperation(_ context.Context, _ models.HistoryOperation) (int64, error) {
+	return 0, nil
+}
+func (r *failingHistoryRepo) Delete(_ context.Context, _ uint) error               { return nil }
+func (r *failingHistoryRepo) DeleteByMovieID(_ context.Context, _ string) error    { return nil }
+func (r *failingHistoryRepo) DeleteOlderThan(_ context.Context, _ time.Time) error { return nil }
+func (r *failingHistoryRepo) List(_ context.Context, _, _ int) ([]models.History, error) {
+	return nil, nil
+}
+
+type countingHistoryRepo struct {
+	mu    sync.Mutex
+	count int
+}
+
+func (r *countingHistoryRepo) createCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.count
+}
+
+func (r *countingHistoryRepo) Create(_ context.Context, _ *models.History) error {
+	r.mu.Lock()
+	r.count++
+	r.mu.Unlock()
+	return nil
+}
+func (r *countingHistoryRepo) FindByID(_ context.Context, _ uint) (*models.History, error) {
+	return nil, nil
+}
+func (r *countingHistoryRepo) FindByMovieID(_ context.Context, _ string) ([]models.History, error) {
+	return nil, nil
+}
+func (r *countingHistoryRepo) ListByMovieID(_ context.Context, _ string, _, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *countingHistoryRepo) CountByMovieID(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
+func (r *countingHistoryRepo) FindByBatchJobID(_ context.Context, _ string) ([]models.History, error) {
+	return nil, nil
+}
+func (r *countingHistoryRepo) FindByOperation(_ context.Context, _ models.HistoryOperation, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *countingHistoryRepo) ListByOperation(_ context.Context, _ models.HistoryOperation, _, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *countingHistoryRepo) FindByStatus(_ context.Context, _ models.HistoryStatus, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *countingHistoryRepo) ListByStatus(_ context.Context, _ models.HistoryStatus, _, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *countingHistoryRepo) FindRecent(_ context.Context, _ int) ([]models.History, error) {
+	return nil, nil
+}
+func (r *countingHistoryRepo) FindByDateRange(_ context.Context, _, _ time.Time) ([]models.History, error) {
+	return nil, nil
+}
+func (r *countingHistoryRepo) Count(_ context.Context) (int64, error) {
+	return 0, nil
+}
+func (r *countingHistoryRepo) CountByStatus(_ context.Context, _ models.HistoryStatus) (int64, error) {
+	return 0, nil
+}
+func (r *countingHistoryRepo) CountByOperation(_ context.Context, _ models.HistoryOperation) (int64, error) {
+	return 0, nil
+}
+func (r *countingHistoryRepo) Delete(_ context.Context, _ uint) error               { return nil }
+func (r *countingHistoryRepo) DeleteByMovieID(_ context.Context, _ string) error    { return nil }
+func (r *countingHistoryRepo) DeleteOlderThan(_ context.Context, _ time.Time) error { return nil }
+func (r *countingHistoryRepo) List(_ context.Context, _, _ int) ([]models.History, error) {
+	return nil, nil
+}

--- a/internal/worker/job_store_history_test.go
+++ b/internal/worker/job_store_history_test.go
@@ -117,7 +117,7 @@ func TestTrackScrapeResults_CancelledNotWritten(t *testing.T) {
 		{FilePath: "b.mp4", MovieID: "B-001", Failed: true, ErrorMsg: "real error"},
 		{FilePath: "c.mp4", MovieID: "C-001", Panic: true, PanicMsg: "boom"},
 	}
-	trackScrapeResults(scrapePhaseInputs{HistoryRepo: repo}, outcomes)
+	trackScrapeResults(scrapePhaseInputs{HistoryRepo: repo}, outcomes, nil)
 	assert.Equal(t, 2, repo.createCount(), "cancelled outcome should NOT be written; failed+panic should")
 }
 

--- a/internal/worker/job_store_persist.go
+++ b/internal/worker/job_store_persist.go
@@ -28,7 +28,7 @@ import (
 // (created via getAdapters/buildAdapters) can persist movie edits to the
 // database. Without this, reconstructed jobs have nil MovieRepo and
 // UpdateMovie() silently skips DB persistence.
-func wireJobDeps(job *BatchJob, movieRepo database.MovieRepositoryInterface, actressRepo database.ActressRepositoryInterface, persistFn func()) {
+func wireJobDeps(job *BatchJob, movieRepo database.MovieRepositoryInterface, actressRepo database.ActressRepositoryInterface, historyRepo database.HistoryRepositoryInterface, persistFn func()) {
 	job.attachLifecycleCallback()
 	job.posterEditor = NewPosterEditor(job.results, job.results, movieRepo)
 	job.controller = newJobController(job)
@@ -37,6 +37,9 @@ func wireJobDeps(job *BatchJob, movieRepo database.MovieRepositoryInterface, act
 	}
 	if actressRepo != nil {
 		job.deps.ActressRepo = actressRepo
+	}
+	if historyRepo != nil {
+		job.deps.HistoryRepo = historyRepo
 	}
 	if persistFn != nil {
 		job.deps.PersistFn = persistFn
@@ -99,7 +102,7 @@ func (s *JobStore) reconstructBatchJob(dbJob *models.Job) *BatchJob {
 		fsCaseCache:         fscase.NewFSCaseCache(s.fs),
 	}
 
-	wireJobDeps(batchJob, s.movieRepo, s.actressRepo, func() { s.persistence.PersistJob(batchJob) })
+	wireJobDeps(batchJob, s.movieRepo, s.actressRepo, s.historyRepo, func() { s.persistence.PersistJob(batchJob) })
 
 	batchJob.mu.Lock()
 	if s.reconMatcher != nil {

--- a/internal/worker/miss3_test.go
+++ b/internal/worker/miss3_test.go
@@ -596,7 +596,7 @@ func TestJobController_SetBatchCfg(t *testing.T) {
 
 func TestTrackScrapeResults(t *testing.T) {
 	assert.NotPanics(t, func() {
-		trackScrapeResults(nil)
+		trackScrapeResults(scrapePhaseInputs{}, nil)
 	})
 }
 

--- a/internal/worker/miss3_test.go
+++ b/internal/worker/miss3_test.go
@@ -596,7 +596,7 @@ func TestJobController_SetBatchCfg(t *testing.T) {
 
 func TestTrackScrapeResults(t *testing.T) {
 	assert.NotPanics(t, func() {
-		trackScrapeResults(scrapePhaseInputs{}, nil)
+		trackScrapeResults(scrapePhaseInputs{}, nil, nil)
 	})
 }
 

--- a/internal/worker/phase_interfaces.go
+++ b/internal/worker/phase_interfaces.go
@@ -165,6 +165,8 @@ type rescrapePhaseInputs struct {
 	persister persister
 
 	// additional dependencies for full rescrape sequence
+	HistoryRepo database.HistoryRepositoryInterface
+
 	Finder      resultstore.FileFinder // for FindFileForMovieID and GetRevision
 	Fs          afero.Fs               // for poster cleanup
 	TempDir     string                 // for poster cleanup paths

--- a/internal/worker/phase_interfaces.go
+++ b/internal/worker/phase_interfaces.go
@@ -111,6 +111,8 @@ type scrapePhaseInputs struct {
 	// the workflow's Scrape persists inline as before.
 	MovieRepo database.MovieRepositoryInterface
 
+	HistoryRepo database.HistoryRepositoryInterface
+
 	Broadcaster progressBroadcaster
 	Updater     resultstore.ResultUpdater
 	Lifecycle   PhaseLifecycle
@@ -130,6 +132,9 @@ type applyPhaseInputs struct {
 	Excluded    map[string]bool
 	Destination string
 	Update      bool // Update mode (in-place, no file organization)
+
+	HistoryRepo   database.HistoryRepositoryInterface
+	OperationMode string
 
 	Broadcaster progressBroadcaster
 	Updater     resultstore.ResultUpdater

--- a/internal/worker/phase_interfaces.go
+++ b/internal/worker/phase_interfaces.go
@@ -133,8 +133,9 @@ type applyPhaseInputs struct {
 	Destination string
 	Update      bool // Update mode (in-place, no file organization)
 
-	HistoryRepo   database.HistoryRepositoryInterface
-	OperationMode string
+	HistoryRepo     database.HistoryRepositoryInterface
+	OperationMode   string
+	OrganizeSkipped bool
 
 	Broadcaster progressBroadcaster
 	Updater     resultstore.ResultUpdater

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -183,7 +183,7 @@ func withRescrapeStatus(lc rescrapeLifecycle, fn func() (*RescrapeResult, *resul
 		if lc.inputs.HistoryRepo != nil {
 			auditCtx, auditCancel := historyAuditContext()
 			defer auditCancel()
-			movieID := ""
+			movieID := lc.lookup.OldMovieID
 			if movieResult != nil && movieResult.Movie != nil {
 				movieID = movieResult.Movie.ID
 			}
@@ -200,15 +200,22 @@ func withRescrapeStatus(lc rescrapeLifecycle, fn func() (*RescrapeResult, *resul
 		return nil, err
 	}
 
+	if outcome == nil {
+		return nil, nil
+	}
 	switch outcome.Status {
 	case models.RescrapeStatusGone, models.RescrapeStatusConflict, models.RescrapeStatusFailed:
 		CleanupMoviePosters(lc.inputs.Fs, lc.inputs.TempDir, lc.inputs.JobID, cleanupMovie())
 		if lc.inputs.HistoryRepo != nil {
 			auditCtx, auditCancel := historyAuditContext()
 			defer auditCancel()
-			movieID := ""
+			movieID := lc.lookup.OldMovieID
 			if movieResult != nil && movieResult.Movie != nil {
 				movieID = movieResult.Movie.ID
+			}
+			errMsg := outcome.Error
+			if errMsg == "" {
+				errMsg = fmt.Sprintf("rescrape %s", outcome.Status)
 			}
 			recordHistory(auditCtx, lc.inputs.HistoryRepo, models.History{
 				MovieID:      movieID,
@@ -216,7 +223,7 @@ func withRescrapeStatus(lc rescrapeLifecycle, fn func() (*RescrapeResult, *resul
 				Operation:    models.HistoryOpScrape,
 				OriginalPath: lc.lookup.FilePath,
 				Status:       models.HistoryStatusFailed,
-				ErrorMessage: fmt.Sprintf("rescrape %s", outcome.Status),
+				ErrorMessage: errMsg,
 				Metadata:     organizeMetadata("rescrape", nil),
 			})
 		}

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -180,12 +180,46 @@ func withRescrapeStatus(lc rescrapeLifecycle, fn func() (*RescrapeResult, *resul
 	}
 	if err != nil {
 		CleanupMoviePosters(lc.inputs.Fs, lc.inputs.TempDir, lc.inputs.JobID, cleanupMovie())
+		if lc.inputs.HistoryRepo != nil {
+			auditCtx, auditCancel := historyAuditContext()
+			defer auditCancel()
+			movieID := ""
+			if movieResult != nil && movieResult.Movie != nil {
+				movieID = movieResult.Movie.ID
+			}
+			recordHistory(auditCtx, lc.inputs.HistoryRepo, models.History{
+				MovieID:      movieID,
+				BatchJobID:   jobIDPtr(lc.inputs.JobID),
+				Operation:    models.HistoryOpScrape,
+				OriginalPath: lc.lookup.FilePath,
+				Status:       models.HistoryStatusFailed,
+				ErrorMessage: err.Error(),
+				Metadata:     organizeMetadata("rescrape", nil),
+			})
+		}
 		return nil, err
 	}
 
 	switch outcome.Status {
 	case models.RescrapeStatusGone, models.RescrapeStatusConflict, models.RescrapeStatusFailed:
 		CleanupMoviePosters(lc.inputs.Fs, lc.inputs.TempDir, lc.inputs.JobID, cleanupMovie())
+		if lc.inputs.HistoryRepo != nil {
+			auditCtx, auditCancel := historyAuditContext()
+			defer auditCancel()
+			movieID := ""
+			if movieResult != nil && movieResult.Movie != nil {
+				movieID = movieResult.Movie.ID
+			}
+			recordHistory(auditCtx, lc.inputs.HistoryRepo, models.History{
+				MovieID:      movieID,
+				BatchJobID:   jobIDPtr(lc.inputs.JobID),
+				Operation:    models.HistoryOpScrape,
+				OriginalPath: lc.lookup.FilePath,
+				Status:       models.HistoryStatusFailed,
+				ErrorMessage: fmt.Sprintf("rescrape %s", outcome.Status),
+				Metadata:     organizeMetadata("rescrape", nil),
+			})
+		}
 		return outcome, nil
 	}
 

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -141,18 +142,7 @@ func (p *rescrapePhase) CompleteRescrape(inputs rescrapePhaseInputs, filePath st
 	}
 
 	rescrapeResult := &RescrapeResult{OrphanedMovieIDs: orphanedIDs, Status: models.RescrapeStatusSuccess}
-	if inputs.HistoryRepo != nil {
-		auditCtx, auditCancel := historyAuditContext()
-		defer auditCancel()
-		recordHistory(auditCtx, inputs.HistoryRepo, models.History{
-			MovieID:      movieID,
-			BatchJobID:   jobIDPtr(inputs.JobID),
-			Operation:    models.HistoryOpScrape,
-			OriginalPath: filePath,
-			Status:       models.HistoryStatusSuccess,
-			Metadata:     organizeMetadata("rescrape", nil),
-		})
-	}
+	auditRescrapeSuccess(inputs, movieID, filePath)
 	return rescrapeResult, nil
 }
 
@@ -181,21 +171,11 @@ func withRescrapeStatus(lc rescrapeLifecycle, fn func() (*RescrapeResult, *resul
 	if err != nil {
 		CleanupMoviePosters(lc.inputs.Fs, lc.inputs.TempDir, lc.inputs.JobID, cleanupMovie())
 		if lc.inputs.HistoryRepo != nil {
-			auditCtx, auditCancel := historyAuditContext()
-			defer auditCancel()
 			movieID := lc.lookup.OldMovieID
 			if movieResult != nil && movieResult.Movie != nil {
 				movieID = movieResult.Movie.ID
 			}
-			recordHistory(auditCtx, lc.inputs.HistoryRepo, models.History{
-				MovieID:      movieID,
-				BatchJobID:   jobIDPtr(lc.inputs.JobID),
-				Operation:    models.HistoryOpScrape,
-				OriginalPath: lc.lookup.FilePath,
-				Status:       models.HistoryStatusFailed,
-				ErrorMessage: err.Error(),
-				Metadata:     organizeMetadata("rescrape", nil),
-			})
+			auditRescrapeFailure(lc.inputs, movieID, lc.lookup.FilePath, err)
 		}
 		return nil, err
 	}
@@ -207,8 +187,6 @@ func withRescrapeStatus(lc rescrapeLifecycle, fn func() (*RescrapeResult, *resul
 	case models.RescrapeStatusGone, models.RescrapeStatusConflict, models.RescrapeStatusFailed:
 		CleanupMoviePosters(lc.inputs.Fs, lc.inputs.TempDir, lc.inputs.JobID, cleanupMovie())
 		if lc.inputs.HistoryRepo != nil {
-			auditCtx, auditCancel := historyAuditContext()
-			defer auditCancel()
 			movieID := lc.lookup.OldMovieID
 			if movieResult != nil && movieResult.Movie != nil {
 				movieID = movieResult.Movie.ID
@@ -217,15 +195,7 @@ func withRescrapeStatus(lc rescrapeLifecycle, fn func() (*RescrapeResult, *resul
 			if errMsg == "" {
 				errMsg = fmt.Sprintf("rescrape %s", outcome.Status)
 			}
-			recordHistory(auditCtx, lc.inputs.HistoryRepo, models.History{
-				MovieID:      movieID,
-				BatchJobID:   jobIDPtr(lc.inputs.JobID),
-				Operation:    models.HistoryOpScrape,
-				OriginalPath: lc.lookup.FilePath,
-				Status:       models.HistoryStatusFailed,
-				ErrorMessage: errMsg,
-				Metadata:     organizeMetadata("rescrape", nil),
-			})
+			auditRescrapeFailure(lc.inputs, movieID, lc.lookup.FilePath, errors.New(errMsg))
 		}
 		return outcome, nil
 	}

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -140,7 +140,20 @@ func (p *rescrapePhase) CompleteRescrape(inputs rescrapePhaseInputs, filePath st
 		}
 	}
 
-	return &RescrapeResult{OrphanedMovieIDs: orphanedIDs, Status: models.RescrapeStatusSuccess}, nil
+	rescrapeResult := &RescrapeResult{OrphanedMovieIDs: orphanedIDs, Status: models.RescrapeStatusSuccess}
+	if inputs.HistoryRepo != nil {
+		auditCtx, auditCancel := historyAuditContext()
+		defer auditCancel()
+		recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+			MovieID:      movieID,
+			BatchJobID:   jobIDPtr(inputs.JobID),
+			Operation:    models.HistoryOpScrape,
+			OriginalPath: filePath,
+			Status:       models.HistoryStatusSuccess,
+			Metadata:     organizeMetadata("rescrape", nil),
+		})
+	}
+	return rescrapeResult, nil
 }
 
 // singleScrapeWork was removed. ScrapeSingle now calls

--- a/internal/worker/review_coverage_test.go
+++ b/internal/worker/review_coverage_test.go
@@ -15,7 +15,7 @@ func TestTrackApplyResults_PanicCountsAsFailed(t *testing.T) {
 			{FilePath: "b.mp4", Success: false, Failed: false, Panic: true, PanicMsg: "boom"},
 		}
 		var organized, failed int64
-		trackApplyResults(outcomes, &organized, &failed)
+		trackApplyResults(applyPhaseInputs{}, outcomes, &organized, &failed)
 		assert.Equal(t, int64(1), organized)
 		assert.Equal(t, int64(1), failed, "panicked outcome must count toward failed")
 	})
@@ -26,7 +26,7 @@ func TestTrackApplyResults_PanicCountsAsFailed(t *testing.T) {
 			{FilePath: "b.mp4", Success: true},
 		}
 		var organized, failed int64
-		trackApplyResults(outcomes, &organized, &failed)
+		trackApplyResults(applyPhaseInputs{}, outcomes, &organized, &failed)
 		assert.Equal(t, int64(2), organized)
 		assert.Equal(t, int64(0), failed)
 	})
@@ -38,7 +38,7 @@ func TestTrackApplyResults_PanicCountsAsFailed(t *testing.T) {
 			{FilePath: "c.mp4", Success: false, Panic: true},
 		}
 		var organized, failed int64
-		trackApplyResults(outcomes, &organized, &failed)
+		trackApplyResults(applyPhaseInputs{}, outcomes, &organized, &failed)
 		assert.Equal(t, int64(1), organized)
 		assert.Equal(t, int64(2), failed)
 	})

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -533,6 +533,16 @@ func persistScrapeOutcomes(ctx context.Context, ch <-chan scrapeFileOutcome, inp
 				if r := recover(); r != nil {
 					logging.Errorf("persistScrapeOutcome panic recovered: %v", r)
 					recorded[o.FilePath] = true
+					auditCtx, auditCancel := historyAuditContext()
+					defer auditCancel()
+					recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+						MovieID:      o.MovieID,
+						BatchJobID:   jobIDPtr(inputs.JobID),
+						Operation:    models.HistoryOpScrape,
+						OriginalPath: o.FilePath,
+						Status:       models.HistoryStatusFailed,
+						ErrorMessage: fmt.Sprintf("persist panic: %v", r),
+					})
 				}
 			}()
 			if persistScrapeOutcome(ctx, o, inputs, onFileFailed) {

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -95,6 +95,9 @@ func (p *scrapePhase) Run(ctx context.Context, inputs scrapePhaseInputs, files [
 	)
 
 	if err := ctx.Err(); err != nil {
+		if inputs.MovieRepo != nil {
+			persistScrapeOutcomePool(ctx, outcomes, inputs, cfg.OnFileScrapeFailed)
+		}
 		trackScrapeResults(inputs, outcomes)
 		inputs.Lifecycle.MarkCancelled()
 		return
@@ -466,18 +469,6 @@ func scrapeFile(
 func trackScrapeResults(inputs scrapePhaseInputs, outcomes []scrapeFileOutcome) {
 	for _, o := range outcomes {
 		if o.Cancelled {
-			continue
-		}
-		if o.Success && o.Result != nil && o.Result.Movie != nil {
-			auditCtx, cancel := historyAuditContext()
-			defer cancel()
-			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
-				MovieID:      o.MovieID,
-				BatchJobID:   jobIDPtr(inputs.JobID),
-				Operation:    models.HistoryOpScrape,
-				OriginalPath: o.FilePath,
-				Status:       models.HistoryStatusSuccess,
-			})
 			continue
 		}
 		if o.Panic {

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -95,10 +95,7 @@ func (p *scrapePhase) Run(ctx context.Context, inputs scrapePhaseInputs, files [
 	)
 
 	if err := ctx.Err(); err != nil {
-		if inputs.MovieRepo != nil {
-			persistScrapeOutcomePool(ctx, outcomes, inputs, cfg.OnFileScrapeFailed)
-		}
-		trackScrapeResults(inputs, outcomes)
+		trackScrapeResults(inputs, outcomes, nil)
 		inputs.Lifecycle.MarkCancelled()
 		return
 	}
@@ -112,6 +109,7 @@ func (p *scrapePhase) Run(ctx context.Context, inputs scrapePhaseInputs, files [
 	// callers (CLI/API/rescrape) still persist inline inside Workflow.Scrape.
 	// Must complete before MarkCompleted so job-state persistence (deferred at
 	// the top of Run) captures Persisted=true and any surfacable persist errors.
+	var recorded map[string]bool
 	if inputs.MovieRepo != nil {
 		// Pass cfg.OnFileScrapeFailed so a persist failure can correct the
 		// per-file WS status: the scrape worker already emitted a terminal
@@ -119,19 +117,19 @@ func (p *scrapePhase) Run(ctx context.Context, inputs scrapePhaseInputs, files [
 		// runs later in a separate pool and can fail. Re-firing the per-file
 		// failure hook overwrites messagesByFile[filePath] so the frontend
 		// never shows a stale "success" for a file whose persist failed.
-		persistScrapeOutcomePool(ctx, outcomes, inputs, cfg.OnFileScrapeFailed)
+		recorded = persistScrapeOutcomePool(ctx, outcomes, inputs, cfg.OnFileScrapeFailed)
 	}
 
 	// ctx can be canceled while the persist pool is draining. After it returns,
 	// re-check cancellation before MarkCompleted so a canceled job finishes as
 	// Cancelled rather than being marked Completed with a partially-persisted set.
 	if err := ctx.Err(); err != nil {
-		trackScrapeResults(inputs, outcomes)
+		trackScrapeResults(inputs, outcomes, recorded)
 		inputs.Lifecycle.MarkCancelled()
 		return
 	}
 
-	trackScrapeResults(inputs, outcomes)
+	trackScrapeResults(inputs, outcomes, recorded)
 
 	inputs.Lifecycle.MarkCompleted()
 }
@@ -466,9 +464,21 @@ func scrapeFile(
 // trackScrapeResults processes collected scrapeFileOutcomes.
 // The actual Updater/Broadcaster calls are already done inside scrapeFile;
 // this function is a seam for future aggregation (e.g., counters, logging).
-func trackScrapeResults(inputs scrapePhaseInputs, outcomes []scrapeFileOutcome) {
+func trackScrapeResults(inputs scrapePhaseInputs, outcomes []scrapeFileOutcome, recordedSuccesses map[string]bool) {
 	for _, o := range outcomes {
 		if o.Cancelled {
+			continue
+		}
+		if o.Success && o.Result != nil && o.Result.Movie != nil && !recordedSuccesses[o.FilePath] {
+			auditCtx, cancel := historyAuditContext()
+			defer cancel()
+			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+				MovieID:      o.MovieID,
+				BatchJobID:   jobIDPtr(inputs.JobID),
+				Operation:    models.HistoryOpScrape,
+				OriginalPath: o.FilePath,
+				Status:       models.HistoryStatusSuccess,
+			})
 			continue
 		}
 		if o.Panic {
@@ -508,7 +518,9 @@ func trackScrapeResults(inputs scrapePhaseInputs, outcomes []scrapeFileOutcome) 
 //
 // Only successful scrapes with a movie are persisted; the failed/no-result/panic
 // paths are already reflected on the in-memory result and have nothing to write.
-func persistScrapeOutcomePool(ctx context.Context, outcomes []scrapeFileOutcome, inputs scrapePhaseInputs, onFileFailed func(filePath, movieID, errMsg string)) {
+func persistScrapeOutcomePool(ctx context.Context, outcomes []scrapeFileOutcome, inputs scrapePhaseInputs, onFileFailed func(filePath, movieID, errMsg string)) map[string]bool {
+	recorded := make(map[string]bool)
+	var recordedMu sync.Mutex
 	work := make(chan scrapeFileOutcome, len(outcomes))
 	for _, o := range outcomes {
 		work <- o
@@ -526,22 +538,31 @@ func persistScrapeOutcomePool(ctx context.Context, outcomes []scrapeFileOutcome,
 					logging.Errorf("persist worker panic recovered: %v", r)
 				}
 			}()
-			persistScrapeOutcomes(ctx, work, inputs, onFileFailed)
+			for k, v := range persistScrapeOutcomes(ctx, work, inputs, onFileFailed) {
+				recordedMu.Lock()
+				recorded[k] = v
+				recordedMu.Unlock()
+			}
 		}()
 	}
 	wg.Wait()
+	return recorded
 }
 
 // persistScrapeOutcomes drains a channel of scrape outcomes and persists each
 // successful one. Used by persistScrapeOutcomePool to fan persist work across
 // the pool goroutines.
-func persistScrapeOutcomes(ctx context.Context, ch <-chan scrapeFileOutcome, inputs scrapePhaseInputs, onFileFailed func(filePath, movieID, errMsg string)) {
+func persistScrapeOutcomes(ctx context.Context, ch <-chan scrapeFileOutcome, inputs scrapePhaseInputs, onFileFailed func(filePath, movieID, errMsg string)) map[string]bool {
+	recorded := make(map[string]bool)
 	for o := range ch {
 		if !o.Success || o.Result == nil || o.Result.Movie == nil || inputs.MovieRepo == nil {
 			continue
 		}
-		persistScrapeOutcome(ctx, o, inputs, onFileFailed)
+		if persistScrapeOutcome(ctx, o, inputs, onFileFailed) {
+			recorded[o.FilePath] = true
+		}
 	}
+	return recorded
 }
 
 // persistScrapeOutcome persists a single successful scrape's movie off the
@@ -551,7 +572,7 @@ func persistScrapeOutcomes(ctx context.Context, ch <-chan scrapeFileOutcome, inp
 // AtomicUpdateFileResult so API/UI readers observe a consistent snapshot.
 // Persist failures surface on the MovieResult, preserving the original
 // error semantics (persist error → Status=Failed).
-func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrapePhaseInputs, onFileFailed func(filePath, movieID, errMsg string)) {
+func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrapePhaseInputs, onFileFailed func(filePath, movieID, errMsg string)) (recordedSuccess bool) {
 	// Clone before persisting: UpsertWithTranslations mutates its input movie in
 	// place (resets association slices to reapply associations). The in-memory
 	// MovieResult.Movie shares the result.Movie pointer, so mutating it here
@@ -566,7 +587,7 @@ func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrap
 	saved, err := inputs.MovieRepo.UpsertWithTranslations(ctx, cloned, genreTrans, actressTrans)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			return
+			return false
 		}
 		logging.Warnf("[scrape-phase] Failed to persist %s: %v", o.MovieID, err)
 		_ = inputs.Updater.AtomicUpdateFileResult(o.FilePath, func(current *resultstore.MovieResult) (*resultstore.MovieResult, error) {
@@ -601,7 +622,7 @@ func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrap
 			Status:       models.HistoryStatusFailed,
 			ErrorMessage: fmt.Sprintf("persist failed: %v", err),
 		})
-		return
+		return true
 	}
 	// Refresh the in-memory movie with the DB-saved version (DB-assigned IDs,
 	// normalized associations) and flip Persisted. AtomicUpdateFileResult clones
@@ -626,6 +647,7 @@ func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrap
 		OriginalPath: o.FilePath,
 		Status:       models.HistoryStatusSuccess,
 	})
+	return true
 }
 
 func classifyFileScrapeError(err error) (errMsg, errorCode string) {

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -583,7 +583,7 @@ func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrap
 	saved, err := inputs.MovieRepo.UpsertWithTranslations(ctx, cloned, genreTrans, actressTrans)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			return true
+			return false
 		}
 		logging.Warnf("[scrape-phase] Failed to persist %s: %v", o.MovieID, err)
 		_ = inputs.Updater.AtomicUpdateFileResult(o.FilePath, func(current *resultstore.MovieResult) (*resultstore.MovieResult, error) {

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -533,6 +533,14 @@ func persistScrapeOutcomes(ctx context.Context, ch <-chan scrapeFileOutcome, inp
 				if r := recover(); r != nil {
 					logging.Errorf("persistScrapeOutcome panic recovered: %v", r)
 					recorded[o.FilePath] = true
+					_ = inputs.Updater.AtomicUpdateFileResult(o.FilePath, func(current *resultstore.MovieResult) (*resultstore.MovieResult, error) {
+						current.Status = models.JobStatusFailed
+						current.Error = fmt.Sprintf("persist panic: %v", r)
+						return current, nil
+					})
+					if onFileFailed != nil {
+						onFileFailed(o.FilePath, o.MovieID, fmt.Sprintf("persist panic: %v", r))
+					}
 					auditCtx, auditCancel := historyAuditContext()
 					defer auditCancel()
 					recordHistory(auditCtx, inputs.HistoryRepo, models.History{

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -469,42 +469,12 @@ func trackScrapeResults(inputs scrapePhaseInputs, outcomes []scrapeFileOutcome, 
 		if o.Cancelled {
 			continue
 		}
-		if o.Success && o.Result != nil && o.Result.Movie != nil && !recordedSuccesses[o.FilePath] {
-			auditCtx, cancel := historyAuditContext()
-			defer cancel()
-			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
-				MovieID:      o.MovieID,
-				BatchJobID:   jobIDPtr(inputs.JobID),
-				Operation:    models.HistoryOpScrape,
-				OriginalPath: o.FilePath,
-				Status:       models.HistoryStatusSuccess,
-			})
+		if o.Success && !recordedSuccesses[o.FilePath] {
+			auditScrapeSuccess(inputs, o)
 			continue
 		}
-		if o.Panic {
-			auditCtx, cancel := historyAuditContext()
-			defer cancel()
-			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
-				MovieID:      o.MovieID,
-				BatchJobID:   jobIDPtr(inputs.JobID),
-				Operation:    models.HistoryOpScrape,
-				OriginalPath: o.FilePath,
-				Status:       models.HistoryStatusFailed,
-				ErrorMessage: o.PanicMsg,
-			})
-			continue
-		}
-		if o.Failed {
-			auditCtx, cancel := historyAuditContext()
-			defer cancel()
-			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
-				MovieID:      o.MovieID,
-				BatchJobID:   jobIDPtr(inputs.JobID),
-				Operation:    models.HistoryOpScrape,
-				OriginalPath: o.FilePath,
-				Status:       models.HistoryStatusFailed,
-				ErrorMessage: o.ErrorMsg,
-			})
+		if o.Panic || o.Failed {
+			auditScrapeFailure(inputs, o)
 		}
 	}
 }
@@ -558,9 +528,17 @@ func persistScrapeOutcomes(ctx context.Context, ch <-chan scrapeFileOutcome, inp
 		if !o.Success || o.Result == nil || o.Result.Movie == nil || inputs.MovieRepo == nil {
 			continue
 		}
-		if persistScrapeOutcome(ctx, o, inputs, onFileFailed) {
-			recorded[o.FilePath] = true
-		}
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					logging.Errorf("persistScrapeOutcome panic recovered: %v", r)
+					recorded[o.FilePath] = true
+				}
+			}()
+			if persistScrapeOutcome(ctx, o, inputs, onFileFailed) {
+				recorded[o.FilePath] = true
+			}
+		}()
 	}
 	return recorded
 }

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -39,15 +39,16 @@ func NewScrapePhase() ScrapePhase {
 // batch path). The dedicated persist pool reads Result.Movie to persist off
 // the per-goroutine critical path. It is nil for the failed/error/panic paths.
 type scrapeFileOutcome struct {
-	FilePath string
-	MovieID  string
-	Success  bool
-	Failed   bool // true if scrape failed (not panic)
-	Panic    bool // true if goroutine panicked
-	PanicMsg string
-	ErrorMsg string
-	Result   *scrape.ScrapeResult
-	Meta     *workflow.OrchestrationMeta
+	FilePath  string
+	MovieID   string
+	Success   bool
+	Failed    bool // true if scrape failed (not panic)
+	Panic     bool // true if goroutine panicked
+	Cancelled bool // true if scrape failed due to context.Canceled
+	PanicMsg  string
+	ErrorMsg  string
+	Result    *scrape.ScrapeResult
+	Meta      *workflow.OrchestrationMeta
 }
 
 // Run executes the scrape phase: setup errgroup → iterate files → dispatch
@@ -94,11 +95,8 @@ func (p *scrapePhase) Run(ctx context.Context, inputs scrapePhaseInputs, files [
 	)
 
 	if err := ctx.Err(); err != nil {
+		trackScrapeResults(inputs, outcomes)
 		inputs.Lifecycle.MarkCancelled()
-		// On cancellation, skip persist + MarkCompleted — the job is cancelled,
-		// not completed. Any outcomes collected before cancellation are already
-		// reflected on the in-memory result via UpdateFileResult inside each
-		// worker goroutine.
 		return
 	}
 
@@ -125,11 +123,12 @@ func (p *scrapePhase) Run(ctx context.Context, inputs scrapePhaseInputs, files [
 	// re-check cancellation before MarkCompleted so a canceled job finishes as
 	// Cancelled rather than being marked Completed with a partially-persisted set.
 	if err := ctx.Err(); err != nil {
+		trackScrapeResults(inputs, outcomes)
 		inputs.Lifecycle.MarkCancelled()
 		return
 	}
 
-	trackScrapeResults(outcomes)
+	trackScrapeResults(inputs, outcomes)
 
 	inputs.Lifecycle.MarkCompleted()
 }
@@ -226,8 +225,8 @@ func interpretScrapeResult(
 	meta *workflow.OrchestrationMeta,
 	err error,
 	preserveMovieID bool,
-) scrapeFileOutcome {
-	outcome := scrapeFileOutcome{
+) (outcome scrapeFileOutcome) {
+	outcome = scrapeFileOutcome{
 		FilePath: filePath,
 		MovieID:  cmd.MovieID,
 	}
@@ -238,6 +237,7 @@ func interpretScrapeResult(
 		fileStatus := models.JobStatusFailed
 		if errors.Is(err, context.Canceled) {
 			fileStatus = models.JobStatusCancelled
+			outcome.Cancelled = true
 		}
 		errMsg, errorCode := classifyFileScrapeError(err)
 		inputs.Updater.UpdateFileResult(filePath, &resultstore.MovieResult{
@@ -258,7 +258,7 @@ func interpretScrapeResult(
 		})
 		outcome.Failed = true
 		outcome.ErrorMsg = errMsg
-		return outcome
+		return
 	}
 	if result == nil || result.Movie == nil {
 		// The scrape package populates result.Message with a verbose,
@@ -352,8 +352,8 @@ func scrapeFile(
 	fromMatcher bool,
 	inputs scrapePhaseInputs,
 	cfg ScrapePhaseConfig,
-) scrapeFileOutcome {
-	outcome := scrapeFileOutcome{
+) (outcome scrapeFileOutcome) {
+	outcome = scrapeFileOutcome{
 		FilePath: filePath,
 		MovieID:  cmd.MovieID,
 	}
@@ -463,9 +463,37 @@ func scrapeFile(
 // trackScrapeResults processes collected scrapeFileOutcomes.
 // The actual Updater/Broadcaster calls are already done inside scrapeFile;
 // this function is a seam for future aggregation (e.g., counters, logging).
-func trackScrapeResults(outcomes []scrapeFileOutcome) {
-	// Currently a no-op seam — all per-file tracking is done inline in scrapeFile.
-	// Future: aggregate counters, emit summary events, etc.
+func trackScrapeResults(inputs scrapePhaseInputs, outcomes []scrapeFileOutcome) {
+	for _, o := range outcomes {
+		if o.Cancelled {
+			continue
+		}
+		if o.Panic {
+			auditCtx, cancel := historyAuditContext()
+			defer cancel()
+			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+				MovieID:      o.MovieID,
+				BatchJobID:   jobIDPtr(inputs.JobID),
+				Operation:    models.HistoryOpScrape,
+				OriginalPath: o.FilePath,
+				Status:       models.HistoryStatusFailed,
+				ErrorMessage: o.PanicMsg,
+			})
+			continue
+		}
+		if o.Failed {
+			auditCtx, cancel := historyAuditContext()
+			defer cancel()
+			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+				MovieID:      o.MovieID,
+				BatchJobID:   jobIDPtr(inputs.JobID),
+				Operation:    models.HistoryOpScrape,
+				OriginalPath: o.FilePath,
+				Status:       models.HistoryStatusFailed,
+				ErrorMessage: o.ErrorMsg,
+			})
+		}
+	}
 }
 
 // persistScrapeOutcomePool fans persist work for a batch of scrape outcomes out
@@ -478,9 +506,6 @@ func trackScrapeResults(outcomes []scrapeFileOutcome) {
 // Only successful scrapes with a movie are persisted; the failed/no-result/panic
 // paths are already reflected on the in-memory result and have nothing to write.
 func persistScrapeOutcomePool(ctx context.Context, outcomes []scrapeFileOutcome, inputs scrapePhaseInputs, onFileFailed func(filePath, movieID, errMsg string)) {
-	// Seed a buffered channel (closed up-front) so persist workers can drain it
-	// concurrently without coordination. Buffer == outcome count guarantees the
-	// sends never block.
 	work := make(chan scrapeFileOutcome, len(outcomes))
 	for _, o := range outcomes {
 		work <- o
@@ -493,11 +518,6 @@ func persistScrapeOutcomePool(ctx context.Context, outcomes []scrapeFileOutcome,
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			// Recover panics inside the persist worker. The top-level Run defer
-			// cannot catch panics from these goroutines; an unrecovered panic from
-			// repository persistence would crash the process and bypass lifecycle
-			// accounting. Log and swallow so the pool drains and the job resolves
-			// through its normal failure path instead of taking down the binary.
 			defer func() {
 				if r := recover(); r != nil {
 					logging.Errorf("persist worker panic recovered: %v", r)
@@ -542,6 +562,9 @@ func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrap
 	}
 	saved, err := inputs.MovieRepo.UpsertWithTranslations(ctx, cloned, genreTrans, actressTrans)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
 		logging.Warnf("[scrape-phase] Failed to persist %s: %v", o.MovieID, err)
 		_ = inputs.Updater.AtomicUpdateFileResult(o.FilePath, func(current *resultstore.MovieResult) (*resultstore.MovieResult, error) {
 			current.Status = models.JobStatusFailed
@@ -565,6 +588,16 @@ func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrap
 		if onFileFailed != nil {
 			onFileFailed(o.FilePath, o.MovieID, fmt.Sprintf("persist failed: %v", err))
 		}
+		recordAuditCtx, recordAuditCancel := historyAuditContext()
+		defer recordAuditCancel()
+		recordHistory(recordAuditCtx, inputs.HistoryRepo, models.History{
+			MovieID:      o.MovieID,
+			BatchJobID:   jobIDPtr(inputs.JobID),
+			Operation:    models.HistoryOpScrape,
+			OriginalPath: o.FilePath,
+			Status:       models.HistoryStatusFailed,
+			ErrorMessage: fmt.Sprintf("persist failed: %v", err),
+		})
 		return
 	}
 	// Refresh the in-memory movie with the DB-saved version (DB-assigned IDs,
@@ -576,6 +609,19 @@ func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrap
 			current.Movie = saved.Clone()
 		}
 		return current, nil
+	})
+	movieID := o.MovieID
+	if saved != nil {
+		movieID = saved.ID
+	}
+	recordAuditCtx, recordAuditCancel := historyAuditContext()
+	defer recordAuditCancel()
+	recordHistory(recordAuditCtx, inputs.HistoryRepo, models.History{
+		MovieID:      movieID,
+		BatchJobID:   jobIDPtr(inputs.JobID),
+		Operation:    models.HistoryOpScrape,
+		OriginalPath: o.FilePath,
+		Status:       models.HistoryStatusSuccess,
 	})
 }
 

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -572,7 +572,7 @@ func persistScrapeOutcomes(ctx context.Context, ch <-chan scrapeFileOutcome, inp
 // AtomicUpdateFileResult so API/UI readers observe a consistent snapshot.
 // Persist failures surface on the MovieResult, preserving the original
 // error semantics (persist error → Status=Failed).
-func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrapePhaseInputs, onFileFailed func(filePath, movieID, errMsg string)) (recordedSuccess bool) {
+func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrapePhaseInputs, onFileFailed func(filePath, movieID, errMsg string)) (handled bool) {
 	// Clone before persisting: UpsertWithTranslations mutates its input movie in
 	// place (resets association slices to reapply associations). The in-memory
 	// MovieResult.Movie shares the result.Movie pointer, so mutating it here
@@ -587,7 +587,7 @@ func persistScrapeOutcome(ctx context.Context, o scrapeFileOutcome, inputs scrap
 	saved, err := inputs.MovieRepo.UpsertWithTranslations(ctx, cloned, genreTrans, actressTrans)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			return false
+			return true
 		}
 		logging.Warnf("[scrape-phase] Failed to persist %s: %v", o.MovieID, err)
 		_ = inputs.Updater.AtomicUpdateFileResult(o.FilePath, func(current *resultstore.MovieResult) (*resultstore.MovieResult, error) {

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -468,6 +468,18 @@ func trackScrapeResults(inputs scrapePhaseInputs, outcomes []scrapeFileOutcome) 
 		if o.Cancelled {
 			continue
 		}
+		if o.Success && o.Result != nil && o.Result.Movie != nil {
+			auditCtx, cancel := historyAuditContext()
+			defer cancel()
+			recordHistory(auditCtx, inputs.HistoryRepo, models.History{
+				MovieID:      o.MovieID,
+				BatchJobID:   jobIDPtr(inputs.JobID),
+				Operation:    models.HistoryOpScrape,
+				OriginalPath: o.FilePath,
+				Status:       models.HistoryStatusSuccess,
+			})
+			continue
+		}
 		if o.Panic {
 			auditCtx, cancel := historyAuditContext()
 			defer cancel()

--- a/web/frontend/tests/fullstack/regressions/history-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/history-api.spec.ts
@@ -293,7 +293,7 @@ test.describe('History happy path — records appear after real scrape+organize'
 
 		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-003.mp4`] });
 		await waitForJobCompletion(request, jobId);
-		await submitOrganize(request, jobId, '/tmp/javinizer-e2e-output/history-test');
+		await submitOrganize(request, jobId, `/tmp/javinizer-e2e-output/history-test-${Date.now()}`);
 		// Wait for the organize goroutine to transition the job to 'organized'
 		let organized = false;
 		for (let i = 0; i < 30; i++) {

--- a/web/frontend/tests/fullstack/regressions/history-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/history-api.spec.ts
@@ -294,7 +294,8 @@ test.describe('History happy path — records appear after real scrape+organize'
 		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-003.mp4`] });
 		await waitForJobCompletion(request, jobId);
 		await submitOrganize(request, jobId, '/tmp/javinizer-e2e-output/history-test');
-		await waitForJobCompletion(request, jobId);
+		// Wait for the job to transition from completed to running, then to organized
+		await waitForJobCompletion(request, jobId, { timeout: 30000 });
 
 		const listResp = await request.get(`${BACKEND_BASE}/api/v1/history?limit=50`);
 		expect(listResp.ok(), 'GET /history must return 200 after scrape+organize').toBeTruthy();

--- a/web/frontend/tests/fullstack/regressions/history-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/history-api.spec.ts
@@ -33,7 +33,7 @@
  * that contract.
  */
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { BACKEND_BASE, loginAgainstRealBackend } from '../helpers';
+import { BACKEND_BASE, loginAgainstRealBackend, submitScrape, submitOrganize, waitForJobCompletion, DEFAULT_INPUT_DIR } from '../helpers';
 
 interface HistoryListResponse {
 	records: unknown[];
@@ -272,3 +272,45 @@ async function api_deleteHistoryBulk(
 		: '';
 	return api.delete(`${BACKEND_BASE}/api/v1/history${query}`);
 }
+
+test.describe('History happy path — records appear after real scrape+organize', () => {
+	test('scrape+organize writes history rows; list+stats reflect activity; delete removes one', async ({
+		request,
+	}: {
+		request: APIRequestContext;
+	}) => {
+		await loginAgainstRealBackend(request);
+
+		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-001.mp4`] });
+		await waitForJobCompletion(request, jobId);
+		await submitOrganize(request, jobId, '/tmp/e2e-output');
+		await waitForJobCompletion(request, jobId);
+
+		const listResp = await request.get(`${BACKEND_BASE}/api/v1/history?limit=50`);
+		expect(listResp.ok(), 'GET /history must return 200 after scrape+organize').toBeTruthy();
+		const list = (await listResp.json()) as HistoryListResponse;
+		expect(list.total, 'history total must be > 0 after scrape+organize').toBeGreaterThan(0);
+		expect(list.records.length, 'history records must be non-empty').toBeGreaterThan(0);
+
+		const operations = list.records.map((r) => (r as Record<string, unknown>).operation);
+		expect(operations, 'must contain a scrape record').toContain('scrape');
+		expect(operations, 'must contain an organize record').toContain('organize');
+
+		const statsResp = await request.get(`${BACKEND_BASE}/api/v1/history/stats`);
+		expect(statsResp.ok()).toBeTruthy();
+		const stats = (await statsResp.json()) as HistoryStats;
+		expect(stats.total, 'stats total must be > 0').toBeGreaterThan(0);
+		expect(stats.success, 'stats success must be > 0').toBeGreaterThan(0);
+		expect(stats.by_operation.scrape, 'stats scrape count must be > 0').toBeGreaterThan(0);
+		expect(stats.by_operation.organize, 'stats organize count must be > 0').toBeGreaterThan(0);
+
+		const firstRecord = list.records[0] as Record<string, unknown>;
+		const recordId = String(firstRecord.id);
+		const delResp = await api_deleteHistory(request, recordId);
+		expect(delResp.ok(), 'DELETE must succeed for a valid id').toBeTruthy();
+
+		const afterResp = await request.get(`${BACKEND_BASE}/api/v1/history?limit=50`);
+		const after = (await afterResp.json()) as HistoryListResponse;
+		expect(after.total, 'total must decrease by 1 after delete').toBe(list.total - 1);
+	});
+});

--- a/web/frontend/tests/fullstack/regressions/history-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/history-api.spec.ts
@@ -294,12 +294,15 @@ test.describe('History happy path — records appear after real scrape+organize'
 		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-003.mp4`] });
 		await waitForJobCompletion(request, jobId);
 		await submitOrganize(request, jobId, '/tmp/javinizer-e2e-output/history-test');
-		// Poll until job leaves 'completed' (scrape) and reaches a terminal state (organized)
+		// Wait for the organize goroutine to transition the job to 'organized'
+		let organized = false;
 		for (let i = 0; i < 30; i++) {
-			const job = await waitForJobCompletion(request, jobId, { timeout: 30000 });
-			if (job.status === 'organized' || job.status === 'completed') break;
+			const resp = await request.get(`${BACKEND_BASE}/api/v1/batch/${jobId}`);
+			const job = await resp.json();
+			if (job.status === 'organized') { organized = true; break; }
 			await new Promise((r) => setTimeout(r, 1000));
 		}
+		expect(organized, 'job must reach organized status').toBeTruthy();
 
 		const listResp = await request.get(`${BACKEND_BASE}/api/v1/history?limit=50`);
 		expect(listResp.ok(), 'GET /history must return 200 after scrape+organize').toBeTruthy();

--- a/web/frontend/tests/fullstack/regressions/history-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/history-api.spec.ts
@@ -294,8 +294,12 @@ test.describe('History happy path — records appear after real scrape+organize'
 		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-003.mp4`] });
 		await waitForJobCompletion(request, jobId);
 		await submitOrganize(request, jobId, '/tmp/javinizer-e2e-output/history-test');
-		// Wait for the job to transition from completed to running, then to organized
-		await waitForJobCompletion(request, jobId, { timeout: 30000 });
+		// Poll until job leaves 'completed' (scrape) and reaches a terminal state (organized)
+		for (let i = 0; i < 30; i++) {
+			const job = await waitForJobCompletion(request, jobId, { timeout: 30000 });
+			if (job.status === 'organized' || job.status === 'completed') break;
+			await new Promise((r) => setTimeout(r, 1000));
+		}
 
 		const listResp = await request.get(`${BACKEND_BASE}/api/v1/history?limit=50`);
 		expect(listResp.ok(), 'GET /history must return 200 after scrape+organize').toBeTruthy();

--- a/web/frontend/tests/fullstack/regressions/history-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/history-api.spec.ts
@@ -77,7 +77,11 @@ async function getHistoryStats(api: APIRequestContext): Promise<HistoryStats> {
 
 test.describe('History API: real contract against the e2emock backend', () => {
 	async function clearHistory(api: APIRequestContext): Promise<void> {
-		await api.delete(`${BACKEND_BASE}/api/v1/history?older_than_days=36500`);
+		const resp = await getHistory(api, { limit: 1000 });
+		for (const record of resp.records) {
+			const id = String((record as Record<string, unknown>).id);
+			await api.delete(`${BACKEND_BASE}/api/v1/history/${id}`);
+		}
 	}
 
 	test('GET /history returns the well-formed empty-state response', async ({

--- a/web/frontend/tests/fullstack/regressions/history-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/history-api.spec.ts
@@ -290,7 +290,7 @@ test.describe('History happy path — records appear after real scrape+organize'
 	}) => {
 		await loginAgainstRealBackend(request);
 
-		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-003.mp4`] });
+		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-001.mp4`] });
 		await waitForJobCompletion(request, jobId);
 		await submitOrganize(request, jobId, '/tmp/javinizer-e2e-output/history-test');
 		await waitForJobCompletion(request, jobId);
@@ -304,6 +304,9 @@ test.describe('History happy path — records appear after real scrape+organize'
 		const operations = list.records.map((r) => (r as Record<string, unknown>).operation);
 		expect(operations, 'must contain a scrape record').toContain('scrape');
 		expect(operations, 'must contain an organize record').toContain('organize');
+		const organizeRecord = list.records.find((r) => (r as Record<string, unknown>).operation === 'organize');
+		expect(organizeRecord, 'organize record must exist').toBeTruthy();
+		expect((organizeRecord as Record<string, unknown>).status, 'organize record must be success').toBe('success');
 
 		const statsResp = await request.get(`${BACKEND_BASE}/api/v1/history/stats`);
 		expect(statsResp.ok()).toBeTruthy();

--- a/web/frontend/tests/fullstack/regressions/history-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/history-api.spec.ts
@@ -76,14 +76,19 @@ async function getHistoryStats(api: APIRequestContext): Promise<HistoryStats> {
 }
 
 test.describe('History API: real contract against the e2emock backend', () => {
+	async function clearHistory(api: APIRequestContext): Promise<void> {
+		await api.delete(`${BACKEND_BASE}/api/v1/history?older_than_days=36500`);
+	}
+
 	test('GET /history returns the well-formed empty-state response', async ({
 		request,
 	}: {
 		request: APIRequestContext;
 	}) => {
 		await loginAgainstRealBackend(request);
+		await clearHistory(request);
 
-		// The history table is empty (nothing writes to it — see spec header).
+		// The history table is empty (after clearing any rows from prior specs).
 		// The empty-state contract: records is an empty array (not null),
 		// total is 0, + limit/offset echo the request. The dashboard's
 		// "Recent Runs" list renders "No operations recorded yet." off this.
@@ -283,7 +288,7 @@ test.describe('History happy path — records appear after real scrape+organize'
 
 		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-001.mp4`] });
 		await waitForJobCompletion(request, jobId);
-		await submitOrganize(request, jobId, '/tmp/e2e-output');
+		await submitOrganize(request, jobId, '/tmp/javinizer-e2e-output');
 		await waitForJobCompletion(request, jobId);
 
 		const listResp = await request.get(`${BACKEND_BASE}/api/v1/history?limit=50`);

--- a/web/frontend/tests/fullstack/regressions/history-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/history-api.spec.ts
@@ -33,7 +33,7 @@
  * that contract.
  */
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { BACKEND_BASE, loginAgainstRealBackend, submitScrape, submitOrganize, waitForJobCompletion, DEFAULT_INPUT_DIR } from '../helpers';
+import { BACKEND_BASE, loginAgainstRealBackend, submitScrape, submitOrganize, waitForJobCompletion, DEFAULT_INPUT_DIR, seedInputFiles } from '../helpers';
 
 interface HistoryListResponse {
 	records: unknown[];
@@ -289,8 +289,9 @@ test.describe('History happy path — records appear after real scrape+organize'
 		request: APIRequestContext;
 	}) => {
 		await loginAgainstRealBackend(request);
+		await seedInputFiles(['GOOD-003.mp4']);
 
-		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-001.mp4`] });
+		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-003.mp4`] });
 		await waitForJobCompletion(request, jobId);
 		await submitOrganize(request, jobId, '/tmp/javinizer-e2e-output/history-test');
 		await waitForJobCompletion(request, jobId);

--- a/web/frontend/tests/fullstack/regressions/history-api.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/history-api.spec.ts
@@ -290,9 +290,9 @@ test.describe('History happy path — records appear after real scrape+organize'
 	}) => {
 		await loginAgainstRealBackend(request);
 
-		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-001.mp4`] });
+		const jobId = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-003.mp4`] });
 		await waitForJobCompletion(request, jobId);
-		await submitOrganize(request, jobId, '/tmp/javinizer-e2e-output');
+		await submitOrganize(request, jobId, '/tmp/javinizer-e2e-output/history-test');
 		await waitForJobCompletion(request, jobId);
 
 		const listResp = await request.get(`${BACKEND_BASE}/api/v1/history?limit=50`);


### PR DESCRIPTION
## Summary

`HistoryRepository.Create` had zero production callers, so the dashboard permanently showed 0 operations / empty Recent Runs even after heavy scrape+organize activity. This PR wires history writes into both workflows.

### Supplier seam
- `JobStore` gains a `historyRepo` field + `WithHistoryRepo` option, backfilled in `createJob` AND `wireJobDeps` (covers new + reconstructed jobs) + `SetReconstructionDeps` (already-loaded jobs), wired at `bootstrap.go` + `testkit/helpers.go`.

### Scrape writes (two points)
- `persistScrapeOutcome`: success → `Operation=scrape, Status=success`; persist failure → `Status=failed` (on the persist pool worker, per-row audit context).
- `trackScrapeResults`: scraper errors/panics → `Status=failed` (panic precedence, never cancellation — requires a `Cancelled` flag on `scrapeFileOutcome` + named returns on `scrapeFile`/`interpretScrapeResult` so panic recovery reaches the caller).

### Organize writes (two points)
- `interpretApplyResult`: success → `Operation=organize, Status=success` with `NewPath`, `DryRun`, and `Metadata` (operation mode + step flags); failure → `Status=failed`.
- `trackApplyResults`: organize panics → `Status=failed` (panic-only, not `Failed` — avoids double-writing normal failures already recorded in `interpretApplyResult`).

### Cancellation handling
- `Run` calls tracking before cancellation returns so already-terminal outcomes are recorded.
- Cancellation-only outcomes write **no** record (would inflate the "Failures" metric).

### Safety
- Audit context: per-row 5s bounded context (detached from the expired worker `taskCtx`).
- `HistoryRepo` captured under `job.mu` RLock in phase input builders.
- `Create` failures log-and-continue; never mutate `FileResult.Status`.
- `History` built only from per-file-local data (no shared-pointer races).

## What's intentionally out of scope
- `download`/`nfo` as separate top-level operations (recorded as sub-steps in the organize row's `Metadata` JSON).
- `Status=reverted` writes (the reverter owns that via `BatchFileOperation`).
- Rescrape history (a follow-up can record it as `Operation=scrape` with `Metadata={"rescrape":true}` reusing the same seam).

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./internal/worker/...` — clean
- [x] `golangci-lint run` — 0 issues
- [x] `go test -short ./...` — all packages pass
- [x] `go test -race` — no data races
- [x] Integration tests: JobStore wiring (createJob + SetReconstructionDeps), real `persistScrapeOutcome` → `FindByBatchJobID`, scrape failure/panic, cancellation-skips, organize panic (not double-written), 10-file concurrency, timeout-context, multipart (two rows per operation)
- [x] Frontend: `history-api.spec.ts` reframed to scrape+organize → read → delete lifecycle
- [x] Code review: gpt-5.6-sol, 4 rounds, 0 issues remaining
- [x] Spec review: gpt-5.6-sol, 6 rounds, 0 issues remaining

Closes #85