### PR TITLE
fix(ci): harden release version flow and add artifact assertions

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -73,6 +73,8 @@ jobs:
       - name: Resolve release metadata
         id: meta
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
@@ -120,7 +122,7 @@ jobs:
             fi
           elif [[ "${event_name}" == "workflow_dispatch" ]]; then
             release_type="${{ inputs.release_type }}"
-            input_version="${{ inputs.version }}"
+            input_version="${INPUT_VERSION}"
             create_release="${{ inputs.create_release }}"
             draft="${{ inputs.draft }}"
             is_nightly="false"
@@ -130,6 +132,7 @@ jobs:
               prerelease="true"
               publish_latest="false"
               is_nightly="true"
+              create_release="false"
             else
               case "${release_type}" in
                 stable)
@@ -154,6 +157,7 @@ jobs:
                   version="${input_version}"
                   prerelease="true"
                   publish_latest="false"
+                  create_release="false"
                   ;;
                 *)
                   echo "Unknown release type: ${release_type}" >&2
@@ -174,7 +178,9 @@ jobs:
               exit 1
             fi
           else
-            if [[ ! "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            release_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+            describe_re='-[0-9]+-g[0-9A-Fa-f]+(-dirty)?$'
+            if [[ ! "${version}" =~ ${release_re} ]] || [[ "${version}" =~ ${describe_re} ]]; then
               echo "Version does not match expected format: ${version}" >&2
               exit 1
             fi
@@ -184,6 +190,16 @@ jobs:
             if [[ "${tracked_version}" != "${version}" ]]; then
               echo "Tracked version (${tracked_version}) does not match requested release version (${version})" >&2
               exit 1
+            fi
+          fi
+
+          if [[ "${event_name}" == "workflow_dispatch" && -n "${input_version:-}" ]]; then
+            if git rev-parse -q --verify "refs/tags/${input_version}" >/dev/null 2>&1; then
+              tag_commit="$(git rev-list -n 1 "refs/tags/${input_version}")"
+              if [[ "${tag_commit}" != "${GITHUB_SHA}" ]]; then
+                echo "Tag ${input_version} points at ${tag_commit} but this run checked out ${GITHUB_SHA}; re-run the workflow from that tag/ref" >&2
+                exit 1
+              fi
             fi
           fi
 
@@ -330,6 +346,20 @@ jobs:
             -X github.com/javinizer/javinizer-go/internal/version.Commit=${COMMIT} \
             -X github.com/javinizer/javinizer-go/internal/version.BuildDate=${BUILD_DATE}" \
             -o "dist/${output}" ./cmd/javinizer
+
+      - name: Verify binary version
+        if: matrix.artifact_suffix == 'linux-amd64'
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          actual="$(./dist/${{ env.BINARY_NAME }}-${{ matrix.artifact_suffix }} version --short)"
+          if [[ "${actual}" != "${EXPECTED_VERSION}" ]]; then
+            echo "Binary version mismatch: got '${actual}', want '${EXPECTED_VERSION}'"
+            exit 1
+          fi
+          echo "Binary version OK: ${actual}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
@@ -807,6 +837,27 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.suffix }}
           cache-to: type=gha,scope=${{ matrix.suffix }},mode=max
 
+      - name: Verify pushed image version
+        if: needs.prepare-release.outputs.create_release == 'true' || needs.prepare-release.outputs.is_nightly == 'true'
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare-release.outputs.version }}
+          IMAGE_REF: ${{ steps.image.outputs.name }}:${{ needs.prepare-release.outputs.docker_version }}-${{ matrix.suffix }}
+        run: |
+          set -euo pipefail
+          docker pull "${IMAGE_REF}"
+          actual="$(docker run --rm --entrypoint /usr/local/bin/javinizer "${IMAGE_REF}" version --short)"
+          if [[ "${actual}" != "${EXPECTED_VERSION}" ]]; then
+            echo "Image binary version mismatch: got '${actual}', want '${EXPECTED_VERSION}'"
+            exit 1
+          fi
+          label="$(docker image inspect "${IMAGE_REF}" --format '{{ index .Config.Labels "org.opencontainers.image.version" }}')"
+          if [[ "${label}" != "${EXPECTED_VERSION}" ]]; then
+            echo "Image label version mismatch: got '${label}', want '${EXPECTED_VERSION}'"
+            exit 1
+          fi
+          echo "Image version OK: ${actual} (label: ${label})"
+
   merge-manifest:
     name: Merge multi-arch manifest (GHCR)
     needs: [prepare-release, build-docker]
@@ -863,7 +914,7 @@ jobs:
           prerelease="${{ needs.prepare-release.outputs.prerelease }}"
 
           tags=("${ver}")
-          [[ "${publish_latest}" == "true" ]] && tags+=("latest")
+          [[ "${publish_latest}" == "true" && "${prerelease}" != "true" ]] && tags+=("latest")
           [[ "${is_nightly}" == "true" ]] && tags+=("nightly" "nightly-${commit}")
           if [[ "${prerelease}" != "true" && -n "${major}" ]]; then
             tags+=("v${major}")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,6 +256,16 @@ jobs:
     - name: Install frontend dependencies
       run: npm ci --prefix web/frontend
 
