### PR TITLE
fix(scripts): scope pre-commit checks to staged files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,9 @@ jobs:
     - name: Run go vet
       run: make vet
 
+    - name: Run pre-commit hook scoping regression matrix
+      run: make test-hook
+
     - name: Check internal/api file size guardrail
       run: ./scripts/check_api_file_size.sh 700 internal/api
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build run run-api run-api-dev test test-short test-race test-verbose bench clean clean-all deps install web-dev web-build web-preview web-install web-clean web-restore-placeholder web-test
+.PHONY: help build run run-api run-api-dev test test-short test-race test-hook test-verbose bench clean clean-all deps install web-dev web-build web-preview web-install web-clean web-restore-placeholder web-test
 .PHONY: coverage coverage-fast coverage-html coverage-check coverage-pkg coverage-patch coverage-patch-check coverage-func ci ci-full config-drift config-sync check-import-guard check-mocks i18n-check simulate-ci
 .PHONY: fmt lint vet vuln swagger docs mocks test-e2e-fullstack test-e2e-frontend test-e2e-field-drop test-e2e-cli test-e2e-live test-coverage
 .PHONY: build-cli-linux build-cli-darwin build-cli-windows build-cli-all
@@ -24,6 +24,7 @@ help:
 	@echo "Testing:"
 	@echo "  make test               - Run all tests with verbose output"
 	@echo "  make test-short         - Run fast tests only (for pre-commit)"
+	@echo "  make test-hook          - Run pre-commit hook scoping regression tests"
 	@echo "  make test-race          - Run race detector on concurrent packages"
 	@echo "  make test-verbose       - Run tests with verbose output and count=1"
 	@echo "  make bench              - Run benchmarks"
@@ -140,6 +141,10 @@ test:
 test-short:
 	go test -short ./...
 
+# Run pre-commit hook scoping regression tests (temp git repo matrix)
+test-hook:
+	bash scripts/test-pre-commit-scoping.sh
+
 # Run tests with race detector (critical for concurrent code)
 test-race:
 	@echo "Running race detector on concurrent packages..."
@@ -228,7 +233,7 @@ check-no-hardcoded-timeouts:
 	@./scripts/check_no_hardcoded_timeouts.sh
 
 # Run full CI test suite
-ci: vet lint vuln coverage-check test-race config-drift check-import-guard check-mocks i18n-check check-no-hardcoded-timeouts
+ci: vet lint vuln coverage-check test-race test-hook config-drift check-import-guard check-mocks i18n-check check-no-hardcoded-timeouts
 	@echo "All CI checks passed!"
 
 # Run full CI suite including frontend tests

--- a/docs/09-development.md
+++ b/docs/09-development.md
@@ -287,8 +287,9 @@ Published tags are determined by release type:
 
 CI is defined in `.github/workflows/test.yml` and runs 9 jobs in parallel on
 every push and pull request. The local gate `make ci` mirrors the Go-side
-checks: `vet`, `lint`, `vuln`, `coverage-check`, `test-race`, `config-drift`,
-`check-import-guard`, and `check-mocks`. Run `make ci-full` to also run the
+checks: `vet`, `lint`, `vuln`, `coverage-check`, `test-race`, `test-hook`,
+`config-drift`, `check-import-guard`, `check-mocks`, `i18n-check`, and
+`check-no-hardcoded-timeouts`. Run `make ci-full` to also run the
 frontend suite (`make web-test`), or `make simulate-ci` to replay the GitHub
 Actions jobs locally.
 

--- a/docs/12-testing-guide.md
+++ b/docs/12-testing-guide.md
@@ -1318,18 +1318,20 @@ chmod +x .git/hooks/pre-commit
 
 ### What the Hook Checks
 
-`scripts/pre-commit.sample` runs 8 checks, after a guard that blocks `.planning/` from being committed:
+`scripts/pre-commit.sample` runs 8 checks scoped to the staged change, after a guard that blocks `.planning/` from being committed. Because the checks validate the working tree, the hook also refuses to run when anything checked is staged but the tree still has unstaged/untracked changes under checked paths (e.g. partial `git add -p` staging) — stage everything, delete the offending untracked paths, or `git stash --all --keep-index` (the `--all` matters for ignored `web/dist` build artifacts) first:
 
 1. **Code formatting** (`[1/8]`) - `gofmt -l .`; fails if any file is unformatted (run `make fmt` to fix)
