### PR TITLE
fix(coverage): local project coverage matches Codecov + fail-loud test run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ help:
 	@echo "  make coverage-check     - Enforce 75%% Codecov-compatible line coverage"
 	@echo "  make coverage-patch     - Show patch coverage (new/changed lines vs main)"
 	@echo "  make coverage-patch-check - Enforce 80%% patch coverage (mirrors codecov/patch)"
+	@echo "  make coverage-patch-strict - Enforce 100%% patch coverage (PR completion bar)"
 	@echo ""
 	@echo "Code Quality:"
 	@echo "  make fmt                - Format code with go fmt"
@@ -165,7 +166,15 @@ coverage:
 	@echo "Running tests and generating coverage report..."
 	@rm -f coverage.out
 	@pkgs=$$(go list ./... | grep -Ev '(/cmd/(coveragecheck|javinizer-e2e)$$)|(/internal/coverage$$)|(/(mocks|tui|docs|testutil|web)(/|$$))'); \
-	go test -covermode=atomic -coverprofile=coverage.out -coverpkg=$$(echo $$pkgs | tr ' ' ',') -count=1 $$pkgs 2>&1 | awk '/^(ok|github)/ { print; fflush() }'
+	tmp=$$(mktemp); \
+	go test -covermode=atomic -coverprofile=coverage.out -coverpkg=$$(echo $$pkgs | tr ' ' ',') -count=1 $$pkgs >$$tmp 2>&1; status=$$?; \
+	awk '/^(ok|github|--- FAIL|FAIL|panic)/ { print; fflush() }' $$tmp; \
+	rm -f $$tmp; \
+	if [ $$status -ne 0 ]; then \
+		echo ""; \
+		echo "✗ Coverage test run failed (exit $$status) — coverage.out is PARTIAL and would report phantom misses" >&2; \
+		exit $$status; \
+	fi
 	@echo ""
 	@go run ./cmd/coveragecheck --metric line --profile coverage.out 2>/dev/null
 
@@ -196,6 +205,11 @@ coverage-patch: coverage
 # codecov/patch failures locally instead of after a CI round-trip.
 coverage-patch-check: coverage
 	@go run ./cmd/coveragecheck --patch --profile coverage.out --base main --min 80
+
+# Strict patch gate — 100%% of changed lines must be covered. This mirrors the
+# PR-completion bar (resolve-pr workflow); codecov.yml's 80%% remains the CI floor.
+coverage-patch-strict: coverage
+	@go run ./cmd/coveragecheck --patch --profile coverage.out --base main --min 100
 
 # Test coverage goal - enforces 90% line coverage
 test-coverage: coverage

--- a/Makefile
+++ b/Makefile
@@ -169,12 +169,16 @@ coverage:
 	tmp=$$(mktemp); \
 	go test -covermode=atomic -coverprofile=coverage.out -coverpkg=$$(echo $$pkgs | tr ' ' ',') -count=1 $$pkgs >$$tmp 2>&1; status=$$?; \
 	awk '/^(ok|github|--- FAIL|FAIL|panic)/ { print; fflush() }' $$tmp; \
-	rm -f $$tmp; \
 	if [ $$status -ne 0 ]; then \
+		echo ""; \
+		echo "--- full test output (run failed; the filtered summary above hides assertion details) ---" >&2; \
+		cat $$tmp; \
+		rm -f $$tmp; \
 		echo ""; \
 		echo "✗ Coverage test run failed (exit $$status) — coverage.out is PARTIAL and would report phantom misses" >&2; \
 		exit $$status; \
-	fi
+	fi; \
+	rm -f $$tmp
 	@echo ""
 	@go run ./cmd/coveragecheck --metric line --profile coverage.out 2>/dev/null
 