+    - name: Resolve version
+      id: version
+      run: |
+        version="$(./scripts/version.sh)"
+        if [ -z "$version" ]; then
+          echo "Failed to resolve version"
+          exit 1
+        fi
+        echo "value=$version" >> "$GITHUB_OUTPUT"
+
     - name: Download dependencies
       run: go mod download
 
@@ -285,12 +295,19 @@ jobs:
 
     - name: Verify binary
       run: |
+        set -euo pipefail
         if [ ! -f bin/javinizer ]; then
           echo "Binary not created"
           exit 1
         fi
         chmod +x bin/javinizer
-        ./bin/javinizer --version || echo "Version check completed"
+        binary_version="$(./bin/javinizer version --short)"
+        expected="${{ steps.version.outputs.value }}"
+        if [ "${binary_version}" != "${expected}" ]; then
+          echo "Binary version mismatch: got '${binary_version}', want '${expected}'"
+          exit 1
+        fi
+        echo "Binary version OK: ${binary_version}"
 
     - name: Verify embedded web UI
       shell: bash
@@ -359,10 +376,16 @@ jobs:
 
     - name: Verify Docker metadata and version output
       run: |
-        docker run --rm --entrypoint /usr/local/bin/javinizer javinizer:test version --short
+        set -euo pipefail
+        expected="${{ steps.version.outputs.value }}"
+        binary_version="$(docker run --rm --entrypoint /usr/local/bin/javinizer javinizer:test version --short)"
+        if [ "${binary_version}" != "${expected}" ]; then
+          echo "Docker binary version mismatch: got '${binary_version}', want '${expected}'"
+          exit 1
+        fi
         image_version="$(docker inspect javinizer:test --format '{{ index .Config.Labels "org.opencontainers.image.version" }}')"
-        if [ "$image_version" != "${{ steps.version.outputs.value }}" ]; then
-          echo "Docker image label version mismatch: $image_version"
+        if [ "${image_version}" != "${expected}" ]; then
+          echo "Docker image label version mismatch: got '${image_version}', want '${expected}'"
           exit 1
         fi
 


### PR DESCRIPTION
## Summary

Hardening pass over the CLI/Docker release pipeline's version flow (`cli-release.yml`) and PR-CI version checks (`test.yml`):

- **Docker `latest` is now gated on non-prereleases** — previously any pushed tag (including `vX.Y.Z-rc.N`) re-tagged `:latest` on GHCR, because `publish_latest=true` was set before prerelease detection and manifest assembly never consulted `prerelease`. GitHub-side `make_latest` was already gated; only Docker was exposed.
- **Snapshots can no longer create GitHub releases** — `create_release=false` is now forced in both snapshot dispatch branches (the `create_release` input defaults to `true` and was silently inherited). This also suppresses Docker pushes and Discord notifications for manual snapshot runs; scheduled nightly behavior is unchanged.
- **Dispatch runs must build the commit their version names** — for `workflow_dispatch` with a version input that matches an existing tag, the tag's commit must equal `GITHUB_SHA`, otherwise the run fails fast with a re-dispatch hint. (Stable/prerelease were already covered indirectly by tracked-version equality; snapshot-with-input was not.)
- **Release versions are strictly validated** — no leading zeros, `-` required as prerelease separator, and git-describe distance strings (`v1.2.3-5-g<sha>[-dirty]`) explicitly rejected. All existing repo tags still pass.
- **Built artifacts are now asserted to report the release version** — `build-linux` runs `version --short` on the amd64 binary before upload; `build-docker` pulls each pushed per-arch image and asserts both the embedded binary version and the OCI label; previously the release pipeline never executed any artifact (only `imagetools inspect`).
- **PR CI compares fatally** — `test.yml`'s Docker job now compares the container's `version --short` output (previously printed and discarded, label-only assert), and the Build Verification job's `--version || echo` no-op is now a fatal compare against a pre-build `scripts/version.sh` oracle (pre-build so `--dirty` cannot diverge from what `make build` injects).
- `inputs.version` now reaches the metadata step via `env:` instead of direct shell interpolation.

## Verification

- Both workflow files parse (14 / 12 jobs intact); new step placement and `if:` gates confirmed structurally.
- Version-regex behavior simulated against 15 cases (accept: `v1.4.0`, `-rc.1`, `-alpha.2.1`, `v0.0.0-<sha>`; reject: `v1.2.3.rc1`, leading zeros, describe-distance strings); nightly regex behavior unchanged.
- Tag-commit validation plumbing proven live (`rev-list -n 1` peels annotated+lightweight tags; nounset guard inert on push/schedule).
- Pre-commit hooks green: gofmt, go vet, full `go test -short`, build verification, swagger freshness.

## Known accepted limitations

- Numeric prerelease identifiers with leading zeros (`v1.2.3-01`) still pass the release regex (not full SemVer 2.0 strictness).
- A tag literally named like a git-describe fallback (`v0.0.0-<sha>`) still passes — well-formed semver, unchanged from prior behavior.
- Nightly versions remain un-prefixed (`0.0.0-nightly.<sha7>`) by design; Homebrew/Scoop strip `v` independently.