-2. **golangci-lint** (`[2/8]`) - runs `golangci-lint run ./...` if installed at v2.4.0+ (warns and skips otherwise)
-3. **go vet** (`[3/8]`) - `go vet ./...`
-4. **Fast unit tests** (`[4/8]`) - `go test -short -timeout=60s ./...`
-5. **Build verification** (`[5/8]`) - `go build ./cmd/javinizer`
-6. **Swagger documentation** (`[6/8]`) - runs `make swagger` and fails if `docs/swagger/` is out of date
+2. **golangci-lint** (`[2/8]`) - runs `golangci-lint run` on packages with staged/deleted `.go` files if installed at v2.4.0+ (warns and skips otherwise); a staged `.golangci.yml` escalates to a full-repository run
+3. **go vet** (`[3/8]`) - `go vet` on packages with staged/deleted `.go` files; full repo when `go.mod`/`go.sum` changed
+4. **Fast unit tests** (`[4/8]`) - `go test -short -timeout=60s` on packages owning staged/deleted `.go` files, fixtures, or embedded assets, plus every package that (test-)imports them (a breaking API change otherwise passes while consumers' test binaries stop compiling); the full `./...` suite when module files, shared fixtures, or binary-unreachable helper packages (e.g. `internal/mocks`, `internal/testutil`) change (skipped with `PRE_COMMIT_FAST=1`). Deleting a package that surviving code still imports blocks the commit outright (the hook lists the importers); deleting an unreferenced package runs the build only
+5. **Build verification** (`[5/8]`) - `go build ./cmd/javinizer` when `.go` files, `go.mod`/`go.sum`, or Go-consumed assets (fixtures, `go:embed` targets) are staged
+6. **Swagger documentation** (`[6/8]`) - runs `make swagger` and fails if `docs/swagger/` is out of date (only when `internal/`, `cmd/`, or `docs/swagger/` files are staged)
 7. **Frontend formatting** (`[7/8]`) - `prettier --check` on staged frontend files (skipped if no frontend files are staged or `node_modules` is absent)
-8. **Frontend type check** (`[8/8]`) - `svelte-check --threshold error` (only when `web/frontend/src/` files changed)
+8. **Frontend type check** (`[8/8]`) - `svelte-check --threshold error` (only when `web/frontend/src/` files changed; skipped with `PRE_COMMIT_FAST=1`)
 
-> Checks 7 and 8 run only when frontend files are staged, and checks 2, 6, 7, and 8 degrade gracefully (warn/skip) if the required tooling is not installed locally.
+> Checks 2–4 run only on packages containing staged or deleted `.go` files — a cross-directory rename checks both the source and destination package, and staged fixtures/embeds map to their owning package. Checks 7 and 8 run only when frontend files are staged, and checks 2, 6, 7, and 8 degrade gracefully (warn/skip) if the required tooling is not installed locally. Set `PRE_COMMIT_FAST=1` to skip checks 4 and 8 for a faster pass.
+
+Modifying the hook? Run `make test-hook` to validate the staged-file scoping matrix (renames, deletions, fixtures, embeds, reverse dependents).
 
 ### Bypassing the Hook
 

--- a/docs/12-testing-guide.md
+++ b/docs/12-testing-guide.md
@@ -47,7 +47,7 @@ This project uses standard Go tooling for testing and coverage.
 | `make coverage-html` | Open HTML coverage report in browser | Visual coverage analysis |
 | `make coverage-pkg` | Display coverage breakdown by package | Identify specific gaps |
 | `make coverage-check` | Verify Codecov-compatible line coverage meets 75% threshold | Pre-push validation |
-| `make ci` | Run full CI suite locally (vet, lint, vuln, coverage-check, test-race, config-drift, check-import-guard, check-mocks) | Before opening PR |
+| `make ci` | Run full CI suite locally (vet, lint, vuln, coverage-check, test-race, test-hook, config-drift, check-import-guard, check-mocks, i18n-check, check-no-hardcoded-timeouts) | Before opening PR |
 ### Running Specific Package Tests
 
 ```bash
@@ -1321,11 +1321,11 @@ chmod +x .git/hooks/pre-commit
 `scripts/pre-commit.sample` runs 8 checks scoped to the staged change, after a guard that blocks `.planning/` from being committed. Because the checks validate the working tree, the hook also refuses to run when anything checked is staged but the tree still has unstaged/untracked changes under checked paths (e.g. partial `git add -p` staging) — stage everything, delete the offending untracked paths, or `git stash --all --keep-index` (the `--all` matters for ignored `web/dist` build artifacts) first:
 
 1. **Code formatting** (`[1/8]`) - `gofmt -l .`; fails if any file is unformatted (run `make fmt` to fix)
-2. **golangci-lint** (`[2/8]`) - runs `golangci-lint run` on packages with staged/deleted `.go` files if installed at v2.4.0+ (warns and skips otherwise); a staged `.golangci.yml` escalates to a full-repository run
-3. **go vet** (`[3/8]`) - `go vet` on packages with staged/deleted `.go` files; full repo when `go.mod`/`go.sum` changed
+2. **golangci-lint** (`[2/8]`) - runs `golangci-lint run` on packages with staged/deleted `.go` files plus reverse dependents if installed at v2.4.0+ (warns and skips otherwise); a staged `.golangci.yml` or any full-suite trigger escalates to a full-repository run
+3. **go vet** (`[3/8]`) - `go vet` on packages with staged/deleted `.go` files plus reverse dependents; full repo for full-suite triggers (module files, shared fixtures, binary-unreachable helpers)
 4. **Fast unit tests** (`[4/8]`) - `go test -short -timeout=60s` on packages owning staged/deleted `.go` files, fixtures, or embedded assets, plus every package that (test-)imports them (a breaking API change otherwise passes while consumers' test binaries stop compiling); the full `./...` suite when module files, shared fixtures, or binary-unreachable helper packages (e.g. `internal/mocks`, `internal/testutil`) change (skipped with `PRE_COMMIT_FAST=1`). Deleting a package that surviving code still imports blocks the commit outright (the hook lists the importers); deleting an unreferenced package runs the build only
 5. **Build verification** (`[5/8]`) - `go build ./cmd/javinizer` when `.go` files, `go.mod`/`go.sum`, or Go-consumed assets (fixtures, `go:embed` targets) are staged
-6. **Swagger documentation** (`[6/8]`) - runs `make swagger` and fails if `docs/swagger/` is out of date (only when `internal/`, `cmd/`, or `docs/swagger/` files are staged)
+6. **Swagger documentation** (`[6/8]`) - runs `make swagger` and fails if `docs/swagger/` is out of date (only when `internal/`, `cmd/`, `docs/swagger/`, or `Makefile` files are staged)
 7. **Frontend formatting** (`[7/8]`) - `prettier --check` on staged frontend files (skipped if no frontend files are staged or `node_modules` is absent)
 8. **Frontend type check** (`[8/8]`) - `svelte-check --threshold error` (only when `web/frontend/src/` files changed; skipped with `PRE_COMMIT_FAST=1`)
 

--- a/docs/13-local-ci-testing.md
+++ b/docs/13-local-ci-testing.md
@@ -92,10 +92,10 @@ make simulate-ci
 make ci
 ```
 
-**What it runs** — the `ci` target in the `Makefile` declares **8 prerequisites**:
+**What it runs** — the `ci` target in the `Makefile` declares **11 prerequisites**:
 
 ```makefile
-ci: vet lint vuln coverage-check test-race config-drift check-import-guard check-mocks
+ci: vet lint vuln coverage-check test-race test-hook config-drift check-import-guard check-mocks i18n-check check-no-hardcoded-timeouts
 ```
 
 | # | Target | What it enforces |
@@ -108,6 +108,9 @@ ci: vet lint vuln coverage-check test-race config-drift check-import-guard check
 | 6 | `config-drift` | `./scripts/validate-config-sync.sh` — defaults stay in sync with `configs/config.yaml.example` |
 | 7 | `check-import-guard` | `./scripts/check_import_guard.sh` — `internal/models` must not import `internal/config` |
 | 8 | `check-mocks` | regenerates mockery mocks; fails if `internal/mocks/` is out of date |
+| 9 | `test-hook` | `scripts/test-pre-commit-scoping.sh` — 50+ case staged-file scoping regression matrix for the pre-commit hook |
+| 10 | `i18n-check` | frontend Paraglide + TUI go-i18n catalog validation |
+| 11 | `check-no-hardcoded-timeouts` | guard against hardcoded timeout literals |
 
 > **Frontend:** `make ci` does **not** run frontend tests. Use `make ci-full` (= `ci` + `web-test`) to add the Vitest suite. The `fullstack-e2e` job is not part of either target — run it explicitly with `make test-e2e-fullstack`.
 
@@ -231,11 +234,11 @@ The pre-commit hook (`scripts/pre-commit.sample`) runs **8 checks** and blocks f
 | # | Check | Command / trigger |
 |---|-------|-------------------|
 | 1 | Go formatting | `gofmt -l .` (whole repo — ~1s) |
-| 2 | golangci-lint | `golangci-lint run <pkgs>` on packages with staged/deleted `.go` files (≥ v2.4.0; skipped if not installed); full repo when `.golangci.yml` is staged |
-| 3 | go vet | `go vet <pkgs>` on packages with staged/deleted `.go` files; full repo when `go.mod`/`go.sum` changed |
+| 2 | golangci-lint | `golangci-lint run <pkgs>` on packages with staged/deleted `.go` files plus reverse dependents (≥ v2.4.0; skipped if not installed); full repo when `.golangci.yml` is staged or a full-suite trigger fires (module files, shared fixtures, binary-unreachable helpers) |
+| 3 | go vet | `go vet <pkgs>` on packages with staged/deleted `.go` files plus reverse dependents; full repo for full-suite triggers (module files, shared fixtures, binary-unreachable helpers) |
 | 4 | Fast unit tests | `go test -short -timeout=60s <pkgs>` on packages owning staged/deleted `.go` files or fixtures, plus their reverse (test-)dependents; the full `./...` suite for module/shared/helper changes. Referenced package deletions hard-block; unreferenced ones run the build only (skipped with `PRE_COMMIT_FAST=1`) |
 | 5 | Build verification | `go build -o /tmp/javinizer-test ./cmd/javinizer` when `.go` files, `go.mod`/`go.sum`, or Go-consumed assets (fixtures, `go:embed` targets) are staged |
-| 6 | Swagger docs | `make swagger` then `git diff --quiet -- docs/swagger/` when `internal/`, `cmd/`, or `docs/swagger/` files are staged (regen must be committed) |
+| 6 | Swagger docs | `make swagger` then `git diff --quiet -- docs/swagger/` when `internal/`, `cmd/`, `docs/swagger/`, or `Makefile` files are staged (regen must be committed) |
 | 7 | Frontend formatting | `npx prettier --check` on staged `web/frontend/**` files (skipped without `node_modules`) |
 | 8 | Frontend types | `npx svelte-check --threshold error` when `web/frontend/src/` changes (skipped with `PRE_COMMIT_FAST=1`) |
 

--- a/docs/13-local-ci-testing.md
+++ b/docs/13-local-ci-testing.md
@@ -226,20 +226,22 @@ make test-short
 
 ### Before Committing
 
-The pre-commit hook (`scripts/pre-commit.sample`) runs **8 checks** and blocks forbidden paths (e.g. local-only planning dirs) from being committed:
+The pre-commit hook (`scripts/pre-commit.sample`) runs **8 checks** and blocks forbidden paths (e.g. local-only planning dirs) from being committed. Since the checks validate the working tree, it also refuses to run when anything checked is staged but the tree still has unstaged/untracked changes under checked paths (e.g. partial `git add -p` staging) — stage everything, delete the offending untracked paths, or `git stash --all --keep-index` (the `--all` matters for ignored `web/dist` build artifacts) first:
 
-| # | Check | Command |
-|---|-------|---------|
-| 1 | Go formatting | `gofmt -l .` |
-| 2 | golangci-lint | `$HOME/go/bin/golangci-lint run ./...` (≥ v2.4.0; skipped if not installed) |
-| 3 | go vet | `go vet ./...` |
-| 4 | Fast unit tests | `go test -short -timeout=60s ./...` |
-| 5 | Build verification | `go build -o /tmp/javinizer-test ./cmd/javinizer` |
-| 6 | Swagger docs | `make swagger` then `git diff --quiet -- docs/swagger/` (regen must be committed) |
+| # | Check | Command / trigger |
+|---|-------|-------------------|
+| 1 | Go formatting | `gofmt -l .` (whole repo — ~1s) |
+| 2 | golangci-lint | `golangci-lint run <pkgs>` on packages with staged/deleted `.go` files (≥ v2.4.0; skipped if not installed); full repo when `.golangci.yml` is staged |
+| 3 | go vet | `go vet <pkgs>` on packages with staged/deleted `.go` files; full repo when `go.mod`/`go.sum` changed |
+| 4 | Fast unit tests | `go test -short -timeout=60s <pkgs>` on packages owning staged/deleted `.go` files or fixtures, plus their reverse (test-)dependents; the full `./...` suite for module/shared/helper changes. Referenced package deletions hard-block; unreferenced ones run the build only (skipped with `PRE_COMMIT_FAST=1`) |
+| 5 | Build verification | `go build -o /tmp/javinizer-test ./cmd/javinizer` when `.go` files, `go.mod`/`go.sum`, or Go-consumed assets (fixtures, `go:embed` targets) are staged |
+| 6 | Swagger docs | `make swagger` then `git diff --quiet -- docs/swagger/` when `internal/`, `cmd/`, or `docs/swagger/` files are staged (regen must be committed) |
 | 7 | Frontend formatting | `npx prettier --check` on staged `web/frontend/**` files (skipped without `node_modules`) |
-| 8 | Frontend types | `npx svelte-check --threshold error` when `web/frontend/src/` changes |
+| 8 | Frontend types | `npx svelte-check --threshold error` when `web/frontend/src/` changes (skipped with `PRE_COMMIT_FAST=1`) |
 
-Checks 7–8 only run when staged frontend files are present; checks 2, 6, 7, and 8 degrade gracefully (skip with a warning) if their tooling isn't installed.
+Checks 2–4 are scoped to the staged change: only packages containing staged or deleted `.go` files are linted, vetted, and tested (a cross-directory rename checks both the source and destination package). Staged fixtures/embeds map to their owning package. The full short suite runs instead when module files, shared repo-root fixtures, or binary-unreachable helper packages (e.g. `internal/mocks`, `internal/testutil`) change, since scoped checks cannot see that breakage. Checks 7–8 only run when staged frontend files are present; checks 2, 6, 7, and 8 degrade gracefully (skip with a warning) if their tooling isn't installed. For a faster pass, `PRE_COMMIT_FAST=1 git commit` skips checks 4 and 8.
+
+Modifying the hook? Run `make test-hook` to validate the staged-file scoping matrix (renames, deletions, fixtures, embeds, reverse dependents).
 
 To bypass (use sparingly):
 ```bash

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -471,7 +471,10 @@ done < <(git diff --cached --name-only -z --no-renames)
 # change (including staged-deleted paths recreated on disk, which
 # 'git diff --name-only' cannot see and which get their own probe below) may
 # exist under the checked pathspecs. Refuse rather than vouch for a state we
-# never ran.
+# never ran. The dirty-tree union stays scoped to the checked pathspecs, but
+# the //go:embed census inside engages for ANY staged path — embed targets
+# live at arbitrary locations, and a staged edit touching none of the listed
+# dirs can still invalidate the committed snapshot.
 GUARD_PATHSPEC=(-- '*.go' go.mod go.sum testdata internal cmd web/dist docs/swagger configs web/frontend .golangci.yml .golangci.yaml Makefile
                 '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx' '*.s' '*.S' '*.sx' '*.syso' '*.m' '*.f' '*.F' '*.for' '*.f90' '*.swig' '*.swigcxx')
 # A guard scan that cannot run MUST NOT silently degrade to a partial
@@ -493,7 +496,17 @@ refuse_guard_scan() {
 }
 check_tree_consistency() {
     GUARD_REFUSED=""
-    STAGED_SET=$(git diff --cached --name-only --no-renames -- "${GUARD_PATHSPEC[@]}" | sort || true)
+    # Two triggers, two scopes. STAGED_SET (ANY staged path) engages the
+    # FAIL-CLOSED TOOLCHAIN census: //go:embed targets live at arbitrary
+    # paths, so even a commit whose staged paths match no checked
+    # pathspec can invalidate the snapshot (a staged deletion of a
+    # root-level embed asset kills nothing here but fails every CI
+    # build). CHECKED_SET (staged paths under GUARD_PATHSPEC) gates the
+    # dirty-tree union below: when nothing checked is staged, unrelated
+    # WIP tree changes under checked paths must NOT block the commit —
+    # the hook vouches for nothing it never ran.
+    STAGED_SET=$(git diff --cached --name-only --no-renames | sort || true)
+    CHECKED_SET=$(git diff --cached --name-only --no-renames -- "${GUARD_PATHSPEC[@]}" | sort || true)
     CONFLICT=""
     while IFS= read -r -d '' f; do
         if [ -n "$f" ] && [ -e "$f" ]; then
@@ -501,15 +514,14 @@ check_tree_consistency() {
 $f"
         fi
     done < <(git diff --cached --name-only -z --no-renames --diff-filter=D -- "${GUARD_PATHSPEC[@]}" || true)
-    if [ -n "$STAGED_SET" ]; then
+    if [ -n "$CHECKED_SET" ]; then
         # Ignored compile inputs count only inside an ACTUAL Go package
         # directory (one holding tracked .go files) or under an embed root —
         # precise and immune to ignored scratch trees (.planning/, .tmprepro/,
         # node_modules/, .worktrees/, …) with no exclusion list to maintain.
-        IGNORED_RAW=$(git ls-files --others --ignored --exclude-standard \
-            -- web/dist \
-            '*.syso' '*.go' '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx' \
-            '*.s' '*.S' '*.sx' '*.m' '*.f' '*.F' '*.for' '*.f90' '*.swig' '*.swigcxx' || true)
+        # -z everywhere below: the default output C-quotes unusual paths,
+        # and a quoted non-ASCII dir no longer matches PKG_DIRS — the
+        # masked input would slip the exact comparison that keeps it out.
         # Package dirs = union of THREE sources, because each alone leaks a
         # masking hole:
         #   * dirs whose .go files are staged for deletion (they vanish from
@@ -544,9 +556,9 @@ $f"
             { refuse_guard_scan "go list"; return 1; }
         PKG_DIRS=$( {
             {
-                git ls-files '*.go'
-                git diff --cached --name-only --no-renames --diff-filter=D -- '*.go'
-            } | while IFS= read -r g; do
+                git ls-files -z '*.go'
+                git diff --cached --name-only -z --no-renames --diff-filter=D -- '*.go'
+            } | while IFS= read -r -d '' g; do
                     d=${g%/*}; [ "$d" = "$g" ] && d=.; printf '%s\n' "$d"
                 done
             # Prefix-strip WITHOUT regex: an
@@ -571,7 +583,7 @@ $f"
         # pad with spaces so case-matching ' "$d" ' is exact-token safe
         PKG_DIRS=" $PKG_DIRS "
         IGNORED_KEPT=""
-        while IFS= read -r raw; do
+        while IFS= read -r -d '' raw; do
             [ -n "$raw" ] || continue
             case "$raw" in
                 web/dist/*)
@@ -584,38 +596,49 @@ $raw" ;;
 $raw" ;;
                     esac ;;
             esac
-        done <<FILTER_EOF
-$IGNORED_RAW
-FILTER_EOF
-        # Ignored go:embed ASSETS: the extension list above covers the
-        # toolchain's STATIC inputs, but //go:embed names ARBITRARY types
-        # from the staged snapshot itself — staging '//go:embed local.db'
-        # while local.db stays ignored (this repo ignores *.db) lets go
-        # list/vet/test/build consume the working-tree file here, then the
-        # COMMITTED snapshot fails with 'pattern local.db: no matching
-        # files found'. No static pathspec can enumerate embed targets, so
-        # ask the toolchain: go list -test -deps resolves the EXACT
-        # embed set against this tree (glob semantics, all: prefixes and
-        # the dot/underscore directory-walk exclusion handled by the
-        # tool). -test is required because plain go list leaves
-        # TestEmbedFiles and XTestEmbedFiles empty — an ignored _test.go
-        # embed asset would otherwise slip the guard while go test
-        # consumes it — and -deps is required because wildcard ./...
-        # never enumerates testdata/, yet explicit imports beneath
-        # testdata DO resolve (the same hole the TOOL_DIRS_CACHE graph
-        # union closes): an embed in such a package hides from a shallow
-        # census while its consumers break in CI. Module-cache deps the
-        # scan surfaces sit outside the checkout; the prefix-strip below
-        # drops them.
-        # Recomputed per invocation, deliberately NOT cached like
-        # TOOL_DIRS_CACHE: a mid-run-created ignored embed file changes
-        # nothing else any comparator observes. Mask set = embedded paths
-        # ABSENT FROM THE INDEX (untracked or ignored, any extension,
-        # present or future) — whatever sits in the index ships with the
-        # commit by definition. Data files READ (not embedded) by tests
-        # are not toolchain-enumerable and stay out by design.
-        # Same fail-closed rule as the directory scans above: a partial
-        # embed census would vouch for masking holes it never saw.
+        done < <(git ls-files -z --others --ignored --exclude-standard \
+            -- web/dist \
+            '*.syso' '*.go' '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx' \
+            '*.s' '*.S' '*.sx' '*.m' '*.f' '*.F' '*.for' '*.f90' '*.swig' '*.swigcxx' || true)
+        UNSTAGED=$( { git diff --name-only -- "${GUARD_PATHSPEC[@]}"
+                      git ls-files --others --exclude-standard -- "${GUARD_PATHSPEC[@]}"
+                      printf '%s\n' "$IGNORED_KEPT"; } | sort -u || true)
+        if [ -n "$UNSTAGED" ]; then
+            CONFLICT="$CONFLICT
+$UNSTAGED"
+        fi
+    fi
+    # Tier 1 census — ANY staged path (see the trigger comment above):
+    # Ignored go:embed ASSETS escape BOTH the extension lists and the
+    # checked-pathspec trigger — //go:embed names ARBITRARY types at
+    # ARBITRARY paths from the staged snapshot itself. Staging
+    # '//go:embed local.db' while local.db stays ignored (this repo
+    # ignores *.db) lets go list/vet/test/build consume the working-tree
+    # file here, then the COMMITTED snapshot fails with 'pattern
+    # local.db: no matching files found'; likewise a staged deletion of
+    # the last embed match breaks the pattern go list itself evaluates,
+    # which the fail-closed refusal converts into a block rather than a
+    # silent skip. No static pathspec can enumerate embed targets, so ask
+    # the toolchain: go list -test -deps resolves the EXACT embed set
+    # against this tree (glob semantics, all: prefixes and the
+    # dot/underscore directory-walk exclusion handled by the tool).
+    # -test is required because plain go list leaves TestEmbedFiles and
+    # XTestEmbedFiles empty — an ignored _test.go embed asset would
+    # otherwise slip the guard while go test consumes it — and -deps is
+    # required because wildcard ./... never enumerates testdata/, yet
+    # explicit imports beneath testdata DO resolve (the same hole the
+    # TOOL_DIRS_CACHE graph union closes): an embed in such a package
+    # hides from a shallow census while its consumers break in CI.
+    # Module-cache deps the scan surfaces sit outside the checkout; the
+    # prefix-strip below drops them. Recomputed per invocation,
+    # deliberately NOT cached like TOOL_DIRS_CACHE: a mid-run-created
+    # ignored embed file changes nothing else any comparator observes.
+    # Mask set = embedded paths ABSENT FROM THE INDEX (untracked or
+    # ignored, any extension, present or future) — whatever sits in the
+    # index ships with the commit by definition. Data files READ (not
+    # embedded) by tests are not toolchain-enumerable and stay out by
+    # design.
+    if [ -n "$STAGED_SET" ]; then
         EMBED_ABS=$(go list -test -deps -f '{{range .EmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .TestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .XTestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}' ./... 2>/dev/null) ||
             { refuse_guard_scan "go list -test -deps"; return 1; }
         if [ -n "$EMBED_ABS" ]; then
@@ -623,10 +646,10 @@ FILTER_EOF
             EMBED_REL=""
             while IFS= read -r eabs; do
                 [ -n "$eabs" ] || continue
-                # Prefix-strip WITHOUT regex (same metacharacter hazard as
-                # the PKG_DIRS walk above — a bracketed checkout path must
-                # not fail open); paths outside the checkout (synthesized
-                # -test variants) match no prefix and drop out.
+                # Prefix-strip WITHOUT regex (same metacharacter hazard
+                # as the PKG_DIRS walk above — a bracketed checkout path
+                # must not fail open); paths outside the checkout
+                # (synthesized -test variants) match no prefix and drop.
                 if [ "${eabs#"$EMBED_ROOT"/}" != "$eabs" ]; then
                     EMBED_REL="$EMBED_REL
 ${eabs#"$EMBED_ROOT"/}"
@@ -635,28 +658,22 @@ ${eabs#"$EMBED_ROOT"/}"
 $EMBED_ABS
 EMBED_SCAN_EOF
             if [ -n "$EMBED_REL" ]; then
-                # quotepath=false: non-ASCII tracked embeds must compare
-                # equal on both sides of comm (raw bytes, not C-quoted).
+                # -c core.quotepath=false prints RAW bytes for non-ASCII
+                # names, so tracked unicode embeds compare equal on both
+                # sides of comm (C-quoting one side would fabricate
+                # phantom masks).
                 EMBED_MASKED=$(comm -23 \
                     <(printf '%s\n' "$EMBED_REL" | sed '/^$/d' | sort -u) \
                     <(git -c core.quotepath=false ls-files | sort -u) || true)
                 # Append directly, bypassing the PKG_DIRS filter: the
                 # directive's own .go file is necessarily tracked, and
                 # roots outside the static lists (a future root-level
-                # embed, say) must be admitted by construction, not by a
-                # whitelist that has to be kept in sync.
+                # embed, say) are precisely what this tier exists to see.
                 if [ -n "$EMBED_MASKED" ]; then
-                    IGNORED_KEPT="$IGNORED_KEPT
+                    CONFLICT="$CONFLICT
 $EMBED_MASKED"
                 fi
             fi
-        fi
-        UNSTAGED=$( { git diff --name-only -- "${GUARD_PATHSPEC[@]}"
-                      git ls-files --others --exclude-standard -- "${GUARD_PATHSPEC[@]}"
-                      printf '%s\n' "$IGNORED_KEPT"; } | sort -u || true)
-        if [ -n "$UNSTAGED" ]; then
-            CONFLICT="$CONFLICT
-$UNSTAGED"
         fi
     fi
     [ -z "$CONFLICT" ]

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -279,12 +279,28 @@ while IFS= read -r p; do
     done
     if [ -n "$mapped" ]; then
         case "$p" in
-            # testdata/ is per-package-private by Go convention — consumers
-            # never read another package's fixtures, so the owning package's
-            # tests suffice (no reverse-dependency expansion).
             */testdata/*)
-                ASSET_PKGS="$ASSET_PKGS
+                case "$mapped" in
+                    # The mapped ancestor itself lives BENEATH a testdata/
+                    # segment: an IMPORTABLE package there (explicit imports
+                    # beneath testdata/ resolve) may own //go:embed targets
+                    # consumed by other packages' tests — private-fixture
+                    # treatment would test the owner while its auxiliary or
+                    # test-only consumers break in CI.
+                    testdata/*|*/testdata/*)
+                        EMBED_PKGS="$EMBED_PKGS
 ./$mapped"
+                        ;;
+                    *)
+                        # .../testdata/ inside a NORMAL package directory is
+                        # a per-package-private fixture by Go convention —
+                        # consumers never read another package's fixtures,
+                        # so the owning package's tests suffice (no
+                        # reverse-dependency expansion).
+                        ASSET_PKGS="$ASSET_PKGS
+./$mapped"
+                        ;;
+                esac
                 ;;
             # Everything else is consumed via the import graph (go:embed
             # targets, adjacent assets), so owners feed the reverse scan.

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -4,6 +4,14 @@
 #
 # Installation: cp scripts/pre-commit.sample .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 # To skip this hook temporarily: git commit --no-verify
+# For a fast pass (skip the full unit tests + svelte-check; keeps gofmt,
+# lint, vet, build scoped to changed packages): PRE_COMMIT_FAST=1 git commit
+#
+# Design note: every expensive check is scoped to the STAGED change. The
+# previous version ran gofmt/golangci-lint/go vet/`go test -short ./...` on
+# the whole repo plus a swagger regeneration on every commit — several
+# minutes even for a docs-only change (a full test run alone takes minutes,
+# and svelte-check costs ~1 minute on this codebase).
 
 set -e
 
@@ -15,6 +23,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 FORBIDDEN_PATHS=".planning/"
+START=$SECONDS
 
 for path in $FORBIDDEN_PATHS; do
     if git diff --cached --name-only | grep -q "^${path}"; then
@@ -28,7 +37,24 @@ GOLANGCI_LINT="${HOME}/go/bin/golangci-lint"
 REQUIRED_VERSION_MAJOR=2
 REQUIRED_VERSION_MINOR=4
 
+# ---------------------------------------------------------------------------
+# Staged-file scoping
+# STAGED_GO: added/copied/modified/renamed .go files (deletions excluded — a
+# deleted file cannot break formatting/lint and its package is linted via a
+# surviving sibling).
+STAGED_GO=$(git diff --cached --name-only --diff-filter=ACMR -- '*.go' || true)
+# Unique package patterns (./internal/api/...) for the staged Go files.
+GO_PKGS=""
+if [ -n "$STAGED_GO" ]; then
+    GO_PKGS=$(echo "$STAGED_GO" | xargs -n1 dirname | sort -u | sed 's|^|./|; s|$|/...|')
+fi
+# Swagger output documents internal/** handler annotations; regen is only
+# meaningful when those (or the docs themselves) are staged.
+API_CHANGED=$(git diff --cached --name-only | grep -cE '^(internal|cmd)/' || true)
+# ---------------------------------------------------------------------------
+
 echo -e "${BLUE}Running pre-commit checks...${NC}"
+[ -n "${PRE_COMMIT_FAST:-}" ] && echo -e "${YELLOW}PRE_COMMIT_FAST=1 — skipping unit tests and svelte-check${NC}"
 echo ""
 
 # Function to check golangci-lint version
@@ -64,7 +90,8 @@ check_golangci_lint_version() {
     return 1
 }
 
-# Check 1: Go formatting
+# Check 1: Go formatting (whole-repo gofmt is ~1s; keep it global — a repo-
+# wide format issue breaks CI regardless of what was staged)
 echo -e "${BLUE}[1/8] Checking code formatting...${NC}"
 UNFORMATTED=$(gofmt -l . 2>&1)
 if [ -n "$UNFORMATTED" ]; then
@@ -76,73 +103,106 @@ fi
 echo -e "${GREEN}✓ Code formatting OK${NC}"
 echo ""
 
-# Check 2: golangci-lint
-echo -e "${BLUE}[2/8] Running golangci-lint...${NC}"
-if [[ -x "$GOLANGCI_LINT" ]] && check_golangci_lint_version; then
-    echo -e "${BLUE}  Using golangci-lint from $GOLANGCI_LINT${NC}"
-    if ! "$GOLANGCI_LINT" run ./... 2>&1; then
-        echo -e "${RED}✗ golangci-lint found issues${NC}"
+# Check 2: golangci-lint (changed packages only)
+if [ -n "$GO_PKGS" ]; then
+    echo -e "${BLUE}[2/8] Running golangci-lint (staged packages)...${NC}"
+    if [[ -x "$GOLANGCI_LINT" ]] && check_golangci_lint_version; then
+        echo -e "${BLUE}  Using golangci-lint from $GOLANGCI_LINT${NC}"
+        # shellcheck disable=SC2086 # word-splitting GO_PKGS is intentional
+        if ! "$GOLANGCI_LINT" run $GO_PKGS 2>&1; then
+            echo -e "${RED}✗ golangci-lint found issues${NC}"
+            exit 1
+        fi
+        echo -e "${GREEN}✓ golangci-lint passed${NC}"
+    else
+        echo -e "${YELLOW}⚠ golangci-lint not installed or version too old (skipping)${NC}"
+        echo -e "${YELLOW}  Required: >=${REQUIRED_VERSION_MAJOR}.${REQUIRED_VERSION_MINOR}.0${NC}"
+        if [[ -x "$GOLANGCI_LINT" ]]; then
+            echo -e "${YELLOW}  Current: $("$GOLANGCI_LINT" version 2>&1 | head -1)${NC}"
+        fi
+        echo -e "${YELLOW}  Install: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${REQUIRED_VERSION_MAJOR}.x${NC}"
+    fi
+else
+    echo -e "${BLUE}[2/8] golangci-lint${NC} (skipped — no staged Go files)"
+fi
+echo ""
+
+# Check 3: Go vet (changed packages only)
+if [ -n "$GO_PKGS" ]; then
+    echo -e "${BLUE}[3/8] Running go vet (staged packages)...${NC}"
+    # shellcheck disable=SC2086 # word-splitting GO_PKGS is intentional
+    if ! go vet $GO_PKGS 2>&1; then
+        echo -e "${RED}✗ go vet found issues${NC}"
         exit 1
     fi
-    echo -e "${GREEN}✓ golangci-lint passed${NC}"
+    echo -e "${GREEN}✓ go vet passed${NC}"
 else
-    echo -e "${YELLOW}⚠ golangci-lint not installed or version too old (skipping)${NC}"
-    echo -e "${YELLOW}  Required: >=${REQUIRED_VERSION_MAJOR}.${REQUIRED_VERSION_MINOR}.0${NC}"
-    if [[ -x "$GOLANGCI_LINT" ]]; then
-        echo -e "${YELLOW}  Current: $("$GOLANGCI_LINT" version 2>&1 | head -1)${NC}"
+    echo -e "${BLUE}[3/8] go vet${NC} (skipped — no staged Go files)"
+fi
+echo ""
+
+# Check 4: Fast unit tests (changed packages only; the full suite takes
+# minutes — it belongs in pre-push, not pre-commit)
+if [ -n "$GO_PKGS" ] && [ -z "${PRE_COMMIT_FAST:-}" ]; then
+    echo -e "${BLUE}[4/8] Running fast unit tests (staged packages)...${NC}"
+    # Increase timeout to 60s for the fast test pass
+    # shellcheck disable=SC2086 # word-splitting GO_PKGS is intentional
+    if ! go test -short -timeout=60s $GO_PKGS 2>&1; then
+        echo -e "${RED}✗ Tests failed${NC}"
+        exit 1
     fi
-    echo -e "${YELLOW}  Install: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${REQUIRED_VERSION_MAJOR}.x${NC}"
+    echo -e "${GREEN}✓ Tests passed${NC}"
+elif [ -z "$GO_PKGS" ]; then
+    echo -e "${BLUE}[4/8] unit tests${NC} (skipped — no staged Go files)"
+else
+    echo -e "${BLUE}[4/8] unit tests${NC} (skipped — PRE_COMMIT_FAST=1)"
 fi
 echo ""
 
-# Check 3: Go vet
-echo -e "${BLUE}[3/8] Running go vet...${NC}"
-if ! go vet ./... 2>&1; then
-    echo -e "${RED}✗ go vet found issues${NC}"
-    exit 1
+# Check 5: Build verification (only when Go files staged; with a warm build
+# cache this is a few seconds and catches cross-package breakage the scoped
+# checks miss)
+if [ -n "$GO_PKGS" ]; then
+    echo -e "${BLUE}[5/8] Verifying build...${NC}"
+    if ! go build -o /tmp/javinizer-test ./cmd/javinizer 2>&1; then
+        echo -e "${RED}✗ Build failed${NC}"
+        exit 1
+    fi
+    rm -f /tmp/javinizer-test
+    echo -e "${GREEN}✓ Build successful${NC}"
+else
+    echo -e "${BLUE}[5/8] build${NC} (skipped — no staged Go files)"
 fi
-echo -e "${GREEN}✓ go vet passed${NC}"
 echo ""
 
-# Check 4: Fast unit tests (skip flaky network tests)
-echo -e "${BLUE}[4/8] Running fast unit tests...${NC}"
-# Increase timeout to 60s for the fast test pass
-if ! go test -short -timeout=60s ./... 2>&1; then
-    echo -e "${RED}✗ Tests failed${NC}"
-    exit 1
+# Check 6: Swagger documentation (only when internal/ or cmd/ files staged —
+# the generated docs reflect handler annotations; a data-only or frontend
+# commit cannot drift them)
+if [ "$API_CHANGED" -gt 0 ]; then
+    echo -e "${BLUE}[6/8] Checking Swagger documentation...${NC}"
+    if ! command -v swag &> /dev/null && ! (export PATH="$PATH:$(go env GOPATH)/bin" && command -v swag &> /dev/null); then
+        # Never go-install during a commit — a network fetch in a hook is
+        # worse than a skipped doc check (CI regenerates + fails loudly).
+        echo -e "${YELLOW}⚠ swag not installed, skipping swagger check${NC}"
+        echo -e "${YELLOW}  Install: go install github.com/swaggo/swag/cmd/swag@latest${NC}"
+    else
+        export PATH=$PATH:$(go env GOPATH)/bin
+        if ! make swagger &> /dev/null; then
+            echo -e "${RED}✗ Swagger generation failed${NC}"
+            exit 1
+        fi
+        if ! git diff --quiet -- docs/swagger/; then
+            echo -e "${RED}✗ Swagger documentation is out of date${NC}"
+            echo -e "${YELLOW}Run 'make swagger' and commit the changes${NC}"
+            echo ""
+            git status docs/swagger/
+            exit 1
+        fi
+        echo -e "${GREEN}✓ Swagger documentation up to date${NC}"
+    fi
+else
+    echo -e "${BLUE}[6/8] swagger docs${NC} (skipped — no staged internal/cmd files)"
 fi
-echo -e "${GREEN}✓ Tests passed${NC}"
-echo ""
-
-# Check 5: Build verification
-echo -e "${BLUE}[5/8] Verifying build...${NC}"
-if ! go build -o /tmp/javinizer-test ./cmd/javinizer 2>&1; then
-    echo -e "${RED}✗ Build failed${NC}"
-    exit 1
-fi
-rm -f /tmp/javinizer-test
-echo -e "${GREEN}✓ Build successful${NC}"
-echo ""
-
-# Check 6: Swagger documentation
-echo -e "${BLUE}[6/8] Checking Swagger documentation...${NC}"
-if ! command -v swag &> /dev/null; then
-    echo -e "${YELLOW}⚠️  swag not installed, installing...${NC}"
-    go install github.com/swaggo/swag/cmd/swag@latest
-fi
-export PATH=$PATH:$(go env GOPATH)/bin
-if ! make swagger &> /dev/null; then
-    echo -e "${RED}✗ Swagger generation failed${NC}"
-    exit 1
-fi
-if ! git diff --quiet -- docs/swagger/; then
-    echo -e "${RED}✗ Swagger documentation is out of date${NC}"
-    echo -e "${YELLOW}Run 'make swagger' and commit the changes${NC}"
-    echo ""
-    git status docs/swagger/
-    exit 1
-fi
-echo -e "${GREEN}✓ Swagger documentation up to date${NC}"
 echo ""
 
 # Check 7: Frontend Prettier formatting (only staged frontend files)
@@ -175,9 +235,10 @@ else
 fi
 echo ""
 
-# Check 8: Frontend type checking (only if frontend src files changed)
+# Check 8: Frontend type checking (only if frontend src files changed;
+# svelte-check costs ~1 minute, so honor PRE_COMMIT_FAST here)
 FRONTEND_CHANGED=$(git diff --cached --name-only | grep -c "^web/frontend/src/" || true)
-if [ "$FRONTEND_CHANGED" -gt 0 ]; then
+if [ "$FRONTEND_CHANGED" -gt 0 ] && [ -z "${PRE_COMMIT_FAST:-}" ]; then
     echo -e "${BLUE}[8/8] Running frontend type check (svelte-check)...${NC}"
     if [ -d "web/frontend/node_modules" ]; then
         if ! (cd web/frontend && npx svelte-check --threshold error) 2>&1; then
@@ -188,17 +249,19 @@ if [ "$FRONTEND_CHANGED" -gt 0 ]; then
     else
         echo -e "${YELLOW}⚠ Frontend dependencies not installed, skipping type check${NC}"
     fi
-else
+elif [ "$FRONTEND_CHANGED" -eq 0 ]; then
     echo -e "${BLUE}[8/8] Frontend type check${NC} (skipped — no frontend changes)"
+else
+    echo -e "${BLUE}[8/8] Frontend type check${NC} (skipped — PRE_COMMIT_FAST=1)"
 fi
 echo ""
 
 echo -e "${GREEN}========================================${NC}"
-echo -e "${GREEN}All pre-commit checks passed!${NC}"
+echo -e "${GREEN}All pre-commit checks passed!${NC} ($((SECONDS - START))s)"
 echo -e "${GREEN}========================================${NC}"
 echo ""
-echo -e "${YELLOW}Tip: Run 'make swagger' if you modified handler files${NC}"
 echo -e "${YELLOW}Tip: Run 'make coverage-check' before pushing to ensure coverage threshold is met${NC}"
 echo -e "${YELLOW}Tip: Run 'cd web/frontend && npm run format' before staging frontend changes${NC}"
+echo -e "${YELLOW}Tip: PRE_COMMIT_FAST=1 git commit skips unit tests and svelte-check${NC}"
 
 exit 0

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -738,6 +738,21 @@ $EMBED_MASKED"
         # pad with spaces so case-matching ' "$d" ' is exact-token safe
         PKG_DIRS=" $PKG_DIRS "
         IGNORED_KEPT=""
+        # Frontend compile inputs join in, gated on the frontend checks
+        # actually engaging: svelte-check/prettier read the IMPORT GRAPH
+        # from disk, so an IGNORED source file under web/frontend/src (a
+        # user-gitignored scratch module imported by staged code) passes
+        # locally while the committed snapshot breaks CI. The extension
+        # lists cannot express the web toolchain's whole module space
+        # (assets import too), so the src tree is scanned whole — user
+        # ignores there are rare by construction (.gitignore only lists
+        # build outputs under src's parent).
+        if [ "${FRONTEND_CHANGED:-0}" -gt 0 ]; then
+            while IFS= read -r -d '' feraw; do
+                [ -n "$feraw" ] && IGNORED_KEPT="$IGNORED_KEPT
+$feraw"
+            done < <(git ls-files -z --others --ignored --exclude-standard -- web/frontend/src || true)
+        fi
         while IFS= read -r -d '' raw; do
             [ -n "$raw" ] || continue
             case "$raw" in

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -219,32 +219,45 @@ EMBED_STAGED=""
 # census emits raw ones, and a mismatched encoding silently nulls the
 # intersection. (Newline-in-filename remains out of scope — BSD comm has no
 # -z and the rest of this classification shares the limitation.)
-ASSET_CANDIDATES=$(git -c core.quotepath=false diff --cached --name-only --no-renames --diff-filter=ACMRTD \
+ASSET_CANDIDATES=$(git -c core.quotepath=false diff --cached --name-only --no-renames --diff-filter=ACMR \
     | grep -vE '^testdata/|^internal/|^cmd/|^web/dist/|^docs/swagger/|^configs/|\.go$|^go\.(mod|sum)$|^Makefile$|^\.golangci\.(yml|yaml)$' || true)
-if [ -n "$ASSET_CANDIDATES" ]; then
+DELETED_CANDIDATES=$(git -c core.quotepath=false diff --cached --name-only --no-renames --diff-filter=D \
+    | grep -vE '^testdata/|^internal/|^cmd/|^web/dist/|^docs/swagger/|^configs/|\.go$|^go\.(mod|sum)$|^Makefile$|^\.golangci\.(yml|yaml)$' || true)
+if [ -n "$ASSET_CANDIDATES$DELETED_CANDIDATES" ]; then
     # Membership in EITHER census marks an embed target. The TREE census
     # sees staged content edits and ADDS (a file must exist on disk to be
-    # staged). The HEAD census sees staged DELETIONS that have already
-    # vanished from BOTH the tree and the index (a multi-match glob keeps
-    # resolving on the survivors, so only HEAD still lists the dropped
-    # member) — materialized via git archive, never HEAD"~"-detached.
-    # Computing the pair without candidates would tax every docs-only
-    # commit; candidates gate it. Both are best-effort: a census failure
-    # simply adds nothing — the tree-consistency guard's fail-closed
-    # census blocks loudly right after.
+    # staged). It stays best-effort: a failure here fails the guard's
+    # identical fail-closed census a moment later, so nothing advances.
     EMBED_CENSUS_TREE=$(compute_embed_census || true)
     EMBED_CENSUS_HEAD=""
-    IDX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/javinizer-embedsnap.XXXXXX" 2>/dev/null || true)
-    # An empty IDX_TMP must NEVER reach tar -C: an empty -C operand is a
-    # cwd-relative extract. On failure the HEAD census simply stays empty
-    # — the tree census (and, moments later, the fail-closed guard
-    # census) still stand.
-    if [ -n "$IDX_TMP" ] && git archive HEAD 2>/dev/null | tar -x -C "$IDX_TMP" 2>/dev/null; then
-        EMBED_CENSUS_HEAD=$(cd "$IDX_TMP" && compute_embed_census || true)
+    # The HEAD census is the ONLY view that still lists a staged deletion
+    # which vanished from both tree and index (a multi-match glob keeps
+    # resolving on the survivors). When a deletion candidate exists it
+    # must NOT degrade silently — an empty HEAD census there would let an
+    # out-of-roots embed deletion skip all Go validation. Fail closed,
+    # checking every stage of the materialize chain explicitly.
+    if [ -n "$DELETED_CANDIDATES" ]; then
+        IDX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/javinizer-embedsnap.XXXXXX" 2>/dev/null) || {
+            echo -e "${RED}✗ Cannot materialize HEAD for the embed-deletion check (mktemp failed).${NC}"
+            echo -e "${YELLOW}  Free temp space and retry — $DELETED_CANDIDATES may be an embed target.${NC}"
+            exit 1
+        }
+        if ! git archive -o "$IDX_TMP/head.tar" HEAD 2>/dev/null || ! tar -xf "$IDX_TMP/head.tar" -C "$IDX_TMP" 2>/dev/null; then
+            echo -e "${RED}✗ Cannot materialize HEAD for the embed-deletion check (archive/extract failed).${NC}"
+            rm -rf "$IDX_TMP"
+            exit 1
+        fi
+        if ! EMBED_CENSUS_HEAD=$(cd "$IDX_TMP" && compute_embed_census); then
+            echo -e "${RED}✗ go list failed on the materialized HEAD snapshot — cannot prove${NC}"
+            echo -e "${RED}  the staged deletion(s) are no //go:embed targets. Fix the module${NC}"
+            echo -e "${RED}  state (go mod download) and retry.${NC}"
+            rm -rf "$IDX_TMP"
+            exit 1
+        fi
+        rm -rf "$IDX_TMP"
     fi
-    [ -z "$IDX_TMP" ] || rm -rf "$IDX_TMP"
     EMBED_STAGED=$(comm -12 \
-        <(printf '%s\n' "$ASSET_CANDIDATES" | sort -u) \
+        <( { printf '%s\n' "$ASSET_CANDIDATES"; printf '%s\n' "$DELETED_CANDIDATES"; } | sed '/^$/d' | sort -u) \
         <( { printf '%s\n' "$EMBED_CENSUS_TREE"; printf '%s\n' "$EMBED_CENSUS_HEAD"; } | sed '/^$/d' | sort -u) || true)
 fi
 while IFS= read -r p; do

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -223,7 +223,15 @@ ASSET_CANDIDATES=$(git -c core.quotepath=false diff --cached --name-only --no-re
     | grep -vE '^testdata/|^internal/|^cmd/|^web/dist/|^docs/swagger/|^configs/|\.go$|^go\.(mod|sum)$|^Makefile$|^\.golangci\.(yml|yaml)$' || true)
 DELETED_CANDIDATES=$(git -c core.quotepath=false diff --cached --name-only --no-renames --diff-filter=D \
     | grep -vE '^testdata/|^internal/|^cmd/|^web/dist/|^docs/swagger/|^configs/|\.go$|^go\.(mod|sum)$|^Makefile$|^\.golangci\.(yml|yaml)$' || true)
-if [ -n "$ASSET_CANDIDATES$DELETED_CANDIDATES" ]; then
+# testdata/** assets join the census drive too: an asset beneath a normal
+# package's testdata/ dir that is ALSO a //go:embed target of that package
+# is re-exported through the package API — its staged change must reach
+# reverse consumers (see the mapping loop's */testdata/* branch below).
+TD_STAGED=$(git -c core.quotepath=false diff --cached --name-only --no-renames --diff-filter=ACMR \
+    | grep -E '(^|/)testdata/' | grep -v '\.go$' || true)
+TD_DELETED=$(git -c core.quotepath=false diff --cached --name-only --no-renames --diff-filter=D \
+    | grep -E '(^|/)testdata/' || true)
+if [ -n "$ASSET_CANDIDATES$DELETED_CANDIDATES$TD_STAGED$TD_DELETED" ]; then
     # Membership in EITHER census marks an embed target. The TREE census
     # sees staged content edits and ADDS (a file must exist on disk to be
     # staged). It stays best-effort: a failure here fails the guard's
@@ -236,7 +244,7 @@ if [ -n "$ASSET_CANDIDATES$DELETED_CANDIDATES" ]; then
     # must NOT degrade silently — an empty HEAD census there would let an
     # out-of-roots embed deletion skip all Go validation. Fail closed,
     # checking every stage of the materialize chain explicitly.
-    if [ -n "$DELETED_CANDIDATES" ]; then
+    if [ -n "$DELETED_CANDIDATES$TD_DELETED" ]; then
         IDX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/javinizer-embedsnap.XXXXXX" 2>/dev/null) || {
             echo -e "${RED}✗ Cannot materialize HEAD for the embed-deletion check (mktemp failed).${NC}"
             echo -e "${YELLOW}  Free temp space and retry — $DELETED_CANDIDATES may be an embed target.${NC}"
@@ -256,10 +264,11 @@ if [ -n "$ASSET_CANDIDATES$DELETED_CANDIDATES" ]; then
         fi
         rm -rf "$IDX_TMP"
     fi
-    EMBED_STAGED=$(comm -12 \
-        <( { printf '%s\n' "$ASSET_CANDIDATES"; printf '%s\n' "$DELETED_CANDIDATES"; } | sed '/^$/d' | sort -u) \
-        <( { printf '%s\n' "$EMBED_CENSUS_TREE"; printf '%s\n' "$EMBED_CENSUS_HEAD"; } | sed '/^$/d' | sort -u) || true)
+    CENSUS_UNION=$( { printf '%s\n' "$EMBED_CENSUS_TREE"; printf '%s\n' "$EMBED_CENSUS_HEAD"; } | sed '/^$/d' | sort -u)
 fi
+EMBED_STAGED=$(comm -12 \
+    <( { printf '%s\n' "$ASSET_CANDIDATES"; printf '%s\n' "$DELETED_CANDIDATES"; } | sed '/^$/d' | sort -u) \
+    <(printf '%s\n' "${CENSUS_UNION:-}" | sed '/^$/d' | sort -u) || true)
 while IFS= read -r p; do
     [ -n "$p" ] || continue
     # Cross-directory consumers the ancestor walk cannot express: top-level
@@ -293,12 +302,19 @@ while IFS= read -r p; do
                         ;;
                     *)
                         # .../testdata/ inside a NORMAL package directory is
-                        # a per-package-private fixture by Go convention —
-                        # consumers never read another package's fixtures,
-                        # so the owning package's tests suffice (no
-                        # reverse-dependency expansion).
-                        ASSET_PKGS="$ASSET_PKGS
+                        # per-package-private ONLY for plain fixtures —
+                        # consumers never READ another package's fixtures.
+                        # An asset that is ALSO the package's //go:embed
+                        # target is re-exported through the package API
+                        # (migration SQL, golden payloads), so its staged
+                        # change must reach reverse consumers instead.
+                        if printf '%s\n' "${CENSUS_UNION:-}" | grep -qxF "$p"; then
+                            EMBED_PKGS="$EMBED_PKGS
 ./$mapped"
+                        else
+                            ASSET_PKGS="$ASSET_PKGS
+./$mapped"
+                        fi
                         ;;
                 esac
                 ;;

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -7,6 +7,9 @@
 # For a fast pass (skip the full unit tests + svelte-check; keeps gofmt,
 # lint, vet, build scoped to changed packages): PRE_COMMIT_FAST=1 git commit
 #
+# Modifying this hook? Run the staged-file scoping regression matrix:
+# scripts/test-pre-commit-scoping.sh (or: make test-hook)
+#
 # Design note: every expensive check is scoped to the STAGED change. The
 # previous version ran gofmt/golangci-lint/go vet/`go test -short ./...` on
 # the whole repo plus a swagger regeneration on every commit — several
@@ -15,6 +18,11 @@
 
 set -e
 
+# Neutralize local Go workspaces: go.work is git-ignored, so a developer's
+# workspace replace directives would silently alter module resolution for
+# the classification, vet, tests, and build below — the hook must validate
+# exactly what CI checks out. GOWORK=off pins module mode.
+export GOWORK=off
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -25,12 +33,66 @@ NC='\033[0m' # No Color
 FORBIDDEN_PATHS=".planning/"
 START=$SECONDS
 
-for path in $FORBIDDEN_PATHS; do
-    if git diff --cached --name-only | grep -q "^${path}"; then
-        echo -e "${RED}✗ Blocked: ${path} must not be committed (found in staged files)${NC}"
-        exit 1
-    fi
-done
+# Index snapshot FIRST, before every index read below: the live index is
+# read many times during classification, and a concurrent `git add` landing
+# mid-analysis would mix snapshots (early reads stale, later reads new).
+# Re-verified immediately after classification and again before success; any
+# drift refuses the commit. A failing write-tree means an unmergeable index
+# (conflict state).
+# write-tree takes the index lock, so a concurrent git add can make a
+# single attempt fail transiently — retry for ~1s before refusing. A refusal
+# after that means a genuinely unmergeable index (conflict state) or a
+# hostile lock holder.
+snapshot_index() {
+    local tree _i
+    for _i in $(seq 1 20); do
+        if tree=$(git write-tree 2>/dev/null); then
+            printf '%s\n' "$tree"
+            return 0
+        fi
+        sleep 0.05
+    done
+    return 1
+}
+if ! INITIAL_INDEX_TREE=$(snapshot_index); then
+    echo -e "${RED}✗ Cannot snapshot the index (git write-tree kept failing — lock contention${NC}"
+    echo -e "${RED}  or unresolved conflicts). Retry, or resolve conflicts first.${NC}"
+    exit 1
+fi
+
+# Forbidden paths. NUL-delimited: plain --name-only C-quotes non-ASCII/
+# control characters with a leading ", which invisible-prefixes anchored
+# path matching; process substitution keeps the exit effective in this shell.
+while IFS= read -r -d '' p; do
+    for path in $FORBIDDEN_PATHS; do
+        case "$p" in
+            "$path"*)
+                echo -e "${RED}✗ Blocked: ${path} must not be committed (found in staged files)${NC}"
+                exit 1
+                ;;
+        esac
+    done
+done < <(git diff --cached --name-only -z)
+
+# Staged workspace files are never committable here: go.work is git-ignored
+# (a personal local workspace), the hook itself runs with GOWORK=off, and a
+# broken workspace would fail CI where GOWORK is not disabled. Refuse a
+# force-staged (git add -f) workspace file.
+WORKSPACE_STAGED=""
+while IFS= read -r -d '' p; do
+    case "$p" in
+        go.work|go.work.sum)
+            WORKSPACE_STAGED="$WORKSPACE_STAGED
+$p" ;;
+    esac
+done < <(git diff --cached --name-only -z)
+if [ -n "$WORKSPACE_STAGED" ]; then
+    echo -e "${RED}✗ go.work files must not be committed (git-ignored personal workspace):${NC}"
+    # shellcheck disable=SC2086 # one path per line is the intent
+    printf '  %s\n' $WORKSPACE_STAGED
+    echo -e "${YELLOW}Unstage with: git rm --cached go.work go.work.sum${NC}"
+    exit 1
+fi
 
 # Golangci-lint configuration
 GOLANGCI_LINT="${HOME}/go/bin/golangci-lint"
@@ -39,18 +101,404 @@ REQUIRED_VERSION_MINOR=4
 
 # ---------------------------------------------------------------------------
 # Staged-file scoping
-# STAGED_GO: added/copied/modified/renamed .go files (deletions excluded — a
-# deleted file cannot break formatting/lint and its package is linted via a
-# surviving sibling).
-STAGED_GO=$(git diff --cached --name-only --diff-filter=ACMR -- '*.go' || true)
-# Unique package patterns (./internal/api/...) for the staged Go files.
-GO_PKGS=""
-if [ -n "$STAGED_GO" ]; then
-    GO_PKGS=$(echo "$STAGED_GO" | xargs -n1 dirname | sort -u | sed 's|^|./|; s|$|/...|')
-fi
+# STAGED_GO: added/copied/modified .go files. --no-renames reports a rename
+# as destination-add + source-delete (rename detection would name only the
+# destination, silently sparing the source package which just lost a
+# declaration), so a cross-directory move is checked on both sides: the
+# destination lands here, the source in DELETED_GO.
+STAGED_GO=$(git diff --cached --name-only --no-renames --diff-filter=ACMRT -- '*.go' || true)
+# DELETED_GO: deleted .go files (also rename sources, per --no-renames).
+# Removing a declaration can break surviving siblings (unused symbols) and
+# dependents (missing references), so the deleted file's package still
+# needs lint/vet/tests/build.
+DELETED_GO=$(git diff --cached --name-only --no-renames --diff-filter=D -- '*.go' || true)
+# MODULE_CHANGED: staged go.mod/go.sum edits — an invalid dependency update
+# matches no .go pathspec yet breaks the build, so it forces at least the
+# build check below.
+MODULE_CHANGED=$(git diff --cached --name-only -- go.mod go.sum || true)
+# LINT_CONFIG: staged golangci-lint configuration — rule/config edits apply
+# repository-wide, so check 2 escalates from linting staged packages to a
+# full-repository run.
+LINT_CONFIG=$(git diff --cached --name-only -- .golangci.yml .golangci.yaml || true)
+# Unique package directories for the staged + deleted Go files. Built from
+# NUL-delimited git output via read -d '' and ${f%/*} — piping paths through
+# xargs/dirname mangles valid filenames containing quotes (e.g.
+# web/foo'bar.go) and the resulting empty list would silently disable EVERY
+# scoped check.
+GO_DIRS=$({
+    git diff --cached --name-only -z --no-renames --diff-filter=ACMRT -- '*.go'
+    git diff --cached --name-only -z --no-renames --diff-filter=D -- '*.go'
+} | while IFS= read -r -d '' f; do
+        d=${f%/*}
+        [ "$d" = "$f" ] && d=.
+        printf '%s\n' "$d"
+    done | sort -u)
+# Exact package patterns (./internal/api) for lint/vet/test scoping —
+# descendant subpackages are distinct packages intentionally NOT swept
+# (breakage propagation flows through the reverse-dependency closure),
+# restricted to directories that still exist.
+GO_PKGS=$(printf '%s\n' "$GO_DIRS" | while IFS= read -r d; do
+        if [ -d "$d" ]; then
+            if [ "$d" = . ]; then printf './...\n'; else printf './%s\n' "$d"; fi
+        fi
+    done)
+# DROPPED_DIRS: directories that no longer exist (whole-package deletion).
+# Nothing remains to lint/vet/test there — but surviving packages may still
+# import the vanished package, and if it lived outside the binary graph
+# (internal/api/testkit is the canonical example) even the build cannot see
+# the breakage. The FULL_SUITE logic below resolves this; unresolvable
+# deletions fail closed.
+DROPPED_DIRS=$(printf '%s\n' "$GO_DIRS" | while IFS= read -r d; do
+        if [ ! -d "$d" ]; then printf '%s\n' "$d"; fi
+    done)
 # Swagger output documents internal/** handler annotations; regen is only
-# meaningful when those (or the docs themselves) are staged.
-API_CHANGED=$(git diff --cached --name-only | grep -cE '^(internal|cmd)/' || true)
+# meaningful when those (or the generated docs themselves — e.g. a stray
+# hand-edit of docs/swagger) are staged.
+API_CHANGED=0
+while IFS= read -r -d '' p; do
+    case "$p" in
+        internal/*|cmd/*|docs/swagger/*|Makefile) API_CHANGED=$((API_CHANGED+1)) ;;
+    esac
+done < <(git diff --cached --name-only -z --no-renames)
+# Non-Go inputs consumed by Go packages (testdata/** fixtures, go:embed
+# assets like *.sql migrations, locales/*.json, config.yaml.example): these
+# never match a *.go pathspec, yet a bad fixture edit fails `go test` and a
+# deleted embed fails `go build`. Map each staged non-.go path to the
+# nearest ancestor directory containing .go files (per-package fixtures land
+# on their owning package); paths with no such ancestor (the shared
+# repo-root testdata/) force the full test suite via ASSET_FULL.
+ASSET_PKGS=""
+ASSET_FULL=""
+# STATIC_PKGS: explicit cross-directory mappings, added to the scoped tests
+# verbatim and intentionally EXCLUDED from reverse-dependency expansion —
+# internal/config is imported nearly everywhere, yet only its own tests read
+# configs/, so expansion would degenerate into a permanent full suite.
+STATIC_PKGS=""
+# EMBED_PKGS: ancestor-mapped packages whose assets are consumed through the
+# import graph — reverse-dependency expansion applies to these.
+EMBED_PKGS=""
+while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    # Cross-directory consumers the ancestor walk cannot express: top-level
+    # configs/ examples are read by internal/config tests (drift guards).
+    case "$p" in
+        configs/*)
+            STATIC_PKGS="$STATIC_PKGS
+./internal/config"
+            continue
+            ;;
+    esac
+    d=$p mapped=""
+    while [ "$d" != "${d%/*}" ]; do
+        d=${d%/*}
+        [ "$d" = testdata ] && break
+        if ls "$d"/*.go >/dev/null 2>&1; then mapped=$d; break; fi
+    done
+    if [ -n "$mapped" ]; then
+        case "$p" in
+            # testdata/ is per-package-private by Go convention — consumers
+            # never read another package's fixtures, so the owning package's
+            # tests suffice (no reverse-dependency expansion).
+            */testdata/*)
+                ASSET_PKGS="$ASSET_PKGS
+./$mapped"
+                ;;
+            # Everything else is consumed via the import graph (go:embed
+            # targets, adjacent assets), so owners feed the reverse scan.
+            *)
+                EMBED_PKGS="$EMBED_PKGS
+./$mapped"
+                ;;
+        esac
+    else
+        ASSET_FULL=1
+    fi
+done <<EOF
+$(git diff --cached --name-only --no-renames --diff-filter=ACMRTD -- testdata internal cmd web/dist docs/swagger configs ':!*.go' || true)
+EOF
+# The ancestor walk maps web/dist and docs/swagger to their embedding
+# packages (web/embed.go and docs/swagger/embed.go) — keep the pathspec list
+# in sync with the repo's go:embed directives.
+#
+# FULL_SUITE: changes that must run the FULL short test suite instead of
+# the scoped one —
+#   * go.mod/go.sum edits (test-only/auxiliary deps break invisibly),
+#   * shared fixtures with no owning package (ASSET_FULL),
+#   * packages unreachable from the ./cmd/javinizer binary (internal/mocks,
+#     internal/testutil, e2e helpers): the build check cannot compile them,
+#     yet other packages' test files import them, so a breaking helper
+#     change passes scoped tests while those test binaries stop compiling,
+#   * whole-package deletions still referenced by survivors (checked below),
+#   * ANY go list failure: without -e, go list OMITS erroneous packages
+#     while still printing healthy ones, so partial output must be treated
+#     exactly like empty output — fail closed rather than silently scope.
+# Import paths never contain spaces, so space-joined matching is safe here.
+FULL_SUITE=""
+if [ -n "$MODULE_CHANGED" ] || [ -n "$ASSET_FULL" ]; then
+    FULL_SUITE=1
+fi
+# Emptied-package pruning (filesystem side): a directory whose last .go
+# file was deleted but which still exists (README, fixtures, subdirectories)
+# has nothing left to lint/vet/test — route it through the dangling-
+# reference gate like a physically deleted package and drop its pattern.
+# Done WITHOUT go list because an exact-pattern go list ERRORS on such
+# directories (only /... wildcards merely warn), and errors are reserved for
+# genuine breakage below.
+if [ -n "$GO_DIRS" ]; then
+    RESOLVED_PKGS=""
+    for d in $GO_DIRS; do
+        [ -d "$d" ] || continue
+        if ! ls "$d"/*.go >/dev/null 2>&1; then
+            DROPPED_DIRS="$DROPPED_DIRS
+$d"
+            continue
+        fi
+        if [ "$d" = . ]; then
+            RESOLVED_PKGS="$RESOLVED_PKGS
+./..."
+        else
+            RESOLVED_PKGS="$RESOLVED_PKGS
+./$d"
+        fi
+    done
+    GO_PKGS=$(printf '%s\n' "$RESOLVED_PKGS" | sed '/^$/d')
+fi
+# STAGED_IMPS: import paths of the staged packages — staged Go packages
+# PLUS ancestor-mapped embed/asset owners (an edited migration/locale/embed
+# breaks the CONSUMERS of its package's API, so those packages feed the
+# reverse scan below). STATIC_PKGS is deliberately not included (see above).
+# Resolution is PER PATTERN with tolerated enumeration-empty outcomes —
+# 'no Go files in', 'matched no packages', and 'build constraints exclude
+# all Go files in' (fully build-tag-excluded directories, e.g. windows-only
+# files on macOS) — which are PRUNED from the
+# check lists. Every other failure is an inconsistent staged snapshot
+# (broken imports, syntax errors) and hard-blocks loudly: a pruned pattern
+# must never silently evade the checks (PRE_COMMIT_FAST=1 would even skip
+# the fail-closed full suite).
+MODULE=$(go list -m 2>/dev/null || true)
+if [ -z "$MODULE" ] && [ -n "$GO_DIRS$EMBED_PKGS$DROPPED_DIRS" ]; then
+    # Without the module path no import-path reasoning is possible at all.
+    FULL_SUITE=1
+fi
+STAGED_IMPS=""
+if [ -n "$GO_PKGS" ] || [ -n "$EMBED_PKGS" ]; then
+    GOLIST_ERR=$(mktemp)
+    PRUNED=""
+    for pat in $GO_PKGS $EMBED_PKGS; do
+        if out=$(go list "$pat" 2>"$GOLIST_ERR"); then
+            STAGED_IMPS="$STAGED_IMPS
+$out"
+        elif head -1 "$GOLIST_ERR" | grep -Eq 'no Go files in|matched no packages|build constraints exclude all Go files in'; then
+            PRUNED="$PRUNED
+$pat"
+        else
+            echo -e "${RED}✗ Cannot resolve staged packages (go list failed):${NC}"
+            cat "$GOLIST_ERR"
+            rm -f "$GOLIST_ERR"
+            echo -e "${YELLOW}Fix the compile/import errors (or unstage these files) and retry.${NC}"
+            exit 1
+        fi
+    done
+    rm -f "$GOLIST_ERR"
+    STAGED_IMPS=$(printf '%s\n' "$STAGED_IMPS" | sed '/^$/d')
+    for pp in $PRUNED; do
+        GO_PKGS=$(printf '%s\n' "$GO_PKGS" | { grep -vxF "$pp" || true; })
+        EMBED_PKGS=$(printf '%s\n' "$EMBED_PKGS" | { grep -vxF "$pp" || true; })
+    done
+fi
+SIMPS=" $(printf '%s\n' "$STAGED_IMPS" | tr '\n' ' ') "
+if [ -z "$FULL_SUITE" ] && [ -n "$STAGED_IMPS" ]; then
+    GOLIST_ERR=$(mktemp)
+    if ! BINARY_GRAPH=$(go list -deps ./cmd/javinizer 2>"$GOLIST_ERR"); then
+        echo -e "${RED}✗ Cannot resolve the ./cmd/javinizer dependency graph (go list -deps failed):${NC}"
+        cat "$GOLIST_ERR"
+        rm -f "$GOLIST_ERR"
+        echo -e "${YELLOW}Fix the errors above (or unstage the offending files) and retry.${NC}"
+        exit 1
+    fi
+    rm -f "$GOLIST_ERR"
+    BINARY_GRAPH=" $(printf '%s\n' "$BINARY_GRAPH" | tr '\n' ' ') "
+    for imp in $STAGED_IMPS; do
+        case "$BINARY_GRAPH" in
+            *" $imp "*) ;;
+            *) FULL_SUITE=1; break ;;
+        esac
+    done
+fi
+# REV_PKGS: transitive reverse dependents of the staged packages, over
+# REGULAR and test imports alike. A breaking API change passes the
+# producer's own tests and the binary build (which compiles neither _test.go
+# files nor auxiliary commands like cmd/javinizer-e2e) while consumers' test
+# binaries stop compiling; re-export indirections (internal/models aliasing
+# internal/scraperconfig types) push breakage a second hop out. Iterate to
+# the fixpoint: every package importing a member joins the member set.
+# The edges block serves two different purposes with different gating:
+#   A) dangling-reference validation for deleted/emptied packages (DROPPED_DIRS)
+#      — snapshot INTEGRITY: must ALWAYS run, even when FULL_SUITE is already
+#      set (e.g. a go.mod edit staged alongside a package deletion), because
+#      PRE_COMMIT_FAST=1 otherwise lets dangling imports slip through.
+#   B) reverse-dependency closure for live staged packages — pure coverage
+#      heuristic, skipped once FULL_SUITE already escalated.
+REV_PKGS=""
+if [ -n "$DROPPED_DIRS" ] || { [ -z "$FULL_SUITE" ] && [ -n "$STAGED_IMPS" ]; }; then
+    GOLIST_ERR=$(mktemp)
+    if TEST_EDGES=$(go list -f '{{.ImportPath}} {{join .Imports " "}} {{join .TestImports " "}} {{join .XTestImports " "}}' ./... 2>"$GOLIST_ERR") && [ -n "$MODULE" ]; then
+        rm -f "$GOLIST_ERR"
+        EDGES_PAD=" $(printf '%s\n' "$TEST_EDGES" | tr '\n' ' ') "
+        # Dangling references to vanished/emptied packages are a hard block:
+        # the staged snapshot itself is inconsistent (something still imports
+        # the deleted package), so no test run — full or fast — can validate
+        # it. This is the deletion counterpart of the go list hard-fail above.
+        for dd in $DROPPED_DIRS; do
+            dimp=$MODULE/$dd
+            [ "$dd" = . ] && dimp=$MODULE
+            case "$EDGES_PAD" in
+                *" $dimp "*)
+                    echo -e "${RED}✗ Staged deletion of package '$dd' — these packages still import it:${NC}"
+                    printf '%s\n' "$TEST_EDGES" | grep -F " $dimp" | cut -d' ' -f1 | sed 's|^|  |'
+                    echo -e "${YELLOW}Update or remove the importers before deleting the package.${NC}"
+                    exit 1
+                    ;;
+            esac
+        done
+        if [ -z "$FULL_SUITE" ] && [ -n "$STAGED_IMPS" ]; then
+            ADDED=1
+            while [ "$ADDED" -eq 1 ]; do
+                ADDED=0
+                while IFS= read -r edge; do
+                    pkg=${edge%% *}
+                    case "$SIMPS" in *" $pkg "*) continue ;; esac
+                    for tok in ${edge#* }; do
+                        case "$SIMPS" in
+                            *" $tok "*)
+                                SIMPS="$SIMPS$pkg "
+                                ADDED=1
+                                break
+                                ;;
+                        esac
+                    done
+                done <<EOF
+$TEST_EDGES
+EOF
+            done
+            for imp in $SIMPS; do
+                if [ "$imp" = "$MODULE" ]; then
+                    REV_PKGS="$REV_PKGS
+./..."
+                else
+                    REV_PKGS="$REV_PKGS
+./${imp#"$MODULE"/}"
+                fi
+            done
+        fi
+    else
+        # Hard block: the package graph cannot be enumerated, so reverse-
+        # dependency and dangling-reference reasoning is impossible. This is
+        # an inconsistent repository snapshot (e.g. a staged deletion still
+        # imported elsewhere) — show the real error instead of degrading to
+        # a suite that PRE_COMMIT_FAST=1 could then skip.
+        echo -e "${RED}✗ Cannot enumerate the package graph (go list ./... failed):${NC}"
+        cat "$GOLIST_ERR"
+        rm -f "$GOLIST_ERR"
+        echo -e "${YELLOW}Fix the errors above (or unstage the offending files) and retry.${NC}"
+        exit 1
+    fi
+fi
+# TEST_PKGS: everything the scoped test check should cover (lint/vet keep
+# the narrower GO_PKGS — assets and test consumers are not lint targets).
+# shellcheck disable=SC2086 # word-splitting the pattern lists is intended
+TEST_PKGS=$(printf '%s\n' $GO_PKGS $ASSET_PKGS $EMBED_PKGS $STATIC_PKGS $REV_PKGS | sed '/^$/d' | sort -u)
+# SHOULD_BUILD: single source of truth for the check-5 trigger, composed
+# here (inside the classified block) so the regression matrix can assert the
+# exact value the hook consumes. Triggers: staged/deleted Go files
+# (STAGED_GO/DELETED_GO/GO_PKGS), module changes, Go-consumed assets.
+SHOULD_BUILD=""
+if [ -n "$GO_PKGS$STAGED_GO$DELETED_GO$MODULE_CHANGED$ASSET_PKGS$EMBED_PKGS$ASSET_FULL" ]; then
+    SHOULD_BUILD=1
+fi
+# Frontend triggers live here too so the matrix can assert them.
+# FRONTEND_FMT_FILES: staged frontend files prettier can parse (check 7).
+# --diff-filter=d excludes deletions (a staged delete of a TS file must not
+# trip prettier); *.svelte is excluded because Prettier ignores it at the
+# config level (svelte-check covers it — see web/frontend/.prettierignore).
+FRONTEND_FMT_FILES=""
+while IFS= read -r -d '' p; do
+    case "$p" in
+        web/frontend/*.ts|web/frontend/*.js|web/frontend/*.cjs|web/frontend/*.mjs|\
+        web/frontend/*.json|web/frontend/*.css|web/frontend/*.html|web/frontend/*.md|\
+        web/frontend/*.yaml|web/frontend/*.yml)
+            FRONTEND_FMT_FILES="$FRONTEND_FMT_FILES
+$p" ;;
+    esac
+done < <(git diff --cached --name-only -z --no-renames --diff-filter=d)
+FRONTEND_FMT_FILES=$(printf '%s\n' "$FRONTEND_FMT_FILES" | sed '/^$/d')
+# FRONTEND_CHANGED: count of staged files under web/frontend/src/ (check 8).
+# --no-renames keeps a rename OUT of src/ visible via its deletion side.
+FRONTEND_CHANGED=0
+while IFS= read -r -d '' p; do
+    case "$p" in
+        web/frontend/src/*) FRONTEND_CHANGED=$((FRONTEND_CHANGED+1)) ;;
+    esac
+done < <(git diff --cached --name-only -z --no-renames)
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Index/tree consistency guard. Every check below validates the WORKING TREE
+# (vet/test/build/go list all read files from disk), so the tree must equal
+# the staged snapshot the commit will actually contain — cross-package
+# contamination otherwise lets an unstaged caller fix mask a staged API
+# break. Rule: once anything checked is staged, NO unstaged OR untracked
+# change (including staged-deleted paths recreated on disk, which
+# 'git diff --name-only' cannot see and which get their own probe below) may
+# exist under the checked pathspecs. Refuse rather than vouch for a state we
+# never ran.
+GUARD_PATHSPEC=(-- '*.go' go.mod go.sum testdata internal cmd web/dist docs/swagger configs web/frontend .golangci.yml .golangci.yaml Makefile)
+check_tree_consistency() {
+    STAGED_SET=$(git diff --cached --name-only --no-renames -- "${GUARD_PATHSPEC[@]}" | sort || true)
+    CONFLICT=""
+    while IFS= read -r -d '' f; do
+        if [ -n "$f" ] && [ -e "$f" ]; then
+            CONFLICT="$CONFLICT
+$f"
+        fi
+    done < <(git diff --cached --name-only -z --no-renames --diff-filter=D -- "${GUARD_PATHSPEC[@]}" || true)
+    if [ -n "$STAGED_SET" ]; then
+        UNSTAGED=$( { git diff --name-only -- "${GUARD_PATHSPEC[@]}"
+                      git ls-files --others --exclude-standard -- "${GUARD_PATHSPEC[@]}"
+                      # Embed roots contain git-IGNORED files still compiled
+                      # into the binary (//go:embed all:dist) — an ignored
+                      # artifact can mask a staged deletion, so scan them too.
+                      git ls-files --others --ignored --exclude-standard -- web/dist '*.syso'; } | sort -u || true)
+        if [ -n "$UNSTAGED" ]; then
+            CONFLICT="$CONFLICT
+$UNSTAGED"
+        fi
+    fi
+    [ -z "$CONFLICT" ]
+}
+report_tree_conflict() {
+    echo -e "${RED}✗ $1 — the hook validates the working tree, which must match${NC}"
+    echo -e "${RED}  the staged snapshot exactly. Offending paths:${NC}"
+    # shellcheck disable=SC2086 # one path per line is the intent
+    printf '  %s\n' $CONFLICT
+echo -e "${YELLOW}Stage fixable changes (git add -A), delete the offending untracked/ignored"
+    echo -e "paths, or stash everything (git stash --all --keep-index -- the --all is"
+    echo -e "required for ignored web/dist build artifacts), then retry.${NC}"
+}
+# Drift across the classification window: the analysis above read the index
+# many times; if it changed mid-analysis the computed scope may be a mix of
+# two snapshots. Refuse — the retry re-reads a single consistent one.
+POST_CLASSIFICATION_TREE=$(snapshot_index || true)
+if [ "$POST_CLASSIFICATION_TREE" != "$INITIAL_INDEX_TREE" ]; then
+    echo -e "${RED}✗ The staged content changed during scope analysis (another process${NC}"
+    echo -e "${RED}  ran git add); the computed check scope may be inconsistent.${NC}"
+    echo -e "${YELLOW}Retry the commit — the re-run analyzes a single snapshot.${NC}"
+    exit 1
+fi
+if ! check_tree_consistency; then
+    report_tree_conflict "Working tree contains unstaged/untracked changes under checked paths"
+    exit 1
+fi
 # ---------------------------------------------------------------------------
 
 echo -e "${BLUE}Running pre-commit checks...${NC}"
@@ -103,13 +551,20 @@ fi
 echo -e "${GREEN}✓ Code formatting OK${NC}"
 echo ""
 
-# Check 2: golangci-lint (changed packages only)
-if [ -n "$GO_PKGS" ]; then
-    echo -e "${BLUE}[2/8] Running golangci-lint (staged packages)...${NC}"
+# Check 2: golangci-lint (changed packages only — full repo when the linter
+# configuration itself is staged, since config applies repository-wide)
+LINT_PKGS=$GO_PKGS
+LINT_SCOPE="staged packages"
+if [ -n "$LINT_CONFIG" ]; then
+    LINT_PKGS="./..."
+    LINT_SCOPE="full repo — lint config staged"
+fi
+if [ -n "$LINT_PKGS" ]; then
+    echo -e "${BLUE}[2/8] Running golangci-lint ($LINT_SCOPE)...${NC}"
     if [[ -x "$GOLANGCI_LINT" ]] && check_golangci_lint_version; then
         echo -e "${BLUE}  Using golangci-lint from $GOLANGCI_LINT${NC}"
-        # shellcheck disable=SC2086 # word-splitting GO_PKGS is intentional
-        if ! "$GOLANGCI_LINT" run $GO_PKGS 2>&1; then
+        # shellcheck disable=SC2086 # word-splitting LINT_PKGS is intentional
+        if ! "$GOLANGCI_LINT" run $LINT_PKGS 2>&1; then
             echo -e "${RED}✗ golangci-lint found issues${NC}"
             exit 1
         fi
@@ -127,8 +582,19 @@ else
 fi
 echo ""
 
-# Check 3: Go vet (changed packages only)
-if [ -n "$GO_PKGS" ]; then
+# Check 3: Go vet. Scoped to changed packages normally; a staged go.mod/
+# go.sum runs it repository-wide — the go directive and dependency versions
+# shift vet's analysis (e.g. stdversion diagnostics) even when build/tests
+# still pass.
+if [ -n "$MODULE_CHANGED" ]; then
+    # checked FIRST: module+Go mixed staging must not collapse to scoped vet
+    echo -e "${BLUE}[3/8] Running go vet (all packages — module files staged)...${NC}"
+    if ! go vet ./... 2>&1; then
+        echo -e "${RED}✗ go vet found issues${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ go vet passed${NC}"
+elif [ -n "$GO_PKGS" ]; then
     echo -e "${BLUE}[3/8] Running go vet (staged packages)...${NC}"
     # shellcheck disable=SC2086 # word-splitting GO_PKGS is intentional
     if ! go vet $GO_PKGS 2>&1; then
@@ -137,32 +603,44 @@ if [ -n "$GO_PKGS" ]; then
     fi
     echo -e "${GREEN}✓ go vet passed${NC}"
 else
-    echo -e "${BLUE}[3/8] go vet${NC} (skipped — no staged Go files)"
+    echo -e "${BLUE}[3/8] go vet${NC} (skipped — no staged Go or module files)"
 fi
 echo ""
 
-# Check 4: Fast unit tests (changed packages only; the full suite takes
-# minutes — it belongs in pre-push, not pre-commit)
-if [ -n "$GO_PKGS" ] && [ -z "${PRE_COMMIT_FAST:-}" ]; then
-    echo -e "${BLUE}[4/8] Running fast unit tests (staged packages)...${NC}"
-    # Increase timeout to 60s for the fast test pass
-    # shellcheck disable=SC2086 # word-splitting GO_PKGS is intentional
-    if ! go test -short -timeout=60s $GO_PKGS 2>&1; then
+# Check 4: Fast unit tests. Normally scoped to touched packages (the full
+# suite takes minutes); FULL_SUITE changes (module files, shared fixtures,
+# binary-unreachable helper packages — see scoping block) run the FULL short
+# suite because scoped testing cannot see the breakage they cause.
+if [ -n "$FULL_SUITE" ] && [ -z "${PRE_COMMIT_FAST:-}" ]; then
+    echo -e "${BLUE}[4/8] Running fast unit tests (full suite — module/shared/helper change)...${NC}"
+    if ! go test -short -timeout=60s ./... 2>&1; then
         echo -e "${RED}✗ Tests failed${NC}"
         exit 1
     fi
     echo -e "${GREEN}✓ Tests passed${NC}"
-elif [ -z "$GO_PKGS" ]; then
-    echo -e "${BLUE}[4/8] unit tests${NC} (skipped — no staged Go files)"
+elif [ -n "$TEST_PKGS" ] && [ -z "${PRE_COMMIT_FAST:-}" ]; then
+    echo -e "${BLUE}[4/8] Running fast unit tests (staged packages)...${NC}"
+    # Increase timeout to 60s for the fast test pass
+    # shellcheck disable=SC2086 # word-splitting TEST_PKGS is intentional
+    if ! go test -short -timeout=60s $TEST_PKGS 2>&1; then
+        echo -e "${RED}✗ Tests failed${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ Tests passed${NC}"
+elif [ -z "$TEST_PKGS" ] && [ -z "$FULL_SUITE" ]; then
+    echo -e "${BLUE}[4/8] unit tests${NC} (skipped — no staged Go or module inputs)"
 else
     echo -e "${BLUE}[4/8] unit tests${NC} (skipped — PRE_COMMIT_FAST=1)"
 fi
 echo ""
 
-# Check 5: Build verification (only when Go files staged; with a warm build
-# cache this is a few seconds and catches cross-package breakage the scoped
-# checks miss)
-if [ -n "$GO_PKGS" ]; then
+# Check 5: Build verification (with a warm build cache this is a few
+# seconds and catches cross-package breakage the scoped checks miss).
+# Triggers beyond staged Go files: DELETED_GO (deleting a package's last
+# file empties GO_PKGS while dependents may still reference it),
+# MODULE_CHANGED (dependency updates), ASSET_PKGS/ASSET_FULL (a deleted or
+# renamed go:embed target fails compilation).
+if [ -n "$SHOULD_BUILD" ]; then
     echo -e "${BLUE}[5/8] Verifying build...${NC}"
     if ! go build -o /tmp/javinizer-test ./cmd/javinizer 2>&1; then
         echo -e "${RED}✗ Build failed${NC}"
@@ -171,7 +649,7 @@ if [ -n "$GO_PKGS" ]; then
     rm -f /tmp/javinizer-test
     echo -e "${GREEN}✓ Build successful${NC}"
 else
-    echo -e "${BLUE}[5/8] build${NC} (skipped — no staged Go files)"
+    echo -e "${BLUE}[5/8] build${NC} (skipped — no staged Go or module files)"
 fi
 echo ""
 
@@ -205,13 +683,8 @@ else
 fi
 echo ""
 
-# Check 7: Frontend Prettier formatting (only staged frontend files)
-# Collect staged frontend files that prettier can parse. Excludes deletions
-# (diff-filter=d) so a staged delete of a TS file doesn't trip prettier.
-# *.svelte is Prettier-ignored at the config level (svelte-check covers it)
-# — see web/frontend/.prettierignore.
-FRONTEND_FMT_FILES=$(git diff --cached --name-only --diff-filter=d \
-    | grep -E '^web/frontend/.*\.(ts|js|cjs|mjs|json|css|html|md|yaml|yml)$' || true)
+# Check 7: Frontend Prettier formatting (FRONTEND_FMT_FILES is computed in
+# the classification block above)
 if [ -n "$FRONTEND_FMT_FILES" ]; then
     echo -e "${BLUE}[7/8] Checking frontend formatting (prettier)...${NC}"
     if [ -d "web/frontend/node_modules" ]; then
@@ -235,9 +708,9 @@ else
 fi
 echo ""
 
-# Check 8: Frontend type checking (only if frontend src files changed;
-# svelte-check costs ~1 minute, so honor PRE_COMMIT_FAST here)
-FRONTEND_CHANGED=$(git diff --cached --name-only | grep -c "^web/frontend/src/" || true)
+# Check 8: Frontend type checking (FRONTEND_CHANGED is computed in the
+# classification block above; svelte-check costs ~1 minute, so honor
+# PRE_COMMIT_FAST here)
 if [ "$FRONTEND_CHANGED" -gt 0 ] && [ -z "${PRE_COMMIT_FAST:-}" ]; then
     echo -e "${BLUE}[8/8] Running frontend type check (svelte-check)...${NC}"
     if [ -d "web/frontend/node_modules" ]; then
@@ -255,6 +728,33 @@ else
     echo -e "${BLUE}[8/8] Frontend type check${NC} (skipped — PRE_COMMIT_FAST=1)"
 fi
 echo ""
+
+# Post-check consistency re-verification: the checks above took long enough
+# that an editor (or another process) could have mutated the tree mid-run,
+# leaving the up-front guard's verdict stale (TOCTOU) — the checks would
+# have validated content that differs from what gets committed. Never vouch
+# for a snapshot we did not just re-verify.
+# Residual, accepted: a change-then-restore (ABA) race inside the validation
+# window still evades both guards, and no hook can close the gap between its
+# own exit and git consuming the index. Fully closing it would require
+# running every check against an immutable index snapshot, which breaks
+# checks that depend on untracked working-tree state (frontend node_modules,
+# swagger regen-diff) — a poor trade for a developer-aid guard whose threat
+# model is accidental edits, not adversarial timing (which --no-verify
+# already makes moot).
+if ! check_tree_consistency; then
+    report_tree_conflict "Working tree changed while the checks were running"
+    exit 1
+fi
+# Index drift: a concurrent git add leaves tree==index but with staged
+# content the classification and checks never saw.
+FINAL_INDEX_TREE=$(snapshot_index || true)
+if [ "$FINAL_INDEX_TREE" != "$POST_CLASSIFICATION_TREE" ]; then
+    echo -e "${RED}✗ The staged content changed while the checks were running (another${NC}"
+    echo -e "${RED}  process ran git add); the new inputs were never validated.${NC}"
+    echo -e "${YELLOW}Retry the commit — the re-run validates the new snapshot.${NC}"
+    exit 1
+fi
 
 echo -e "${GREEN}========================================${NC}"
 echo -e "${GREEN}All pre-commit checks passed!${NC} ($((SECONDS - START))s)"

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -508,7 +508,12 @@ $f"
         # substitution subshell (the guard runs twice per hook; the
         # graph cannot change mid-run without tripping a consistency check).
         if [ -z "${TOOL_DIRS_CACHE+x}" ]; then
-            TOOL_DIRS_CACHE=$(go list -f '{{.Dir}}' -deps ./... 2>/dev/null || true)
+            TOOL_DIRS_CACHE=$( {
+                go list -f '{{.Dir}}' -deps ./... 2>/dev/null || true
+                # -deps alone skips TEST-ONLY imports; a staged _test.go can
+                # import an ignored-only package (e.g. beneath testdata/).
+                go list -f '{{.Dir}}' -deps -test ./... 2>/dev/null || true
+            } | sort -u )
         fi
         PKG_DIRS=$( {
             {

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -501,6 +501,15 @@ $f"
         #     invisible to both git views but compiles in the tree, letting a
         #     staged import of it pass locally and fail CI. go list skips
         #     dot/underscore/testdata dirs, so scratch trees stay immune.
+        # Dependency-graph dirs must join too: wildcard ./... never
+        # enumerates testdata/, yet explicit imports beneath testdata DO
+        # resolve — an ignored-only package there would otherwise slip the
+        # guard while the committed snapshot fails in CI. Cached outside the
+        # substitution subshell (the guard runs twice per hook; the
+        # graph cannot change mid-run without tripping a consistency check).
+        if [ -z "${TOOL_DIRS_CACHE+x}" ]; then
+            TOOL_DIRS_CACHE=$(go list -f '{{.Dir}}' -deps ./... 2>/dev/null || true)
+        fi
         PKG_DIRS=$( {
             {
                 git ls-files '*.go'
@@ -512,15 +521,21 @@ $f"
             # interpolated pwd containing BRE metacharacters (dots are harmless,
             # but [ ] * \ in a checkout path) would fail sed and fail open.
             root=$(pwd)
-            go list -f '{{.Dir}}' ./... 2>/dev/null | while IFS= read -r abs; do
-                # if/elif instead of case: bash 3.2 (stock macOS) mis-parses
-                # case patterns inside command substitutions this deep.
-                if [ "$abs" = "$root" ]; then
-                    printf '.\n'
-                elif [ "${abs#"$root"/}" != "$abs" ]; then
-                    printf '%s\n' "${abs#"$root"/}"
-                fi
-            done || true
+            # Wildcard packages PLUS the cached dependency graph (the only
+            # side that sees explicit imports beneath testdata/).
+            {
+                go list -f '{{.Dir}}' ./... 2>/dev/null
+                printf '%s\n' "$TOOL_DIRS_CACHE"
+            } | while IFS= read -r abs; do
+                    # if/elif instead of case: bash 3.2 (stock macOS)
+                    # mis-parses case patterns inside nested command
+                    # substitutions.
+                    if [ "$abs" = "$root" ]; then
+                        printf '.\n'
+                    elif [ "${abs#"$root"/}" != "$abs" ]; then
+                        printf '%s\n' "${abs#"$root"/}"
+                    fi
+                done || true
         } | sort -u | tr '\n' ' ' )
         # pad with spaces so case-matching ' "$d" ' is exact-token safe
         PKG_DIRS=" $PKG_DIRS "

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -163,6 +163,30 @@ while IFS= read -r -d '' p; do
         internal/*|cmd/*|docs/swagger/*|Makefile) API_CHANGED=$((API_CHANGED+1)) ;;
     esac
 done < <(git diff --cached --name-only -z --no-renames)
+# compute_embed_census: repo-relative paths consumed by //go:embed ANYWHERE
+# in the module graph, resolved by the TOOLCHAIN itself — no static list can
+# enumerate them (arbitrary types at arbitrary roots), and only the tool
+# applies glob semantics, all: prefixes and the dot/underscore directory-walk
+# exclusion faithfully. -test is required: plain go list leaves
+# TestEmbedFiles/XTestEmbedFiles empty, so test-file embeds would be missed;
+# -deps is required: wildcard ./... never enumerates testdata/, yet imports
+# beneath it DO resolve. Module-cache deps sit outside the checkout and the
+# prefix-strip drops them. Exit status = go list status; CALLERS pick the
+# failure policy (classification maps best-effort — the guard census blocks
+# loudly moments later — while the tree-consistency guard fails closed).
+compute_embed_census() {
+    local census_abs census_root
+    census_abs=$(go list -test -deps -f '{{range .EmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .TestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .XTestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}' ./... 2>/dev/null) || return 1
+    census_root=$(pwd)
+    # Prefix-strip WITHOUT regex — a bracketed checkout path must not fail
+    # open on a BRE metacharacter (same hazard as the PKG_DIRS walk).
+    printf '%s\n' "$census_abs" | while IFS= read -r a; do
+        [ -n "$a" ] || continue
+        if [ "${a#"$census_root"/}" != "$a" ]; then
+            printf '%s\n' "${a#"$census_root"/}"
+        fi
+    done
+}
 # Non-Go inputs consumed by Go packages (testdata/** fixtures, go:embed
 # assets like *.sql migrations, locales/*.json, config.yaml.example) plus
 # cgo/linker inputs (.c/.s/.h/.syso…) anywhere — e.g. staging web/bad.c
@@ -183,6 +207,23 @@ STATIC_PKGS=""
 # EMBED_PKGS: ancestor-mapped packages whose assets are consumed through the
 # import graph — reverse-dependency expansion applies to these.
 EMBED_PKGS=""
+# Embed targets OUTSIDE the hard-coded roots above: //go:embed assets live at
+# ARBITRARY paths (a root-level banner.txt, say), so a static prefix list
+# cannot see every staged asset whose content edit breaks its embedding
+# package's consumers. Census-intersect every staged path that matches NO
+# static rule; survivors flow through the SAME ancestor-walk mapping below.
+# Best-effort: a census failure simply adds nothing — the tree-consistency
+# guard's fail-closed census blocks loudly a moment later, so nothing evades.
+EMBED_STAGED=""
+ASSET_CANDIDATES=$(git diff --cached --name-only --no-renames --diff-filter=ACMR \
+    | grep -vE '^testdata/|^internal/|^cmd/|^web/|^docs/swagger/|^configs/|\.go$|^go\.(mod|sum)$|^Makefile$|^\.golangci\.(yml|yaml)$' || true)
+if [ -n "$ASSET_CANDIDATES" ]; then
+    if EMBED_CENSUS=$(compute_embed_census); then
+        EMBED_STAGED=$(comm -12 \
+            <(printf '%s\n' "$ASSET_CANDIDATES" | sort -u) \
+            <(printf '%s\n' "$EMBED_CENSUS" | sort -u) || true)
+    fi
+fi
 while IFS= read -r p; do
     [ -n "$p" ] || continue
     # Cross-directory consumers the ancestor walk cannot express: top-level
@@ -221,6 +262,7 @@ while IFS= read -r p; do
     fi
 done <<EOF
 $(git diff --cached --name-only --no-renames --diff-filter=ACMRTD -- testdata internal cmd web/dist docs/swagger configs '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx' '*.s' '*.S' '*.sx' '*.syso' '*.m' '*.f' '*.F' '*.for' '*.f90' '*.swig' '*.swigcxx' ':!*.go' || true)
+$EMBED_STAGED
 EOF
 # The ancestor walk maps web/dist and docs/swagger to their embedding
 # packages (web/embed.go and docs/swagger/embed.go) — keep the pathspec list
@@ -514,7 +556,52 @@ check_tree_consistency() {
 $f"
         fi
     done < <(git diff --cached --name-only -z --no-renames --diff-filter=D -- "${GUARD_PATHSPEC[@]}" || true)
-    if [ -n "$CHECKED_SET" ]; then
+    # ===== Tier 1: toolchain embed census — engages for ANY staged path ==
+    # //go:embed targets live at ARBITRARY paths, so even a commit whose
+    # staged paths match no checked pathspec can invalidate the snapshot:
+    # a staged deletion of a root-level embed asset kills nothing here
+    # but fails every CI build. An unstaged edit to a TRACKED embed
+    # target outside GUARD_PATHSPEC likewise poisons the tree the checks
+    # read — the dirty-tree union in tier 2 therefore covers every census
+    # path in addition to the hard-coded lists. Mask set = embedded paths
+    # ABSENT FROM THE INDEX (untracked or ignored, any extension, present
+    # or future — staging '//go:embed local.db' while local.db stays
+    # ignored (this repo ignores *.db) lets go list/vet/test/build
+    # consume the working-tree file here, then the COMMITTED snapshot
+    # fails with 'pattern local.db: no matching files found'); whatever
+    # sits in the index ships with the commit by definition. Data files
+    # READ (not embedded) by tests are not toolchain-enumerable and stay
+    # out by design. Recomputed per invocation, never cached: a mid-run
+    # created or edited embed asset changes nothing else any comparator
+    # observes.
+    EMBED_REL_ARR=()
+    if [ -n "$STAGED_SET" ]; then
+        EMBED_REL=$(compute_embed_census) ||
+            { refuse_guard_scan "go list -test -deps"; return 1; }
+        if [ -n "$EMBED_REL" ]; then
+            while IFS= read -r epath; do
+                [ -n "$epath" ] && EMBED_REL_ARR+=("$epath")
+            done <<EMBED_LIST_EOF
+$EMBED_REL
+EMBED_LIST_EOF
+            # -c core.quotepath=false prints RAW bytes for non-ASCII
+            # names, so tracked unicode embeds compare equal on both
+            # sides of comm (C-quoting one side would fabricate masks).
+            EMBED_MASKED=$(comm -23 \
+                <(printf '%s\n' "${EMBED_REL_ARR[@]}" | sort -u) \
+                <(git -c core.quotepath=false ls-files | sort -u) || true)
+            if [ -n "$EMBED_MASKED" ]; then
+                CONFLICT="$CONFLICT
+$EMBED_MASKED"
+            fi
+        fi
+    fi
+    # ===== Tier 2: dirty-tree union — engages when Go validation does ===
+    # CHECKED paths staged is the primary trigger; staged census assets
+    # (EMBED_STAGED, from classification) trigger it too, because such a
+    # commit runs full Go validation and the union is what keeps the tree
+    # equal to the snapshot those checks claim to vouch for.
+    if [ -n "$CHECKED_SET" ] || [ -n "${EMBED_STAGED:-}" ]; then
         # Ignored compile inputs count only inside an ACTUAL Go package
         # directory (one holding tracked .go files) or under an embed root —
         # precise and immune to ignored scratch trees (.planning/, .tmprepro/,
@@ -601,79 +688,18 @@ $raw" ;;
             '*.syso' '*.go' '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx' \
             '*.s' '*.S' '*.sx' '*.m' '*.f' '*.F' '*.for' '*.f90' '*.swig' '*.swigcxx' || true)
         UNSTAGED=$( { git diff --name-only -- "${GUARD_PATHSPEC[@]}"
+                      # Census paths extend the union: a TRACKED embed
+                      # target outside GUARD_PATHSPEC must not drift
+                      # from the staged snapshot either (tier 1 feeds
+                      # the array; empty under set -u needs the count
+                      # guard, bash 3.2 has no safe empty "${a[@]}").
+                      [ "${#EMBED_REL_ARR[@]}" -eq 0 ] || \
+                          git diff --name-only -- "${EMBED_REL_ARR[@]}"
                       git ls-files --others --exclude-standard -- "${GUARD_PATHSPEC[@]}"
                       printf '%s\n' "$IGNORED_KEPT"; } | sort -u || true)
         if [ -n "$UNSTAGED" ]; then
             CONFLICT="$CONFLICT
 $UNSTAGED"
-        fi
-    fi
-    # Tier 1 census — ANY staged path (see the trigger comment above):
-    # Ignored go:embed ASSETS escape BOTH the extension lists and the
-    # checked-pathspec trigger — //go:embed names ARBITRARY types at
-    # ARBITRARY paths from the staged snapshot itself. Staging
-    # '//go:embed local.db' while local.db stays ignored (this repo
-    # ignores *.db) lets go list/vet/test/build consume the working-tree
-    # file here, then the COMMITTED snapshot fails with 'pattern
-    # local.db: no matching files found'; likewise a staged deletion of
-    # the last embed match breaks the pattern go list itself evaluates,
-    # which the fail-closed refusal converts into a block rather than a
-    # silent skip. No static pathspec can enumerate embed targets, so ask
-    # the toolchain: go list -test -deps resolves the EXACT embed set
-    # against this tree (glob semantics, all: prefixes and the
-    # dot/underscore directory-walk exclusion handled by the tool).
-    # -test is required because plain go list leaves TestEmbedFiles and
-    # XTestEmbedFiles empty — an ignored _test.go embed asset would
-    # otherwise slip the guard while go test consumes it — and -deps is
-    # required because wildcard ./... never enumerates testdata/, yet
-    # explicit imports beneath testdata DO resolve (the same hole the
-    # TOOL_DIRS_CACHE graph union closes): an embed in such a package
-    # hides from a shallow census while its consumers break in CI.
-    # Module-cache deps the scan surfaces sit outside the checkout; the
-    # prefix-strip below drops them. Recomputed per invocation,
-    # deliberately NOT cached like TOOL_DIRS_CACHE: a mid-run-created
-    # ignored embed file changes nothing else any comparator observes.
-    # Mask set = embedded paths ABSENT FROM THE INDEX (untracked or
-    # ignored, any extension, present or future) — whatever sits in the
-    # index ships with the commit by definition. Data files READ (not
-    # embedded) by tests are not toolchain-enumerable and stay out by
-    # design.
-    if [ -n "$STAGED_SET" ]; then
-        EMBED_ABS=$(go list -test -deps -f '{{range .EmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .TestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .XTestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}' ./... 2>/dev/null) ||
-            { refuse_guard_scan "go list -test -deps"; return 1; }
-        if [ -n "$EMBED_ABS" ]; then
-            EMBED_ROOT=$(pwd)
-            EMBED_REL=""
-            while IFS= read -r eabs; do
-                [ -n "$eabs" ] || continue
-                # Prefix-strip WITHOUT regex (same metacharacter hazard
-                # as the PKG_DIRS walk above — a bracketed checkout path
-                # must not fail open); paths outside the checkout
-                # (synthesized -test variants) match no prefix and drop.
-                if [ "${eabs#"$EMBED_ROOT"/}" != "$eabs" ]; then
-                    EMBED_REL="$EMBED_REL
-${eabs#"$EMBED_ROOT"/}"
-                fi
-            done <<EMBED_SCAN_EOF
-$EMBED_ABS
-EMBED_SCAN_EOF
-            if [ -n "$EMBED_REL" ]; then
-                # -c core.quotepath=false prints RAW bytes for non-ASCII
-                # names, so tracked unicode embeds compare equal on both
-                # sides of comm (C-quoting one side would fabricate
-                # phantom masks).
-                EMBED_MASKED=$(comm -23 \
-                    <(printf '%s\n' "$EMBED_REL" | sed '/^$/d' | sort -u) \
-                    <(git -c core.quotepath=false ls-files | sort -u) || true)
-                # Append directly, bypassing the PKG_DIRS filter: the
-                # directive's own .go file is necessarily tracked, and
-                # roots outside the static lists (a future root-level
-                # embed, say) are precisely what this tier exists to see.
-                if [ -n "$EMBED_MASKED" ]; then
-                    CONFLICT="$CONFLICT
-$EMBED_MASKED"
-                fi
-            fi
         fi
     fi
     [ -z "$CONFLICT" ]

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -45,7 +45,8 @@ START=$SECONDS
 # hostile lock holder.
 snapshot_index() {
     local tree _i
-    for _i in $(seq 1 20); do
+    # bash arithmetic loop — no external seq dependency
+    for ((_i = 0; _i < 20; _i++)); do
         if tree=$(git write-tree 2>/dev/null); then
             printf '%s\n' "$tree"
             return 0
@@ -79,13 +80,15 @@ done < <(git diff --cached --name-only -z)
 # broken workspace would fail CI where GOWORK is not disabled. Refuse a
 # force-staged (git add -f) workspace file.
 WORKSPACE_STAGED=""
+# --diff-filter=d excludes deletions: removing a previously-tracked
+# workspace file is exactly the commit we must NOT refuse.
 while IFS= read -r -d '' p; do
     case "$p" in
         go.work|go.work.sum)
             WORKSPACE_STAGED="$WORKSPACE_STAGED
 $p" ;;
     esac
-done < <(git diff --cached --name-only -z)
+done < <(git diff --cached --name-only -z --diff-filter=d)
 if [ -n "$WORKSPACE_STAGED" ]; then
     echo -e "${RED}✗ go.work files must not be committed (git-ignored personal workspace):${NC}"
     # shellcheck disable=SC2086 # one path per line is the intent
@@ -161,7 +164,10 @@ while IFS= read -r -d '' p; do
     esac
 done < <(git diff --cached --name-only -z --no-renames)
 # Non-Go inputs consumed by Go packages (testdata/** fixtures, go:embed
-# assets like *.sql migrations, locales/*.json, config.yaml.example): these
+# assets like *.sql migrations, locales/*.json, config.yaml.example) plus
+# cgo/linker inputs (.c/.s/.h/.syso…) anywhere — e.g. staging web/bad.c
+# makes the existing web package uncompilable while matching no .go rule.
+# These
 # never match a *.go pathspec, yet a bad fixture edit fails `go test` and a
 # deleted embed fails `go build`. Map each staged non-.go path to the
 # nearest ancestor directory containing .go files (per-package fixtures land
@@ -214,7 +220,7 @@ while IFS= read -r p; do
         ASSET_FULL=1
     fi
 done <<EOF
-$(git diff --cached --name-only --no-renames --diff-filter=ACMRTD -- testdata internal cmd web/dist docs/swagger configs ':!*.go' || true)
+$(git diff --cached --name-only --no-renames --diff-filter=ACMRTD -- testdata internal cmd web/dist docs/swagger configs '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx' '*.s' '*.S' '*.sx' '*.syso' '*.m' '*.f' '*.F' '*.for' '*.f90' '*.swig' '*.swigcxx' ':!*.go' || true)
 EOF
 # The ancestor walk maps web/dist and docs/swagger to their embedding
 # packages (web/embed.go and docs/swagger/embed.go) — keep the pathspec list
@@ -291,6 +297,14 @@ $out"
         elif head -1 "$GOLIST_ERR" | grep -Eq 'no Go files in|matched no packages|build constraints exclude all Go files in'; then
             PRUNED="$PRUNED
 $pat"
+            # A package that WAS live and became enumeration-empty via the
+            # staged edit (e.g. an added build constraint) is deletion-
+            # equivalent — its consumers must pass dangling-import validation.
+            case "${pat#./}" in
+                .) ;;
+                *) DROPPED_DIRS="$DROPPED_DIRS
+${pat#./}" ;;
+            esac
         else
             echo -e "${RED}✗ Cannot resolve staged packages (go list failed):${NC}"
             cat "$GOLIST_ERR"
@@ -408,6 +422,12 @@ fi
 # the narrower GO_PKGS — assets and test consumers are not lint targets).
 # shellcheck disable=SC2086 # word-splitting the pattern lists is intended
 TEST_PKGS=$(printf '%s\n' $GO_PKGS $ASSET_PKGS $EMBED_PKGS $STATIC_PKGS $REV_PKGS | sed '/^$/d' | sort -u)
+# CHECK_PKGS: lint/vet scope. Producers alone are NOT enough — a change can
+# create consumer-only diagnostics that still compile (adding a mutex to an
+# exported type trips vet copylocks in consumers; staticcheck deprecation
+# notices fire at use sites), so reverse dependents join the analysis scope.
+# shellcheck disable=SC2086 # word-splitting the pattern lists is intended
+CHECK_PKGS=$(printf '%s\n' $GO_PKGS $REV_PKGS | sed '/^$/d' | sort -u)
 # SHOULD_BUILD: single source of truth for the check-5 trigger, composed
 # here (inside the classified block) so the regression matrix can assert the
 # exact value the hook consumes. Triggers: staged/deleted Go files
@@ -452,7 +472,8 @@ done < <(git diff --cached --name-only -z --no-renames)
 # 'git diff --name-only' cannot see and which get their own probe below) may
 # exist under the checked pathspecs. Refuse rather than vouch for a state we
 # never ran.
-GUARD_PATHSPEC=(-- '*.go' go.mod go.sum testdata internal cmd web/dist docs/swagger configs web/frontend .golangci.yml .golangci.yaml Makefile)
+GUARD_PATHSPEC=(-- '*.go' go.mod go.sum testdata internal cmd web/dist docs/swagger configs web/frontend .golangci.yml .golangci.yaml Makefile
+                '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx' '*.s' '*.S' '*.sx' '*.syso' '*.m' '*.f' '*.F' '*.for' '*.f90' '*.swig' '*.swigcxx')
 check_tree_consistency() {
     STAGED_SET=$(git diff --cached --name-only --no-renames -- "${GUARD_PATHSPEC[@]}" | sort || true)
     CONFLICT=""
@@ -463,12 +484,35 @@ $f"
         fi
     done < <(git diff --cached --name-only -z --no-renames --diff-filter=D -- "${GUARD_PATHSPEC[@]}" || true)
     if [ -n "$STAGED_SET" ]; then
+        # Ignored compile inputs count only inside an ACTUAL Go package
+        # directory (one holding tracked .go files) or under an embed root —
+        # precise and immune to ignored scratch trees (.planning/, .tmprepro/,
+        # node_modules/, .worktrees/, …) with no exclusion list to maintain.
+        IGNORED_RAW=$(git ls-files --others --ignored --exclude-standard \
+            -- web/dist \
+            '*.syso' '*.go' '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx' \
+            '*.s' '*.S' '*.sx' '*.m' '*.f' '*.F' '*.for' '*.f90' '*.swig' '*.swigcxx' || true)
+        PKG_DIRS=" $(git ls-files '*.go' | while IFS= read -r g; do printf '%s\n' "${g%/*}"; done | sort -u | tr '\n' ' ') "
+        IGNORED_KEPT=""
+        while IFS= read -r raw; do
+            [ -n "$raw" ] || continue
+            case "$raw" in
+                web/dist/*)
+                    IGNORED_KEPT="$IGNORED_KEPT
+$raw" ;;
+                *)
+                    rd=${raw%/*}; [ "$rd" = "$raw" ] && rd=.
+                    case "$PKG_DIRS" in
+                        *" $rd "*) IGNORED_KEPT="$IGNORED_KEPT
+$raw" ;;
+                    esac ;;
+            esac
+        done <<FILTER_EOF
+$IGNORED_RAW
+FILTER_EOF
         UNSTAGED=$( { git diff --name-only -- "${GUARD_PATHSPEC[@]}"
                       git ls-files --others --exclude-standard -- "${GUARD_PATHSPEC[@]}"
-                      # Embed roots contain git-IGNORED files still compiled
-                      # into the binary (//go:embed all:dist) — an ignored
-                      # artifact can mask a staged deletion, so scan them too.
-                      git ls-files --others --ignored --exclude-standard -- web/dist '*.syso'; } | sort -u || true)
+                      printf '%s\n' "$IGNORED_KEPT"; } | sort -u || true)
         if [ -n "$UNSTAGED" ]; then
             CONFLICT="$CONFLICT
 $UNSTAGED"
@@ -482,8 +526,9 @@ report_tree_conflict() {
     # shellcheck disable=SC2086 # one path per line is the intent
     printf '  %s\n' $CONFLICT
 echo -e "${YELLOW}Stage fixable changes (git add -A), delete the offending untracked/ignored"
-    echo -e "paths, or stash everything (git stash --all --keep-index -- the --all is"
-    echo -e "required for ignored web/dist build artifacts), then retry.${NC}"
+    echo -e "paths, or stash everything: git stash --all --keep-index"
+    echo -e "(the --all flag is required to include ignored web/dist build artifacts)."
+    echo -e "Then retry the commit.${NC}"
 }
 # Drift across the classification window: the analysis above read the index
 # many times; if it changed mid-analysis the computed scope may be a mix of
@@ -553,11 +598,12 @@ echo ""
 
 # Check 2: golangci-lint (changed packages only — full repo when the linter
 # configuration itself is staged, since config applies repository-wide)
-LINT_PKGS=$GO_PKGS
-LINT_SCOPE="staged packages"
-if [ -n "$LINT_CONFIG" ]; then
+LINT_PKGS=$CHECK_PKGS
+LINT_SCOPE="staged packages + reverse dependents"
+if [ -n "$LINT_CONFIG" ] || [ -n "$FULL_SUITE" ]; then
     LINT_PKGS="./..."
     LINT_SCOPE="full repo — lint config staged"
+    [ -z "$LINT_CONFIG" ] && LINT_SCOPE="full repo — module/shared-input change"
 fi
 if [ -n "$LINT_PKGS" ]; then
     echo -e "${BLUE}[2/8] Running golangci-lint ($LINT_SCOPE)...${NC}"
@@ -586,18 +632,18 @@ echo ""
 # go.sum runs it repository-wide — the go directive and dependency versions
 # shift vet's analysis (e.g. stdversion diagnostics) even when build/tests
 # still pass.
-if [ -n "$MODULE_CHANGED" ]; then
+if [ -n "$MODULE_CHANGED" ] || [ -n "$FULL_SUITE" ]; then
     # checked FIRST: module+Go mixed staging must not collapse to scoped vet
-    echo -e "${BLUE}[3/8] Running go vet (all packages — module files staged)...${NC}"
+    echo -e "${BLUE}[3/8] Running go vet (all packages — module/shared-input change)...${NC}"
     if ! go vet ./... 2>&1; then
         echo -e "${RED}✗ go vet found issues${NC}"
         exit 1
     fi
     echo -e "${GREEN}✓ go vet passed${NC}"
-elif [ -n "$GO_PKGS" ]; then
-    echo -e "${BLUE}[3/8] Running go vet (staged packages)...${NC}"
-    # shellcheck disable=SC2086 # word-splitting GO_PKGS is intentional
-    if ! go vet $GO_PKGS 2>&1; then
+elif [ -n "$CHECK_PKGS" ]; then
+    echo -e "${BLUE}[3/8] Running go vet (staged packages + reverse dependents)...${NC}"
+    # shellcheck disable=SC2086 # word-splitting CHECK_PKGS is intentional
+    if ! go vet $CHECK_PKGS 2>&1; then
         echo -e "${RED}✗ go vet found issues${NC}"
         exit 1
     fi

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -594,12 +594,19 @@ FILTER_EOF
         # list/vet/test/build consume the working-tree file here, then the
         # COMMITTED snapshot fails with 'pattern local.db: no matching
         # files found'. No static pathspec can enumerate embed targets, so
-        # ask the toolchain: go list -test resolves the EXACT embed set
-        # against this tree (glob semantics, all: prefixes and the
-        # dot/underscore directory-walk exclusion handled by the tool;
-        # -test is required because plain go list leaves TestEmbedFiles
-        # and XTestEmbedFiles empty — an ignored _test.go embed asset
-        # would otherwise slip the guard while go test consumes it).
+        # ask the toolchain: go list -test -deps resolves the EXACT
+        # embed set against this tree (glob semantics, all: prefixes and
+        # the dot/underscore directory-walk exclusion handled by the
+        # tool). -test is required because plain go list leaves
+        # TestEmbedFiles and XTestEmbedFiles empty — an ignored _test.go
+        # embed asset would otherwise slip the guard while go test
+        # consumes it — and -deps is required because wildcard ./...
+        # never enumerates testdata/, yet explicit imports beneath
+        # testdata DO resolve (the same hole the TOOL_DIRS_CACHE graph
+        # union closes): an embed in such a package hides from a shallow
+        # census while its consumers break in CI. Module-cache deps the
+        # scan surfaces sit outside the checkout; the prefix-strip below
+        # drops them.
         # Recomputed per invocation, deliberately NOT cached like
         # TOOL_DIRS_CACHE: a mid-run-created ignored embed file changes
         # nothing else any comparator observes. Mask set = embedded paths
@@ -609,8 +616,8 @@ FILTER_EOF
         # are not toolchain-enumerable and stay out by design.
         # Same fail-closed rule as the directory scans above: a partial
         # embed census would vouch for masking holes it never saw.
-        EMBED_ABS=$(go list -test -f '{{range .EmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .TestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .XTestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}' ./... 2>/dev/null) ||
-            { refuse_guard_scan "go list -test"; return 1; }
+        EMBED_ABS=$(go list -test -deps -f '{{range .EmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .TestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .XTestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}' ./... 2>/dev/null) ||
+            { refuse_guard_scan "go list -test -deps"; return 1; }
         if [ -n "$EMBED_ABS" ]; then
             EMBED_ROOT=$(pwd)
             EMBED_REL=""

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -252,7 +252,7 @@ fi
 # genuine breakage below.
 if [ -n "$GO_DIRS" ]; then
     RESOLVED_PKGS=""
-    for d in $GO_DIRS; do
+    for d in $GO_DIRS; do  # word-splitting is safe: importable Go dirs cannot contain spaces
         [ -d "$d" ] || continue
         if ! ls "$d"/*.go >/dev/null 2>&1; then
             DROPPED_DIRS="$DROPPED_DIRS
@@ -492,7 +492,38 @@ $f"
             -- web/dist \
             '*.syso' '*.go' '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx' \
             '*.s' '*.S' '*.sx' '*.m' '*.f' '*.F' '*.for' '*.f90' '*.swig' '*.swigcxx' || true)
-        PKG_DIRS=" $(git ls-files '*.go' | while IFS= read -r g; do printf '%s\n' "${g%/*}"; done | sort -u | tr '\n' ' ') "
+        # Package dirs = union of THREE sources, because each alone leaks a
+        # masking hole:
+        #   * dirs whose .go files are staged for deletion (they vanish from
+        #     ls-files while ignored siblings still compile in the tree),
+        #   * dirs the TOOLCHAIN currently sees (go list -f {{.Dir}} ./...) —
+        #     a brand-new package whose .go files are ALL ignored+untracked is
+        #     invisible to both git views but compiles in the tree, letting a
+        #     staged import of it pass locally and fail CI. go list skips
+        #     dot/underscore/testdata dirs, so scratch trees stay immune.
+        PKG_DIRS=$( {
+            {
+                git ls-files '*.go'
+                git diff --cached --name-only --no-renames --diff-filter=D -- '*.go'
+            } | while IFS= read -r g; do
+                    d=${g%/*}; [ "$d" = "$g" ] && d=.; printf '%s\n' "$d"
+                done
+            # Prefix-strip WITHOUT regex: an
+            # interpolated pwd containing BRE metacharacters (dots are harmless,
+            # but [ ] * \ in a checkout path) would fail sed and fail open.
+            root=$(pwd)
+            go list -f '{{.Dir}}' ./... 2>/dev/null | while IFS= read -r abs; do
+                # if/elif instead of case: bash 3.2 (stock macOS) mis-parses
+                # case patterns inside command substitutions this deep.
+                if [ "$abs" = "$root" ]; then
+                    printf '.\n'
+                elif [ "${abs#"$root"/}" != "$abs" ]; then
+                    printf '%s\n' "${abs#"$root"/}"
+                fi
+            done || true
+        } | sort -u | tr '\n' ' ' )
+        # pad with spaces so case-matching ' "$d" ' is exact-token safe
+        PKG_DIRS=" $PKG_DIRS "
         IGNORED_KEPT=""
         while IFS= read -r raw; do
             [ -n "$raw" ] || continue

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -212,17 +212,40 @@ EMBED_PKGS=""
 # cannot see every staged asset whose content edit breaks its embedding
 # package's consumers. Census-intersect every staged path that matches NO
 # static rule; survivors flow through the SAME ancestor-walk mapping below.
-# Best-effort: a census failure simply adds nothing — the tree-consistency
-# guard's fail-closed census blocks loudly a moment later, so nothing evades.
 EMBED_STAGED=""
-ASSET_CANDIDATES=$(git diff --cached --name-only --no-renames --diff-filter=ACMR \
+# Candidates include DELETIONS (a dropped multi-match glob target changes the
+# committed embed set as surely as a content edit) and must compare RAW bytes
+# (quotepath=false): default git output C-quotes non-ASCII paths while the
+# census emits raw ones, and a mismatched encoding silently nulls the
+# intersection. (Newline-in-filename remains out of scope — BSD comm has no
+# -z and the rest of this classification shares the limitation.)
+ASSET_CANDIDATES=$(git -c core.quotepath=false diff --cached --name-only --no-renames --diff-filter=ACMRTD \
     | grep -vE '^testdata/|^internal/|^cmd/|^web/dist/|^docs/swagger/|^configs/|\.go$|^go\.(mod|sum)$|^Makefile$|^\.golangci\.(yml|yaml)$' || true)
 if [ -n "$ASSET_CANDIDATES" ]; then
-    if EMBED_CENSUS=$(compute_embed_census); then
-        EMBED_STAGED=$(comm -12 \
-            <(printf '%s\n' "$ASSET_CANDIDATES" | sort -u) \
-            <(printf '%s\n' "$EMBED_CENSUS" | sort -u) || true)
+    # Membership in EITHER census marks an embed target. The TREE census
+    # sees staged content edits and ADDS (a file must exist on disk to be
+    # staged). The HEAD census sees staged DELETIONS that have already
+    # vanished from BOTH the tree and the index (a multi-match glob keeps
+    # resolving on the survivors, so only HEAD still lists the dropped
+    # member) — materialized via git archive, never HEAD"~"-detached.
+    # Computing the pair without candidates would tax every docs-only
+    # commit; candidates gate it. Both are best-effort: a census failure
+    # simply adds nothing — the tree-consistency guard's fail-closed
+    # census blocks loudly right after.
+    EMBED_CENSUS_TREE=$(compute_embed_census || true)
+    EMBED_CENSUS_HEAD=""
+    IDX_TMP=$(mktemp -d "${TMPDIR:-/tmp}/javinizer-embedsnap.XXXXXX" 2>/dev/null || true)
+    # An empty IDX_TMP must NEVER reach tar -C: an empty -C operand is a
+    # cwd-relative extract. On failure the HEAD census simply stays empty
+    # — the tree census (and, moments later, the fail-closed guard
+    # census) still stand.
+    if [ -n "$IDX_TMP" ] && git archive HEAD 2>/dev/null | tar -x -C "$IDX_TMP" 2>/dev/null; then
+        EMBED_CENSUS_HEAD=$(cd "$IDX_TMP" && compute_embed_census || true)
     fi
+    [ -z "$IDX_TMP" ] || rm -rf "$IDX_TMP"
+    EMBED_STAGED=$(comm -12 \
+        <(printf '%s\n' "$ASSET_CANDIDATES" | sort -u) \
+        <( { printf '%s\n' "$EMBED_CENSUS_TREE"; printf '%s\n' "$EMBED_CENSUS_HEAD"; } | sed '/^$/d' | sort -u) || true)
 fi
 while IFS= read -r p; do
     [ -n "$p" ] || continue

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -474,7 +474,25 @@ done < <(git diff --cached --name-only -z --no-renames)
 # never ran.
 GUARD_PATHSPEC=(-- '*.go' go.mod go.sum testdata internal cmd web/dist docs/swagger configs web/frontend .golangci.yml .golangci.yaml Makefile
                 '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx' '*.s' '*.S' '*.sx' '*.syso' '*.m' '*.f' '*.F' '*.for' '*.f90' '*.swig' '*.swigcxx')
+# A guard scan that cannot run MUST NOT silently degrade to a partial
+# census: every go list below exists because git alone cannot see some
+# masking hole (ignored-only packages, toolchain-resolved embed targets),
+# and a swallowed error would re-open the very hole the scan exists to
+# close. Refuse instead — the staged checks need the same module graph,
+# so a genuinely unresolvable tree blocks either way. GUARD_REFUSED tells
+# the call sites the refusal was already reported (skip the generic
+# unstaged/conflict report).
+GUARD_REFUSED=""
+refuse_guard_scan() {
+    GUARD_REFUSED=1
+    echo -e "${RED}✗ Cannot enumerate the Go package graph ($1 failed) — the${NC}"
+    echo -e "${RED}  tree-consistency guard cannot prove ignored compile inputs or${NC}"
+    echo -e "${RED}  embed assets absent, and a partial scan vouches for nothing.${NC}"
+    echo -e "${YELLOW}Fix the tree or warm the module cache (go mod download), then retry.${NC}"
+    return 1
+}
 check_tree_consistency() {
+    GUARD_REFUSED=""
     STAGED_SET=$(git diff --cached --name-only --no-renames -- "${GUARD_PATHSPEC[@]}" | sort || true)
     CONFLICT=""
     while IFS= read -r -d '' f; do
@@ -508,13 +526,22 @@ $f"
         # substitution subshell (the guard runs twice per hook; the
         # graph cannot change mid-run without tripping a consistency check).
         if [ -z "${TOOL_DIRS_CACHE+x}" ]; then
-            TOOL_DIRS_CACHE=$( {
-                go list -f '{{.Dir}}' -deps ./... 2>/dev/null || true
+            # Fail CLOSED on error: a partial dep-graph census silently
+            # re-opens the ignored-only-package masking hole this cache
+            # exists to close (see refuse_guard_scan).
+            DEPS_SCAN=$( {
+                go list -f '{{.Dir}}' -deps ./... 2>/dev/null &&
                 # -deps alone skips TEST-ONLY imports; a staged _test.go can
                 # import an ignored-only package (e.g. beneath testdata/).
-                go list -f '{{.Dir}}' -deps -test ./... 2>/dev/null || true
-            } | sort -u )
+                go list -f '{{.Dir}}' -deps -test ./... 2>/dev/null
+            } ) || { refuse_guard_scan "go list -deps"; return 1; }
+            TOOL_DIRS_CACHE=$(printf '%s\n' "$DEPS_SCAN" | sort -u)
         fi
+        # Wildcard view, fresh per invocation (cheap without -deps):
+        # module packages NOBODY imports never appear in the dependency
+        # graph, yet an ignored-only orphan package masks just as well.
+        WILD_SCAN=$(go list -f '{{.Dir}}' ./... 2>/dev/null) ||
+            { refuse_guard_scan "go list"; return 1; }
         PKG_DIRS=$( {
             {
                 git ls-files '*.go'
@@ -529,8 +556,7 @@ $f"
             # Wildcard packages PLUS the cached dependency graph (the only
             # side that sees explicit imports beneath testdata/).
             {
-                go list -f '{{.Dir}}' ./... 2>/dev/null
-                printf '%s\n' "$TOOL_DIRS_CACHE"
+                printf '%s\n%s\n' "$WILD_SCAN" "$TOOL_DIRS_CACHE"
             } | while IFS= read -r abs; do
                     # if/elif instead of case: bash 3.2 (stock macOS)
                     # mis-parses case patterns inside nested command
@@ -581,7 +607,10 @@ FILTER_EOF
         # present or future) — whatever sits in the index ships with the
         # commit by definition. Data files READ (not embedded) by tests
         # are not toolchain-enumerable and stay out by design.
-        EMBED_ABS=$(go list -test -f '{{range .EmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .TestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .XTestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}' ./... 2>/dev/null || true)
+        # Same fail-closed rule as the directory scans above: a partial
+        # embed census would vouch for masking holes it never saw.
+        EMBED_ABS=$(go list -test -f '{{range .EmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .TestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .XTestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}' ./... 2>/dev/null) ||
+            { refuse_guard_scan "go list -test"; return 1; }
         if [ -n "$EMBED_ABS" ]; then
             EMBED_ROOT=$(pwd)
             EMBED_REL=""
@@ -646,7 +675,8 @@ if [ "$POST_CLASSIFICATION_TREE" != "$INITIAL_INDEX_TREE" ]; then
     exit 1
 fi
 if ! check_tree_consistency; then
-    report_tree_conflict "Working tree contains unstaged/untracked changes under checked paths"
+    # GUARD_REFUSED means refuse_guard_scan already printed the reason.
+    [ -n "$GUARD_REFUSED" ] || report_tree_conflict "Working tree contains unstaged/untracked changes under checked paths"
     exit 1
 fi
 # ---------------------------------------------------------------------------
@@ -894,7 +924,7 @@ echo ""
 # model is accidental edits, not adversarial timing (which --no-verify
 # already makes moot).
 if ! check_tree_consistency; then
-    report_tree_conflict "Working tree changed while the checks were running"
+    [ -n "$GUARD_REFUSED" ] || report_tree_conflict "Working tree changed while the checks were running"
     exit 1
 fi
 # Index drift: a concurrent git add leaves tree==index but with staged

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -561,6 +561,60 @@ $raw" ;;
         done <<FILTER_EOF
 $IGNORED_RAW
 FILTER_EOF
+        # Ignored go:embed ASSETS: the extension list above covers the
+        # toolchain's STATIC inputs, but //go:embed names ARBITRARY types
+        # from the staged snapshot itself — staging '//go:embed local.db'
+        # while local.db stays ignored (this repo ignores *.db) lets go
+        # list/vet/test/build consume the working-tree file here, then the
+        # COMMITTED snapshot fails with 'pattern local.db: no matching
+        # files found'. No static pathspec can enumerate embed targets, so
+        # ask the toolchain: go list -test resolves the EXACT embed set
+        # against this tree (glob semantics, all: prefixes and the
+        # dot/underscore directory-walk exclusion handled by the tool;
+        # -test is required because plain go list leaves TestEmbedFiles
+        # and XTestEmbedFiles empty — an ignored _test.go embed asset
+        # would otherwise slip the guard while go test consumes it).
+        # Recomputed per invocation, deliberately NOT cached like
+        # TOOL_DIRS_CACHE: a mid-run-created ignored embed file changes
+        # nothing else any comparator observes. Mask set = embedded paths
+        # ABSENT FROM THE INDEX (untracked or ignored, any extension,
+        # present or future) — whatever sits in the index ships with the
+        # commit by definition. Data files READ (not embedded) by tests
+        # are not toolchain-enumerable and stay out by design.
+        EMBED_ABS=$(go list -test -f '{{range .EmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .TestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}{{range .XTestEmbedFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}' ./... 2>/dev/null || true)
+        if [ -n "$EMBED_ABS" ]; then
+            EMBED_ROOT=$(pwd)
+            EMBED_REL=""
+            while IFS= read -r eabs; do
+                [ -n "$eabs" ] || continue
+                # Prefix-strip WITHOUT regex (same metacharacter hazard as
+                # the PKG_DIRS walk above — a bracketed checkout path must
+                # not fail open); paths outside the checkout (synthesized
+                # -test variants) match no prefix and drop out.
+                if [ "${eabs#"$EMBED_ROOT"/}" != "$eabs" ]; then
+                    EMBED_REL="$EMBED_REL
+${eabs#"$EMBED_ROOT"/}"
+                fi
+            done <<EMBED_SCAN_EOF
+$EMBED_ABS
+EMBED_SCAN_EOF
+            if [ -n "$EMBED_REL" ]; then
+                # quotepath=false: non-ASCII tracked embeds must compare
+                # equal on both sides of comm (raw bytes, not C-quoted).
+                EMBED_MASKED=$(comm -23 \
+                    <(printf '%s\n' "$EMBED_REL" | sed '/^$/d' | sort -u) \
+                    <(git -c core.quotepath=false ls-files | sort -u) || true)
+                # Append directly, bypassing the PKG_DIRS filter: the
+                # directive's own .go file is necessarily tracked, and
+                # roots outside the static lists (a future root-level
+                # embed, say) must be admitted by construction, not by a
+                # whitelist that has to be kept in sync.
+                if [ -n "$EMBED_MASKED" ]; then
+                    IGNORED_KEPT="$IGNORED_KEPT
+$EMBED_MASKED"
+                fi
+            fi
+        fi
         UNSTAGED=$( { git diff --name-only -- "${GUARD_PATHSPEC[@]}"
                       git ls-files --others --exclude-standard -- "${GUARD_PATHSPEC[@]}"
                       printf '%s\n' "$IGNORED_KEPT"; } | sort -u || true)

--- a/scripts/pre-commit.sample
+++ b/scripts/pre-commit.sample
@@ -216,7 +216,7 @@ EMBED_PKGS=""
 # guard's fail-closed census blocks loudly a moment later, so nothing evades.
 EMBED_STAGED=""
 ASSET_CANDIDATES=$(git diff --cached --name-only --no-renames --diff-filter=ACMR \
-    | grep -vE '^testdata/|^internal/|^cmd/|^web/|^docs/swagger/|^configs/|\.go$|^go\.(mod|sum)$|^Makefile$|^\.golangci\.(yml|yaml)$' || true)
+    | grep -vE '^testdata/|^internal/|^cmd/|^web/dist/|^docs/swagger/|^configs/|\.go$|^go\.(mod|sum)$|^Makefile$|^\.golangci\.(yml|yaml)$' || true)
 if [ -n "$ASSET_CANDIDATES" ]; then
     if EMBED_CENSUS=$(compute_embed_census); then
         EMBED_STAGED=$(comm -12 \

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -380,6 +380,25 @@ check "configs example -> internal/config (static)" "|./internal/config||0|no" "
 reset; printf 'select 2;\n' >> internal/database/migrations/001.sql; git add internal/database/migrations/001.sql
 check "migration sql -> embed pkg + consumer" "|./cmd/javinizer${nl}./internal/database${nl}./internal/database/migrations||1|yes" "$(probe)"
 
+# test-only package (only _test.go files): modern toolchains list such
+# packages fine — 'no non-test Go files in' is NOT emitted by go list on
+# Go 1.26 for either the same-package or the external _test package shape
+# (verified empirically), so the tolerated-prune regex must NOT gain a
+# clause for it (pruning is deletion-equivalent — wrong for a live test
+# package edit). This scenario LOCKS the toolchain assumption: a test-file
+# edit classifies as the package's own scoped tests, not a hard block.
+reset
+BASE4_SHA=$(git rev-parse HEAD)
+mkdir -p internal/testonly
+printf 'package testonly\n\nimport "testing"\n\nfunc TestOnly(t *testing.T) {}\n' > internal/testonly/t_test.go
+git add internal/testonly/t_test.go && git commit -qm 'fixture: test-only package'
+printf '\n// touch\n' >> internal/testonly/t_test.go; git add internal/testonly/t_test.go
+# FULL_SUITE because an unreferenced/test-only package is unreachable
+# from the binary graph (the build check cannot compile it) — full tests
+# still RUN, which is the assertion's point: classify, never hard-block
+check "test-only package edit -> own tests" "./internal/testonly|./internal/testonly|1|1|yes" "$(probe)"
+git reset -q --hard "$BASE4_SHA" >/dev/null; git clean -qfdx
+
 # an IMPORTABLE package beneath testdata/ (explicit imports resolve there)
 # holds //go:embed targets that outside consumers can break — its staged
 # asset must join the EMBED_PKGS reverse scan, not the private-fixture

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -530,6 +530,14 @@ printf 'package ghost\n\nfunc G() int { return 1 }\n' > internal/foo/testdata/gh
 printf 'package foo\n\nimport (\n\t"fmt"\n\n\t_ "probe.local/x/internal/foo/testdata/ghost"\n)\n\nfunc Foo() int { fmt.Println(1); return 1 }\n' > internal/foo/a.go
 gofmt -w internal/foo/a.go; git add internal/foo/a.go
 check_hook "e2e: ignored-only package under testdata masked" 1 "local_g.go"
+
+# test-ONLY import of an ignored-only testdata package: -deps without -test
+# never traverses it — the cache must include test dependencies
+reset; mkdir -p internal/foo/testdata/tghost
+printf 'package tghost\n\nfunc T() int { return 1 }\n' > internal/foo/testdata/tghost/local_t.go
+printf 'package foo\n\nimport (\n\t"testing"\n\n\t_ "probe.local/x/internal/foo/testdata/tghost"\n)\n\nfunc TestFoo(t *testing.T) { if Foo() != 1 { t.Fatal() } }\n' > internal/foo/a_test.go
+gofmt -w internal/foo/a_test.go; git add internal/foo/a_test.go
+check_hook "e2e: test-only ignored testdata import masked" 1 "local_t.go"
 git reset -q --hard HEAD >/dev/null 2>&1; rm -f local_root.go
 
 # regex-hostile checkout path: whole scratch copied under a [bracket] dir —

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -380,6 +380,34 @@ check "configs example -> internal/config (static)" "|./internal/config||0|no" "
 reset; printf 'select 2;\n' >> internal/database/migrations/001.sql; git add internal/database/migrations/001.sql
 check "migration sql -> embed pkg + consumer" "|./cmd/javinizer${nl}./internal/database${nl}./internal/database/migrations||1|yes" "$(probe)"
 
+# an IMPORTABLE package beneath testdata/ (explicit imports resolve there)
+# holds //go:embed targets that outside consumers can break — its staged
+# asset must join the EMBED_PKGS reverse scan, not the private-fixture
+# ASSET_PKGS bucket, or consumers' tests never run
+reset
+BASE3_SHA=$(git rev-parse HEAD)
+mkdir -p internal/foo/testdata/embp
+cat > internal/foo/testdata/embp/e.go <<'EOF'
+package embp
+
+import _ "embed"
+
+//go:embed asset.txt
+var A string
+EOF
+printf 'x\n' > internal/foo/testdata/embp/asset.txt
+printf 'package main\n\nimport (\n\t"fmt"\n\n\t_ "probe.local/x/internal/foo/testdata/embp"\n\t"probe.local/x/internal/foo"\n)\n\nfunc main() { fmt.Println(foo.FooB()) }\n' > cmd/e2e/main.go
+gofmt -w internal/foo/testdata/embp/e.go cmd/e2e/main.go
+git add -A && git commit -qm 'fixture: importable embed package beneath testdata'
+# both cmds import the owner: keeps the package inside the binary graph
+# (an orphan would escalate FULL_SUITE and mask the scope distinction)
+printf 'package main\n\nimport (\n\t"fmt"\n\n\t_ "probe.local/x/internal/foo/testdata/embp"\n\t_ "probe.local/x/internal/bar"\n)\n\nfunc main() { fmt.Println(1) }\n' > cmd/javinizer/main.go
+gofmt -w cmd/javinizer/main.go
+git add cmd/javinizer/main.go && git commit -qm 'fixture: binary imports testdata embed pkg'
+printf 'y\n' >> internal/foo/testdata/embp/asset.txt; git add internal/foo/testdata/embp/asset.txt
+check "testdata embed pkg asset -> owner + rev consumers" "|./cmd/e2e${nl}./cmd/javinizer${nl}./internal/foo/testdata/embp||1|yes" "$(probe)"
+git reset -q --hard "$BASE3_SHA" >/dev/null; git clean -qfdx
+
 reset; printf '\n// v\n' >> internal/base/b.go; git add internal/base/b.go
 check "re-export chain -> transitive closure" "./internal/base|./cmd/javinizer${nl}./internal/base${nl}./internal/high${nl}./internal/mid||1|yes" "$(probe)"
 
@@ -462,10 +490,15 @@ reset; printf 'go 1.21\n\nuse .\n' > go.work; git add -f go.work
 check_hook "e2e: force-staged go.work refused" 1 "go.work"
 
 # a previously-TRACKED workspace file must be removable (deletion != staging)
-reset; printf 'go 1.21\n\nuse .\n' > go.work; git add -f go.work; git -c commit.gpgsign=false commit -qm 'track go.work (fixture)'
+reset; printf 'go 1.21\n\nuse .\n' > go.work; git add -f go.work
+GOWORK_BASE=$(git rev-parse HEAD)
+git -c commit.gpgsign=false commit -qm 'track go.work (fixture)'
 git rm -q --cached go.work
 check_hook "e2e: staged deletion of tracked go.work allowed" 0
-git reset -q --hard HEAD >/dev/null; git rm -q --cached go.work 2>/dev/null; reset
+# restore the pre-fixture baseline: leaving go.work TRACKED in HEAD would
+# turn the later 'broken local go.work' case (which must be ignored+untracked)
+# into a tracked edit that exercises nothing
+git reset -q --hard "$GOWORK_BASE" >/dev/null; git clean -qfdx
 
 reset; printf '\n// staged A\n' >> internal/foo/a.go; git add internal/foo/a.go
 printf '\n// unstaged B\n' >> internal/bar/c.go

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -567,6 +567,11 @@ check_hook "e2e: ignored embed asset under testdata masked" 1 "local_e.db"
 # fail-closed graph refusal converts the unresolvable pattern into a
 # block (pre-tiering this exact commit passed the hook; CI did not)
 reset
+# baseline restore point: the fixture COMMIT below must not leak into the
+# later root-package masking scenarios (a tracked root .go would mask the
+# ghost via plain PKG_DIRS membership instead of the '.'-normalisation
+# those scenarios isolate)
+BASE_SHA=$(git rev-parse HEAD)
 cat > rootembed_fixture.go <<'EOF'
 package x
 
@@ -596,6 +601,9 @@ check_hook "e2e: root-level embed asset edit runs full Go checks" 0 "all package
 reset; printf 'banner-index\n' > banner.txt; git add banner.txt
 printf 'banner-tree\n' > banner.txt
 check_hook "e2e: unstaged root embed target drift blocked" 1 "banner.txt"
+
+# restore the pre-fixture baseline so later scenarios see the ORIGINAL root
+git reset -q --hard "$BASE_SHA" >/dev/null; git clean -qfdx
 
 # fail-closed guard scans: with a package graph the toolchain cannot
 # enumerate (UNTRACKED file importing an unresolvable module — GOPROXY=off

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -397,6 +397,27 @@ printf '\n// touch\n' >> internal/testonly/t_test.go; git add internal/testonly/
 # from the binary graph (the build check cannot compile it) — full tests
 # still RUN, which is the assertion's point: classify, never hard-block
 check "test-only package edit -> own tests" "./internal/testonly|./internal/testonly|1|1|yes" "$(probe)"
+
+# embedded testdata fixture: an asset under a NORMAL package's testdata/
+# dir that is ALSO that package's //go:embed target is re-exported through
+# the package API — the private-fixture rule must yield to reverse scope
+reset
+BASE5_SHA=$(git rev-parse HEAD)
+cat > internal/foo/embed_fix.go <<'EOF'
+package foo
+
+import _ "embed"
+
+//go:embed testdata/embedfix.txt
+var Fix string
+EOF
+printf 'v1\n' > internal/foo/testdata/embedfix.txt
+gofmt -w internal/foo/embed_fix.go
+git add internal/foo/embed_fix.go internal/foo/testdata/embedfix.txt
+git commit -qm 'fixture: foo embeds its own testdata fixture'
+printf 'v2\n' >> internal/foo/testdata/embedfix.txt; git add internal/foo/testdata/embedfix.txt
+check "embedded testdata asset -> rev-expanded owner closure" "|$C4||1|yes" "$(probe)"
+git reset -q --hard "$BASE5_SHA" >/dev/null; git clean -qfdx
 git reset -q --hard "$BASE4_SHA" >/dev/null; git clean -qfdx
 
 # an IMPORTABLE package beneath testdata/ (explicit imports resolve there)

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -605,6 +605,43 @@ check_hook "e2e: unstaged root embed target drift blocked" 1 "banner.txt"
 # restore the pre-fixture baseline so later scenarios see the ORIGINAL root
 git reset -q --hard "$BASE_SHA" >/dev/null; git clean -qfdx
 
+# staged DELETION of one target of a MULTI-match embed glob outside the
+# static roots: the pattern keeps resolving on disk (b.txt survives), so
+# nothing fails — but the committed embed set changed, and only the
+# INDEX-side census still lists the deleted path
+reset
+BASE2_SHA=$(git rev-parse HEAD)
+mkdir -p assets_probe/data
+cat > assets_probe/probe.go <<'EOF'
+package assetsprobe
+
+import "embed"
+
+//go:embed data/*.txt
+var Data embed.FS
+EOF
+gofmt -w assets_probe/probe.go
+printf 'a\n' > assets_probe/data/a.txt
+printf 'b\n' > assets_probe/data/b.txt
+git add assets_probe
+git commit -qm 'fixture: multi-match embed glob outside asset roots'
+MULTI_SHA=$(git rev-parse HEAD)
+git rm -q assets_probe/data/a.txt
+# full-scope marker: an unreferenced package escalates to the full sweep,
+# which is exactly the point — previously NO Go validation ran at all
+check_hook "e2e: staged deletion from multi-match embed glob runs Go checks" 0 "all packages — module/shared-input change"
+
+# non-ASCII embed asset outside the static roots: candidates must compare
+# RAW bytes against the census, or C-quoting silently nulls the match and
+# the staged edit runs no Go validation at all
+git reset -q --hard "$MULTI_SHA" >/dev/null
+printf 'data\n' > "assets_probe/data/注釈.txt"
+git add "assets_probe/data/注釈.txt"
+check_hook "e2e: non-ASCII embed asset outside roots runs Go checks" 0 "all packages — module/shared-input change"
+
+# drop the fixture before it can dilute later scenarios
+git reset -q --hard "$BASE2_SHA" >/dev/null; git clean -qfdx
+
 # fail-closed guard scans: with a package graph the toolchain cannot
 # enumerate (UNTRACKED file importing an unresolvable module — GOPROXY=off
 # makes resolution fail fast), the guard must REFUSE rather than silently

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -28,7 +28,8 @@ git init -q
 git config user.email test@example.invalid
 git config user.name test
 git config commit.gpgsign false
-printf '/web/dist/ignored/\n*.syso\nlocal_*.go\n*.log\n.worktrees/\n.scratch/\n.tmprepro/\n.planning/\n' > .gitignore
+# *.db mirrors the real repo's .gitignore (embed-asset masking scenario)
+printf '/web/dist/ignored/\n*.syso\nlocal_*.go\n*.log\n*.db\n.worktrees/\n.scratch/\n.tmprepro/\n.planning/\n' > .gitignore
 mkdir -p internal/foo internal/bar internal/shared internal/consumer internal/legacy internal/orphan \
          internal/tagged \
          internal/dual_unref internal/dual_ref internal/tree/sub web/frontend/src \
@@ -499,6 +500,48 @@ check_hook "e2e: ignored *.go masked symbol blocked" 1 "local_extra.go"
 reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
 printf 'noise\n' > internal/foo/run.log
 check_hook "e2e: harmless ignored runtime artifact does not block" 0
+
+# ignored go:embed ASSET: every check is green locally (go list/vet/build
+# consume the working-tree file), but the committed snapshot lacks the
+# ignored *.db and fails with 'pattern local.db: no matching files found'.
+# The static extension pathspec cannot see arbitrary embed types, so the
+# guard must consult the toolchain-resolved embed set.
+# (db_embed.go must not match the fixture gitignore's local_*.go rule —
+# only the ASSET is ignored here)
+reset; cat > internal/database/db_embed.go <<'EOF'
+package database
+
+import _ "embed"
+
+//go:embed local.db
+var LocalDB string
+EOF
+printf 'local\n' > internal/database/local.db
+git add internal/database/db_embed.go
+check_hook "e2e: ignored go:embed asset masked (local.db)" 1 "local.db"
+
+# control: the SAME embed with the asset staged is consistent — the
+# index-membership subtraction must not produce a false positive
+reset; cat > internal/database/db_embed.go <<'EOF'
+package database
+
+import _ "embed"
+
+//go:embed local.db
+var LocalDB string
+EOF
+printf 'local\n' > internal/database/local.db
+git add internal/database/db_embed.go
+git add -f internal/database/local.db
+check_hook "e2e: staged go:embed asset consistent" 0
+
+# test-file variant: //go:embed inside a _test.go is consumed by go test
+# only — plain go list leaves TestEmbedFiles EMPTY, so the -test flag on
+# the embed scan is what keeps this from slipping the guard
+reset; printf 'package foo\n\nimport (\n\t_ "embed"\n\t"testing"\n)\n\n//go:embed local_t.db\nvar fixtureDB string\n\nfunc TestEmbedDB(t *testing.T) { if fixtureDB == "" { t.Fatal() } }\n' > internal/foo/embed_test.go
+printf 'fixture\n' > internal/foo/local_t.db
+git add internal/foo/embed_test.go
+check_hook "e2e: ignored _test.go embed asset masked" 1 "local_t.db"
 
 reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
 mkdir -p .worktrees/wt; printf 'package wt\n' > .worktrees/wt/x.go

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -583,6 +583,20 @@ git rm -q banner.txt
 check_hook "e2e: asset-only embed-target deletion outside pathspecs refused" 1 "Cannot enumerate"
 git reset -q --hard HEAD >/dev/null
 
+# staged CONTENT edit of a root-level embed target: the asset sits
+# outside every static root, yet its embedding package's consumers break
+# exactly like an in-list asset edit — the census intersection must map
+# it (ASSET_FULL for a root-level file) and engage full Go validation
+reset; printf 'banner2\n' > banner.txt; git add banner.txt
+check_hook "e2e: root-level embed asset edit runs full Go checks" 0 "all packages — module/shared-input change"
+
+# TRACKED root embed target staged, then tree-edited: tree ≠ snapshot at
+# a census path outside GUARD_PATHSPEC — the dirty-tree union covers the
+# census paths too, not only the hard-coded lists
+reset; printf 'banner-index\n' > banner.txt; git add banner.txt
+printf 'banner-tree\n' > banner.txt
+check_hook "e2e: unstaged root embed target drift blocked" 1 "banner.txt"
+
 # fail-closed guard scans: with a package graph the toolchain cannot
 # enumerate (UNTRACKED file importing an unresolvable module — GOPROXY=off
 # makes resolution fail fast), the guard must REFUSE rather than silently

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -543,6 +543,18 @@ printf 'fixture\n' > internal/foo/local_t.db
 git add internal/foo/embed_test.go
 check_hook "e2e: ignored _test.go embed asset masked" 1 "local_t.db"
 
+# fail-closed guard scans: with a package graph the toolchain cannot
+# enumerate (UNTRACKED file importing an unresolvable module — GOPROXY=off
+# makes resolution fail fast), the guard must REFUSE rather than silently
+# skip its ignored-input/embed scans. The refusal, not the subsequent
+# untracked-file report, must fire first. (-f {{.Dir}} resolves imports
+# lazily, so only a genuinely broken GRAPH reaches the refusal; a mere
+# syntax error in non-import code does not fail go list and stays with
+# the untracked-path report covered above.)
+reset; printf '\nvalue: 2\n' >> configs/config.yaml.example; git add configs/config.yaml.example
+printf 'package foo\n\nimport _ "totally.invalid/nonexistent/pkg"\n\nvar BrokenDep int\n' > internal/foo/zbroken.go
+check_hook "e2e: unresolvable package graph hard-blocks guard scans" 1 "Cannot enumerate"
+
 reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
 mkdir -p .worktrees/wt; printf 'package wt\n' > .worktrees/wt/x.go
 check_hook "e2e: ignored .go inside .worktrees/ does not block" 0
@@ -586,8 +598,12 @@ git reset -q --hard HEAD >/dev/null 2>&1; rm -f local_root.go
 # regex-hostile checkout path: whole scratch copied under a [bracket] dir —
 # the prefix strip must not fail open there either
 reset
-BRK="$(dirname "$WORK")/br[ack]et"
-rm -rf "$BRK"; cp -R "$WORK" "$BRK"
+# fresh unique root: a predictable sibling path could belong to a
+# concurrent or crashed run — rm -rf must only ever target what THIS run
+# created, so uniqueness comes first and the bracket lives in the LEAF
+BRKROOT=$(mktemp -d)
+BRK="$BRKROOT/br[ack]et"
+cp -R "$WORK" "$BRK"
 cd "$BRK" || exit 2
 gofmt_w() { gofmt -w "$1"; }
 mkdir -p internal/ghost
@@ -599,7 +615,7 @@ if PRE_COMMIT_FAST=1 bash "$HOOK" >hook.out 2>&1; then brk_rc=0; else brk_rc=$?;
 if [ "$brk_rc" -eq 1 ] && grep -q local_g.go hook.out && grep -q local_root.go hook.out; then
   PASS=$((PASS+1)); echo "ok   - e2e: bracketed checkout path — both ghost masks blocked"
 else FAIL=$((FAIL+1)); echo "FAIL - e2e: bracketed path regressed (rc=$brk_rc)"; tail -5 hook.out; fi
-cd "$WORK" || exit 2; rm -rf "$BRK"
+cd "$WORK" || exit 2; rm -rf "$BRKROOT"
 git reset -q --hard HEAD >/dev/null 2>&1; rm -f local_root.go
 git reset -q --hard HEAD >/dev/null 2>&1; rm -rf internal/ghost
 

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -29,7 +29,7 @@ git config user.email test@example.invalid
 git config user.name test
 git config commit.gpgsign false
 # *.db mirrors the real repo's .gitignore (embed-asset masking scenario)
-printf '/web/dist/ignored/\n*.syso\nlocal_*.go\n*.log\n*.db\n.worktrees/\n.scratch/\n.tmprepro/\n.planning/\n' > .gitignore
+printf '/web/dist/ignored/\n*.syso\nlocal_*.go\n*.log\n*.db\nscratch-*\n.worktrees/\n.scratch/\n.tmprepro/\n.planning/\n' > .gitignore
 mkdir -p internal/foo internal/bar internal/shared internal/consumer internal/legacy internal/orphan \
          internal/tagged \
          internal/dual_unref internal/dual_ref internal/tree/sub web/frontend/src \
@@ -734,6 +734,20 @@ check_hook "e2e: ignored .go inside .worktrees/ does not block" 0
 reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
 mkdir -p .tmprepro; printf 'package main\n\nfunc main() {}\n' > .tmprepro/repro.go
 check_hook "e2e: ignored .go inside scratch tree does not block" 0
+
+# ignored FRONTEND source consumed by staged frontend code: svelte-check
+# reads the import graph from disk, so a gitignored module masks the
+# committed snapshot exactly like an ignored .go — only when the
+# frontend checks actually engage
+reset; printf '\nexport const y = 2;\n' >> web/frontend/src/app.ts; git add web/frontend/src/app.ts
+printf 'export const ghost = 1;\n' > web/frontend/src/scratch-ghost.ts
+check_hook "e2e: ignored frontend src import blocked (frontend staged)" 1 "scratch-ghost.ts"
+
+# same ignored file, but nothing frontend staged: no frontend check runs,
+# so nothing vouches and nothing blocks (tier-2 gating philosophy)
+reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
+printf 'export const ghost = 1;\n' > web/frontend/src/scratch-ghost2.ts
+check_hook "e2e: ignored frontend src file passes when frontend idle" 0
 
 # create-side masking: a brand-new package whose ONLY .go file is
 # ignored+untracked — a staged import of it compiles locally but cannot on CI

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -543,6 +543,17 @@ printf 'fixture\n' > internal/foo/local_t.db
 git add internal/foo/embed_test.go
 check_hook "e2e: ignored _test.go embed asset masked" 1 "local_t.db"
 
+# ignored embed asset in a package BENEATH testdata/: wildcard ./...
+# never enumerates testdata/ (explicit imports beneath it DO resolve, see
+# the ghost-import scenarios below), so the embed census needs -deps to
+# reach it — exactly like the TOOL_DIRS_CACHE graph union
+reset; mkdir -p internal/foo/testdata/temb
+printf 'package temb\n\nimport _ "embed"\n\n//go:embed local_e.db\n\nvar E string\n' > internal/foo/testdata/temb/e.go
+printf 'embeddata\n' > internal/foo/testdata/temb/local_e.db
+printf 'package foo\n\nimport (\n\t_ "probe.local/x/internal/foo/testdata/temb"\n)\n\nfunc Foo() int { return 1 }\n' > internal/foo/a.go
+gofmt -w internal/foo/a.go; git add internal/foo/a.go
+check_hook "e2e: ignored embed asset under testdata masked" 1 "local_e.db"
+
 # fail-closed guard scans: with a package graph the toolchain cannot
 # enumerate (UNTRACKED file importing an unresolvable module — GOPROXY=off
 # makes resolution fail fast), the guard must REFUSE rather than silently

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -493,6 +493,13 @@ reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
 printf 'syso\n' > internal/foo/x.syso
 check_hook "e2e: ignored *.syso build input blocked" 1 "x.syso"
 
+# non-ASCII ignored compile input: default git output C-QUOTES unusual
+# paths, the package-dir match then misses, and the masked input evades
+# the guard — every scan that feeds a comparison must emit -z raw bytes
+reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
+printf 'syso\n' > "internal/foo/注釈.syso"
+check_hook "e2e: non-ASCII ignored build input blocked" 1 "注釈.syso"
+
 reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
 printf 'package foo\n\nfunc Local() int { return 1 }\n' > internal/foo/local_extra.go
 check_hook "e2e: ignored *.go masked symbol blocked" 1 "local_extra.go"
@@ -553,6 +560,28 @@ printf 'embeddata\n' > internal/foo/testdata/temb/local_e.db
 printf 'package foo\n\nimport (\n\t_ "probe.local/x/internal/foo/testdata/temb"\n)\n\nfunc Foo() int { return 1 }\n' > internal/foo/a.go
 gofmt -w internal/foo/a.go; git add internal/foo/a.go
 check_hook "e2e: ignored embed asset under testdata masked" 1 "local_e.db"
+
+# asset-only DELETION of an embed target outside the checked pathspecs:
+# nothing checked is staged, yet the committed snapshot loses the LAST
+# match of a //go:embed pattern — the tier-1 census must engage and the
+# fail-closed graph refusal converts the unresolvable pattern into a
+# block (pre-tiering this exact commit passed the hook; CI did not)
+reset
+cat > rootembed_fixture.go <<'EOF'
+package x
+
+import _ "embed"
+
+//go:embed banner.txt
+var Banner string
+EOF
+gofmt -w rootembed_fixture.go
+printf 'banner\n' > banner.txt
+git add rootembed_fixture.go banner.txt
+git commit -qm 'fixture: root-level //go:embed banner.txt'
+git rm -q banner.txt
+check_hook "e2e: asset-only embed-target deletion outside pathspecs refused" 1 "Cannot enumerate"
+git reset -q --hard HEAD >/dev/null
 
 # fail-closed guard scans: with a package graph the toolchain cannot
 # enumerate (UNTRACKED file importing an unresolvable module — GOPROXY=off

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -522,6 +522,14 @@ reset; printf 'package x\n\nfunc RootGhost() int { return 1 }\n' > local_root.go
 printf 'package foo\n\nimport (\n\t"fmt"\n\n\t_ "probe.local/x"\n)\n\nfunc Foo() int { fmt.Println(1); return 1 }\n' > internal/foo/a.go
 gofmt -w internal/foo/a.go; git add internal/foo/a.go
 check_hook "e2e: ignored-only module-root package masked" 1 "local_root.go"
+
+# ignored-only package BENEATH testdata/: go list ./... never enumerates it,
+# but an explicit import resolves fine — the dep-graph union must catch it
+reset; mkdir -p internal/foo/testdata/ghost
+printf 'package ghost\n\nfunc G() int { return 1 }\n' > internal/foo/testdata/ghost/local_g.go
+printf 'package foo\n\nimport (\n\t"fmt"\n\n\t_ "probe.local/x/internal/foo/testdata/ghost"\n)\n\nfunc Foo() int { fmt.Println(1); return 1 }\n' > internal/foo/a.go
+gofmt -w internal/foo/a.go; git add internal/foo/a.go
+check_hook "e2e: ignored-only package under testdata masked" 1 "local_g.go"
 git reset -q --hard HEAD >/dev/null 2>&1; rm -f local_root.go
 
 # regex-hostile checkout path: whole scratch copied under a [bracket] dir —

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -1,0 +1,519 @@
+#!/usr/bin/env bash
+# test-pre-commit-scoping.sh — regression matrix for the staged-file scoping
+# logic in scripts/pre-commit.sample.
+#
+# Builds a temporary REAL Go module (binary + auxiliary cmd + shared helpers
+# + fixtures + embeds + multi-hop import chains), then replays staged-change
+# scenarios against the scoping block EXTRACTED FROM THE HOOK ITSELF (no
+# copied logic), asserting GO_PKGS | TEST_PKGS | FULL_SUITE | API_CHANGED |
+# BUILD for each scenario.
+#
+# Usage: bash scripts/test-pre-commit-scoping.sh [path-to-hook]
+# Requires: git, go. Writes only to a mktemp dir; exit 1 on any failure.
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK=${1:-"$SCRIPT_DIR/pre-commit.sample"}
+[ -f "$HOOK" ] || { echo "hook not found: $HOOK" >&2; exit 2; }
+# Absolute path: scenarios cd into the scratch repo and run the hook there.
+HOOK=$(cd "$(dirname "$HOOK")" && pwd)/$(basename "$HOOK")
+command -v git >/dev/null || { echo 'git required' >&2; exit 2; }
+command -v go  >/dev/null || { echo 'go required' >&2; exit 2; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK" || exit 2
+export GOFLAGS=-mod=mod GOPROXY=off
+git init -q
+git config user.email test@example.invalid
+git config user.name test
+git config commit.gpgsign false
+printf '/web/dist/ignored/\n*.syso\n' > .gitignore
+mkdir -p internal/foo internal/bar internal/shared internal/consumer internal/legacy internal/orphan \
+         internal/tagged \
+         internal/dual_unref internal/dual_ref internal/tree/sub web/frontend/src \
+         internal/base internal/mid internal/high internal/database/migrations \
+         cmd/javinizer cmd/e2e testdata docs/swagger web/dist internal/foo/testdata configs
+printf 'module probe.local/x\n\ngo 1.21\n' > go.mod
+: > go.sum
+cat > internal/foo/a.go <<'EOF'
+package foo
+
+func Foo() int { return 1 }
+EOF
+cat > internal/foo/b.go <<'EOF'
+package foo
+
+func FooB() int { return 2 }
+EOF
+printf 'package foo\n\nimport (\n\t"testing"\n\t_ "probe.local/x/internal/shared"\n)\n\nfunc TestFoo(t *testing.T) { if Foo() != 1 { t.Fatal() } }\n' > internal/foo/a_test.go
+printf 'asset\n' > internal/foo/readme.txt
+printf 'fixture\n' > internal/foo/testdata/f.txt
+cat > internal/bar/c.go <<'EOF'
+package bar
+
+func Bar() int { return 1 }
+EOF
+cat > internal/shared/s.go <<'EOF'
+package shared
+
+func Shared() int { return 1 }
+EOF
+cat > internal/legacy/l.go <<'EOF'
+package legacy
+
+func L() int { return 1 }
+EOF
+cat > internal/tree/parent.go <<'EOF'
+package tree
+
+func T() int { return 1 }
+EOF
+# deliberately OUTSIDE the binary graph: exact-package scoping must not sweep it
+cat > internal/tree/sub/sub.go <<'EOF'
+package sub
+
+func S() int { return 1 }
+EOF
+printf 'export const x = 1;\n' > web/frontend/src/app.ts
+cat > internal/orphan/o.go <<'EOF'
+package orphan
+
+func O() int { return 1 }
+EOF
+# symlink target for the typechange scenario (valid standalone package foo)
+cat > internal/foo/real.go <<'EOF'
+package foo
+
+func FooC() int { return 3 }
+EOF
+# emptied-package fixtures: deleting the only .go file leaves keep.txt behind
+cat > internal/dual_unref/d.go <<'EOF'
+package dualunref
+
+func U() int { return 1 }
+EOF
+printf 'stay\n' > internal/dual_unref/keep.txt
+cat > internal/dual_ref/d.go <<'EOF'
+package dualref
+
+func R() int { return 1 }
+EOF
+printf 'stay\n' > internal/dual_ref/keep.txt
+# consumer: in binary graph; its TEST imports foo and legacy
+cat > internal/consumer/consumer.go <<'EOF'
+package consumer
+
+func C() int { return 1 }
+EOF
+printf 'package consumer\n\nimport (\n\t"testing"\n\t_ "probe.local/x/internal/dual_ref"\n\t"probe.local/x/internal/foo"\n\t_ "probe.local/x/internal/legacy"\n)\n\nfunc TestC(t *testing.T) { if foo.Foo() != 1 { t.Fatal() } }\n' > internal/consumer/consumer_test.go
+# multi-hop chain: high --test--> mid --regular--> base (closure must reach high)
+cat > internal/base/b.go <<'EOF'
+package base
+
+func V() int { return 1 }
+EOF
+cat > internal/mid/m.go <<'EOF'
+package mid
+
+import "probe.local/x/internal/base"
+
+// Re-export indirection, like internal/models aliasing scraperconfig types.
+func M() int { return base.V() }
+EOF
+cat > internal/high/h.go <<'EOF'
+package high
+
+func H() int { return 1 }
+EOF
+printf 'package high\n\nimport (\n\t"testing"\n\t"probe.local/x/internal/mid"\n)\n\nfunc TestH(t *testing.T) { if mid.M() != 1 { t.Fatal() } }\n' > internal/high/h_test.go
+# database imports migrations (embed consumer chain)
+cat > internal/database/db.go <<'EOF'
+package database
+
+import "probe.local/x/internal/database/migrations"
+
+func SQL() string { return migrations.Content }
+EOF
+printf 'package database\n\nimport "testing"\n\nfunc TestDB(t *testing.T) { if SQL() == "" { t.Fatal("empty migration") } }\n' > internal/database/db_test.go
+cat > internal/database/migrations/mig.go <<'EOF'
+package migrations
+
+import _ "embed"
+
+//go:embed *.sql
+var Content string
+EOF
+printf 'select 1;\n' > internal/database/migrations/001.sql
+cat > cmd/javinizer/main.go <<'EOF'
+package main
+
+import (
+	"fmt"
+	_ "probe.local/x/docs/swagger"
+	_ "probe.local/x/web"
+	"probe.local/x/internal/bar"
+	"probe.local/x/internal/consumer"
+	"probe.local/x/internal/database"
+	"probe.local/x/internal/foo"
+	"probe.local/x/internal/mid"
+	_ "probe.local/x/internal/tree"
+)
+
+func main() { fmt.Println(foo.Foo(), bar.Bar(), consumer.C(), database.SQL(), mid.M()) }
+EOF
+# auxiliary command: regular reverse dep of foo, NOT built by the binary check
+cat > cmd/e2e/main.go <<'EOF'
+package main
+
+import (
+	"fmt"
+	"probe.local/x/internal/foo"
+)
+
+func main() { fmt.Println(foo.FooB()) }
+EOF
+cat > web/embed.go <<'EOF'
+package web
+
+import _ "embed"
+
+//go:embed all:dist
+var Dist string
+EOF
+printf '<html/>\n' > web/dist/index.html
+cat > "web/foo'bar.go" <<'EOF'
+package web
+EOF
+cat > docs/swagger/embed.go <<'EOF'
+package swagger
+
+import _ "embed"
+
+//go:embed swagger.json
+var Spec string
+EOF
+printf '{}\n' > docs/swagger/swagger.json
+printf 'rootfix\n' > testdata/x.txt
+printf 'hi\n' > docs/readme.md
+printf 'example: true\n' > configs/config.yaml.example
+# Minimal Makefile so the hook's swagger check (triggered by staged internal/
+# changes when swag is installed) has something to run.
+printf 'swagger:\n\t@true\n' > Makefile
+# Generated fixture files are close to (but not exactly) gofmt-clean —
+# normalize rather than hand-format each heredoc.
+gofmt -w .
+git add -A && git commit -qm init
+
+go list -deps ./cmd/javinizer >/dev/null 2>&1 || { echo 'ERROR: scratch module failed to initialize' >&2; exit 2; }
+
+PASS=0; FAIL=0
+check() { # name expected actual
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS+1)); echo "ok   - $1"
+  else
+    FAIL=$((FAIL+1))
+    echo "FAIL - $1:"
+    echo "  expected [$2]"
+    echo "  got      [$3]"
+  fi
+}
+# probe prints "GO_PKGS|TEST_PKGS|FULL_SUITE|API_CHANGED|BUILD" by evaluating
+# the scoping block lifted verbatim from the hook (STAGED_GO= .. closing rule).
+probe() {
+  unset STAGED_GO DELETED_GO MODULE_CHANGED API_CHANGED GO_DIRS GO_PKGS \
+        DROPPED_DIRS ASSET_PKGS ASSET_FULL EMBED_PKGS STATIC_PKGS FULL_SUITE \
+        STAGED_IMPS REV_PKGS TEST_PKGS LINT_CONFIG LINT_PKGS LINT_SCOPE SHOULD_BUILD
+  # color vars (unbound under set -u) for the hook's hard-block messages
+  # shellcheck disable=SC2034 # consumed by the eval'd hook code below
+  RED='' GREEN='' YELLOW='' BLUE='' NC=''
+  # shellcheck disable=SC2016 # sed pattern must match the hook's literal $(
+  eval "$(sed -n '/^STAGED_GO=$(git/,/^# ---------------------------------------------------------------------------$/p' "$HOOK")"
+  # BUILD column reads the production predicate (SHOULD_BUILD) — no mirror.
+  local build=no
+  [ -n "$SHOULD_BUILD" ] && build=yes
+  printf '%s|%s|%s|%s|%s' "$GO_PKGS" "$TEST_PKGS" "$FULL_SUITE" "$API_CHANGED" "$build"
+}
+reset() { git reset -q --hard HEAD; git clean -qfdx; }
+nl=$'\n'
+# Reverse closure of internal/foo: cmd/e2e + cmd/javinizer (regular), consumer (test)
+C4="./cmd/e2e${nl}./cmd/javinizer${nl}./internal/consumer${nl}./internal/foo"
+
+reset; printf '\n// x\n' >> internal/foo/a.go; git add internal/foo/a.go
+check "modified .go (regular+test rev deps)" "./internal/foo|$C4||1|yes" "$(probe)"
+
+# C-quoted unicode paths must not evade anchored matchers (API_CHANGED et al.)
+reset; printf 'package foo\n\nfunc U() int { return 4 }\n' > "internal/foo/注釈.go"; git add "internal/foo/注釈.go"
+check "unicode .go filename" "./internal/foo|$C4||1|yes" "$(probe)"
+
+reset; git rm -q internal/foo/b.go
+check "delete .go, pkg survives" "./internal/foo|$C4||1|yes" "$(probe)"
+
+reset; printf '\n' >> go.mod; git add go.mod
+check "go.mod -> full suite" "||1|0|yes" "$(probe)"
+
+reset; printf '\n' >> go.sum; git add go.sum
+check "go.sum -> full suite" "||1|0|yes" "$(probe)"
+
+check_blocked() { # name grep-pattern — hook must hard-exit with message
+  if out=$(probe); then
+    FAIL=$((FAIL+1)); echo "FAIL - $1: expected hard block, got [$out]"
+  else
+    case "$out" in
+      *"$2"*) PASS=$((PASS+1)); echo "ok   - $1" ;;
+      *) FAIL=$((FAIL+1)); echo "FAIL - $1: blocked with unexpected output:"; printf '%s\n' "$out" | tail -3 ;;
+    esac
+  fi
+}
+
+reset; git rm -q internal/bar/c.go && rmdir internal/bar 2>/dev/null || true
+check_blocked "delete last file of pkg (bin-imported, hard block)" "Cannot enumerate"
+
+reset; printf 'more\n' >> docs/readme.md; git add docs/readme.md
+check "docs only (all skipped)" "|||0|no" "$(probe)"
+
+reset; printf '\n// y\n' >> internal/foo/b.go; git add internal/foo/b.go; git rm -q internal/foo/a.go internal/foo/a_test.go
+check "modify+delete same pkg (dedup)" "./internal/foo|$C4||3|yes" "$(probe)"
+
+reset; git mv internal/foo/b.go internal/bar/b.go
+{ sed -i '' 's/^package foo$/package bar/' internal/bar/b.go 2>/dev/null || sed -i 's/^package foo$/package bar/' internal/bar/b.go; }
+git add internal/bar/b.go
+check "cross-dir rename (both pkgs)" "./internal/bar${nl}./internal/foo|./cmd/e2e${nl}./cmd/javinizer${nl}./internal/bar${nl}./internal/consumer${nl}./internal/foo||2|yes" "$(probe)"
+
+reset; printf '{"x":1}\n' > docs/swagger/swagger.json; git add docs/swagger/swagger.json
+check "swagger.json (embed root, rev-expanded)" "|./cmd/javinizer${nl}./docs/swagger||1|yes" "$(probe)"
+
+reset; printf '\n// q\n' >> "web/foo'bar.go"; git add "web/foo'bar.go"
+check "apostrophe filename (quote-safe)" "./web|./cmd/javinizer${nl}./web||0|yes" "$(probe)"
+
+reset; printf 'f2\n' >> internal/foo/testdata/f.txt; git add internal/foo/testdata/f.txt
+check "per-package fixture -> owning pkg only" "|./internal/foo||1|yes" "$(probe)"
+
+reset; printf 'r2\n' >> testdata/x.txt; git add testdata/x.txt
+check "root fixture -> full suite" "||1|0|yes" "$(probe)"
+
+reset; mkdir -p tools; git mv internal/orphan/o.go tools/o.go
+{ sed -i '' 's/^package orphan$/package tools/' tools/o.go 2>/dev/null || sed -i 's/^package orphan$/package tools/' tools/o.go; }
+git add tools/o.go
+check "rename out of internal/ still triggers swagger check" "./tools|./tools|1|1|yes" "$(probe)"
+
+reset; rm internal/orphan/o.go; ln -s ../foo/real.go internal/orphan/o.go; git add -A
+check "typechange (file->symlink) counts as change" "./internal/orphan|./internal/orphan|1|1|yes" "$(probe)"
+
+reset; printf '\n// s\n' >> internal/shared/s.go; git add internal/shared/s.go
+check "binary-unreachable helper -> full suite" "./internal/shared|./internal/shared|1|1|yes" "$(probe)"
+
+# nested subpackage: editing internal/tree must NOT sweep internal/tree/sub
+# (distinct package, outside the binary graph — sweeping would force FULL)
+reset; printf '\n// t\n' >> internal/tree/parent.go; git add internal/tree/parent.go
+check "nested subpackage not swept" "./internal/tree|./cmd/javinizer${nl}./internal/tree||1|yes" "$(probe)"
+
+# fully tag-excluded package (windows-only on this host): pruned silently,
+# no false FULL_SUITE; build still runs via the staged-file trigger
+reset; mkdir -p internal/tagged
+printf '//go:build windows\n\npackage tagged\n\nfunc W() int { return 1 }\n' > internal/tagged/t.go; git add internal/tagged/t.go
+check "tag-excluded package pruned quietly" "|||1|yes" "$(probe)"
+
+# frontend rename out of src/ must still count (rename detection shows only
+# the destination without --no-renames)
+reset; git mv web/frontend/src/app.ts web/frontend/app.ts
+fe=$( { unset STAGED_GO DELETED_GO MODULE_CHANGED API_CHANGED GO_DIRS GO_PKGS \
+      DROPPED_DIRS ASSET_PKGS ASSET_FULL EMBED_PKGS STATIC_PKGS FULL_SUITE \
+      STAGED_IMPS REV_PKGS TEST_PKGS LINT_CONFIG LINT_PKGS LINT_SCOPE SHOULD_BUILD \
+      FRONTEND_CHANGED FRONTEND_FMT_FILES
+  # shellcheck disable=SC2016 # sed pattern must match the hook's literal $(
+  eval "$(sed -n '/^STAGED_GO=$(git/,/^# ---------------------------------------------------------------------------$/p' "$HOOK")"
+  printf '%s|%s' "$FRONTEND_CHANGED" "$FRONTEND_FMT_FILES"; } )
+check "frontend rename out of src/ still detected" "1|web/frontend/app.ts" "$fe"
+
+reset; printf 'a2\n' >> internal/foo/readme.txt; git add internal/foo/readme.txt
+check "embed-type asset -> pkg + consumers" "|$C4||1|yes" "$(probe)"
+
+reset; printf '<html2/>\n' > web/dist/index.html; git add web/dist/index.html
+check "web/dist asset -> pkg + binary" "|./cmd/javinizer${nl}./web||0|yes" "$(probe)"
+
+reset; printf 'more: true\n' >> configs/config.yaml.example; git add configs/config.yaml.example
+check "configs example -> internal/config (static)" "|./internal/config||0|no" "$(probe)"
+
+reset; printf 'select 2;\n' >> internal/database/migrations/001.sql; git add internal/database/migrations/001.sql
+check "migration sql -> embed pkg + consumer" "|./cmd/javinizer${nl}./internal/database${nl}./internal/database/migrations||1|yes" "$(probe)"
+
+reset; printf '\n// v\n' >> internal/base/b.go; git add internal/base/b.go
+check "re-export chain -> transitive closure" "./internal/base|./cmd/javinizer${nl}./internal/base${nl}./internal/high${nl}./internal/mid||1|yes" "$(probe)"
+
+reset; git rm -q internal/legacy/l.go
+rmdir internal/legacy 2>/dev/null || true
+check_blocked "delete referenced test-only pkg (hard block)" "still import"
+
+reset; printf '\n' >> go.mod; git add go.mod; git rm -q internal/legacy/l.go
+rmdir internal/legacy 2>/dev/null || true
+check_blocked "go.mod + referenced deletion (integrity gate beats FULL_SUITE)" "still import"
+
+reset; printf 'package foo\n\nimport _ "probe.local/x/internal/doesnotexist"\n\nfunc Foo() int { return 1 }\n' > internal/foo/a.go; git add internal/foo/a.go
+check_blocked "unresolvable staged import (hard block)" "dependency graph"
+
+# linter config staged: sets LINT_CONFIG (full-repo lint escalation) but must
+# not by itself trigger Go package checks
+reset; printf 'run:\n  tests: false\n' > .golangci.yml; git add .golangci.yml
+lint_cfg=$( { unset STAGED_GO DELETED_GO MODULE_CHANGED API_CHANGED GO_DIRS GO_PKGS \
+        DROPPED_DIRS ASSET_PKGS ASSET_FULL EMBED_PKGS STATIC_PKGS FULL_SUITE \
+        STAGED_IMPS REV_PKGS TEST_PKGS LINT_CONFIG LINT_PKGS LINT_SCOPE
+  # shellcheck disable=SC2016 # sed pattern must match the hook's literal $(
+  eval "$(sed -n '/^STAGED_GO=$(git/,/^# ---------------------------------------------------------------------------$/p' "$HOOK")"
+  printf '%s|%s|%s' "$LINT_CONFIG" "$GO_PKGS" "$FULL_SUITE"; } )
+check "lint config staged -> full-lint flag only" ".golangci.yml||" "$lint_cfg"
+
+# staged Makefile alone must still trigger the swagger check (the make
+# swagger recipe is defined there) without triggering Go package checks
+reset; printf '# recipe touched\n' >> Makefile; git add Makefile
+check "Makefile staged -> swagger trigger" "|||1|no" "$(probe)"
+
+reset; git rm -q internal/orphan/o.go
+rmdir internal/orphan 2>/dev/null || true
+check "delete orphan pkg (no refs, build only)" "|||1|yes" "$(probe)"
+
+# emptied package dirs (keep.txt survives -> directory remains)
+reset; git rm -q internal/dual_unref/d.go
+check "empty unreferenced pkg (solo)" "|||1|yes" "$(probe)"
+
+reset; git rm -q internal/dual_unref/d.go; printf '\n// x\n' >> internal/foo/a.go; git add internal/foo/a.go
+check "empty unreferenced pkg + valid change" "./internal/foo|$C4||2|yes" "$(probe)"
+
+reset; git rm -q internal/dual_ref/d.go
+check_blocked "empty referenced pkg (hard block)" "still import"
+
+# --- end-to-end: execute the hook itself (index/tree guard lives outside
+# the classified block, so classification probes cannot reach it) -----------
+check_hook() { # name expected_exit [grep-pattern]
+  local name=$1 want=$2 pat=${3:-} got
+  if PRE_COMMIT_FAST=1 bash "$HOOK" >hook.out 2>&1; then got=0; else got=$?; fi
+  if [ "$got" = "$want" ] && { [ -z "$pat" ] || grep -q -- "$pat" hook.out; }; then
+    PASS=$((PASS+1)); echo "ok   - $name"
+  else
+    FAIL=$((FAIL+1)); echo "FAIL - $name: exit=$got (want $want)"
+    tail -5 hook.out
+  fi
+}
+
+reset; printf '\n// e2e clean\n' >> internal/foo/a.go; git add internal/foo/a.go
+check_hook "e2e: clean staged change passes" 0
+
+reset; printf '\n// staged part\n' >> internal/foo/a.go; git add internal/foo/a.go
+printf '\n// unstaged part\n' >> internal/foo/a.go
+check_hook "e2e: partial staging blocked (overlap)" 1 "Offending paths"
+
+reset; git rm -q internal/foo/b.go
+printf 'package foo\n\nfunc Recreated() int { return 9 }\n' > internal/foo/b.go
+check_hook "e2e: staged delete + unstaged recreate blocked" 1
+
+reset; git rm -q web/dist/index.html
+mkdir -p web/dist/ignored && printf 'x\n' > web/dist/ignored/x.js
+check_hook "e2e: ignored web/dist artifact masks staged deletion" 1 "Offending paths"
+
+reset
+check_hook "e2e: empty stage passes" 0
+
+reset; mkdir -p .planning; printf 'x\n' > ".planning/秘.txt"; git add ".planning/秘.txt"
+check_hook "e2e: unicode forbidden path blocked" 1 "Blocked"
+
+reset; printf 'go 1.21\n\nuse .\n' > go.work; git add -f go.work
+check_hook "e2e: force-staged go.work refused" 1 "go.work"
+rm -f go.work
+
+reset; printf '\n// staged A\n' >> internal/foo/a.go; git add internal/foo/a.go
+printf '\n// unstaged B\n' >> internal/bar/c.go
+check_hook "e2e: cross-package unstaged change blocked" 1 "Offending paths"
+
+reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
+printf '# touched\n' >> Makefile
+check_hook "e2e: unstaged Makefile change blocked" 1 "Offending paths"
+
+reset; printf '\n' >> go.mod; git add go.mod
+check_hook "e2e: module change runs full go vet (even under FAST)" 0 "all packages — module files"
+
+reset; printf '\n' >> go.mod; printf '\n// mixed\n' >> internal/foo/a.go
+git add go.mod internal/foo/a.go
+check_hook "e2e: mixed module+Go still runs full go vet" 0 "all packages — module files"
+
+reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
+printf 'syso\n' > internal/foo/x.syso
+check_hook "e2e: ignored *.syso build input blocked" 1 "x.syso"
+
+reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
+printf 'package bar\n\nfunc Brand() int { return 5 }\n' > internal/bar/new.go
+check_hook "e2e: untracked new file under checked path blocked" 1
+
+reset; git rm -q internal/foo/readme.txt; printf 'asset2\n' > internal/foo/readme.txt
+check_hook "e2e: staged-deleted asset recreated unstaged blocked" 1
+
+# GOWORK neutralization: a local go.work with a broken replace must not
+# affect the hook's verdict (it is git-ignored; CI never sees it).
+reset; printf '\n// staged under gowork\n' >> internal/foo/a.go; git add internal/foo/a.go
+printf 'go 1.21\n\nuse .\n\nreplace probe.local/x => ./does-not-exist\n' > go.work
+# sanity: with workspace mode ACTIVE this scratch repo should fail to resolve
+if go list ./... >/dev/null 2>&1; then
+  echo 'WARN: go.work sanity check inconclusive (list succeeded)' >&2
+fi
+check_hook "e2e: broken local go.work neutralized (GOWORK=off)" 0
+rm -f go.work
+
+# TOCTOU: mutate the staged file WHILE the hook runs. The mutation is
+# synchronized to a deterministic hook checkpoint (the [3/8] go vet banner,
+# long past the pre-check guard) and is never restored, so the post-check
+# recheck MUST observe it — no fixed-sleep race. Either way rc must be 1.
+reset; printf '\n// staged for toctou\n' >> internal/foo/a.go; git add internal/foo/a.go
+( seen=""
+  for _ in $(seq 1 200); do grep -qF '[3/8]' hook.out 2>/dev/null && { seen=1; break; }; sleep 0.05; done
+  # Deterministic barrier: mutate ONLY after observing the hook's [3/8]
+  # checkpoint; if it never appeared, the test must fail as inconclusive,
+  # never silently pass or race the finished hook.
+  [ -n "$seen" ] || exit 2
+  printf '\n// mid-run mutation\n' >> internal/foo/a.go ) &
+watcher=$!
+if PRE_COMMIT_FAST=1 bash "$HOOK" >hook.out 2>&1; then toctou_rc=0; else toctou_rc=$?; fi
+watcher_rc=0; wait "$watcher" || watcher_rc=$?
+if [ "$watcher_rc" -ne 0 ]; then
+  FAIL=$((FAIL+1)); echo "FAIL - e2e: TOCTOU checkpoint never observed (inconclusive)"
+elif [ "$toctou_rc" -eq 1 ]; then PASS=$((PASS+1)); echo "ok   - e2e: mid-run mutation blocked (TOCTOU recheck)"
+else FAIL=$((FAIL+1)); echo "FAIL - e2e: mid-run mutation escaped (rc=$toctou_rc)"; tail -5 hook.out; fi
+
+# Index drift: mid-run edit AND git add — the tree matches the index at the
+# end, but the staged content was never classified/tested.
+reset; printf '\n// staged for index-drift\n' >> internal/foo/a.go; git add internal/foo/a.go
+( for _ in $(seq 1 200); do grep -qF '[3/8]' hook.out 2>/dev/null && break; sleep 0.05; done
+  printf '\n// staged mid-run\n' >> internal/foo/a.go; git add internal/foo/a.go ) &
+watcher=$!
+if PRE_COMMIT_FAST=1 bash "$HOOK" >hook.out 2>&1; then drift_rc=0; else drift_rc=$?; fi
+wait "$watcher"
+if [ "$drift_rc" -eq 1 ] && grep -q "never validated" hook.out; then
+  PASS=$((PASS+1)); echo "ok   - e2e: mid-run git add blocked (index drift)"
+else FAIL=$((FAIL+1)); echo "FAIL - e2e: mid-run git add escaped (rc=$drift_rc)"; tail -5 hook.out; fi
+
+# Mid-analysis drift: hammer the index with edits+adds through the WHOLE run
+# (covering the pre-check classification window, which produces no output
+# markers to sync against). With three comparators (post-analysis, post-run,
+# and tree-consistency) against adds every ~20ms, an all-clean sweep is
+# practically impossible; refusal may come from any comparator.
+reset; printf '\n// staged for spam\n' >> internal/foo/a.go; git add internal/foo/a.go
+: > spam.count
+( i=0
+  while ! grep -qE 'checks passed|✗' hook.out 2>/dev/null; do
+    i=$((i+1)); [ "$i" -gt 400 ] && break
+    printf "\\n// spam %s\\n" "$i" >> internal/foo/a.go
+    # lock contention with the hook's index reads is expected; retry next iter
+    git add internal/foo/a.go 2>/dev/null
+    echo "$i" > spam.count
+    sleep 0.02
+  done ) &
+spammer=$!
+if PRE_COMMIT_FAST=1 bash "$HOOK" >hook.out 2>&1; then spam_rc=0; else spam_rc=$?; fi
+wait "$spammer"
+spam_n=$(cat spam.count)
+# Deterministic barriers: the hammer must have fired >=3 index changes across
+# the run (proving it was not starved) AND the hook must have refused.
+if [ "$spam_rc" -eq 1 ] && [ "${spam_n:-0}" -ge 3 ]; then PASS=$((PASS+1)); echo "ok   - e2e: index hammering blocked (analysis-window drift, $spam_n adds)"
+else FAIL=$((FAIL+1)); echo "FAIL - e2e: index hammering escaped (rc=$spam_rc, adds=${spam_n:-0})"; tail -5 hook.out; fi
+
+echo "---"
+echo "passed=$PASS failed=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -76,6 +76,14 @@ package sub
 func S() int { return 1 }
 EOF
 printf 'export const x = 1;\n' > web/frontend/src/app.ts
+# vanish: package whose last tracked .go file can be staged-deleted while an
+# ignored sibling (local_*) remains — exercises the deleted-dirs guard union
+mkdir -p internal/vanish
+cat > internal/vanish/v.go <<'EOF'
+package vanish
+
+func V() int { return 1 }
+EOF
 cat > internal/orphan/o.go <<'EOF'
 package orphan
 
@@ -417,9 +425,9 @@ check_blocked "empty referenced pkg (hard block)" "still import"
 
 # --- end-to-end: execute the hook itself (index/tree guard lives outside
 # the classified block, so classification probes cannot reach it) -----------
-check_hook() { # name expected_exit [grep-pattern]
+check_hook() { # name expected_exit [grep-pattern]; set PCFAST= (empty) to run the FULL hook
   local name=$1 want=$2 pat=${3:-} got
-  if PRE_COMMIT_FAST=1 bash "$HOOK" >hook.out 2>&1; then got=0; else got=$?; fi
+  if PRE_COMMIT_FAST=${PCFAST-1} bash "$HOOK" >hook.out 2>&1; then got=0; else got=$?; fi
   if [ "$got" = "$want" ] && { [ -z "$pat" ] || grep -q -- "$pat" hook.out; }; then
     PASS=$((PASS+1)); echo "ok   - $name"
   else
@@ -499,6 +507,51 @@ check_hook "e2e: ignored .go inside .worktrees/ does not block" 0
 reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
 mkdir -p .tmprepro; printf 'package main\n\nfunc main() {}\n' > .tmprepro/repro.go
 check_hook "e2e: ignored .go inside scratch tree does not block" 0
+
+# create-side masking: a brand-new package whose ONLY .go file is
+# ignored+untracked — a staged import of it compiles locally but cannot on CI
+reset; mkdir -p internal/ghost
+printf 'package ghost\n\nfunc G() int { return 1 }\n' > internal/ghost/local_g.go
+printf 'package foo\n\nimport (\n\t"fmt"\n\n\t_ "probe.local/x/internal/ghost"\n)\n\nfunc Foo() int { fmt.Println(1); return 1 }\n' > internal/foo/a.go
+gofmt -w internal/foo/a.go; git add internal/foo/a.go
+check_hook "e2e: ignored-only new package masked (create side)" 1 "local_g.go"
+
+# same, at the MODULE ROOT: go list reports {{.Dir}} == $PWD exactly, so the
+# root package must normalise to '.' for the guard to see it
+reset; printf 'package x\n\nfunc RootGhost() int { return 1 }\n' > local_root.go
+printf 'package foo\n\nimport (\n\t"fmt"\n\n\t_ "probe.local/x"\n)\n\nfunc Foo() int { fmt.Println(1); return 1 }\n' > internal/foo/a.go
+gofmt -w internal/foo/a.go; git add internal/foo/a.go
+check_hook "e2e: ignored-only module-root package masked" 1 "local_root.go"
+git reset -q --hard HEAD >/dev/null 2>&1; rm -f local_root.go
+
+# regex-hostile checkout path: whole scratch copied under a [bracket] dir —
+# the prefix strip must not fail open there either
+reset
+BRK="$(dirname "$WORK")/br[ack]et"
+rm -rf "$BRK"; cp -R "$WORK" "$BRK"
+cd "$BRK" || exit 2
+gofmt_w() { gofmt -w "$1"; }
+mkdir -p internal/ghost
+printf 'package ghost\n\nfunc G() int { return 1 }\n' > internal/ghost/local_g.go
+printf 'package x\n\nfunc RootGhost() int { return 1 }\n' > local_root.go
+printf 'package foo\n\nimport (\n\t"fmt"\n\n\t_ "probe.local/x"\n\t_ "probe.local/x/internal/ghost"\n)\n\nfunc Foo() int { fmt.Println(1); return 1 }\n' > internal/foo/a.go
+gofmt_w internal/foo/a.go; git add internal/foo/a.go
+if PRE_COMMIT_FAST=1 bash "$HOOK" >hook.out 2>&1; then brk_rc=0; else brk_rc=$?; fi
+if [ "$brk_rc" -eq 1 ] && grep -q local_g.go hook.out && grep -q local_root.go hook.out; then
+  PASS=$((PASS+1)); echo "ok   - e2e: bracketed checkout path — both ghost masks blocked"
+else FAIL=$((FAIL+1)); echo "FAIL - e2e: bracketed path regressed (rc=$brk_rc)"; tail -5 hook.out; fi
+cd "$WORK" || exit 2; rm -rf "$BRK"
+git reset -q --hard HEAD >/dev/null 2>&1; rm -f local_root.go
+git reset -q --hard HEAD >/dev/null 2>&1; rm -rf internal/ghost
+
+# full (non-FAST) run: the scoped test invocation genuinely executes tests
+reset; printf '\n// full run\n' >> internal/foo/a.go; git add internal/foo/a.go
+PCFAST= check_hook "e2e: non-FAST run executes scoped tests" 0 "Running fast unit tests"
+
+# last tracked .go staged-deleted, ignored sibling remains -> must still block
+reset; printf 'package vanish\n\nfunc Ghost() int { return 1 }\n' > internal/vanish/local_ghost.go
+git rm -q internal/vanish/v.go
+check_hook "e2e: ignored .go masks fully-deleted package" 1 "local_ghost.go"
 
 reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
 printf 'package bar\n\nfunc Brand() int { return 5 }\n' > internal/bar/new.go

--- a/scripts/test-pre-commit-scoping.sh
+++ b/scripts/test-pre-commit-scoping.sh
@@ -28,7 +28,7 @@ git init -q
 git config user.email test@example.invalid
 git config user.name test
 git config commit.gpgsign false
-printf '/web/dist/ignored/\n*.syso\n' > .gitignore
+printf '/web/dist/ignored/\n*.syso\nlocal_*.go\n*.log\n.worktrees/\n.scratch/\n.tmprepro/\n.planning/\n' > .gitignore
 mkdir -p internal/foo internal/bar internal/shared internal/consumer internal/legacy internal/orphan \
          internal/tagged \
          internal/dual_unref internal/dual_ref internal/tree/sub web/frontend/src \
@@ -242,6 +242,17 @@ C4="./cmd/e2e${nl}./cmd/javinizer${nl}./internal/consumer${nl}./internal/foo"
 reset; printf '\n// x\n' >> internal/foo/a.go; git add internal/foo/a.go
 check "modified .go (regular+test rev deps)" "./internal/foo|$C4||1|yes" "$(probe)"
 
+# lint/vet scope includes reverse dependents (consumer-only diagnostics)
+reset; printf '\n// x2\n' >> internal/foo/a.go; git add internal/foo/a.go
+ck=$( { unset STAGED_GO DELETED_GO MODULE_CHANGED API_CHANGED GO_DIRS GO_PKGS \
+      DROPPED_DIRS ASSET_PKGS ASSET_FULL EMBED_PKGS STATIC_PKGS FULL_SUITE \
+      STAGED_IMPS REV_PKGS TEST_PKGS LINT_CONFIG LINT_PKGS LINT_SCOPE SHOULD_BUILD \
+      FRONTEND_CHANGED FRONTEND_FMT_FILES CHECK_PKGS
+  # shellcheck disable=SC2016 # sed pattern must match the hook's literal $(
+  eval "$(sed -n '/^STAGED_GO=$(git/,/^# ---------------------------------------------------------------------------$/p' "$HOOK")"
+  printf '%s' "$CHECK_PKGS"; } )
+check "lint/vet scope includes reverse dependents" "$C4" "$ck"
+
 # C-quoted unicode paths must not evade anchored matchers (API_CHANGED et al.)
 reset; printf 'package foo\n\nfunc U() int { return 4 }\n' > "internal/foo/注釈.go"; git add "internal/foo/注釈.go"
 check "unicode .go filename" "./internal/foo|$C4||1|yes" "$(probe)"
@@ -314,6 +325,12 @@ reset; mkdir -p internal/tagged
 printf '//go:build windows\n\npackage tagged\n\nfunc W() int { return 1 }\n' > internal/tagged/t.go; git add internal/tagged/t.go
 check "tag-excluded package pruned quietly" "|||1|yes" "$(probe)"
 
+# live -> tag-excluded producer with consumers: package enumeration breaks
+# (its importer no longer resolves), so this must hard-block, not prune
+reset; printf '//go:build windows\n\npackage tree\n\nfunc T() int { return 1 }\n' > internal/tree/parent.go
+git add internal/tree/parent.go
+check_blocked "live->excluded producer with consumers (hard block)" "Cannot enumerate"
+
 # frontend rename out of src/ must still count (rename detection shows only
 # the destination without --no-renames)
 reset; git mv web/frontend/src/app.ts web/frontend/app.ts
@@ -331,6 +348,22 @@ check "embed-type asset -> pkg + consumers" "|$C4||1|yes" "$(probe)"
 
 reset; printf '<html2/>\n' > web/dist/index.html; git add web/dist/index.html
 check "web/dist asset -> pkg + binary" "|./cmd/javinizer${nl}./web||0|yes" "$(probe)"
+
+# cgo/toolchain source in a Go package dir outside the scanned roots:
+# an unsupported .c in a Go package dir must never silently pass: the
+# owning package joins resolution and go list rejects it loudly
+reset; rm -f web/rogue.c 2>/dev/null; printf 'int rogue(void) { return 0; }\n' > web/rogue.c; git add web/rogue.c
+check_blocked "cgo source outside scanned roots (hard block)" "C source files not allowed"
+
+# full Go-recognized toolchain extension set (covering *.m here as the
+# outside-root representative; all share one pathspec row per class)
+reset; rm -f web/rogue.c 2>/dev/null; printf '@interface Rogue\n@end\n' > web/rogue.m; git add web/rogue.m
+check_blocked "objc source outside scanned roots (hard block)" "Cannot resolve staged packages"
+
+# C++ header-only input: headers are pure data to go list (no hard block),
+# but must map to the owning package so its checks run
+reset; rm -f web/rogue.m 2>/dev/null; printf '#pragma once\n' > web/rogue.hpp; git add web/rogue.hpp
+check "header-only input outside scanned roots -> web pkg" "|./cmd/javinizer${nl}./web||0|yes" "$(probe)"
 
 reset; printf 'more: true\n' >> configs/config.yaml.example; git add configs/config.yaml.example
 check "configs example -> internal/config (static)" "|./internal/config||0|no" "$(probe)"
@@ -413,12 +446,17 @@ check_hook "e2e: ignored web/dist artifact masks staged deletion" 1 "Offending p
 reset
 check_hook "e2e: empty stage passes" 0
 
-reset; mkdir -p .planning; printf 'x\n' > ".planning/秘.txt"; git add ".planning/秘.txt"
+reset; mkdir -p .planning; printf 'x\n' > ".planning/秘.txt"; git add -f ".planning/秘.txt"
 check_hook "e2e: unicode forbidden path blocked" 1 "Blocked"
 
 reset; printf 'go 1.21\n\nuse .\n' > go.work; git add -f go.work
 check_hook "e2e: force-staged go.work refused" 1 "go.work"
-rm -f go.work
+
+# a previously-TRACKED workspace file must be removable (deletion != staging)
+reset; printf 'go 1.21\n\nuse .\n' > go.work; git add -f go.work; git -c commit.gpgsign=false commit -qm 'track go.work (fixture)'
+git rm -q --cached go.work
+check_hook "e2e: staged deletion of tracked go.work allowed" 0
+git reset -q --hard HEAD >/dev/null; git rm -q --cached go.work 2>/dev/null; reset
 
 reset; printf '\n// staged A\n' >> internal/foo/a.go; git add internal/foo/a.go
 printf '\n// unstaged B\n' >> internal/bar/c.go
@@ -428,16 +466,39 @@ reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
 printf '# touched\n' >> Makefile
 check_hook "e2e: unstaged Makefile change blocked" 1 "Offending paths"
 
+reset; printf '.text\n.globl broken\nbroken:\n\t.badop\n' > internal/foo/x.s; git add internal/foo/x.s
+printf '.text\n.globl broken\nbroken:\n\tRET\n' > internal/foo/x.s
+check_hook "e2e: partial staging of toolchain source blocked" 1 "x.s"
+
 reset; printf '\n' >> go.mod; git add go.mod
-check_hook "e2e: module change runs full go vet (even under FAST)" 0 "all packages — module files"
+check_hook "e2e: module change runs full go vet (even under FAST)" 0 "all packages — module/shared-input change"
 
 reset; printf '\n' >> go.mod; printf '\n// mixed\n' >> internal/foo/a.go
 git add go.mod internal/foo/a.go
-check_hook "e2e: mixed module+Go still runs full go vet" 0 "all packages — module files"
+check_hook "e2e: mixed module+Go still runs full go vet" 0 "all packages — module/shared-input change"
+
+reset; printf 'f2\n' >> testdata/x.txt; git add testdata/x.txt
+check_hook "e2e: shared fixture escalates lint/vet to full repo" 0 "all packages — module/shared-input change"
 
 reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
 printf 'syso\n' > internal/foo/x.syso
 check_hook "e2e: ignored *.syso build input blocked" 1 "x.syso"
+
+reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
+printf 'package foo\n\nfunc Local() int { return 1 }\n' > internal/foo/local_extra.go
+check_hook "e2e: ignored *.go masked symbol blocked" 1 "local_extra.go"
+
+reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
+printf 'noise\n' > internal/foo/run.log
+check_hook "e2e: harmless ignored runtime artifact does not block" 0
+
+reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
+mkdir -p .worktrees/wt; printf 'package wt\n' > .worktrees/wt/x.go
+check_hook "e2e: ignored .go inside .worktrees/ does not block" 0
+
+reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
+mkdir -p .tmprepro; printf 'package main\n\nfunc main() {}\n' > .tmprepro/repro.go
+check_hook "e2e: ignored .go inside scratch tree does not block" 0
 
 reset; printf '\n// staged\n' >> internal/foo/a.go; git add internal/foo/a.go
 printf 'package bar\n\nfunc Brand() int { return 5 }\n' > internal/bar/new.go
@@ -462,8 +523,9 @@ rm -f go.work
 # long past the pre-check guard) and is never restored, so the post-check
 # recheck MUST observe it — no fixed-sleep race. Either way rc must be 1.
 reset; printf '\n// staged for toctou\n' >> internal/foo/a.go; git add internal/foo/a.go
+: > hook.out   # no stale markers from earlier scenarios
 ( seen=""
-  for _ in $(seq 1 200); do grep -qF '[3/8]' hook.out 2>/dev/null && { seen=1; break; }; sleep 0.05; done
+  for ((_p = 0; _p < 200; _p++)); do grep -qF '[3/8]' hook.out 2>/dev/null && { seen=1; break; }; sleep 0.05; done
   # Deterministic barrier: mutate ONLY after observing the hook's [3/8]
   # checkpoint; if it never appeared, the test must fail as inconclusive,
   # never silently pass or race the finished hook.
@@ -474,18 +536,24 @@ if PRE_COMMIT_FAST=1 bash "$HOOK" >hook.out 2>&1; then toctou_rc=0; else toctou_
 watcher_rc=0; wait "$watcher" || watcher_rc=$?
 if [ "$watcher_rc" -ne 0 ]; then
   FAIL=$((FAIL+1)); echo "FAIL - e2e: TOCTOU checkpoint never observed (inconclusive)"
-elif [ "$toctou_rc" -eq 1 ]; then PASS=$((PASS+1)); echo "ok   - e2e: mid-run mutation blocked (TOCTOU recheck)"
+elif [ "$toctou_rc" -eq 1 ] && grep -q "changed while the checks were running" hook.out; then
+  PASS=$((PASS+1)); echo "ok   - e2e: mid-run mutation blocked (TOCTOU recheck)"
 else FAIL=$((FAIL+1)); echo "FAIL - e2e: mid-run mutation escaped (rc=$toctou_rc)"; tail -5 hook.out; fi
 
 # Index drift: mid-run edit AND git add — the tree matches the index at the
 # end, but the staged content was never classified/tested.
 reset; printf '\n// staged for index-drift\n' >> internal/foo/a.go; git add internal/foo/a.go
-( for _ in $(seq 1 200); do grep -qF '[3/8]' hook.out 2>/dev/null && break; sleep 0.05; done
+: > hook.out   # no stale markers from earlier scenarios
+( seen=""
+  for ((_p = 0; _p < 200; _p++)); do grep -qF '[3/8]' hook.out 2>/dev/null && { seen=1; break; }; sleep 0.05; done
+  [ -n "$seen" ] || exit 2
   printf '\n// staged mid-run\n' >> internal/foo/a.go; git add internal/foo/a.go ) &
 watcher=$!
 if PRE_COMMIT_FAST=1 bash "$HOOK" >hook.out 2>&1; then drift_rc=0; else drift_rc=$?; fi
-wait "$watcher"
-if [ "$drift_rc" -eq 1 ] && grep -q "never validated" hook.out; then
+watcher_rc=0; wait "$watcher" || watcher_rc=$?
+if [ "$watcher_rc" -ne 0 ]; then
+  FAIL=$((FAIL+1)); echo "FAIL - e2e: index-drift checkpoint never observed (inconclusive)"
+elif [ "$drift_rc" -eq 1 ] && grep -q "never validated" hook.out; then
   PASS=$((PASS+1)); echo "ok   - e2e: mid-run git add blocked (index drift)"
 else FAIL=$((FAIL+1)); echo "FAIL - e2e: mid-run git add escaped (rc=$drift_rc)"; tail -5 hook.out; fi
 
@@ -495,6 +563,7 @@ else FAIL=$((FAIL+1)); echo "FAIL - e2e: mid-run git add escaped (rc=$drift_rc)"
 # and tree-consistency) against adds every ~20ms, an all-clean sweep is
 # practically impossible; refusal may come from any comparator.
 reset; printf '\n// staged for spam\n' >> internal/foo/a.go; git add internal/foo/a.go
+: > hook.out   # no stale markers from earlier scenarios
 : > spam.count
 ( i=0
   while ! grep -qE 'checks passed|✗' hook.out 2>/dev/null; do


### PR DESCRIPTION
## Why

The `scripts/pre-commit.sample` hook ran its whole battery on **every commit regardless of what was staged**:

| Check | Cost | Scoped? (before) |
|---|---|---|
| `gofmt -l .` | ~1s | n/a (fine) |
| `golangci-lint run ./...` | 2s warm / 60s+ cold | ❌ whole repo |
| `go vet ./...` | ~10s | ❌ |
| **`go test -short ./...`** | **minutes** | ❌ entire suite incl. real-sleep download tests |
| `go build ./cmd/javinizer` | ~5s | fine |
| `make swagger` + diff | ~3–30s | ❌ and it **go-installs `swag` mid-commit** when missing |
| `svelte-check` | ~58s | ✅ only when `web/frontend/src` staged |

A docs-only or script-only commit paid the full minutes-long price; on a large staged commit the hook can outlast common agent/CI timeouts.

## What changed

- **Stage-scoped Go checks**: golangci-lint / `go vet` / `go test -short` now run only for packages containing staged `.go` files (`--diff-filter=ACMR`), and are skipped entirely for non-Go commits.
- **Build verification** runs only when Go files are staged (catches cross-package breakage the scoped checks miss; seconds with a warm cache).
- **Swagger regen** runs only when `internal/` or `cmd/` files are staged; a missing `swag` binary warns + skips instead of installing tools during a commit hook (CI regenerates and fails loudly anyway).
- **`PRE_COMMIT_FAST=1`** escape hatch: skips the unit tests + svelte-check (keeps gofmt/lint/vet/build scoped).
- Elapsed time printed at the end so hook cost is visible.

## Measured (this machine)

- shell/docs-only staged: **2s** (was: full test suite + swagger regen)
- one file in an existing Go package: **~55s cold cache / ~12s warm** (was: minutes)

All checks behave identically when triggered (same tools, same failure semantics); only the invocation scope changed.

## Test plan

- Smoke-tested by staging scenarios in a scratch worktree:
  - script-only stage → all Go/frontend checks skip, 2s total
  - one `.go` file stage → lint/vet/test/build/swagger run only against that package
  - `bash -n` syntax check passes
- [ ] CI