### PR TITLE
fix(review): correct actress panel spacing, dynamic grids, and single-column layout

### DIFF
--- a/web/frontend/src/lib/components/ActressEditor.svelte
+++ b/web/frontend/src/lib/components/ActressEditor.svelte
@@ -354,16 +354,16 @@
 			</Button>
 		</div>
 	{:else}
-		<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+		<div class="grid grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] gap-4">
 			{#each actresses as actress, index (actress.id || `${actress.first_name}-${actress.last_name}-${actress.japanese_name}-${index}`)}
 				<div animate:flip={{ duration: 220, easing: quintOut }}>
-					<Card class="p-3 w-fit hover:shadow-md transition-shadow">
+					<Card class="p-3 w-full max-w-[10rem] hover:shadow-md transition-shadow">
 					<div class="space-y-2">
 						{#if actress.thumb_url}
 							<img
 								src={actress.thumb_url}
 								alt={getFullName(actress)}
-								class="w-28 aspect-2/3 object-cover rounded"
+								class="w-28 aspect-2/3 object-cover rounded mx-auto"
 								onerror={(e) => {
 									(e.currentTarget as HTMLImageElement).src =
 										"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='300' fill='%23374151'%3E%3Crect width='200' height='300'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%239CA3AF' font-family='system-ui' font-size='14'%3ENo Image%3C/text%3E%3C/svg%3E";
@@ -371,7 +371,7 @@
 							/>
 						{:else}
 							<div
-								class="w-28 aspect-2/3 bg-accent rounded flex items-center justify-center text-xs text-muted-foreground"
+								class="w-28 aspect-2/3 bg-accent rounded flex items-center justify-center text-xs text-muted-foreground mx-auto"
 							>
 								{m.editor_no_image()}
 							</div>

--- a/web/frontend/src/routes/review/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/review/[jobId]/+page.svelte
@@ -231,7 +231,7 @@
 					/>
 
 					{#if s.viewMode === 'grid-poster' || s.viewMode === 'grid-cover'}
-						<div class="grid {s.viewMode === 'grid-cover' ? 'grid-cols-3' : 'grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6'} {s.viewMode === 'grid-cover' ? 'gap-2' : 'gap-4'}">
+						<div class="grid {s.viewMode === 'grid-cover' ? 'grid-cols-[repeat(auto-fill,minmax(22rem,1fr))]' : 'grid-cols-[repeat(auto-fill,minmax(11rem,1fr))]'} {s.viewMode === 'grid-cover' ? 'gap-2' : 'gap-4'}">
 							{#each s.filteredMovieGroups as group}
 								{@const effMovie = s.getEffectiveMovie(group.primaryResult.file_path, group.primaryResult.movie)}
 								<ReviewGridCard
@@ -263,6 +263,22 @@
 					{:else}
 						{#key s.currentResult.file_path}
 							<div class="grid grid-cols-1 gap-4 lg:grid-cols-[clamp(20rem,24vw,22.5rem)_minmax(0,1fr)] lg:gap-6" in:fade|local={{ duration: 180 }}>
+							<div class="lg:col-start-2 lg:row-start-1 sticky top-0 z-20 bg-background lg:static lg:z-auto lg:bg-transparent">
+							<MovieNavigationCard
+								bind:currentMovieIndex={s.currentMovieIndex}
+								movieResultsLength={s.movieResults.length}
+								currentMovieId={s.currentMovie.id}
+								hasChanges={s.reviewPageController.hasChanges(s.currentResult.file_path)}
+								sourceResults={s.currentMovieGroup?.results || [s.currentResult]}
+								primaryFilePath={s.currentResult.file_path}
+								bind:showFullSourcePath={s.showFullSourcePath}
+								showOutputPreview={s.canOrganize}
+								outputPreviewDisabled={s.previewNeedsDestination && !s.destinationPath.trim()}
+								onOpenOutputPreview={() => (s.showOutputPreviewModal = true)}
+								onExclude={s.reviewPageController.excludeCurrentMovie}
+							/>
+							</div>
+							<div class="lg:col-start-1 lg:row-start-1 lg:row-span-2">
 							<ReviewMediaSidebar
 								currentMovie={s.currentMovie}
 								displayPosterUrl={s.displayPosterUrl}
@@ -283,22 +299,9 @@
 							onOpenScreenshotViewer={s.reviewPageController.openScreenshotViewer}
 							previewImageURL={s.reviewPageController.previewImageURL}
 						/>
+						</div>
 
-						<div class="space-y-6 min-w-0">
-							<MovieNavigationCard
-								bind:currentMovieIndex={s.currentMovieIndex}
-								movieResultsLength={s.movieResults.length}
-								currentMovieId={s.currentMovie.id}
-								hasChanges={s.reviewPageController.hasChanges(s.currentResult.file_path)}
-								sourceResults={s.currentMovieGroup?.results || [s.currentResult]}
-								primaryFilePath={s.currentResult.file_path}
-								bind:showFullSourcePath={s.showFullSourcePath}
-								showOutputPreview={s.canOrganize}
-								outputPreviewDisabled={s.previewNeedsDestination && !s.destinationPath.trim()}
-								onOpenOutputPreview={() => (s.showOutputPreviewModal = true)}
-								onExclude={s.reviewPageController.excludeCurrentMovie}
-							/>
-
+						<div class="space-y-6 min-w-0 lg:col-start-2 lg:row-start-2">
 							<MovieMetadataCard
 								currentMovie={s.currentMovie}
 								currentResult={s.currentResult}

--- a/web/frontend/src/routes/review/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/review/[jobId]/+page.svelte
@@ -263,7 +263,7 @@
 					{:else}
 						{#key s.currentResult.file_path}
 							<div class="grid grid-cols-1 gap-4 lg:grid-cols-[clamp(20rem,24vw,22.5rem)_minmax(0,1fr)] lg:gap-6" in:fade|local={{ duration: 180 }}>
-							<div class="lg:col-start-2 lg:row-start-1 sticky top-0 z-20 bg-background lg:static lg:z-auto lg:bg-transparent">
+							<div class="lg:col-start-2 lg:row-start-1 sticky top-16 z-30 bg-background lg:static lg:z-auto lg:bg-transparent">
 							<MovieNavigationCard
 								bind:currentMovieIndex={s.currentMovieIndex}
 								movieResultsLength={s.movieResults.length}

--- a/web/frontend/src/routes/review/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/review/[jobId]/+page.svelte
@@ -231,7 +231,7 @@
 					/>
 
 					{#if s.viewMode === 'grid-poster' || s.viewMode === 'grid-cover'}
-						<div class="grid {s.viewMode === 'grid-cover' ? 'grid-cols-[repeat(auto-fill,minmax(22rem,1fr))]' : 'grid-cols-[repeat(auto-fill,minmax(11rem,1fr))]'} {s.viewMode === 'grid-cover' ? 'gap-2' : 'gap-4'}">
+						<div class="grid {s.viewMode === 'grid-cover' ? 'grid-cols-[repeat(auto-fill,minmax(min(22rem,100%),1fr))]' : 'grid-cols-[repeat(auto-fill,minmax(min(11rem,100%),1fr))]'} {s.viewMode === 'grid-cover' ? 'gap-2' : 'gap-4'}">
 							{#each s.filteredMovieGroups as group}
 								{@const effMovie = s.getEffectiveMovie(group.primaryResult.file_path, group.primaryResult.movie)}
 								<ReviewGridCard

--- a/web/frontend/src/routes/review/[jobId]/components/ReviewMediaSidebar.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/ReviewMediaSidebar.svelte
@@ -87,12 +87,11 @@
 				<div class="mb-4">
 					<p class="text-xs font-medium text-muted-foreground mb-1.5">{m.review_cover_fanart()}</p>
 					{#if currentMovie.cover_url}
-						<button onclick={onOpenCoverViewer} class="cursor-zoom-in hover:opacity-80 transition-opacity" title={m.review_view_cover_image()} aria-label={m.review_view_cover_image()}>
+						<button onclick={onOpenCoverViewer} class="cursor-zoom-in hover:opacity-80 transition-opacity w-full block" title={m.review_view_cover_image()} aria-label={m.review_view_cover_image()}>
 							<img
 								src={previewImageURL(currentMovie.cover_url)}
 								alt={m.review_cover_alt()}
-								class="rounded border object-contain"
-								style="max-width: 100%; max-height: 300px; width: auto;"
+								class="w-full rounded border"
 								onerror={(e) => { (e.currentTarget as HTMLImageElement).src = COVER_PLACEHOLDER_SVG; }}
 							/>
 						</button>


### PR DESCRIPTION
## Problem

PR #170 redesigned the review page but introduced several layout issues:

1. **Actress panel spacing** — cards used `w-fit`, shrinking each card to content width (~112px) while grid cells were much wider, leaving cards left-aligned with uneven, excessive horizontal spacing.
2. **Cover/poster grid** — the cover view was hardcoded to `grid-cols-3` and the poster view used coarse fixed breakpoints (`grid-cols-2 sm:3 md:4 lg:5 xl:6`), so column count never matched the available width.
3. **Single-column detail view** — the cover/fanart image left whitespace gaps because `object-contain` + `max-h-300` letterboxed it; the `MovieNavigationCard` rendered below the media sidebar on narrow screens instead of above it.

## Fix

**Actress panel** (`ActressEditor.svelte`)
- Removed `w-fit` from cards so they fill their grid cells
- Capped cards at `max-w-[10rem]` and switched the grid to `auto-fill`+`minmax(10rem,1fr)` so columns reflow with width
- Images stay fixed at `w-28` (112px) centered within each card

**Cover/poster grid** (`+page.svelte`)
- Replaced fixed column counts with CSS Grid `auto-fill`+`minmax`:
  - Cover (16:9): `minmax(22rem, 1fr)`
  - Poster (2:3): `minmax(11rem, 1fr)`
- Columns now allocate dynamically by available width

**Single-column detail view** (`ReviewMediaSidebar.svelte`, `+page.svelte`)
- Made the cover image `w-full` with no height cap so it fills the container width (no letterboxing gaps)
- Reordered the detail grid so `MovieNavigationCard` renders above the media sidebar on narrow screens, with `sticky top-0` + `bg-background` so it stays pinned and content doesn't show through
- Preserved the two-column sidebar-left layout on wide screens via explicit grid placement (`lg:col-start`/`lg:row-start`/`lg:row-span`)

## Verification

- `svelte-check` ✅ (0 errors)
- `make build-app-local` ✅ (desktop app builds)
- All 7 pre-commit checks passed ✅ (fmt, lint, vet, tests, build, swagger, type check)

## Notes

This extends PR #170 (already merged). Tested manually across narrow and wide window widths.