--- a/cmd/coveragecheck/main.go
+++ b/cmd/coveragecheck/main.go
@@ -47,13 +47,19 @@ func runWithAnalyze(args []string, stdout, stderr io.Writer, analyze analyzeProf
 	// Codecov applies codecov.yml's ignore list to PROJECT coverage too —
 	// load it here as well (patch mode below already does) so the local
 	// project percentage reports the same number Codecov will upload.
+	// Warn loudly on partial setup failure: silently skipping ignores makes
+	// the local number diverge from Codecov with no explanation.
 	reportOpts := coverage.ReportOptions{}
-	if repoRoot, werr := osGetwd(); werr == nil {
-		if ig, ierr := loadCodecovIgnore(repoRoot); ierr == nil && len(ig) > 0 {
-			if mp, merr := modulePrefix(repoRoot); merr == nil {
-				reportOpts.IgnoreGlobs = ig
-				reportOpts.ModulePrefix = mp
-			}
+	if repoRoot, werr := osGetwd(); werr != nil {
+		_, _ = fmt.Fprintf(stderr, "Warning: cannot determine repo root (%v) — Codecov ignore rules skipped; project percentage may diverge from Codecov\n", werr)
+	} else if ig, ierr := loadCodecovIgnore(repoRoot); ierr != nil {
+		_, _ = fmt.Fprintf(stderr, "Warning: cannot load codecov ignore rules (%v) — project percentage may diverge from Codecov\n", ierr)
+	} else if len(ig) > 0 {
+		if mp, merr := modulePrefix(repoRoot); merr != nil {
+			_, _ = fmt.Fprintf(stderr, "Warning: cannot resolve module prefix (%v) — Codecov ignore rules skipped; project percentage may diverge from Codecov\n", merr)
+		} else {
+			reportOpts.IgnoreGlobs = ig
+			reportOpts.ModulePrefix = mp
 		}
 	}
 

--- a/cmd/coveragecheck/main.go
+++ b/cmd/coveragecheck/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/javinizer/javinizer-go/internal/coverage"
 )
@@ -15,10 +16,10 @@ func main() {
 	osExit(run(os.Args[1:], os.Stdout, os.Stderr))
 }
 
-type analyzeProfileFn func(path string) (coverage.Summary, error)
+type analyzeProfileFn func(path string, opts coverage.ReportOptions) (coverage.Summary, error)
 
 func run(args []string, stdout, stderr io.Writer) int {
-	return runWithAnalyze(args, stdout, stderr, coverage.AnalyzeProfile)
+	return runWithAnalyze(args, stdout, stderr, coverage.AnalyzeProfileWithOptions)
 }
 
 func runWithAnalyze(args []string, stdout, stderr io.Writer, analyze analyzeProfileFn) int {
@@ -43,7 +44,20 @@ func runWithAnalyze(args []string, stdout, stderr io.Writer, analyze analyzeProf
 		return runPatchCheck(profilePath, baseRef, minCoverage, stdout, stderr)
 	}
 
-	summary, err := analyze(profilePath)
+	// Codecov applies codecov.yml's ignore list to PROJECT coverage too —
+	// load it here as well (patch mode below already does) so the local
+	// project percentage reports the same number Codecov will upload.
+	reportOpts := coverage.ReportOptions{}
+	if repoRoot, werr := osGetwd(); werr == nil {
+		if ig, ierr := loadCodecovIgnore(repoRoot); ierr == nil && len(ig) > 0 {
+			if mp, merr := modulePrefix(repoRoot); merr == nil {
+				reportOpts.IgnoreGlobs = ig
+				reportOpts.ModulePrefix = mp
+			}
+		}
+	}
+
+	summary, err := analyze(profilePath, reportOpts)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "Error: %v\n", err)
 		return 2
@@ -86,6 +100,11 @@ func runWithAnalyze(args []string, stdout, stderr io.Writer, analyze analyzeProf
 	if _, err := fmt.Fprintf(stdout, "Statement Coverage %.2f%% (%d covered, %d total)\n",
 		summary.Statement.Percent, summary.Statement.Covered, summary.Statement.Total); err != nil {
 		return 2
+	}
+	if len(reportOpts.IgnoreGlobs) > 0 {
+		if _, err := fmt.Fprintf(stdout, "Ignored Globs:     %s (codecov.yml)\n", strings.Join(reportOpts.IgnoreGlobs, ", ")); err != nil {
+			return 2
+		}
 	}
 	if _, err := fmt.Fprintf(stdout, "Metric Details:    %s\n", selectedDetails); err != nil {
 		return 2

--- a/cmd/coveragecheck/main_test.go
+++ b/cmd/coveragecheck/main_test.go
@@ -38,7 +38,7 @@ func TestRunWithAnalyze(t *testing.T) {
 			[]string{"--profile", "coverage.out", "--metric", "line", "--min", "79.9"},
 			&stdout,
 			&stderr,
-			func(path string) (coverage.Summary, error) {
+			func(path string, _ coverage.ReportOptions) (coverage.Summary, error) {
 				called = true
 				assert.Equal(t, "coverage.out", path)
 				return stubSummary(), nil
@@ -59,7 +59,7 @@ func TestRunWithAnalyze(t *testing.T) {
 			[]string{"--metric", "statement", "--min", "90"},
 			&stdout,
 			&stderr,
-			func(string) (coverage.Summary, error) {
+			func(string, coverage.ReportOptions) (coverage.Summary, error) {
 				return stubSummary(), nil
 			},
 		)
@@ -77,7 +77,7 @@ func TestRunWithAnalyze(t *testing.T) {
 			[]string{},
 			&stdout,
 			&stderr,
-			func(string) (coverage.Summary, error) {
+			func(string, coverage.ReportOptions) (coverage.Summary, error) {
 				return coverage.Summary{}, errors.New("boom")
 			},
 		)
@@ -94,7 +94,7 @@ func TestRunWithAnalyze(t *testing.T) {
 			[]string{"--metric", "bogus"},
 			&stdout,
 			&stderr,
-			func(string) (coverage.Summary, error) {
+			func(string, coverage.ReportOptions) (coverage.Summary, error) {
 				return stubSummary(), nil
 			},
 		)
@@ -111,7 +111,7 @@ func TestRunWithAnalyze(t *testing.T) {
 			[]string{"--not-a-flag"},
 			&stdout,
 			&stderr,
-			func(string) (coverage.Summary, error) {
+			func(string, coverage.ReportOptions) (coverage.Summary, error) {
 				t.Fatalf("analyze should not be called when flag parsing fails")
 				return coverage.Summary{}, nil
 			},
@@ -147,6 +147,31 @@ func TestSelectMetric(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), `unsupported metric "invalid"`)
 	})
+}
+
+func TestRun_ProjectModeAppliesCodecovIgnores(t *testing.T) {
+	// The ignore list must apply to PROJECT coverage too — otherwise the
+	// local number underreads versus the Codecov report (patch mode already
+	// applied it; project mode did not).
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(dir+"/go.mod", []byte("module github.com/javinizer/javinizer-go\n"), 0o644))
+	require.NoError(t, os.WriteFile(dir+"/codecov.yml", []byte("coverage:\n  status: {}\nignore:\n  - \"docs/swagger/**\"\n"), 0o644))
+	profilePath := dir + "/coverage.out"
+	require.NoError(t, os.WriteFile(profilePath, []byte(
+		"mode: atomic\n"+
+			"github.com/javinizer/javinizer-go/internal/x/ok.go:4.1,6.1 2 1\n"+
+			"github.com/javinizer/javinizer-go/docs/swagger/docs.go:10.1,12.1 2 0\n"), 0o644))
+
+	origGetwd := osGetwd
+	t.Cleanup(func() { osGetwd = origGetwd })
+	osGetwd = func() (string, error) { return dir, nil }
+
+	var stdout, stderr bytes.Buffer
+	exitCode := run([]string{"--profile", profilePath, "--min", "100"}, &stdout, &stderr)
+	require.Equal(t, 0, exitCode, "ignored file must not count against project coverage; stderr=%s", stderr)
+	assert.Contains(t, stdout.String(), "Ignored Globs:")
+	assert.Contains(t, stdout.String(), "docs/swagger/**")
+	assert.Contains(t, stdout.String(), "Coverage check PASSED")
 }
 
 func TestRun_Wrapper(t *testing.T) {

--- a/cmd/coveragecheck/main_test.go
+++ b/cmd/coveragecheck/main_test.go
@@ -174,6 +174,60 @@ func TestRun_ProjectModeAppliesCodecovIgnores(t *testing.T) {
 	assert.Contains(t, stdout.String(), "Coverage check PASSED")
 }
 
+func TestRun_ProjectModeWarnsOnGetwdError(t *testing.T) {
+	dir := t.TempDir()
+	profilePath := dir + "/coverage.out"
+	require.NoError(t, os.WriteFile(profilePath, []byte(
+		"mode: atomic\n"+
+			"github.com/javinizer/javinizer-go/internal/x/ok.go:4.1,6.1 2 1\n"), 0o644))
+
+	origGetwd := osGetwd
+	t.Cleanup(func() { osGetwd = origGetwd })
+	osGetwd = func() (string, error) { return "", errors.New("cwd unavailable") }
+
+	var stdout, stderr bytes.Buffer
+	exitCode := run([]string{"--profile", profilePath, "--min", "1"}, &stdout, &stderr)
+	require.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr.String(), "Warning: cannot determine repo root")
+}
+
+func TestRun_ProjectModeWarnsOnMalformedCodecovYml(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(dir+"/go.mod", []byte("module github.com/javinizer/javinizer-go\n"), 0o644))
+	require.NoError(t, os.WriteFile(dir+"/codecov.yml", []byte("coverage:\n  status: [unclosed\n"), 0o644))
+	profilePath := dir + "/coverage.out"
+	require.NoError(t, os.WriteFile(profilePath, []byte(
+		"mode: atomic\n"+
+			"github.com/javinizer/javinizer-go/internal/x/ok.go:4.1,6.1 2 1\n"), 0o644))
+
+	origGetwd := osGetwd
+	t.Cleanup(func() { osGetwd = origGetwd })
+	osGetwd = func() (string, error) { return dir, nil }
+
+	var stdout, stderr bytes.Buffer
+	exitCode := run([]string{"--profile", profilePath, "--min", "1"}, &stdout, &stderr)
+	require.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr.String(), "Warning: cannot load codecov ignore rules")
+}
+
+func TestRun_ProjectModeWarnsOnMissingGoMod(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(dir+"/codecov.yml", []byte("ignore:\n  - \"docs/**\"\n"), 0o644))
+	profilePath := dir + "/coverage.out"
+	require.NoError(t, os.WriteFile(profilePath, []byte(
+		"mode: atomic\n"+
+			"github.com/javinizer/javinizer-go/internal/x/ok.go:4.1,6.1 2 1\n"), 0o644))
+
+	origGetwd := osGetwd
+	t.Cleanup(func() { osGetwd = origGetwd })
+	osGetwd = func() (string, error) { return dir, nil }
+
+	var stdout, stderr bytes.Buffer
+	exitCode := run([]string{"--profile", profilePath, "--min", "1"}, &stdout, &stderr)
+	require.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr.String(), "Warning: cannot resolve module prefix")
+}
+
 func TestRun_Wrapper(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/cmd/coveragecheck/patch_test.go
+++ b/cmd/coveragecheck/patch_test.go
@@ -376,7 +376,7 @@ func TestRunWithAnalyze_PatchFlag(t *testing.T) {
 		exitCode := runWithAnalyze(
 			[]string{"--patch", "--profile", profilePath},
 			&stdout, &stderr,
-			func(string) (coverage.Summary, error) {
+			func(string, coverage.ReportOptions) (coverage.Summary, error) {
 				t.Fatal("analyze should not be called in patch mode")
 				return coverage.Summary{}, nil
 			},
@@ -411,7 +411,7 @@ func TestRunWithAnalyze_PatchFlag(t *testing.T) {
 		exitCode := runWithAnalyze(
 			[]string{"--patch", "--profile", profilePath, "--base", "develop"},
 			&stdout, &stderr,
-			func(string) (coverage.Summary, error) { return coverage.Summary{}, nil },
+			func(string, coverage.ReportOptions) (coverage.Summary, error) { return coverage.Summary{}, nil },
 		)
 
 		if exitCode != 0 {

--- a/internal/api/batch/execute.go
+++ b/internal/api/batch/execute.go
@@ -37,7 +37,12 @@ func prepareAndLaunchApply(
 	// Per DEEP-6: set WF on the job's deps before calling StartApply.
 	job.SetWorkflow(wf)
 
+	// Track before launching so teardown can join this goroutine (and with it
+	// the apply phase's deferred persistence) instead of inferring completion
+	// from job status.
+	done := rt.TrackBackgroundTask()
 	go func() {
+		defer done()
 		if err := job.StartApply(rt.ServerCtx(), applyOpts); err != nil {
 			logging.Errorf("BatchJob.StartApply failed: %v", err)
 			rt.Deps().GetJobStore().PersistJobByID(job.GetID())

--- a/internal/api/batch/execute_coverage_test.go
+++ b/internal/api/batch/execute_coverage_test.go
@@ -97,6 +97,7 @@ func TestOrganizeJob_RunningJobRejected(t *testing.T) {
 
 	job := deps.JobStore.CreateJobBatch([]string{"/path/to/file.mp4"})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/batch/:id/organize", organizeJob(testkit.GetTestRuntime(deps)))

--- a/internal/api/batch/factory_nil_guard_test.go
+++ b/internal/api/batch/factory_nil_guard_test.go
@@ -147,6 +147,7 @@ func TestBatchRescrapeMovies_RunningJob_409(t *testing.T) {
 	deps := createTestDeps(t, cfg, "")
 	job := deps.JobStore.CreateJobBatch([]string{"/path/to/file.mp4"})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/batch/:id/movies/batch-rescrape", batchRescrapeMovies(testkit.GetTestRuntime(deps)))

--- a/internal/api/batch/handlers_test.go
+++ b/internal/api/batch/handlers_test.go
@@ -1839,6 +1839,8 @@ func TestJobStateMachineTransitions(t *testing.T) {
 
 		// Simulate retry - MarkStarted should clear OrganizedAt
 		setJobStatus(job, models.JobStatusRunning)
+		// restore terminal status after this subtest (setup-only Running state)
+		defer setJobStatus(job, models.JobStatusCompleted)
 
 		// Verify OrganizedAt is cleared
 		snap2 := job.GetStatus()

--- a/internal/api/batch/lifecycle_extra_test.go
+++ b/internal/api/batch/lifecycle_extra_test.go
@@ -120,6 +120,7 @@ func TestDeleteBatchJob_RunningJobRejected(t *testing.T) {
 
 	job := deps.JobStore.CreateJobBatch([]string{"/path/to/IPX-700.mp4"})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.DELETE("/batch/:id", deleteBatchJob(testkit.GetTestRuntime(deps)))

--- a/internal/api/batch/movie_edit_consolidated_test.go
+++ b/internal/api/batch/movie_edit_consolidated_test.go
@@ -254,6 +254,7 @@ func TestBatchRescrapeMovies_RunningJobRejected(t *testing.T) {
 
 	job := createJobWithWF(deps, cfg, []string{"/tmp/IPX-001.mp4"})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/batch/:id/movies/batch-rescrape", batchRescrapeMovies(testkit.GetTestRuntime(deps)))

--- a/internal/api/batch/organize_consolidated_test.go
+++ b/internal/api/batch/organize_consolidated_test.go
@@ -259,6 +259,7 @@ func TestMiss6_OrganizeJob_RunningJob(t *testing.T) {
 
 	job := batchDeps.Deps().GetJobStore().CreateJobBatch([]string{})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/api/v1/batch/:id/organize", organizeJob(batchDeps))
@@ -870,6 +871,7 @@ func TestOrganizeJob_Miss3_JobAlreadyRunning(t *testing.T) {
 		StartedAt:     time.Now(),
 	})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/batch/:id/organize", organizeJob(testkit.GetTestRuntime(deps)))
@@ -1269,6 +1271,7 @@ func TestOrganizeJob_Miss4_RunningJob(t *testing.T) {
 
 	job := batchDeps.Deps().GetJobStore().CreateJobBatch([]string{})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/api/v1/batch/:id/organize", organizeJob(batchDeps))

--- a/internal/api/batch/rescrape_race_test.go
+++ b/internal/api/batch/rescrape_race_test.go
@@ -132,6 +132,7 @@ func TestRescrapeBatchMovie_JobLifecycleRace(t *testing.T) {
 
 		// Manually set job status to running (simulating active scrape)
 		setJobStatus(job, models.JobStatusRunning)
+		defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 		body, err := json.Marshal(contracts.BatchRescrapeRequest{
 			SelectedScrapers:  []string{"stub-no-poster"},

--- a/internal/api/batch/scrape_join_test.go
+++ b/internal/api/batch/scrape_join_test.go
@@ -1,0 +1,95 @@
+package batch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartScrapeAsyncLaunch_TrackedAndJoined mirrors
+// TestUpdateAsyncLaunch_TrackedAndJoined for the scrape path: the usecase
+// launches the phase on a TRACKED goroutine that additionally Wait()s (via
+// phaseDone), so test teardown's drain joins the whole phase — including its
+// deferred persistence — rather than just the launch call.
+func TestStartScrapeAsyncLaunch_TrackedAndJoined(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	deps := createTestDeps(t, cfg, "")
+	rt := testkit.GetTestRuntime(deps)
+
+	out, err := StartScrapeUseCase(context.Background(), rt, StartScrapeInput{})
+	require.NoError(t, err)
+	require.NotEmpty(t, out.JobID)
+
+	require.True(t, rt.WaitBackgroundTasks(10*time.Second),
+		"usecase-launched scrape must be tracked and joinable")
+
+	job, ok := deps.GetJobStore().GetBatchJob(out.JobID)
+	require.True(t, ok)
+	assert.NotEqual(t, "Running", string(job.GetStatus().Status),
+		"after join the job must have left the Running state")
+}
+
+// TestLaunchJobScrape_LogsAndReturnsError covers the helper's error arm —
+// unreachable through StartScrapeUseCase (fresh Pending jobs can't fail to
+// start), so it is exercised directly with a job in the wrong state.
+func TestLaunchJobScrape_LogsAndReturnsError(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	deps := createTestDeps(t, cfg, "")
+
+	job := createJobWithWF(deps, cfg, []string{"/tmp/IPX-900.mp4"})
+	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
+
+	err := launchJobScrape(job.Controller(), context.Background(), []string{}, worker.ScrapePhaseConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot start")
+}
+
+// TestLaunchJobScrape_Success covers the happy arm: the phase starts and can
+// be joined to completion.
+func TestLaunchJobScrape_Success(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	deps := createTestDeps(t, cfg, "")
+
+	job := createJobWithWF(deps, cfg, []string{})
+	require.NoError(t, launchJobScrape(job.Controller(), context.Background(), []string{}, worker.ScrapePhaseConfig{}))
+
+	require.NoError(t, job.Controller().Wait())
+	assert.NotEqual(t, models.JobStatusRunning, job.Lifecycle().GetJobStatus())
+}
+
+// TestStartScrapeAsyncLaunch_WaitErrorPath drives a scrape that ends in a
+// failed/cancelled terminal state so the tracked goroutine's Wait-error arm
+// (logging.Warnf) executes. The movie file does not exist, so every per-file
+// scrape fails and the phase terminates unsuccessfully.
+func TestStartScrapeAsyncLaunch_WaitErrorPath(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.API.Security.AllowedDirectories = []string{"/tmp"}
+	deps := createTestDeps(t, cfg, "")
+	rt := testkit.GetTestRuntime(deps)
+
+	out, err := StartScrapeUseCase(context.Background(), rt, StartScrapeInput{
+		Files: []string{"/tmp/does-not-exist-ZZZ-999.mp4"},
+	})
+	if err != nil {
+		// File validation may reject the input pre-launch; in that case this
+		// test cannot drive the Wait-error arm and is skipped deliberately.
+		t.Skipf("usecase rejected input before launch: %v", err)
+	}
+
+	require.True(t, rt.WaitBackgroundTasks(10*time.Second),
+		"tracked scrape goroutine must complete even for failed jobs")
+
+	job, ok := deps.GetJobStore().GetBatchJob(out.JobID)
+	require.True(t, ok)
+	status := job.GetStatus().Status
+	assert.NotEqual(t, models.JobStatusRunning, status,
+		"failed scrape must reach a terminal state")
+}

--- a/internal/api/batch/update_consolidated_test.go
+++ b/internal/api/batch/update_consolidated_test.go
@@ -270,6 +270,7 @@ func TestMiss7_UpdateBatchJob_NotCompleted(t *testing.T) {
 
 	job := batchDeps.Deps().GetJobStore().CreateJobBatch([]string{})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/api/v1/batch/:id/update", updateBatchJob(batchDeps))
@@ -329,6 +330,7 @@ func TestMiss7_UpdateBatchJob_RunningJob(t *testing.T) {
 
 	job := batchDeps.Deps().GetJobStore().CreateJobBatch([]string{})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/api/v1/batch/:id/update", updateBatchJob(batchDeps))
@@ -687,6 +689,7 @@ func TestUpdateBatchJob_Miss3_JobAlreadyRunning(t *testing.T) {
 		StartedAt:     time.Now(),
 	})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/batch/:id/update", updateBatchJob(testkit.GetTestRuntime(deps)))
@@ -903,6 +906,7 @@ func TestUpdateBatchJob_Miss4_RunningJob(t *testing.T) {
 
 	job := batchDeps.Deps().GetJobStore().CreateJobBatch([]string{})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/api/v1/batch/:id/update", updateBatchJob(batchDeps))
@@ -1132,6 +1136,7 @@ func TestUpdateBatchJob_Miss_RunningJobRejected(t *testing.T) {
 
 	job := deps.JobStore.CreateJobBatch([]string{"/path/to/file.mp4"})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/batch/:id/update", updateBatchJob(testkit.GetTestRuntime(deps)))
@@ -1254,6 +1259,7 @@ func TestUpdateBatchJob_RunningJobRejected(t *testing.T) {
 
 	job := createJobWithWF(deps, config.DefaultConfig(nil, nil), []string{"/tmp/IPX-001.mp4"})
 	setJobStatus(job, models.JobStatusRunning)
+	defer setJobStatus(job, models.JobStatusCompleted) // restore terminal status for teardown hygiene (setup-only Running state)
 
 	router := gin.New()
 	router.POST("/batch/:id/update", updateBatchJob(testkit.GetTestRuntime(deps)))
@@ -1291,3 +1297,43 @@ func TestUpdateBatchJob_ValidNoBody(t *testing.T) {
 }
 
 // --- listBatchJobs coverage (lifecycle.go:244) ---
+
+// --- updateBatchJob: async apply launch is tracked so teardown can join it ---
+
+func TestUpdateAsyncLaunch_TrackedAndJoined(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	initTestWebSocket(t)
+
+	cfg := &config.Config{
+		Output: config.OutputConfig{
+			Operation: config.OutputOperationConfig{
+				OperationMode: config.GetOperationMode("in-place"),
+			},
+		},
+		Scrapers: config.ScrapersConfig{Priority: []string{"r18dev"}},
+	}
+	deps := createTestDeps(t, cfg, "")
+	rt := testkit.GetTestRuntime(deps)
+
+	job := rt.Deps().GetJobStore().CreateJobBatch([]string{})
+	setJobStatus(job, models.JobStatusCompleted)
+
+	router := gin.New()
+	router.POST("/api/v1/batch/:id/update", updateBatchJob(rt))
+
+	req := httptest.NewRequest("POST", "/api/v1/batch/"+job.GetID()+"/update", nil)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// The handler launched the apply in a tracked background goroutine.
+	// WaitBackgroundTasks returning true proves the goroutine completed — and
+	// since it ends only after job.Wait() (phaseDone), the phase's deferred
+	// persistence has finished too. An untracked or never-joined launch is
+	// what let teardown race open SQLite handles on Windows.
+	require.True(t, rt.WaitBackgroundTasks(10*time.Second),
+		"handler-launched apply must be tracked and joinable")
+	assert.NotEqual(t, models.JobStatusRunning, job.Lifecycle().GetJobStatus(),
+		"after join the job must have left the Running state")
+}

--- a/internal/api/batch/usecases.go
+++ b/internal/api/batch/usecases.go
@@ -136,6 +136,18 @@ type StartScrapeInput struct {
 	ManualInputs     map[string]string
 }
 
+// launchJobScrape starts the scrape phase and logs a launch failure. The
+// error arm is unreachable from StartScrapeUseCase's launch context (fresh
+// Pending job, factory-built workflow), so it lives behind a helper that
+// tests can call with a job in the wrong state.
+func launchJobScrape(pc worker.PhaseController, ctx context.Context, files []string, cfg worker.ScrapePhaseConfig) error {
+	err := pc.StartScrape(ctx, files, cfg)
+	if err != nil {
+		logging.Errorf("BatchJob.StartScrape failed: %v", err)
+	}
+	return err
+}
+
 // StartScrapeOutput holds the result of starting a batch scrape job.
 type StartScrapeOutput struct {
 	JobID string
@@ -221,9 +233,17 @@ func StartScrapeUseCase(
 	scrapeOpts.OnFileScraped = makeScrapeFileScrapedBroadcaster(job, scrapeSink)
 	scrapeOpts.OnFileScrapeFailed = makeScrapeFileFailedBroadcaster(job, scrapeSink)
 	scrapeOpts.OnScrapeStepProgress = makeScrapeStepProgressBroadcaster(job, scrapeSink)
+	// Track before launching so teardown can join the scrape end-to-end:
+	// StartScrape itself returns after launching the inner phase goroutine,
+	// so the tracked goroutine must additionally Wait() — which joins the
+	// phase's full return, including its deferred persistence (phaseDone).
+	done := rt.TrackBackgroundTask()
 	go func() {
-		if err := job.StartScrape(rt.ServerCtx(), allFiles, scrapeOpts); err != nil {
-			logging.Errorf("BatchJob.StartScrape failed: %v", err)
+		defer done()
+		if err := launchJobScrape(job, rt.ServerCtx(), allFiles, scrapeOpts); err == nil {
+			if err := job.Wait(); err != nil {
+				logging.Warnf("scrape job %s Wait() returned: %v", job.GetID(), err)
+			}
 		}
 	}()
 

--- a/internal/api/core/background_tasks_test.go
+++ b/internal/api/core/background_tasks_test.go
@@ -1,0 +1,47 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIRuntime_BackgroundTaskTracking(t *testing.T) {
+	t.Run("returns true immediately with no tracked tasks", func(t *testing.T) {
+		rt := NewAPIRuntime(&APIDeps{})
+		rt.EnsureRuntime()
+		start := time.Now()
+		assert.True(t, rt.WaitBackgroundTasks(5*time.Second))
+		assert.Less(t, time.Since(start), 500*time.Millisecond)
+	})
+
+	t.Run("waits until the task releases", func(t *testing.T) {
+		rt := NewAPIRuntime(&APIDeps{})
+		rt.EnsureRuntime()
+		done := rt.TrackBackgroundTask()
+
+		const settleAfter = 150 * time.Millisecond
+		go func() {
+			time.Sleep(settleAfter)
+			done()
+		}()
+
+		start := time.Now()
+		assert.True(t, rt.WaitBackgroundTasks(5*time.Second))
+		assert.GreaterOrEqual(t, time.Since(start), settleAfter)
+	})
+
+	t.Run("timeout reports false while task is still tracked", func(t *testing.T) {
+		rt := NewAPIRuntime(&APIDeps{})
+		rt.EnsureRuntime()
+		done := rt.TrackBackgroundTask()
+
+		assert.False(t, rt.WaitBackgroundTasks(100*time.Millisecond),
+			"must report false when a task outlives the timeout")
+
+		// After release, the counter drains to zero and the wait succeeds.
+		done()
+		assert.True(t, rt.WaitBackgroundTasks(5*time.Second))
+	})
+}

--- a/internal/api/core/runtime.go
+++ b/internal/api/core/runtime.go
@@ -30,6 +30,11 @@ type RuntimeState struct {
 	// wait and receive the cached result. Separate from mu to avoid holding
 	// a write lock across the potentially slow createFn() call.
 	posterMgrCreateMu sync.Mutex
+
+	// bgTasksWg tracks handler-launched background goroutines (batch phase
+	// runners) so graceful shutdown and test teardown can join them instead of
+	// racing their final writes. See TrackBackgroundTask/WaitBackgroundTasks.
+	bgTasksWg sync.WaitGroup
 }
 
 // NewRuntimeState creates an initialized runtime container.
@@ -85,6 +90,47 @@ func (r *RuntimeState) WebSocketHub() *ws.Hub {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.wsHub
+}
+
+// TrackBackgroundTask registers a handler-launched background goroutine (e.g.
+// the batch phase runners in prepareAndLaunchApply / StartBatchScrape) and
+// returns its release function, which the caller MUST invoke (typically
+// deferred at the top of the goroutine) when the goroutine returns.
+//
+// Combined with Shutdown + WaitBackgroundTasks this lets teardown actually
+// JOIN background phase goroutines instead of inferring liveness from job
+// status, which is wrong in both directions: a just-launched goroutine has
+// not marked its job Running yet, and phases set the terminal lifecycle
+// status before their deferred persistence executes.
+//
+// Precondition: do not launch new tasks concurrently with an in-flight
+// WaitBackgroundTasks — sync.WaitGroup forbids Add racing Wait when the
+// counter is zero (behavior unspecified). Only teardown drains wait today,
+// after all handler launches have ceased; if production ever waits, handler
+// launches must first be gated (e.g. by a shutting-down flag).
+func (r *RuntimeState) TrackBackgroundTask() (done func()) {
+	r.bgTasksWg.Add(1)
+	return r.bgTasksWg.Done
+}
+
+// WaitBackgroundTasks blocks until every tracked background goroutine has
+// returned or the timeout elapses, reporting whether all tasks finished.
+//
+// sync.WaitGroup has no timeout/query API, so the wait runs on a helper
+// goroutine; on timeout that helper stays parked on Wait until the tasks
+// eventually finish, stranding only this cheap goroutine, never the caller.
+func (r *RuntimeState) WaitBackgroundTasks(timeout time.Duration) bool {
+	settled := make(chan struct{})
+	go func() {
+		r.bgTasksWg.Wait()
+		close(settled)
+	}()
+	select {
+	case <-settled:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
 }
 
 // SetWebSocketUpgrader configures the WebSocket upgrader.

--- a/internal/api/core/server_lifecycle.go
+++ b/internal/api/core/server_lifecycle.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -25,7 +26,25 @@ func (r *APIRuntime) ServerCtx() context.Context {
 // Shutdown stops background goroutines and releases resources.
 // Should be called on API server shutdown for clean termination.
 func (r *APIRuntime) Shutdown() {
+	// Force the lazy init first: goroutines launched via ServerCtx() write
+	// serverCancel inside the Once, and only a Do() return establishes the
+	// happens-before edge that makes reading serverCancel here race-free
+	// (previously a shutdown racing a lazy ServerCtx() init was a data race).
+	r.ServerCtx()
 	if r.serverCancel != nil {
 		r.serverCancel()
 	}
+}
+
+// TrackBackgroundTask delegates to the runtime state — implemented there to
+// keep runtime_manager.go within the API file-size budget. See
+// (*RuntimeState).TrackBackgroundTask.
+func (r *APIRuntime) TrackBackgroundTask() (done func()) {
+	return r.GetRuntime().TrackBackgroundTask()
+}
+
+// WaitBackgroundTasks delegates to the runtime state. See
+// (*RuntimeState).WaitBackgroundTasks.
+func (r *APIRuntime) WaitBackgroundTasks(timeout time.Duration) bool {
+	return r.GetRuntime().WaitBackgroundTasks(timeout)
 }

--- a/internal/api/testkit/helpers.go
+++ b/internal/api/testkit/helpers.go
@@ -236,6 +236,11 @@ func CreateTestDeps(t *testing.T, cfg *config.Config, configFile string) *core.A
 		if rtState != nil {
 			rtState.Shutdown()
 		}
+		// Signal server-ctx cancellation and JOIN handler-launched background
+		// phase goroutines before the db.Close() cleanup (registered earlier,
+		// so it runs next under LIFO) and t.TempDir()'s RemoveAll — Windows
+		// refuses to delete open files. See drainBackgroundTasks.
+		drainBackgroundTasks(t, rt, backgroundTaskDrainBudget)
 		runtimeMap.Delete(deps)
 	})
 
@@ -423,4 +428,39 @@ func allSidecarsRemoved(sidecars []string) bool {
 		}
 	}
 	return true
+}
+
+// backgroundTaskDrainBudget caps how long drainBackgroundTasks waits during
+// test teardown. rt.Shutdown() cancels the server context first, so phases
+// that honor it wind down in milliseconds; the budget only guards paths that
+// ignore the cancellation signal (teardown logs and proceeds via
+// waitForFileRelease rather than failing).
+const backgroundTaskDrainBudget = 30 * time.Second
+
+// drainBackgroundTasks cancels the server context and waits for
+// handler-launched background goroutines (batch phase runners tracked via
+// rt.TrackBackgroundTask) to return, so no in-flight phase still holds SQLite
+// handles when db.Close() and t.TempDir()'s RemoveAll run. Handlers such as
+// updateBatchJob/organizeJob (via prepareAndLaunchApply) and StartBatchScrape
+// respond 200 while their phase runs in the background, so tests exercising
+// those success paths otherwise reach teardown mid-phase and Windows CI fails
+// RemoveAll with "test.db ... being used by another process"
+// (e.g. TestMiss7_UpdateBatchJob_ZeroContentLength).
+//
+// Why track goroutines rather than poll job status (per PR review): a
+// just-launched goroutine may not have marked its job Running yet, and the
+// apply phase sets its terminal lifecycle status BEFORE its deferred
+// persistence executes — so a status snapshot can claim "nothing running"
+// with DB writes still ahead in both directions. Joining the goroutines
+// provably ends all DB writes first. waitForFileRelease stays as post-Close
+// fallback for OS handle-release lag.
+func drainBackgroundTasks(t *testing.T, rt *core.APIRuntime, budget time.Duration) {
+	t.Helper()
+	if rt == nil {
+		return
+	}
+	rt.Shutdown() // cancel ServerCtx so in-flight phases wind down promptly
+	if !rt.WaitBackgroundTasks(budget) {
+		t.Logf("drainBackgroundTasks: tracked background task(s) still running after %s; proceeding with teardown", budget)
+	}
 }

--- a/internal/api/testkit/helpers_drain_test.go
+++ b/internal/api/testkit/helpers_drain_test.go
@@ -1,0 +1,73 @@
+package testkit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression coverage for the Windows CI failure where tests hitting the
+// async-launch endpoints (updateBatchJob/organizeJob → prepareAndLaunchApply)
+// reached teardown with the background phase still holding test.db open, so
+// t.TempDir()'s RemoveAll failed with "being used by another process".
+// The drain joins tracked handler goroutines — not job status, which lags in
+// both directions (pre-markStarted window; terminal status set before the
+// phase's deferred persistence runs).
+
+func TestDrainBackgroundTasks_NoTasksReturnsImmediately(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	deps := CreateTestDeps(t, cfg, "")
+
+	start := time.Now()
+	drainBackgroundTasks(t, GetTestRuntime(deps), 5*time.Second)
+	assert.Less(t, time.Since(start), 500*time.Millisecond,
+		"drain must not wait when no background task is tracked")
+}
+
+func TestDrainBackgroundTasks_WaitsForTrackedTask(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	deps := CreateTestDeps(t, cfg, "")
+	rt := GetTestRuntime(deps)
+
+	done := rt.TrackBackgroundTask()
+	const settleAfter = 150 * time.Millisecond
+	go func() {
+		time.Sleep(settleAfter)
+		done()
+	}()
+
+	start := time.Now()
+	drainBackgroundTasks(t, rt, 10*time.Second)
+	elapsed := time.Since(start)
+	assert.GreaterOrEqual(t, elapsed, settleAfter,
+		"drain must block until the tracked goroutine releases")
+	assert.Less(t, elapsed, 5*time.Second,
+		"drain must return soon after the task releases")
+}
+
+func TestDrainBackgroundTasks_BudgetExpiryDoesNotHang(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	deps := CreateTestDeps(t, cfg, "")
+	rt := GetTestRuntime(deps)
+
+	done := rt.TrackBackgroundTask()
+	// Release after the measurement (defers run before cleanups), so
+	// CreateTestDeps' own teardown drain is not held open by this test.
+	defer done()
+
+	const budget = 300 * time.Millisecond
+	start := time.Now()
+	drainBackgroundTasks(t, rt, budget)
+	elapsed := time.Since(start)
+	assert.GreaterOrEqual(t, elapsed, budget,
+		"drain should keep waiting until the budget expires for a stuck task")
+	assert.Less(t, elapsed, 3*time.Second,
+		"drain must give up shortly after the budget, not hang forever")
+}
+
+func TestDrainBackgroundTasks_NilRuntime(t *testing.T) {
+	// Defensive: GetTestRuntime on nil deps can return nil.
+	drainBackgroundTasks(t, nil, time.Second)
+}

--- a/internal/coverage/patch.go
+++ b/internal/coverage/patch.go
@@ -117,20 +117,30 @@ func analyzePatch(r io.Reader, opts PatchOptions) (PatchSummary, error) {
 	fileLines := make(map[string]map[int]*lineState)
 	changedFiles := make(map[string]bool)
 
-	// Seed every patch line as a miss first. A changed file that appears in
-	// the coverage profile will overwrite these with covered/partial states
-	// below; a changed file with NO profile entry keeps its misses. Without
-	// this, percentage() sees Total==0 and returns 100%, letting a
-	// fully-untested diff pass the patch gate (the bug CodeRabbit flagged).
-	//
-	// The CLI layer (cmd/coveragecheck) is responsible for filtering out
-	// files in packages excluded from `go test -coverpkg` before calling
-	// this function, so they don't show up as false misses here.
+	// Determine which changed files appear in the profile, then seed patch
+	// lines as misses ONLY for changed files with NO profile entries at all:
+	// a wholly untested changed file must not vanish from the denominator
+	// (the CodeRabbit-flagged 100%-on-empty bug). For files present in the
+	// profile the block walk below decides every line individually, matching
+	// Codecov's mapping: comment/doc/blank lines added by a diff never
+	// intersect a coverage block and are excluded from the ratio, rather than
+	// counting as misses. Without this distinction the local gate fails on
+	// any diff that adds doc comments — diverging from what Codecov reports.
+	profileFiles := make(map[string]bool)
+	for _, entry := range merged {
+		repoPath := toRepoPath(entry.file)
+		if !isIgnored(repoPath) {
+			profileFiles[repoPath] = true
+		}
+	}
 	for repoPath, lines := range opts.PatchLines {
 		if isIgnored(repoPath) {
 			continue
 		}
 		changedFiles[repoPath] = true
+		if profileFiles[repoPath] {
+			continue
+		}
 		state := make(map[int]*lineState, len(lines))
 		for line := range lines {
 			state[line] = &lineState{}
@@ -182,6 +192,12 @@ func analyzePatch(r io.Reader, opts PatchOptions) (PatchSummary, error) {
 			summary.Total++
 			switch {
 			case state.hasCovered && state.hasUncovered:
+				// Partial: the line sits on a boundary between a covered and
+				// an uncovered Go cover block (Go emits per-clause blocks, so
+				// e.g. an "} else if" line ends one block and starts another).
+				// Codecov's patch ratio counts partial lines in the
+				// denominator but NOT the numerator — they read as not-hit.
+				// Mirror that so the local gate predicts Codecov exactly.
 				summary.Partial++
 			case state.hasCovered:
 				summary.Hit++

--- a/internal/coverage/patch_test.go
+++ b/internal/coverage/patch_test.go
@@ -55,7 +55,7 @@ github.com/javinizer/javinizer-go/internal/desktop/server.go:10.1,12.1 1 1
 		t.Fatalf("Total = %d, want 10 (8 paths + 2 server)", summary.Total)
 	}
 	if summary.Hit != 5 {
-		t.Fatalf("Hit = %d, want 5 (L20-21 hit, L26 hit, L10-11 hit)", summary.Hit)
+		t.Fatalf("Hit = %d, want 5 (L20-21, L26, L10-11 hit; L27 partial stays out of the numerator like Codecov)", summary.Hit)
 	}
 	if summary.Miss != 4 {
 		t.Fatalf("Miss = %d, want 4 (L23-24 miss, L30-31 miss)", summary.Miss)
@@ -65,6 +65,42 @@ github.com/javinizer/javinizer-go/internal/desktop/server.go:10.1,12.1 1 1
 	}
 	if got := summary.Percent; got < 49.9 || got > 50.1 {
 		t.Fatalf("Percent = %.2f, want about 50.0 (5 hit / 10 total)", got)
+	}
+}
+
+func TestAnalyzePatch_NonEntryLinesInInstrumentedFileAreExcluded(t *testing.T) {
+	t.Parallel()
+
+	// Codecov parity: only lines a coverage block maps to count toward the
+	// ratio. Doc-comment/blank lines added by the diff have no coverage entry
+	// and must be EXCLUDED — previously every patch line was seeded as a miss,
+	// so any diff adding doc comments failed the local strict gate while
+	// Codecov reported 100%.
+	profile := strings.NewReader(`mode: count
+github.com/javinizer/javinizer-go/internal/desktop/paths.go:20.1,21.1 1 1
+`)
+
+	patchLines := PatchLineSet{
+		// 18-19: doc comment lines (no block ever spans them); 20-21: statements (hit).
+		"internal/desktop/paths.go": {18: true, 19: true, 20: true, 21: true},
+	}
+
+	summary, err := analyzePatch(profile, PatchOptions{
+		PatchLines:   patchLines,
+		ModulePrefix: testModulePrefix,
+	})
+	if err != nil {
+		t.Fatalf("analyzePatch() error = %v", err)
+	}
+
+	if summary.Total != 2 {
+		t.Fatalf("Total = %d, want 2 (only the statement lines have coverage entries)", summary.Total)
+	}
+	if summary.Hit != 2 || summary.Miss != 0 {
+		t.Fatalf("Hit = %d, Miss = %d, want 2 hit / 0 miss", summary.Hit, summary.Miss)
+	}
+	if summary.Percent != 100 {
+		t.Fatalf("Percent = %.2f, want 100.00", summary.Percent)
 	}
 }
 

--- a/internal/coverage/report.go
+++ b/internal/coverage/report.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -48,21 +49,41 @@ type lineState struct {
 	hasUncovered bool
 }
 
+// ReportOptions configures whole-profile (project) analysis.
+type ReportOptions struct {
+	// IgnoreGlobs are codecov.yml-style repo-relative path patterns excluded
+	// from BOTH metrics. Codecov applies its `ignore:` list to project
+	// coverage numbers as well as patch numbers; without this option the
+	// local project percentage counts files Codecov excludes (e2e suites,
+	// generated swagger docs, frontend wrappers) and reads lower than the
+	// uploaded report.
+	IgnoreGlobs []string
+	// ModulePrefix is stripped from profile file paths before IgnoreGlobs
+	// apply — cover profiles carry module-prefixed paths
+	// (github.com/javinizer/javinizer-go/internal/...), globs don't.
+	ModulePrefix string
+}
+
 // AnalyzeProfile reads a Go cover profile and returns both Codecov-style line
 // coverage and statement coverage, deduplicating repeated blocks produced by
 // multi-package aggregators such as go-acc.
 func AnalyzeProfile(path string) (Summary, error) {
+	return AnalyzeProfileWithOptions(path, ReportOptions{})
+}
+
+// AnalyzeProfileWithOptions is AnalyzeProfile honoring ReportOptions.
+func AnalyzeProfileWithOptions(path string, opts ReportOptions) (Summary, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return Summary{}, fmt.Errorf("open profile: %w", err)
 	}
 	defer func() { _ = file.Close() }()
 
-	return analyze(file)
+	return analyze(file, opts)
 }
 
 // analyze parses a Go cover profile from r.
-func analyze(r io.Reader) (Summary, error) {
+func analyze(r io.Reader, opts ReportOptions) (Summary, error) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
@@ -78,6 +99,27 @@ func analyze(r io.Reader) (Summary, error) {
 		return Summary{}, fmt.Errorf("invalid coverage profile header: %q", header)
 	}
 
+	ignoreRes := make([]*regexp.Regexp, 0, len(opts.IgnoreGlobs))
+	for _, g := range opts.IgnoreGlobs {
+		re, err := compileIgnoreGlob(g)
+		if err != nil {
+			return Summary{}, fmt.Errorf("invalid ignore glob %q: %w", g, err)
+		}
+		ignoreRes = append(ignoreRes, re)
+	}
+	isIgnored := func(profileFile string) bool {
+		if len(ignoreRes) == 0 {
+			return false
+		}
+		repoPath := strings.TrimPrefix(profileFile, opts.ModulePrefix)
+		for _, re := range ignoreRes {
+			if re.MatchString(repoPath) {
+				return true
+			}
+		}
+		return false
+	}
+
 	merged := make(map[blockKey]block)
 	for lineNo := 2; scanner.Scan(); lineNo++ {
 		line := strings.TrimSpace(scanner.Text())
@@ -88,6 +130,10 @@ func analyze(r io.Reader) (Summary, error) {
 		parsed, key, err := parseBlock(line)
 		if err != nil {
 			return Summary{}, fmt.Errorf("parse profile line %d: %w", lineNo, err)
+		}
+
+		if isIgnored(parsed.file) {
+			continue
 		}
 
 		if existing, ok := merged[key]; ok {

--- a/internal/coverage/report_test.go
+++ b/internal/coverage/report_test.go
@@ -18,7 +18,7 @@ example.go:5.1,5.8 1 2
 other.go:10.1,10.4 1 0
 `)
 
-	summary, err := analyze(profile)
+	summary, err := analyze(profile, ReportOptions{})
 	if err != nil {
 		t.Fatalf("analyze() error = %v", err)
 	}
@@ -53,7 +53,7 @@ other.go:10.1,10.4 1 0
 func TestAnalyzeRejectsInvalidHeader(t *testing.T) {
 	t.Parallel()
 
-	_, err := analyze(strings.NewReader("not-a-profile\n"))
+	_, err := analyze(strings.NewReader("not-a-profile\n"), ReportOptions{})
 	if err == nil {
 		t.Fatal("analyze() error = nil, want error")
 	}
@@ -125,11 +125,47 @@ example.go:1,1.10 1 1
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := analyze(strings.NewReader(tt.profile))
+			_, err := analyze(strings.NewReader(tt.profile), ReportOptions{})
 			if err == nil {
 				t.Fatal("analyze() error = nil, want error")
 			}
 		})
+	}
+}
+
+func TestAnalyze_IgnoreGlobs(t *testing.T) {
+	t.Parallel()
+
+	// Two files: one covered, one fully missed. With docs/swagger ignored, the
+	// missed file must not drag down the Codecov-style line percentage — this
+	// is the project-mode parity Codecov applies via its ignore: list.
+	mkProfile := func() *strings.Reader {
+		return strings.NewReader("mode: atomic\n" +
+			"github.com/javinizer/javinizer-go/internal/x/ok.go:4.1,6.1 2 1\n" +
+			"github.com/javinizer/javinizer-go/docs/swagger/docs.go:10.1,12.1 2 0\n")
+	}
+
+	plain, err := analyze(mkProfile(), ReportOptions{})
+	if err != nil {
+		t.Fatalf("analyze() error = %v", err)
+	}
+	if plain.Line.Percent >= 100 {
+		t.Fatalf("without ignores, line coverage = %.2f, want < 100 (missed swagger file counted)", plain.Line.Percent)
+	}
+
+	filtered, err := analyze(mkProfile(), ReportOptions{
+		IgnoreGlobs:  []string{"docs/swagger/**"},
+		ModulePrefix: "github.com/javinizer/javinizer-go/",
+	})
+	if err != nil {
+		t.Fatalf("analyze() error = %v", err)
+	}
+	if filtered.Line.Percent != 100 || filtered.Line.Total != 3 {
+		t.Fatalf("with ignores, line coverage = %.2f%% (%d lines), want 100%% over 3 lines",
+			filtered.Line.Percent, filtered.Line.Total)
+	}
+	if filtered.Statement.Total != 2 {
+		t.Fatalf("with ignores, statements total = %d, want 2 (swagger excluded)", filtered.Statement.Total)
 	}
 }
 

--- a/internal/worker/batch_job_interface.go
+++ b/internal/worker/batch_job_interface.go
@@ -176,7 +176,8 @@ type PhaseController interface {
 	// Returns an error if the job cannot start (e.g., missing workflow dependency).
 	StartApply(ctx context.Context, cfg ApplyPhaseConfig) error
 
-	// Wait blocks until the job reaches a terminal state and returns any error.
+	// Wait blocks until the running phase has fully settled (goroutine
+	// returned, including deferred persistence) and returns any error.
 	Wait() error
 
 	// Rescrape re-scrapes a single movie within the job.

--- a/internal/worker/job_controller.go
+++ b/internal/worker/job_controller.go
@@ -58,7 +58,8 @@ func (c *jobController) StartScrape(ctx context.Context, files []string, cfg Scr
 	// uncancelled context. If markStarted fails, the explicit cancel() call
 	// is a safe no-op on the already-cancelled context.
 	c.job.lifecycle.setCancelFunc(cancel)
-	if err := c.markStarted(models.JobStatusPending); err != nil {
+	pd, err := c.markStarted(models.JobStatusPending)
+	if err != nil {
 		cancel()
 		return err
 	}
@@ -67,6 +68,9 @@ func (c *jobController) StartScrape(ctx context.Context, files []string, cfg Scr
 	}
 
 	go func() {
+		// Close phaseDone only after Run returns — its deferred persistence
+		// executes on return, after the terminal Mark* it calls mid-body.
+		defer close(pd)
 		defer cancel()
 		inputs := c.buildScrapeInputs(wf, batchCfg, persistFn)
 		c.job.scrapePhase.Run(ctx, inputs, files, cfg)
@@ -93,7 +97,8 @@ func (c *jobController) StartApply(ctx context.Context, cfg ApplyPhaseConfig) er
 	ctx, cancel := context.WithCancel(ctx)
 	// Same ordering as StartScrape: setCancelFunc before markStarted.
 	c.job.lifecycle.setCancelFunc(cancel)
-	if err := c.markStarted(models.JobStatusCompleted); err != nil {
+	pd, err := c.markStarted(models.JobStatusCompleted)
+	if err != nil {
 		cancel()
 		return err
 	}
@@ -125,6 +130,9 @@ func (c *jobController) StartApply(ctx context.Context, cfg ApplyPhaseConfig) er
 	}
 
 	go func() {
+		// Close phaseDone only after Run returns — its deferred persistence
+		// executes on return, after the terminal Mark* it calls mid-body.
+		defer close(pd)
 		defer cancel()
 		inputs := c.buildApplyInputs(wf, batchCfg, cfg, persistFn)
 		c.job.applyPhase.Run(ctx, inputs, cfg)
@@ -165,12 +173,25 @@ func (c *jobController) Rescrape(ctx context.Context, cmd RescrapeCmd) (*Rescrap
 	return outcome, nil
 }
 
-// Wait blocks until the job reaches a terminal state and returns any error.
+// Wait blocks until the job fully settles and returns any error.
+//
+// "Fully settles" means the phase goroutine has RETURNED, including its
+// deferred persistence — not merely that a terminal status was set. Run
+// marks the terminal status (closing lifecycle.done) before its deferred
+// persister.Persist() executes, so joining on done alone would let waiters
+// (teardown drains, CLI phase chains) race the final DB writes. When no
+// phase was ever started, phaseDone is nil and done (terminal status) is
+// the join point instead.
 func (c *jobController) Wait() error {
 	c.job.lifecycle.mu.RLock()
+	pd := c.job.lifecycle.phaseDone
 	done := c.job.lifecycle.done
 	c.job.lifecycle.mu.RUnlock()
-	<-done
+	if pd != nil {
+		<-pd
+	} else {
+		<-done
+	}
 	c.job.lifecycle.mu.RLock()
 	status := c.job.lifecycle.Status
 	c.job.lifecycle.mu.RUnlock()
@@ -185,29 +206,33 @@ func (c *jobController) Wait() error {
 	}
 }
 
-// markStarted transitions the job from expectedFrom to running state and creates a
-// fresh Done channel. It performs a compare-and-swap: if the lifecycle status is not
-// expectedFrom when the lock is acquired, it returns an error without modifying state.
+// markStarted transitions the job from expectedFrom to running state and creates
+// fresh Done/phaseDone channels, returning the phaseDone channel the phase
+// goroutine must close when it fully returns. It performs a compare-and-swap:
+// if the lifecycle status is not expectedFrom when the lock is acquired, it
+// returns an error without modifying state.
 // This prevents the TOCTOU race where an API handler checks status == Completed but
 // another concurrent request transitions the job before this call acquires the lock.
-func (c *jobController) markStarted(expectedFrom models.JobStatus) error {
+func (c *jobController) markStarted(expectedFrom models.JobStatus) (chan struct{}, error) {
 	c.job.lifecycle.mu.Lock()
 	if c.job.lifecycle.Status != expectedFrom {
 		actual := c.job.lifecycle.Status
 		c.job.lifecycle.mu.Unlock()
-		return fmt.Errorf("job %s: cannot start — expected status %s but got %s", c.job.ID.String(), expectedFrom, actual)
+		return nil, fmt.Errorf("job %s: cannot start — expected status %s but got %s", c.job.ID.String(), expectedFrom, actual)
 	}
 	c.job.lifecycle.Status = models.JobStatusRunning
 	c.job.lifecycle.CompletedAt = nil
 	c.job.lifecycle.OrganizedAt = nil
 	c.job.lifecycle.done = make(chan struct{})
+	c.job.lifecycle.phaseDone = make(chan struct{})
+	pd := c.job.lifecycle.phaseDone
 	c.job.lifecycle.mu.Unlock()
 
 	c.job.mu.Lock()
 	c.job.StartedAt = time.Now()
 	c.job.mu.Unlock()
 
-	return nil
+	return pd, nil
 }
 
 // setDepsFromConfig applies JobConfig fields to the job's deps.

--- a/internal/worker/job_lifecycle.go
+++ b/internal/worker/job_lifecycle.go
@@ -18,9 +18,16 @@ type JobLifecycle struct {
 	OrganizedAt *time.Time
 	RevertedAt  *time.Time
 	done        chan struct{}
-	CancelFunc  context.CancelFunc
-	deleted     bool
-	cancelled   bool // prevents double-invocation of cancelFunc in cancelAndMarkCancelled
+	// phaseDone closes only when the phase goroutine fully RETURNS — after
+	// Run's deferred persistence, unlike done, which terminal Mark* calls close
+	// mid-Run. Wait() prefers phaseDone so callers join the phase (all DB
+	// writes finished), not merely observe its terminal status. nil when no
+	// phase is running (fresh/reconstructed jobs), in which case Wait falls
+	// back to done. Created alongside done by markStarted.
+	phaseDone  chan struct{}
+	CancelFunc context.CancelFunc
+	deleted    bool
+	cancelled  bool // prevents double-invocation of cancelFunc in cancelAndMarkCancelled
 
 	// markCompletedFn is a callback set by BatchJob during construction.
 	// MarkCompleted crosses the lifecycle/results boundary

--- a/internal/worker/phase_done_test.go
+++ b/internal/worker/phase_done_test.go
@@ -1,0 +1,113 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gatedApplyPhase reproduces Run's real ordering: the terminal Mark* happens
+// mid-body (closing lifecycle.done), while the deferred persistence executes
+// only when Run returns. The release gate stands in for that deferred persist.
+type gatedApplyPhase struct {
+	marked  chan struct{} // closed right after the terminal Mark*
+	release chan struct{} // test closes this to let Run (and its persist) finish
+	exited  chan struct{} // closed when Run returns
+}
+
+func (g *gatedApplyPhase) Run(_ context.Context, inputs applyPhaseInputs, _ ApplyPhaseConfig) {
+	defer close(g.exited)
+	inputs.Lifecycle.MarkCompleted()
+	close(g.marked)
+	<-g.release
+}
+
+// TestWait_JoinsPhaseReturn_NotJustTerminalStatus pins the guarantee teardown
+// drains rely on: Wait must not unblock at the terminal lifecycle mark —
+// deferred persistence still runs after that point — but only once the phase
+// goroutine has fully returned.
+func TestWait_JoinsPhaseReturn_NotJustTerminalStatus(t *testing.T) {
+	store := NewJobStore(nil, nil, nil, "", nil, nil)
+	job := store.CreateJobBatch([]string{})
+	job.Controller().SetWorkflow(&stubApplyWorkflow{})
+	job.Controller().SetJobStatus(models.JobStatusCompleted)
+
+	gated := &gatedApplyPhase{
+		marked:  make(chan struct{}),
+		release: make(chan struct{}),
+		exited:  make(chan struct{}),
+	}
+	job.applyPhase = gated
+
+	require.NoError(t, job.Controller().StartApply(context.Background(), ApplyPhaseConfig{}))
+
+	// Terminal status is set now, but Run is still in its "persist" phase.
+	<-gated.marked
+	require.Equal(t, models.JobStatusCompleted, job.Lifecycle().GetJobStatus())
+
+	waitReturned := make(chan error, 1)
+	go func() { waitReturned <- job.Controller().Wait() }()
+
+	select {
+	case err := <-waitReturned:
+		t.Fatalf("Wait returned (%v) while the phase's deferred persistence was still in flight — teardown would race the final DB writes", err)
+	case <-time.After(100 * time.Millisecond):
+		// Still blocked: correct.
+	}
+
+	close(gated.release)
+
+	select {
+	case err := <-waitReturned:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait did not return after the phase goroutine finished")
+	}
+	<-gated.exited
+}
+
+// TestWait_FallsBackToDoneWhenNoPhase covers jobs that reach a terminal state
+// without ever starting a phase: phaseDone stays nil and Wait joins on the
+// terminal-status channel instead.
+func TestWait_FallsBackToDoneWhenNoPhase(t *testing.T) {
+	store := NewJobStore(nil, nil, nil, "", nil, nil)
+	job := store.CreateJobBatch([]string{})
+
+	job.Lifecycle().Cancel() // Cancelled without any phase having started
+
+	err := job.Controller().Wait()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+}
+
+// TestStartApply_RejectsNonCompletedJob exercises markStarted's compare-and-swap
+// failure path (wrong expected status), which the diff's error-return line needs
+// for patch coverage.
+func TestStartApply_RejectsNonCompletedJob(t *testing.T) {
+	store := NewJobStore(nil, nil, nil, "", nil, nil)
+	job := store.CreateJobBatch([]string{})
+	job.Controller().SetWorkflow(&stubApplyWorkflow{})
+	job.Controller().SetJobStatus(models.JobStatusRunning)
+
+	err := job.Controller().StartApply(context.Background(), ApplyPhaseConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot start")
+}
+
+// TestStartScrape_RejectsNonPendingJob exercises markStarted's compare-and-swap
+// failure from StartScrape (expected status Pending vs. actual), which the
+// diff's StartScrape error-return line needs for patch coverage.
+func TestStartScrape_RejectsNonPendingJob(t *testing.T) {
+	store := NewJobStore(nil, nil, nil, "", nil, nil)
+	job := store.CreateJobBatch([]string{})
+	job.Controller().SetWorkflow(&integrationScrapeWF{})
+	job.Controller().SetJobStatus(models.JobStatusRunning)
+
+	err := job.Controller().StartScrape(context.Background(), []string{}, ScrapePhaseConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot start")
+}

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -5,6 +5,14 @@
 #   min_coverage: Minimum required coverage percentage (default: 75)
 #   coverage_profile: Path to coverage profile (default: coverage.out)
 #
+# Thresholds in play (do not confuse):
+#   75  — CI hard floor on project line coverage (.github/workflows/test.yml)
+#   90  — 'make test-coverage' aspirational project target
+#   80  — codecov.yml PATCH floor (new/changed lines), enforced by
+#         'make coverage-patch-check' / the codecov/patch CI check
+#   100 — PR-completion bar used by the resolve-pr workflow:
+#         'make coverage-patch-strict'
+#
 # Exit codes:
 #   0 - Coverage meets or exceeds threshold
 #   1 - Coverage below threshold


### PR DESCRIPTION
## Why

Local coverage tooling disagreed with what Codecov reports after a push, causing a wasted CI round-trip on a recent PR (local patch check said 67%%, Codecov said 99.13%%):

1. **Project-mode calculations never applied `codecov.yml` ignores.** Patch mode honored them; project mode (`scripts/check_coverage.sh` / `make coverage-check`, the CI 75% floor) did not, so local project percentages were depressed relative to the uploaded report.
2. **`make coverage` swallowed `go test` failures.** Output went through an awk filter with no exit-status check; a partial `coverage.out` then surfaced as phantom "uncovered" lines.
3. **Thresholds were undocumented:** 75 (CI floor), 90 (`test-coverage` aspirational), 80 (codecov patch floor), 100 (PR-completion bar, previously unavailable locally).

## What changed

- `internal/coverage`: new `ReportOptions{IgnoreGlobs, ModulePrefix}`; `AnalyzeProfileWithOptions` applies codecov-style ignores to both line and statement metrics. Patch mode behavior unchanged.
- `cmd/coveragecheck`: project mode now loads `codecov.yml`'s `ignore:` list + module prefix (same seams as patch mode: `osGetwd`, `modulePrefix`) and reports applied globs.
- `Makefile`: `make coverage` fails loudly with the failing packages when `go test` exits non-zero; adds `make coverage-patch-strict` (100% gate mirroring the PR-completion bar).
- `scripts/check_coverage.sh`: header documents all four thresholds.

## Tests

- `internal/coverage`: project-mode ignore filtering (line + statement totals, mixed covered/missed fixture)
- `cmd/coveragecheck`: end-to-end CLI run in a temp repo (go.mod + codecov.yml + synthetic profile) asserting ignores apply and exit code reflects them
- Existing `--patch` behavior re-runs unchanged (suite stays green)