### PR TITLE
fix(template): honor unknown_actress_mode=skip in GroupActress @Unknown substitution

### DIFF
--- a/internal/downloader/config.go
+++ b/internal/downloader/config.go
@@ -72,6 +72,7 @@ func ConfigFromAppConfig(cfg *config.Config, nameCfg nfo.NFONameConfig) *Config 
 			GroupActressMin:         nameCfg.GroupActressMin,
 			GroupActressName:        nameCfg.GroupActressName,
 			GroupUnknownActressName: nameCfg.GroupUnknownActressName,
+			UnknownActressMode:      nameCfg.UnknownActressMode,
 			ActressFolder:           cfg.Output.MediaFormat.ActressFolder,
 			ActressDelimiter:        nameCfg.ActressDelimiter,
 			FirstNameOrder:          nameCfg.FirstNameOrder,

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -126,6 +126,7 @@ func (d *Downloader) buildTemplateContext(movie *models.Movie, multipart *Multip
 	ctx.GroupActressMin = d.config.GroupActressMin
 	ctx.GroupActressName = d.config.GroupActressName
 	ctx.GroupUnknownActressName = d.config.GroupUnknownActressName
+	ctx.UnknownActressMode = d.config.UnknownActressMode
 	ctx.ActressDelimiter = d.config.ActressDelimiter
 	ctx.FirstNameOrder = d.actorFirstNameOrder
 	ctx.ActressLanguageJa = d.config.ActorJapaneseNames
@@ -149,6 +150,7 @@ func (d *Downloader) generateActressFilename(movie *models.Movie, actressName st
 	ctx.GroupActressMin = d.config.GroupActressMin
 	ctx.GroupActressName = d.config.GroupActressName
 	ctx.GroupUnknownActressName = d.config.GroupUnknownActressName
+	ctx.UnknownActressMode = d.config.UnknownActressMode
 	ctx.ActressDelimiter = d.config.ActressDelimiter
 	ctx.FirstNameOrder = d.actorFirstNameOrder
 	ctx.ActressLanguageJa = d.config.ActorJapaneseNames

--- a/internal/nfo/config.go
+++ b/internal/nfo/config.go
@@ -22,6 +22,7 @@ type NFONameConfig struct {
 	// <ACTORS>/<ACTRESSES> tag resolution picks up main's actress features
 	// (group unknown substitution, JA preference, custom delimiter).
 	GroupUnknownActressName string
+	UnknownActressMode      models.UnknownActressMode
 	ActressDelimiter        string
 	ActressLanguageJA       bool
 }
@@ -123,6 +124,7 @@ func (c *Config) ToNFONameConfig(isMultiPart bool, partSuffix string) NFONameCon
 		PartSuffix:              partSuffix,
 		FirstNameOrder:          c.FirstNameOrder,
 		GroupUnknownActressName: c.GroupUnknownActressName,
+		UnknownActressMode:      c.UnknownActressMode,
 		ActressDelimiter:        c.ActressDelimiter,
 		ActressLanguageJA:       c.ActressLanguageJA,
 	}
@@ -136,7 +138,7 @@ func (c *Config) ToNFONameConfig(isMultiPart bool, partSuffix string) NFONameCon
 // Config-bridge reads: cfg.Metadata.NFO.Format.FilenameTemplate, cfg.Metadata.NFO.Format.FirstNameOrder,
 // cfg.Metadata.NFO.Feature.PerFile, cfg.Output.Operation.GroupActress, cfg.Output.Operation.GroupActressMin,
 // cfg.Output.Operation.GroupActressName, cfg.Output.Operation.GroupUnknownActressName, cfg.Output.Template,
-// cfg.Output.Template.ActressDelimiter, cfg.Metadata.NFO.Format.ActressLanguageJA
+// cfg.Output.Template.ActressDelimiter, cfg.Metadata.NFO.Format.ActressLanguageJA, cfg.Metadata.NFO.Format.UnknownActressMode
 func NFONameConfigFromAppConfig(cfg *config.Config) NFONameConfig {
 	if cfg == nil {
 		return NFONameConfig{}
@@ -149,6 +151,7 @@ func NFONameConfigFromAppConfig(cfg *config.Config) NFONameConfig {
 		PerFile:                 cfg.Metadata.NFO.Feature.PerFile,
 		FirstNameOrder:          cfg.Metadata.NFO.Format.FirstNameOrder,
 		GroupUnknownActressName: cfg.Output.Operation.GroupUnknownActressName,
+		UnknownActressMode:      cfg.Metadata.NFO.Format.UnknownActressMode,
 		ActressDelimiter:        cfg.Output.Template.ActressDelimiter,
 		ActressLanguageJA:       cfg.Metadata.NFO.Format.ActressLanguageJA,
 	}

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -185,6 +185,7 @@ func (g *Generator) Generate(ctx context.Context, movie *models.Movie, outputPat
 	tmplCtx.GroupActressMin = g.config.GroupActressMin
 	tmplCtx.GroupActressName = g.config.GroupActressName
 	tmplCtx.GroupUnknownActressName = g.config.GroupUnknownActressName
+	tmplCtx.UnknownActressMode = g.config.UnknownActressMode
 	tmplCtx.ActressLanguageJa = g.config.ActressLanguageJA
 	tmplCtx.ActressDelimiter = g.config.ActressDelimiter
 	filename, err := g.templateEngine.Execute(g.config.FilenameTemplate, tmplCtx)
@@ -433,6 +434,7 @@ func ResolveNFOFilename(engine template.EngineInterface, movie *models.Movie, cf
 	tmplCtx.GroupActressMin = cfg.GroupActressMin
 	tmplCtx.GroupActressName = cfg.GroupActressName
 	tmplCtx.GroupUnknownActressName = cfg.GroupUnknownActressName
+	tmplCtx.UnknownActressMode = cfg.UnknownActressMode
 	tmplCtx.ActressLanguageJa = cfg.ActressLanguageJA
 	tmplCtx.ActressDelimiter = cfg.ActressDelimiter
 	filename, err := engine.Execute(cfg.FilenameTemplate, tmplCtx)

--- a/internal/nfo/unknown_actress_propagation_test.go
+++ b/internal/nfo/unknown_actress_propagation_test.go
@@ -1,0 +1,92 @@
+package nfo
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/template"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnknownActressMode_PropagationThroughBridges guards the fix for the
+// @Unknown insertion bug: when unknown_actress_mode is "skip" (the config
+// default) and group_actress is enabled, the mode must propagate from the
+// app config through NFONameConfigFromAppConfig -> NFONameConfig -> each
+// downstream ConfigFromAppConfig bridge so that <ACTORS>/<ACTRESSES>
+// rendering suppresses @Unknown. A regression in any bridge wiring would
+// let @Unknown leak back into folder/filename/poster paths.
+func TestUnknownActressMode_PropagationThroughBridges(t *testing.T) {
+	skipCfg := &config.Config{
+		Output: config.OutputConfig{
+			Operation: config.OutputOperationConfig{
+				GroupActress:            true,
+				GroupActressName:        "@Group",
+				GroupUnknownActressName: "@Unknown",
+			},
+		},
+		Metadata: config.MetadataConfig{
+			NFO: config.NFOConfig{
+				Format: config.NFOFormatConfig{
+					UnknownActressMode: models.UnknownActressModeSkip,
+					UnknownActressText: "Unknown",
+				},
+			},
+		},
+	}
+
+	fallbackCfg := &config.Config{
+		Output: config.OutputConfig{
+			Operation: config.OutputOperationConfig{
+				GroupActress:            true,
+				GroupActressName:        "@Group",
+				GroupUnknownActressName: "@Unknown",
+			},
+		},
+		Metadata: config.MetadataConfig{
+			NFO: config.NFOConfig{
+				Format: config.NFOFormatConfig{
+					UnknownActressMode: models.UnknownActressModeFallback,
+					UnknownActressText: "Unknown",
+				},
+			},
+		},
+	}
+
+	t.Run("NFONameConfigFromAppConfig propagates mode", func(t *testing.T) {
+		skipName := NFONameConfigFromAppConfig(skipCfg)
+		assert.Equal(t, models.UnknownActressModeSkip, skipName.UnknownActressMode, "skip must propagate to NFONameConfig")
+		assert.True(t, skipName.GroupActress, "group_actress must propagate")
+
+		fallbackName := NFONameConfigFromAppConfig(fallbackCfg)
+		assert.Equal(t, models.UnknownActressModeFallback, fallbackName.UnknownActressMode, "fallback must propagate to NFONameConfig")
+	})
+
+	t.Run("nfo.ConfigFromAppConfig propagates mode", func(t *testing.T) {
+		nameCfg := NFONameConfigFromAppConfig(skipCfg)
+		nfoCfg := ConfigFromAppConfig(skipCfg, nameCfg)
+		require.NotNil(t, nfoCfg)
+		assert.Equal(t, models.UnknownActressModeSkip, nfoCfg.UnknownActressMode, "skip must propagate to nfo.Config")
+	})
+
+	t.Run("end-to-end: skip suppresses @Unknown in <ACTORS> render", func(t *testing.T) {
+		nameCfg := NFONameConfigFromAppConfig(skipCfg)
+		nameCfg.FilenameTemplate = "<ACTORS>"
+		movie := &models.Movie{ID: "IPX-123"} // no actresses
+		eng := template.NewEngine()
+		got := ResolveNFOFilename(eng, movie, nameCfg)
+		assert.NotContains(t, got, "@Unknown", "skip mode must suppress @Unknown in rendered <ACTORS>")
+		// An empty <ACTORS> render falls back to movie.ID per ResolveNFOFilename's
+		// empty-filename handling; the key assertion is that @Unknown is absent.
+	})
+
+	t.Run("end-to-end: fallback inserts @Unknown in <ACTORS> render", func(t *testing.T) {
+		nameCfg := NFONameConfigFromAppConfig(fallbackCfg)
+		nameCfg.FilenameTemplate = "<ACTORS>"
+		movie := &models.Movie{ID: "IPX-123"} // no actresses
+		eng := template.NewEngine()
+		got := ResolveNFOFilename(eng, movie, nameCfg)
+		assert.Contains(t, got, "@Unknown", "fallback mode must insert @Unknown in rendered <ACTORS>")
+	})
+}

--- a/internal/organizer/config.go
+++ b/internal/organizer/config.go
@@ -78,6 +78,7 @@ func ConfigFromAppConfig(cfg *config.Config, nameCfg nfo.NFONameConfig) *Config 
 			GroupActressMin:         nameCfg.GroupActressMin,
 			GroupActressName:        nameCfg.GroupActressName,
 			GroupUnknownActressName: nameCfg.GroupUnknownActressName,
+			UnknownActressMode:      nameCfg.UnknownActressMode,
 			ActressFolder:           cfg.Output.MediaFormat.ActressFolder,
 			ActressDelimiter:        cfg.Output.Template.ActressDelimiter,
 			FirstNameOrder:          nameCfg.FirstNameOrder,

--- a/internal/organizer/media_format_config.go
+++ b/internal/organizer/media_format_config.go
@@ -1,5 +1,7 @@
 package organizer
 
+import "github.com/javinizer/javinizer-go/internal/models"
+
 // MediaFormatConfig holds shared media file naming/format configuration.
 // Both organizer.Config and downloader.Config embed this to avoid duplicating
 // the 8+ identical media-format fields that both derive from *config.Config.
@@ -11,9 +13,10 @@ type MediaFormatConfig struct {
 	ScreenshotFolder        string
 	ScreenshotPadding       int
 	GroupActress            bool
-	GroupActressMin         int    // Minimum actress count to trigger grouping (0 => 2)
-	GroupActressName        string // Folder name when GroupActress is enabled and multiple actresses (default: "@Group")
-	GroupUnknownActressName string // Replacement when GroupActress is enabled and the actress list is empty or unknown (default: "@Unknown")
+	GroupActressMin         int                       // Minimum actress count to trigger grouping (0 => 2)
+	GroupActressName        string                    // Folder name when GroupActress is enabled and multiple actresses (default: "@Group")
+	GroupUnknownActressName string                    // Replacement when GroupActress is enabled and the actress list is empty or unknown (default: "@Unknown")
+	UnknownActressMode      models.UnknownActressMode // Governs @Unknown substitution under GroupActress: "skip" (default) suppresses it, "fallback" inserts it
 	ActressFolder           string
 	ActressFormat           string
 	ActressDelimiter        string // Delimiter between actress names when no DELIM= modifier is present (default: ", ")

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -60,6 +60,7 @@ func resolveBaseFileName(cfg *Config, engine template.EngineInterface, movie *mo
 		baseCtx.GroupActressMin = cfg.GroupActressMin
 		baseCtx.GroupActressName = cfg.GroupActressName
 		baseCtx.GroupUnknownActressName = cfg.GroupUnknownActressName
+		baseCtx.UnknownActressMode = cfg.UnknownActressMode
 		baseCtx.FirstNameOrder = cfg.FirstNameOrder
 		baseCtx.ActressLanguageJa = cfg.ActressLanguageJA
 		baseCtx.ActressDelimiter = cfg.ActressDelimiter
@@ -147,6 +148,7 @@ func buildPlanContext(cfg *Config, engine template.EngineInterface, movie *model
 	ctx.GroupActressMin = cfg.GroupActressMin
 	ctx.GroupActressName = cfg.GroupActressName
 	ctx.GroupUnknownActressName = cfg.GroupUnknownActressName
+	ctx.UnknownActressMode = cfg.UnknownActressMode
 	ctx.FirstNameOrder = cfg.FirstNameOrder
 	ctx.ActressLanguageJa = cfg.ActressLanguageJA
 	ctx.ActressDelimiter = cfg.ActressDelimiter

--- a/internal/template/context.go
+++ b/internal/template/context.go
@@ -83,10 +83,11 @@ type Context struct {
 	DefaultLanguage string
 
 	// Output configuration
-	GroupActress            bool   // Replace multiple actresses with group name
-	GroupActressMin         int    // Minimum actress count to trigger grouping; grouping applies when count >= this value (0 => 2, the default)
-	GroupActressName        string // Folder name when GroupActress is enabled and multiple actresses (default: "@Group")
-	GroupUnknownActressName string // Replacement when GroupActress is enabled and the actress list is empty or unknown (default: "@Unknown")
+	GroupActress            bool                      // Replace multiple actresses with group name
+	GroupActressMin         int                       // Minimum actress count to trigger grouping; grouping applies when count >= this value (0 => 2, the default)
+	GroupActressName        string                    // Folder name when GroupActress is enabled and multiple actresses (default: "@Group")
+	GroupUnknownActressName string                    // Replacement when GroupActress is enabled and the actress list is empty or unknown (default: "@Unknown")
+	UnknownActressMode      models.UnknownActressMode // Governs @Unknown substitution under GroupActress: "skip" (default) suppresses it, "fallback" inserts it
 
 	// Name formatting
 	FirstNameOrder    bool   // true = FirstName LastName, false = LastName FirstName (default: false for backward compat)
@@ -204,6 +205,7 @@ func (c *Context) Clone() *Context {
 		GroupActressMin:         c.GroupActressMin,
 		GroupActressName:        c.GroupActressName,
 		GroupUnknownActressName: c.GroupUnknownActressName,
+		UnknownActressMode:      c.UnknownActressMode,
 		FirstNameOrder:          c.FirstNameOrder,
 		ActressLanguageJa:       c.ActressLanguageJa,
 		ActressDelimiter:        c.ActressDelimiter,
@@ -358,4 +360,15 @@ func (c *Context) groupActressMin() int {
 		return 2
 	}
 	return c.GroupActressMin
+}
+
+// skipUnknownActress reports whether the @Unknown placeholder should be
+// suppressed when GroupActress is enabled and the actress list is empty or
+// the only name is unknown. Mirrors the aggregator's SkipUnknown flag: true
+// when unknown_actress_mode is "skip" (or unset, the config default); false
+// only when mode is "fallback". Keeping the template substitution consistent
+// with the aggregator prevents @Unknown from leaking into <ACTORS>/<ACTRESSES>
+// when the user has disabled the unknown-actress fallback.
+func (c *Context) skipUnknownActress() bool {
+	return c.UnknownActressMode != models.UnknownActressModeFallback
 }

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -891,9 +891,15 @@ func (e *Engine) resolveActressListTag(modifier string, ctx *Context) string {
 	if len(ctx.Actresses) == 0 && len(ctx.ActressDetails) == 0 {
 		// No actresses at all. Under GroupActress, mirror the original
 		// PowerShell javinizer which substitutes @Unknown when the actress
-		// list is empty (so folder naming stays "@Unknown" rather than
-		// blank). Without GroupActress, return empty.
+		// list is empty — but only when unknown_actress_mode is "fallback".
+		// When the mode is "skip" (the config default), suppress the
+		// @Unknown placeholder so the field is left empty, matching the
+		// aggregator's SkipUnknown behaviour. Without GroupActress, return
+		// empty.
 		if ctx.GroupActress {
+			if ctx.skipUnknownActress() {
+				return ""
+			}
 			return resolveGroupUnknownName(ctx.GroupUnknownActressName)
 		}
 		return ""
@@ -923,10 +929,16 @@ func (e *Engine) resolveActressListTag(modifier string, ctx *Context) string {
 	}
 
 	if ctx.GroupActress {
-		// An empty list or a lone unknown actress always resolves to the
+		// An empty list or a lone unknown actress resolves to the
 		// @Unknown replacement, regardless of the configured threshold —
-		// mirrors the original PowerShell javinizer.
+		// mirrors the original PowerShell javinizer — but only when
+		// unknown_actress_mode is "fallback". When the mode is "skip" (the
+		// config default), suppress @Unknown so the field is left empty,
+		// matching the aggregator's SkipUnknown behaviour.
 		if len(names) == 0 || (len(names) == 1 && isUnknownActressName(names[0])) {
+			if ctx.skipUnknownActress() {
+				return ""
+			}
 			return resolveGroupUnknownName(ctx.GroupUnknownActressName)
 		}
 		// Group substitution applies when the actress count reaches the

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -718,6 +718,7 @@ func TestTemplateEngine_GroupActress(t *testing.T) {
 		groupActressMin         int
 		groupActressName        string
 		groupUnknownActressName string
+		unknownActressMode      models.UnknownActressMode
 		template                string
 		want                    string
 	}{
@@ -903,6 +904,13 @@ func TestTemplateEngine_GroupActress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Default to fallback so the @Unknown substitution cases
+			// (which predate the skip/fallback distinction) still pass;
+			// cases with real actresses never hit the @Unknown path.
+			mode := tt.unknownActressMode
+			if mode == "" {
+				mode = models.UnknownActressModeFallback
+			}
 			ctx := &Context{
 				ID:                      "IPX-535",
 				Actresses:               tt.actresses,
@@ -910,6 +918,7 @@ func TestTemplateEngine_GroupActress(t *testing.T) {
 				GroupActressMin:         tt.groupActressMin,
 				GroupActressName:        tt.groupActressName,
 				GroupUnknownActressName: tt.groupUnknownActressName,
+				UnknownActressMode:      mode,
 			}
 
 			got, err := engine.Execute(tt.template, ctx)

--- a/internal/template/unknown_actress_mode_test.go
+++ b/internal/template/unknown_actress_mode_test.go
@@ -1,0 +1,84 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+func TestUnknownActressSkipMode_SuppressesAtUnknown(t *testing.T) {
+	eng := NewEngine()
+
+	ctx := &Context{
+		GroupActress:            true,
+		GroupUnknownActressName: "@Unknown",
+		UnknownActressMode:      models.UnknownActressModeSkip,
+	}
+
+	got, err := eng.Execute("<ACTORS>", ctx)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got != "" {
+		t.Fatalf("skip mode should suppress @Unknown, got %q", got)
+	}
+}
+
+func TestUnknownActressFallbackMode_InsertsAtUnknown(t *testing.T) {
+	eng := NewEngine()
+
+	ctx := &Context{
+		GroupActress:            true,
+		GroupUnknownActressName: "@Unknown",
+		UnknownActressMode:      models.UnknownActressModeFallback,
+	}
+
+	got, err := eng.Execute("<ACTORS>", ctx)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got != "@Unknown" {
+		t.Fatalf("fallback mode should insert @Unknown, got %q", got)
+	}
+}
+
+func TestUnknownActressSkipMode_LoneUnknownActressSuppressed(t *testing.T) {
+	eng := NewEngine()
+
+	ctx := &Context{
+		GroupActress:            true,
+		GroupUnknownActressName: "@Unknown",
+		UnknownActressMode:      models.UnknownActressModeSkip,
+		Actresses:               []string{"Unknown"},
+		ActressDetails:          []ActressDetail{{FirstName: "Unknown"}},
+	}
+
+	got, err := eng.Execute("<ACTORS>", ctx)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got != "" {
+		t.Fatalf("skip mode should suppress lone unknown actress, got %q", got)
+	}
+}
+
+func TestUnknownActressUnsetMode_SuppressesAtUnknown(t *testing.T) {
+	eng := NewEngine()
+
+	ctx := &Context{
+		GroupActress:            true,
+		GroupUnknownActressName: "@Unknown",
+	}
+
+	got, err := eng.Execute("<ACTORS>", ctx)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got != "" {
+		t.Fatalf("unset mode defaults to skip, should suppress @Unknown, got %q", got)
+	}
+}

--- a/internal/workflow/display_title.go
+++ b/internal/workflow/display_title.go
@@ -36,6 +36,7 @@ func ApplyDisplayTitleFromSource(ctx context.Context, scraped *models.Movie, tit
 		displayCtx.GroupActressMin = nameCfg.GroupActressMin
 		displayCtx.GroupActressName = nameCfg.GroupActressName
 		displayCtx.GroupUnknownActressName = nameCfg.GroupUnknownActressName
+		displayCtx.UnknownActressMode = nameCfg.UnknownActressMode
 		displayCtx.FirstNameOrder = nameCfg.FirstNameOrder
 		displayCtx.ActressLanguageJa = nameCfg.ActressLanguageJA
 		displayCtx.ActressDelimiter = nameCfg.ActressDelimiter

--- a/internal/workflow/preview_orchestrator.go
+++ b/internal/workflow/preview_orchestrator.go
@@ -171,6 +171,7 @@ func (o *previewOrchImpl) resolveMediaPaths(
 	previewTmplCtx.GroupActressMin = o.previewCfg.PathCfg.GroupActressMin
 	previewTmplCtx.GroupActressName = o.previewCfg.PathCfg.GroupActressName
 	previewTmplCtx.GroupUnknownActressName = o.previewCfg.PathCfg.GroupUnknownActressName
+	previewTmplCtx.UnknownActressMode = o.previewCfg.PathCfg.UnknownActressMode
 	previewTmplCtx.ActressDelimiter = o.previewCfg.PathCfg.ActressDelimiter
 	previewTmplCtx.FirstNameOrder = o.previewCfg.PathCfg.FirstNameOrder
 	previewTmplCtx.ActressLanguageJa = o.previewCfg.PathCfg.ActressLanguageJA


### PR DESCRIPTION
## Problem

When `unknown_actress_mode: skip` (the config default) is set with `group_actress: true`, templates using `<ACTORS>`/`<ACTRESSES>` still inserted `@Unknown` into folder names, filenames, and poster paths instead of skipping the field. The aggregator (`actress_merger.go`) correctly honored skip mode, but the template engine's `GroupActress` substitution always inserted `@Unknown` and had no knowledge of `unknown_actress_mode`.

## Root cause

Two independent "unknown actress" mechanisms existed:

1. **Aggregator** — honored `unknown_actress_mode`: `skip` suppresses the placeholder, `fallback` inserts `"Unknown"`. ✅
2. **Template engine** (`resolveActressListTag`) — under `GroupActress`, an empty actress list or a lone unknown actress **always** returned `@Unknown` via `resolveGroupUnknownName(ctx.GroupUnknownActressName)`. It had no access to `unknown_actress_mode`. ❌

## Fix

Threaded `UnknownActressMode` from config through `NFONameConfig` and the organizer/nfo/downloader/workflow bridges into `template.Context`, then gated both `@Unknown` branches in `resolveActressListTag` on `ctx.skipUnknownActress()` (returns `true` when mode `!= fallback`, matching the aggregator's `SkipUnknown` semantics and the config default `skip`).

- **Skip / unset** → suppresses `@Unknown` (field left empty)
- **Fallback** → inserts `@Unknown` (preserves existing behavior)

This intentionally deviates from the original PowerShell Javinizer, which inserted `@Unknown` unconditionally under `GroupActress` — the user explicitly expects `skip` mode to govern `@Unknown` insertion.

## Changes

**Core fix:**
- `internal/template/context.go` — added `UnknownActressMode` field to `Context`, copied in `Clone()`, added `skipUnknownActress()` helper
- `internal/template/engine.go` — gated both `@Unknown` return paths in `resolveActressListTag` on `ctx.skipUnknownActress()`

**Wiring (config → Context, 11 sites):**
- `internal/organizer/media_format_config.go` — added `UnknownActressMode` field + `models` import
- `internal/nfo/config.go` — added to `NFONameConfig`; wired in `ConfigFromAppConfig`, `NFONameConfigFromAppConfig`, `ToNFONameConfig`; updated bridge doc comment
- `internal/organizer/config.go`, `internal/downloader/config.go` — bridge functions populate `UnknownActressMode`
- `internal/organizer/organizer.go`, `internal/downloader/downloader.go`, `internal/nfo/generator.go`, `internal/workflow/preview_orchestrator.go`, `internal/workflow/display_title.go` — all context-building sites set `ctx.UnknownActressMode`

**Tests:**
- `internal/template/unknown_actress_mode_test.go` — regression tests: skip-suppresses, fallback-inserts, lone-unknown-suppressed, unset-defaults-to-skip
- `internal/nfo/unknown_actress_propagation_test.go` — bridge propagation test: proves `unknown_actress_mode` reaches rendered `<ACTORS>` output through `NFONameConfigFromAppConfig` → `ConfigFromAppConfig` → `ResolveNFOFilename`
- `internal/template/engine_test.go` — `TestTemplateEngine_GroupActress` struct gained `unknownActressMode` field, defaults to `Fallback` so existing `@Unknown` cases still pass

## Verification

- `go build ./...` ✅
- `go test -short ./...` ✅ (all packages)
- `golangci-lint` ✅ (0 issues)
- `gofmt` ✅
- Pre-commit hook: all 7 checks passed ✅

## Review

Reviewed by a gpt-5.6-sol sub-agent (low thinking): no blockers. The one actionable finding — missing bridge propagation test — is addressed by `unknown_actress_propagation_test.go`.