### PR TITLE
fix(batch): persist manual poster crop through organize

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -5667,6 +5667,16 @@ const docTemplate = `{
                 "cropped_poster_url": {
                     "type": "string"
                 },
+                "original_cropped_poster_url": {
+                    "type": "string"
+                },
+                "original_poster_url": {
+                    "description": "Original poster fields echo the server-side pre-edit snapshot\n(backupPosterOriginals), so the client reset baseline never has to guess.\nEmpty when no snapshot was needed (no prior poster).",
+                    "type": "string"
+                },
+                "original_should_crop_poster": {
+                    "type": "boolean"
+                },
                 "poster_crop_bounds": {
                     "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.CropBounds"
                 },

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -5149,8 +5149,18 @@ const docTemplate = `{
                     "type": "string",
                     "example": "美人"
                 },
-                "poster_url": {
+                "poster_crop_bounds": {
                     "description": "Poster / cover (flattened from PosterState — no custom marshaler needed)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.CropBounds"
+                        }
+                    ]
+                },
+                "poster_crop_source_full": {
+                    "type": "boolean"
+                },
+                "poster_url": {
                     "type": "string"
                 },
                 "rating_score": {
@@ -5656,6 +5666,17 @@ const docTemplate = `{
             "properties": {
                 "cropped_poster_url": {
                     "type": "string"
+                },
+                "poster_crop_bounds": {
+                    "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.CropBounds"
+                },
+                "poster_crop_source_full": {
+                    "description": "PosterCropSourceFull echoes whether the bounds were measured against the\nfull-size source. Clients must round-trip it with the bounds: the apply\ngate refuses geometry without it.",
+                    "type": "boolean"
+                },
+                "should_crop_poster": {
+                    "description": "ShouldCropPoster echoes the stored crop intent after a manual crop\n(always false: the manual crop replaces the scraper auto-crop), so\nclients can sync their pending-edits overlay from this response alone.",
+                    "type": "boolean"
                 }
             }
         },
@@ -7240,6 +7261,27 @@ const docTemplate = `{
                 },
                 "window_width": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_javinizer_javinizer-go_internal_models.CropBounds": {
+            "type": "object",
+            "properties": {
+                "height": {
+                    "type": "number"
+                },
+                "source_aspect": {
+                    "description": "SourceAspect is the width/height ratio of the source image the crop was\nmeasured against. The apply phase refuses geometry whose aspect no\nlonger matches the downloaded image, so same-URL source swaps fall back\nto pre-change behavior instead of cropping the wrong image.",
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                },
+                "x": {
+                    "type": "number"
+                },
+                "y": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -5147,8 +5147,18 @@
                     "type": "string",
                     "example": "美人"
                 },
-                "poster_url": {
+                "poster_crop_bounds": {
                     "description": "Poster / cover (flattened from PosterState — no custom marshaler needed)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.CropBounds"
+                        }
+                    ]
+                },
+                "poster_crop_source_full": {
+                    "type": "boolean"
+                },
+                "poster_url": {
                     "type": "string"
                 },
                 "rating_score": {
@@ -5654,6 +5664,17 @@
             "properties": {
                 "cropped_poster_url": {
                     "type": "string"
+                },
+                "poster_crop_bounds": {
+                    "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.CropBounds"
+                },
+                "poster_crop_source_full": {
+                    "description": "PosterCropSourceFull echoes whether the bounds were measured against the\nfull-size source. Clients must round-trip it with the bounds: the apply\ngate refuses geometry without it.",
+                    "type": "boolean"
+                },
+                "should_crop_poster": {
+                    "description": "ShouldCropPoster echoes the stored crop intent after a manual crop\n(always false: the manual crop replaces the scraper auto-crop), so\nclients can sync their pending-edits overlay from this response alone.",
+                    "type": "boolean"
                 }
             }
         },
@@ -7238,6 +7259,27 @@
                 },
                 "window_width": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_javinizer_javinizer-go_internal_models.CropBounds": {
+            "type": "object",
+            "properties": {
+                "height": {
+                    "type": "number"
+                },
+                "source_aspect": {
+                    "description": "SourceAspect is the width/height ratio of the source image the crop was\nmeasured against. The apply phase refuses geometry whose aspect no\nlonger matches the downloaded image, so same-URL source swaps fall back\nto pre-change behavior instead of cropping the wrong image.",
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                },
+                "x": {
+                    "type": "number"
+                },
+                "y": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -5665,6 +5665,16 @@
                 "cropped_poster_url": {
                     "type": "string"
                 },
+                "original_cropped_poster_url": {
+                    "type": "string"
+                },
+                "original_poster_url": {
+                    "description": "Original poster fields echo the server-side pre-edit snapshot\n(backupPosterOriginals), so the client reset baseline never has to guess.\nEmpty when no snapshot was needed (no prior poster).",
+                    "type": "string"
+                },
+                "original_should_crop_poster": {
+                    "type": "boolean"
+                },
                 "poster_crop_bounds": {
                     "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_models.CropBounds"
                 },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1127,6 +1127,16 @@ definitions:
     properties:
       cropped_poster_url:
         type: string
+      original_cropped_poster_url:
+        type: string
+      original_poster_url:
+        description: |-
+          Original poster fields echo the server-side pre-edit snapshot
+          (backupPosterOriginals), so the client reset baseline never has to guess.
+          Empty when no snapshot was needed (no prior poster).
+        type: string
+      original_should_crop_poster:
+        type: boolean
       poster_crop_bounds:
         $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_models.CropBounds'
       poster_crop_source_full:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -767,9 +767,14 @@ definitions:
       original_title:
         example: 美人
         type: string
-      poster_url:
+      poster_crop_bounds:
+        allOf:
+        - $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_models.CropBounds'
         description: Poster / cover (flattened from PosterState — no custom marshaler
           needed)
+      poster_crop_source_full:
+        type: boolean
+      poster_url:
         type: string
       rating_score:
         type: number
@@ -1122,6 +1127,20 @@ definitions:
     properties:
       cropped_poster_url:
         type: string
+      poster_crop_bounds:
+        $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_models.CropBounds'
+      poster_crop_source_full:
+        description: |-
+          PosterCropSourceFull echoes whether the bounds were measured against the
+          full-size source. Clients must round-trip it with the bounds: the apply
+          gate refuses geometry without it.
+        type: boolean
+      should_crop_poster:
+        description: |-
+          ShouldCropPoster echoes the stored crop intent after a manual crop
+          (always false: the manual crop replaces the scraper auto-crop), so
+          clients can sync their pending-edits overlay from this response alone.
+        type: boolean
     type: object
   github_com_javinizer_javinizer-go_internal_api_contracts.PosterFromURLRequest:
     properties:
@@ -2205,6 +2224,24 @@ definitions:
         type: integer
       window_width:
         type: integer
+    type: object
+  github_com_javinizer_javinizer-go_internal_models.CropBounds:
+    properties:
+      height:
+        type: number
+      source_aspect:
+        description: |-
+          SourceAspect is the width/height ratio of the source image the crop was
+          measured against. The apply phase refuses geometry whose aspect no
+          longer matches the downloaded image, so same-URL source swaps fall back
+          to pre-change behavior instead of cropping the wrong image.
+        type: number
+      width:
+        type: number
+      x:
+        type: number
+      "y":
+        type: number
     type: object
   github_com_javinizer_javinizer-go_internal_models.DeepLMode:
     enum:

--- a/internal/api/batch/lifecycle_coverage_test.go
+++ b/internal/api/batch/lifecycle_coverage_test.go
@@ -277,7 +277,9 @@ func (s *stubControlledJob) GetResults() []resultstore.MovieResult              
 // JobEditor methods (required by BatchJobInterface)
 func (s *stubControlledJob) UpdateMovie(context.Context, string, *models.Movie) error { return nil }
 func (s *stubControlledJob) ExcludeFile(string)                                       {}
-func (s *stubControlledJob) UpdatePosterCrop(string, string) error                    { return nil }
+func (s *stubControlledJob) UpdatePosterCrop(string, string, *models.CropBounds, bool) error {
+	return nil
+}
 func (s *stubControlledJob) UpdatePosterFromURL(context.Context, string, string, string) error {
 	return nil
 }

--- a/internal/api/batch/movie_edit.go
+++ b/internal/api/batch/movie_edit.go
@@ -229,7 +229,15 @@ func updateBatchMoviePosterCrop(rt *core.APIRuntime) gin.HandlerFunc {
 		// with the field-override handler (field_override.go).
 		deps.GetJobStore().PersistJobByID(jobID)
 
-		c.JSON(http.StatusOK, contracts.PosterCropResponse{CroppedPosterURL: croppedURL, PosterCropBounds: bounds, ShouldCropPoster: false, PosterCropSourceFull: bounds != nil})
+		// Echo the server-side baseline snapshot so the client Reset flow
+		// restores exactly what the server would (no client-side guessing).
+		resp := contracts.PosterCropResponse{CroppedPosterURL: croppedURL, PosterCropBounds: bounds, ShouldCropPoster: false, PosterCropSourceFull: bounds != nil}
+		if stored, _, found2 := lookupResultByResultID(job, resultID); found2 && stored.Movie != nil {
+			resp.OriginalPosterURL = stored.Movie.Poster.OriginalPosterURL
+			resp.OriginalCroppedPosterURL = stored.Movie.Poster.OriginalCroppedPosterURL
+			resp.OriginalShouldCropPoster = stored.Movie.Poster.OriginalShouldCropPoster
+		}
+		c.JSON(http.StatusOK, resp)
 	}
 }
 

--- a/internal/api/batch/movie_edit.go
+++ b/internal/api/batch/movie_edit.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/worker"
 	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
 )
@@ -63,7 +64,7 @@ func updateBatchMovie(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		_, filePaths, found := lookupResultByResultID(job, resultID)
+		result, filePaths, found := lookupResultByResultID(job, resultID)
 
 		if !found {
 			c.JSON(http.StatusNotFound, contracts.ErrorResponse{Error: fmt.Sprintf("Result %s not found in job", resultID)})
@@ -79,6 +80,20 @@ func updateBatchMovie(rt *core.APIRuntime) gin.HandlerFunc {
 		// canonical no-template/error degradation (display_title.go).
 		movie := contracts.MovieViewToModel(req.Movie)
 		movie.DisplayTitle = movie.Title
+
+		// poster_crop_bounds PATCH semantics: an omitted key preserves the
+		// stored geometry (legacy clients and unrelated edits must not silently
+		// lose a manual crop); an explicit null clears it. The worker-side
+		// UpdateMovie sanitize additionally clears geometry when the poster
+		// source or crop intent changes, so stale bounds carried by an
+		// out-of-sync client cannot survive.
+		if !req.PosterCropBoundsFieldPresent && result.Movie != nil {
+			if stored := result.Movie.Poster.PosterCropBounds; stored != nil {
+				b := *stored
+				movie.Poster.PosterCropBounds = &b
+				movie.Poster.PosterCropSourceFull = result.Movie.Poster.PosterCropSourceFull
+			}
+		}
 		if snap := rt.Snapshot(); snap != nil {
 			if factory, fErr := snap.WorkflowFactory(); fErr == nil && factory != nil {
 				if rendered := factory.RenderDisplayTitle(c.Request.Context(), movie); rendered != "" {
@@ -168,13 +183,45 @@ func updateBatchMoviePosterCrop(rt *core.APIRuntime) gin.HandlerFunc {
 		}
 		croppedURL := cropResult.CroppedURL
 
-		if err := job.UpdatePosterCrop(movieID, croppedURL); err != nil {
+		// Persist the manual crop geometry (normalized 0–1 fractions) next to
+		// the preview URL so the apply phase can reproduce the crop on the
+		// downloaded source image. Bounds are validated in integer pixel space
+		// against the measured source dimensions (exact containment), then
+		// normalized and re-validated. When the legacy already-cropped fallback
+		// served as the source (or its dimensions are undecodable) no applyable
+		// geometry exists: nothing is stored and the response reports null.
+		var bounds *models.CropBounds
+		if cropResult.SourceFull && cropResult.SourceWidth > 0 && cropResult.SourceHeight > 0 {
+			if req.X+req.Width > cropResult.SourceWidth || req.Y+req.Height > cropResult.SourceHeight {
+				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: fmt.Sprintf("crop bounds %dx%d at (%d,%d) exceed source image %dx%d", req.Width, req.Height, req.X, req.Y, cropResult.SourceWidth, cropResult.SourceHeight)})
+				return
+			}
+			nb := models.CropBounds{
+				X:            float64(req.X) / float64(cropResult.SourceWidth),
+				Y:            float64(req.Y) / float64(cropResult.SourceHeight),
+				Width:        float64(req.Width) / float64(cropResult.SourceWidth),
+				Height:       float64(req.Height) / float64(cropResult.SourceHeight),
+				SourceAspect: float64(cropResult.SourceWidth) / float64(cropResult.SourceHeight),
+			}
+			if !nb.Valid() {
+				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: "invalid crop geometry"})
+				return
+			}
+			bounds = &nb
+		}
+
+		if err := job.UpdatePosterCrop(movieID, croppedURL, bounds, bounds != nil); err != nil {
 			logging.Errorf("Failed to update poster crop in job state for %s: %v", movieID, err)
 			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: fmt.Sprintf("Failed to update job state: %v", err)})
 			return
 		}
 
-		c.JSON(http.StatusOK, contracts.PosterCropResponse{CroppedPosterURL: croppedURL})
+		// Persist the job envelope so the manual crop survives a restart before
+		// organize (the geometry is runtime-only, never a DB column). Parity
+		// with the field-override handler (field_override.go).
+		deps.GetJobStore().PersistJobByID(jobID)
+
+		c.JSON(http.StatusOK, contracts.PosterCropResponse{CroppedPosterURL: croppedURL, PosterCropBounds: bounds, ShouldCropPoster: false, PosterCropSourceFull: bounds != nil})
 	}
 }
 

--- a/internal/api/batch/movie_edit.go
+++ b/internal/api/batch/movie_edit.go
@@ -117,6 +117,14 @@ func updateBatchMovie(rt *core.APIRuntime) gin.HandlerFunc {
 				return
 			}
 		}
+
+		// Persist the job envelope so a manual-crop clear (explicit null, or
+		// sanitize clearing it after a source/intent change) survives a restart
+		// — otherwise a reboot reloads the stale bounds from the envelope and a
+		// discarded crop silently resurrects. Parity with the crop and
+		// field-override handlers.
+		deps.GetJobStore().PersistJobByID(jobID)
+
 		c.JSON(http.StatusOK, contracts.MovieResponse{Movie: contracts.MovieViewFromModel(movie)})
 	}
 }

--- a/internal/api/batch/movie_edit.go
+++ b/internal/api/batch/movie_edit.go
@@ -192,10 +192,10 @@ func updateBatchMoviePosterCrop(rt *core.APIRuntime) gin.HandlerFunc {
 		// geometry exists: nothing is stored and the response reports null.
 		var bounds *models.CropBounds
 		if cropResult.SourceFull && cropResult.SourceWidth > 0 && cropResult.SourceHeight > 0 {
-			if req.X+req.Width > cropResult.SourceWidth || req.Y+req.Height > cropResult.SourceHeight {
-				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: fmt.Sprintf("crop bounds %dx%d at (%d,%d) exceed source image %dx%d", req.Width, req.Height, req.X, req.Y, cropResult.SourceWidth, cropResult.SourceHeight)})
-				return
-			}
+			// Normalize pixel bounds to 0–1 fractions of the measured full
+			// source, then validate in the same space the geometry is stored in:
+			// finite components in [0,1], positive size, and unit-square
+			// containment (Valid tolerates float-division error on exact edges).
 			nb := models.CropBounds{
 				X:            float64(req.X) / float64(cropResult.SourceWidth),
 				Y:            float64(req.Y) / float64(cropResult.SourceHeight),
@@ -203,10 +203,10 @@ func updateBatchMoviePosterCrop(rt *core.APIRuntime) gin.HandlerFunc {
 				Height:       float64(req.Height) / float64(cropResult.SourceHeight),
 				SourceAspect: float64(cropResult.SourceWidth) / float64(cropResult.SourceHeight),
 			}
-			if !nb.Valid() {
-				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: "invalid crop geometry"})
-				return
-			}
+			// No extra validity check here: CropWithBounds rejects out-of-range
+			// or non-positive pixel bounds (400 above), so the normalized geometry
+			// is valid by construction (finite components, positive size, unit
+			// containment); sanitize/apply still re-validate before use.
 			bounds = &nb
 		}
 

--- a/internal/api/batch/movie_edit.go
+++ b/internal/api/batch/movie_edit.go
@@ -313,6 +313,11 @@ func updateBatchMoviePosterFromURL(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
+		// Persist the job envelope after the source change cleared the stored
+		// manual crop geometry — otherwise a restart reloads the stale bounds
+		// from the envelope and undoes the invalidation.
+		deps.GetJobStore().PersistJobByID(jobID)
+
 		c.JSON(http.StatusOK, contracts.PosterFromURLResponse{
 			CroppedPosterURL: croppedURL,
 			PosterURL:        req.URL,

--- a/internal/api/batch/movie_edit_poster_crop_test.go
+++ b/internal/api/batch/movie_edit_poster_crop_test.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 
 	workermocks "github.com/javinizer/javinizer-go/internal/mocks/worker"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/poster"
 	"github.com/javinizer/javinizer-go/internal/worker"
 	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
 	"github.com/stretchr/testify/assert"
@@ -66,6 +68,7 @@ func cropJobFixture(t *testing.T, movieID string) (*core.APIDeps, *worker.BatchJ
 	router := gin.New()
 	router.POST("/batch/:id/results/:resultId/poster-crop", updateBatchMoviePosterCrop(testkit.GetTestRuntime(deps)))
 	router.PATCH("/batch/:id/results/:resultId", updateBatchMovie(testkit.GetTestRuntime(deps)))
+	router.POST("/batch/:id/results/:resultId/poster-from-url", updateBatchMoviePosterFromURL(testkit.GetTestRuntime(deps)))
 	return deps, job, router
 }
 
@@ -146,6 +149,45 @@ func TestPosterCrop_StoresNormalizedGeometry(t *testing.T) {
 	assert.Equal(t, *resp.PosterCropBounds, *stored.Poster.PosterCropBounds)
 	assert.True(t, stored.Poster.PosterCropSourceFull)
 	assert.False(t, stored.Poster.ShouldCropPoster)
+}
+
+// Poster-from-URL after a manual crop clears the stored geometry, applies
+// the new source, and persists the envelope. The runtime's poster manager is
+// pre-seeded with the SSRF check bypassed (its documented test seam) so the
+// loopback fixture server is reachable.
+func TestPosterFromURL_SuccessClearsGeometry(t *testing.T) {
+	deps, job, router := cropJobFixture(t, "CROPGEO-009")
+
+	// Pre-seed BEFORE any handler call crops/populates the shared cache.
+	rt := testkit.GetTestRuntime(deps)
+	rt.GetRuntime().GetPosterManager(func() poster.PosterManagerInterface {
+		return poster.NewPosterManager(deps.GetFs(), "data/temp", &http.Client{}).
+			WithSSRFCheck(func(string) error { return nil })
+	})
+
+	require.Equal(t, 200, postCrop(t, router, job, "CROPGEO-009",
+		contracts.PosterCropRequest{X: 0, Y: 0, Width: 400, Height: 600}).Code)
+	require.NotNil(t, storedMovie(t, deps, job, "/path/to/CROPGEO-009.mp4").Poster.PosterCropBounds)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		img := image.NewRGBA(image.Rect(0, 0, 64, 96))
+		w.Header().Set("Content-Type", "image/jpeg")
+		_ = jpeg.Encode(w, img, &jpeg.Options{Quality: 90})
+	}))
+	t.Cleanup(ts.Close)
+
+	body, err := json.Marshal(contracts.PosterFromURLRequest{URL: ts.URL + "/poster.jpg"})
+	require.NoError(t, err)
+	req := httptest.NewRequest("POST", "/batch/"+job.GetID()+"/results/CROPGEO-009/poster-from-url", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
+
+	stored := storedMovie(t, deps, job, "/path/to/CROPGEO-009.mp4")
+	assert.Equal(t, ts.URL+"/poster.jpg", stored.Poster.PosterURL)
+	assert.Nil(t, stored.Poster.PosterCropBounds, "new source invalidates stored geometry")
+	assert.False(t, stored.Poster.PosterCropSourceFull)
 }
 
 // cropErrorJobStore overrides only what the crop handler touches: GetBatchJob

--- a/internal/api/batch/movie_edit_poster_crop_test.go
+++ b/internal/api/batch/movie_edit_poster_crop_test.go
@@ -12,15 +12,19 @@ import (
 	"testing"
 	"time"
 
+	"errors"
 	"github.com/gin-gonic/gin"
 	"github.com/javinizer/javinizer-go/internal/api/contracts"
 	"github.com/javinizer/javinizer-go/internal/api/core"
 	"github.com/javinizer/javinizer-go/internal/api/testkit"
 	"github.com/javinizer/javinizer-go/internal/config"
+
+	workermocks "github.com/javinizer/javinizer-go/internal/mocks/worker"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/worker"
 	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -134,6 +138,37 @@ func TestPosterCrop_StoresNormalizedGeometry(t *testing.T) {
 	assert.Equal(t, *resp.PosterCropBounds, *stored.Poster.PosterCropBounds)
 	assert.True(t, stored.Poster.PosterCropSourceFull)
 	assert.False(t, stored.Poster.ShouldCropPoster)
+}
+
+// cropErrorJobStore overrides only what the crop handler touches: GetBatchJob
+// (returns the configured mock job) and PersistJobByID (no-op).
+type cropErrorJobStore struct {
+	worker.JobStoreInterface
+	job worker.BatchJobInterface
+}
+
+func (s *cropErrorJobStore) GetBatchJob(string) (worker.BatchJobInterface, bool) { return s.job, true }
+func (s *cropErrorJobStore) PersistJobByID(string)                               {}
+
+// A failure inside the job-state update surfaces as 500 after a successful
+// preview crop (mock job drives the otherwise-unreachable error branch).
+func TestPosterCrop_UpdatePosterCropErrorIs500(t *testing.T) {
+	deps, job, router := cropJobFixture(t, "CROPGEO-008")
+
+	mockJob := workermocks.NewMockBatchJobInterface(t)
+	mockJob.EXPECT().GetFileResultByResultID("CROPGEO-008").Return(&resultstore.MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: "/path/to/CROPGEO-008.mp4", MovieID: "CROPGEO-008"},
+		Movie:         &models.Movie{ID: "CROPGEO-008"},
+	}, "/path/to/CROPGEO-008.mp4", true)
+	mockJob.EXPECT().FindMovieResultForMovieID("CROPGEO-008").Return(nil, nil)
+	mockJob.EXPECT().FindFilePathsForMovieID("CROPGEO-008").Return([]string{"/path/to/CROPGEO-008.mp4"})
+	mockJob.EXPECT().UpdatePosterCrop("CROPGEO-008", mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("store exploded"))
+	deps.JobStore = &cropErrorJobStore{job: mockJob}
+
+	w := postCrop(t, router, job, "CROPGEO-008", contracts.PosterCropRequest{X: 0, Y: 0, Width: 400, Height: 600})
+	assert.Equal(t, 500, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "Failed to update job state")
 }
 
 // Pixel-space containment violations against the measured source must be

--- a/internal/api/batch/movie_edit_poster_crop_test.go
+++ b/internal/api/batch/movie_edit_poster_crop_test.go
@@ -133,6 +133,14 @@ func TestPosterCrop_StoresNormalizedGeometry(t *testing.T) {
 	assert.False(t, resp.ShouldCropPoster, "manual crop turns the scraper crop intent off")
 	assert.NotEmpty(t, resp.CroppedPosterURL)
 
+	// The response echoes the server-side baseline snapshot (set on first
+	// poster edit), so the client Reset flow never guesses.
+	assert.Equal(t, "https://cdn.example/poster.jpg", resp.OriginalPosterURL)
+	assert.NotNil(t, resp.OriginalShouldCropPoster)
+	if resp.OriginalShouldCropPoster != nil {
+		assert.True(t, *resp.OriginalShouldCropPoster)
+	}
+
 	stored := storedMovie(t, deps, job, "/path/to/CROPGEO-001.mp4")
 	require.NotNil(t, stored.Poster.PosterCropBounds, "job result must carry the geometry for organize")
 	assert.Equal(t, *resp.PosterCropBounds, *stored.Poster.PosterCropBounds)

--- a/internal/api/batch/movie_edit_poster_crop_test.go
+++ b/internal/api/batch/movie_edit_poster_crop_test.go
@@ -1,0 +1,242 @@
+package batch
+
+import (
+	"bytes"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cropJobFixture wires a batch job with one completed movie result and a
+// 1000x600 test poster stored at the full-source temp path the crop endpoint
+// reads. Returns the job and a router exposing the crop and save endpoints.
+func cropJobFixture(t *testing.T, movieID string) (*core.APIDeps, *worker.BatchJob, *gin.Engine) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	// PosterManager resolves temp posters relative to the working directory.
+	tempDir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	cfg := &config.Config{System: config.SystemConfig{TempDir: "data/temp"}}
+	deps := createTestDeps(t, cfg, "")
+
+	job := deps.JobStore.CreateJobBatch([]string{"/path/to/" + movieID + ".mp4"})
+	setJobResult(job, "/path/to/"+movieID+".mp4", &resultstore.MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: "/path/to/" + movieID + ".mp4", MovieID: movieID},
+		Status:        models.JobStatusCompleted,
+		Movie: &models.Movie{
+			ID:    movieID,
+			Title: "Crop Subject",
+			Poster: models.PosterState{
+				PosterURL:        "https://cdn.example/poster.jpg",
+				CoverURL:         "https://cdn.example/cover.jpg",
+				ShouldCropPoster: true,
+			},
+		},
+		StartedAt: time.Now(),
+	})
+
+	writeTestPoster(t, filepath.Join("data/temp/posters", job.GetID(), movieID+"-full.jpg"), 1000, 600)
+
+	router := gin.New()
+	router.POST("/batch/:id/results/:resultId/poster-crop", updateBatchMoviePosterCrop(testkit.GetTestRuntime(deps)))
+	router.PATCH("/batch/:id/results/:resultId", updateBatchMovie(testkit.GetTestRuntime(deps)))
+	return deps, job, router
+}
+
+func writeTestPoster(t *testing.T, path string, w, h int) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: 120, G: 80, B: 40, A: 255})
+		}
+	}
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, jpeg.Encode(f, img, &jpeg.Options{Quality: 90}))
+}
+
+func postCrop(t *testing.T, router *gin.Engine, job *worker.BatchJob, resultID string, body contracts.PosterCropRequest) *httptest.ResponseRecorder {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest("POST", "/batch/"+job.GetID()+"/results/"+resultID+"/poster-crop", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func patchMovie(t *testing.T, router *gin.Engine, job *worker.BatchJob, resultID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("PATCH", "/batch/"+job.GetID()+"/results/"+resultID, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func storedMovie(t *testing.T, deps *core.APIDeps, job *worker.BatchJob, filePath string) *models.Movie {
+	t.Helper()
+	ej, ok := deps.JobStore.GetBatchJob(job.GetID())
+	require.True(t, ok)
+	res, err := ej.GetMovieResult(filePath)
+	require.NoError(t, err)
+	require.NotNil(t, res.Movie)
+	return res.Movie
+}
+
+// A crop against the full-size source stores normalized geometry on the job
+// result and echoes it (plus the resulting crop intent) in the response.
+func TestPosterCrop_StoresNormalizedGeometry(t *testing.T) {
+	deps, job, router := cropJobFixture(t, "CROPGEO-001")
+
+	w := postCrop(t, router, job, "CROPGEO-001", contracts.PosterCropRequest{X: 100, Y: 60, Width: 400, Height: 540})
+	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
+
+	var resp contracts.PosterCropResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.PosterCropBounds, "response must echo applyable geometry")
+	assert.InDelta(t, 0.1, resp.PosterCropBounds.X, 1e-9)
+	assert.InDelta(t, 0.1, resp.PosterCropBounds.Y, 1e-9)
+	assert.InDelta(t, 0.4, resp.PosterCropBounds.Width, 1e-9)
+	assert.InDelta(t, 0.9, resp.PosterCropBounds.Height, 1e-9)
+	assert.InDelta(t, 1000.0/600.0, resp.PosterCropBounds.SourceAspect, 1e-9)
+	assert.False(t, resp.ShouldCropPoster, "manual crop turns the scraper crop intent off")
+	assert.NotEmpty(t, resp.CroppedPosterURL)
+
+	stored := storedMovie(t, deps, job, "/path/to/CROPGEO-001.mp4")
+	require.NotNil(t, stored.Poster.PosterCropBounds, "job result must carry the geometry for organize")
+	assert.Equal(t, *resp.PosterCropBounds, *stored.Poster.PosterCropBounds)
+	assert.True(t, stored.Poster.PosterCropSourceFull)
+	assert.False(t, stored.Poster.ShouldCropPoster)
+}
+
+// Pixel-space containment violations against the measured source must be
+// rejected with 400 — no geometry is stored beyond the image edge.
+func TestPosterCrop_ContainmentViolationRejected(t *testing.T) {
+	for _, body := range []contracts.PosterCropRequest{
+		{X: 950, Y: 0, Width: 100, Height: 100}, // x+w=1050 > 1000
+		{X: 0, Y: 500, Width: 100, Height: 200}, // y+h=700 > 600
+	} {
+		deps, job, router := cropJobFixture(t, "CROPGEO-002")
+		w := postCrop(t, router, job, "CROPGEO-002", body)
+		assert.Equal(t, 400, w.Code, "body %+v must be rejected: %s", body, w.Body.String())
+
+		stored := storedMovie(t, deps, job, "/path/to/CROPGEO-002.mp4")
+		assert.Nil(t, stored.Poster.PosterCropBounds)
+	}
+}
+
+// Legacy jobs (full-size source already cleaned up) keep pre-change behavior:
+// the crop still refreshes the preview, but no applyable geometry is stored
+// and the response reports poster_crop_bounds: null.
+func TestPosterCrop_LegacyFallbackStoresNothing(t *testing.T) {
+	deps, job, router := cropJobFixture(t, "CROPGEO-003")
+	// Remove the full source, keep only the already-cropped preview.
+	require.NoError(t, os.Remove(filepath.Join("data/temp/posters", job.GetID(), "CROPGEO-003-full.jpg")))
+	writeTestPoster(t, filepath.Join("data/temp/posters", job.GetID(), "CROPGEO-003.jpg"), 400, 600)
+
+	w := postCrop(t, router, job, "CROPGEO-003", contracts.PosterCropRequest{X: 0, Y: 0, Width: 200, Height: 300})
+	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+	assert.JSONEq(t, "null", string(raw["poster_crop_bounds"]), "legacy fallback must echo null bounds")
+
+	stored := storedMovie(t, deps, job, "/path/to/CROPGEO-003.mp4")
+	assert.Nil(t, stored.Poster.PosterCropBounds)
+	assert.False(t, stored.Poster.PosterCropSourceFull)
+	assert.False(t, stored.Poster.ShouldCropPoster, "crop intent behavior unchanged from pre-change")
+}
+
+// PATCH presence semantics: a movie save that omits poster_crop_bounds
+// (legacy client, unrelated metadata edit) preserves stored geometry.
+func TestUpdateBatchMovie_OmittedCropBoundsPreserved(t *testing.T) {
+	deps, job, router := cropJobFixture(t, "CROPGEO-004")
+	require.Equal(t, 200, postCrop(t, router, job, "CROPGEO-004",
+		contracts.PosterCropRequest{X: 0, Y: 0, Width: 400, Height: 600}).Code)
+
+	body := `{"movie": {"code": "CROPGEO-004", "id": "CROPGEO-004", "title": "Edited Title", "poster_url": "https://cdn.example/poster.jpg", "cover_url": "https://cdn.example/cover.jpg", "should_crop_poster": false}}`
+	w := patchMovie(t, router, job, "CROPGEO-004", body)
+	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
+
+	stored := storedMovie(t, deps, job, "/path/to/CROPGEO-004.mp4")
+	assert.Equal(t, "Edited Title", stored.Title)
+	require.NotNil(t, stored.Poster.PosterCropBounds, "omitted poster_crop_bounds must preserve stored geometry")
+	assert.InDelta(t, 0.4, stored.Poster.PosterCropBounds.Width, 1e-9)
+}
+
+// An explicit poster_crop_bounds: null in a movie save clears stored geometry.
+func TestUpdateBatchMovie_ExplicitNullClearsCropBounds(t *testing.T) {
+	deps, job, router := cropJobFixture(t, "CROPGEO-005")
+	require.Equal(t, 200, postCrop(t, router, job, "CROPGEO-005",
+		contracts.PosterCropRequest{X: 0, Y: 0, Width: 400, Height: 600}).Code)
+
+	body := `{"movie": {"code": "CROPGEO-005", "id": "CROPGEO-005", "title": "Crop Subject", "poster_url": "https://cdn.example/poster.jpg", "cover_url": "https://cdn.example/cover.jpg", "should_crop_poster": false, "poster_crop_bounds": null}}`
+	w := patchMovie(t, router, job, "CROPGEO-005", body)
+	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
+
+	stored := storedMovie(t, deps, job, "/path/to/CROPGEO-005.mp4")
+	assert.Nil(t, stored.Poster.PosterCropBounds, "explicit null must clear stored geometry")
+	assert.False(t, stored.Poster.PosterCropSourceFull)
+}
+
+// A stale overlay that re-uploads the pre-crop crop intent alongside omitted
+// geometry cannot resurrect stale geometry — the stored geometry is cleared,
+// restoring pre-change behavior for out-of-sync clients.
+func TestUpdateBatchMovie_IntentChangeClearsCropBounds(t *testing.T) {
+	deps, job, router := cropJobFixture(t, "CROPGEO-006")
+	require.Equal(t, 200, postCrop(t, router, job, "CROPGEO-006",
+		contracts.PosterCropRequest{X: 0, Y: 0, Width: 400, Height: 600}).Code)
+
+	body := `{"movie": {"code": "CROPGEO-006", "id": "CROPGEO-006", "title": "Crop Subject", "poster_url": "https://cdn.example/poster.jpg", "cover_url": "https://cdn.example/cover.jpg", "should_crop_poster": true}}`
+	w := patchMovie(t, router, job, "CROPGEO-006", body)
+	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
+
+	stored := storedMovie(t, deps, job, "/path/to/CROPGEO-006.mp4")
+	assert.Nil(t, stored.Poster.PosterCropBounds, "intent change must clear stored geometry")
+	assert.True(t, stored.Poster.ShouldCropPoster, "client intent is applied")
+}
+
+// A correctly synced client re-sends the geometry with the save: unchanged
+// source + intent keeps it intact (the organize-amplifier server half).
+func TestUpdateBatchMovie_SyncedOverlayKeepsCropBounds(t *testing.T) {
+	deps, job, router := cropJobFixture(t, "CROPGEO-007")
+	require.Equal(t, 200, postCrop(t, router, job, "CROPGEO-007",
+		contracts.PosterCropRequest{X: 100, Y: 60, Width: 400, Height: 540}).Code)
+
+	body := `{"movie": {"code": "CROPGEO-007", "id": "CROPGEO-007", "title": "Synced Save", "poster_url": "https://cdn.example/poster.jpg", "cover_url": "https://cdn.example/cover.jpg", "should_crop_poster": false, "poster_crop_bounds": {"x": 0.1, "y": 0.1, "width": 0.4, "height": 0.9, "source_aspect": 1.6666666666666667}, "poster_crop_source_full": true}}`
+	w := patchMovie(t, router, job, "CROPGEO-007", body)
+	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
+
+	stored := storedMovie(t, deps, job, "/path/to/CROPGEO-007.mp4")
+	assert.Equal(t, "Synced Save", stored.Title)
+	require.NotNil(t, stored.Poster.PosterCropBounds, "synced overlay must keep geometry through save")
+	assert.InDelta(t, 0.4, stored.Poster.PosterCropBounds.Width, 1e-9)
+	assert.True(t, stored.Poster.PosterCropSourceFull)
+}

--- a/internal/api/contracts/movie_types.go
+++ b/internal/api/contracts/movie_types.go
@@ -117,6 +117,12 @@ type PosterCropResponse struct {
 	// full-size source. Clients must round-trip it with the bounds: the apply
 	// gate refuses geometry without it.
 	PosterCropSourceFull bool `json:"poster_crop_source_full"`
+	// Original poster fields echo the server-side pre-edit snapshot
+	// (backupPosterOriginals), so the client reset baseline never has to guess.
+	// Empty when no snapshot was needed (no prior poster).
+	OriginalPosterURL        string `json:"original_poster_url"`
+	OriginalCroppedPosterURL string `json:"original_cropped_poster_url"`
+	OriginalShouldCropPoster *bool  `json:"original_should_crop_poster"`
 }
 
 // PosterFromURLRequest represents a request to download a poster from a URL.

--- a/internal/api/contracts/movie_types.go
+++ b/internal/api/contracts/movie_types.go
@@ -66,18 +66,28 @@ type UpdateMovieRequest struct {
 // distinguish an omitted field (preserve stored geometry) from an explicit
 // null (clear geometry).
 func (r *UpdateMovieRequest) UnmarshalJSON(data []byte) error {
-	type Alias UpdateMovieRequest
-	if err := json.Unmarshal(data, (*Alias)(r)); err != nil {
+	var raw struct {
+		Movie json.RawMessage `json:"movie"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 	r.PosterCropBoundsFieldPresent = false
-	var probe struct {
-		Movie map[string]json.RawMessage `json:"movie"`
+	if string(raw.Movie) == "null" || len(raw.Movie) == 0 {
+		r.Movie = nil // binding:"required" reports this downstream
+		return nil
 	}
-	if err := json.Unmarshal(data, &probe); err != nil {
+	var mv MovieView
+	if err := json.Unmarshal(raw.Movie, &mv); err != nil {
 		return err
 	}
-	_, r.PosterCropBoundsFieldPresent = probe.Movie["poster_crop_bounds"]
+	r.Movie = &mv
+	var keys map[string]json.RawMessage
+	// raw.Movie decoded into a struct above, so it is a JSON object and the
+	// map decode cannot fail; on the impossible failure the key reads absent
+	// (the safe default: preserve stored geometry).
+	_ = json.Unmarshal(raw.Movie, &keys)
+	_, r.PosterCropBoundsFieldPresent = keys["poster_crop_bounds"]
 	return nil
 }
 

--- a/internal/api/contracts/movie_types.go
+++ b/internal/api/contracts/movie_types.go
@@ -1,5 +1,11 @@
 package contracts
 
+import (
+	"encoding/json"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
 // ScrapeRequest represents the scrape request payload
 type ScrapeRequest struct {
 	ID               string   `json:"id" binding:"required" example:"IPX-535"`
@@ -48,6 +54,31 @@ type MoviesResponse struct {
 // UpdateMovieRequest represents the update movie request payload
 type UpdateMovieRequest struct {
 	Movie *MovieView `json:"movie" binding:"required"`
+	// PosterCropBoundsFieldPresent records whether the movie payload contained
+	// the poster_crop_bounds key (even as an explicit null). PATCH semantics
+	// per the poster-crop-persistence contract: omitted preserves stored
+	// geometry; explicit null clears it. Not part of the wire format.
+	PosterCropBoundsFieldPresent bool `json:"-"`
+}
+
+// UnmarshalJSON decodes the request while tracking presence of the
+// poster_crop_bounds key on the nested movie object — required to
+// distinguish an omitted field (preserve stored geometry) from an explicit
+// null (clear geometry).
+func (r *UpdateMovieRequest) UnmarshalJSON(data []byte) error {
+	type Alias UpdateMovieRequest
+	if err := json.Unmarshal(data, (*Alias)(r)); err != nil {
+		return err
+	}
+	r.PosterCropBoundsFieldPresent = false
+	var probe struct {
+		Movie map[string]json.RawMessage `json:"movie"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return err
+	}
+	_, r.PosterCropBoundsFieldPresent = probe.Movie["poster_crop_bounds"]
+	return nil
 }
 
 // PosterCropRequest represents manual poster crop coordinates in source-image pixels.
@@ -61,9 +92,21 @@ type PosterCropRequest struct {
 	MaxPosterHeight *int `json:"max_poster_height,omitempty" binding:"omitempty,min=0"`
 }
 
-// PosterCropResponse returns the updated temp cropped poster URL.
+// PosterCropResponse returns the updated temp cropped poster URL plus the
+// effective normalized crop geometry (fractions of the full-size source),
+// or null when the crop was measured against a legacy already-cropped
+// preview and no applyable geometry exists.
 type PosterCropResponse struct {
-	CroppedPosterURL string `json:"cropped_poster_url"`
+	CroppedPosterURL string             `json:"cropped_poster_url"`
+	PosterCropBounds *models.CropBounds `json:"poster_crop_bounds"`
+	// ShouldCropPoster echoes the stored crop intent after a manual crop
+	// (always false: the manual crop replaces the scraper auto-crop), so
+	// clients can sync their pending-edits overlay from this response alone.
+	ShouldCropPoster bool `json:"should_crop_poster"`
+	// PosterCropSourceFull echoes whether the bounds were measured against the
+	// full-size source. Clients must round-trip it with the bounds: the apply
+	// gate refuses geometry without it.
+	PosterCropSourceFull bool `json:"poster_crop_source_full"`
 }
 
 // PosterFromURLRequest represents a request to download a poster from a URL.

--- a/internal/api/contracts/movie_types_test.go
+++ b/internal/api/contracts/movie_types_test.go
@@ -1,0 +1,62 @@
+package contracts
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The presence flag distinguishes an omitted poster_crop_bounds key
+// (preserve stored geometry) from an explicit null (clear it).
+func TestUpdateMovieRequestUnmarshal_PosterCropBoundsPresence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("key present as null", func(t *testing.T) {
+		var r UpdateMovieRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"movie":{"code":"ABC-1","poster_crop_bounds":null}}`), &r))
+		require.NotNil(t, r.Movie)
+		assert.True(t, r.PosterCropBoundsFieldPresent)
+		assert.Nil(t, r.Movie.PosterCropBounds)
+	})
+
+	t.Run("key present with value", func(t *testing.T) {
+		var r UpdateMovieRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"movie":{"poster_crop_bounds":{"x":0.1,"y":0.1,"width":0.4,"height":0.9}}}`), &r))
+		assert.True(t, r.PosterCropBoundsFieldPresent)
+		require.NotNil(t, r.Movie.PosterCropBounds)
+		assert.InDelta(t, 0.4, r.Movie.PosterCropBounds.Width, 1e-9)
+	})
+
+	t.Run("key omitted", func(t *testing.T) {
+		var r UpdateMovieRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"movie":{"code":"ABC-1"}}`), &r))
+		require.NotNil(t, r.Movie)
+		assert.False(t, r.PosterCropBoundsFieldPresent)
+	})
+
+	t.Run("movie null leaves Movie nil for binding validation", func(t *testing.T) {
+		var r UpdateMovieRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"movie":null}`), &r))
+		assert.Nil(t, r.Movie)
+		assert.False(t, r.PosterCropBoundsFieldPresent)
+	})
+
+	t.Run("typed envelope mismatch errors", func(t *testing.T) {
+		// Well-formed JSON of the wrong shape reaches our envelope decode;
+		// truncated input like `{` errors inside encoding/json instead.
+		var r UpdateMovieRequest
+		assert.Error(t, json.Unmarshal([]byte(`[1]`), &r))
+	})
+
+	t.Run("truncated input errors", func(t *testing.T) {
+		var r UpdateMovieRequest
+		assert.Error(t, json.Unmarshal([]byte(`{`), &r))
+	})
+
+	t.Run("non-object movie errors", func(t *testing.T) {
+		var r UpdateMovieRequest
+		assert.Error(t, json.Unmarshal([]byte(`{"movie":5}`), &r))
+	})
+}

--- a/internal/api/contracts/movie_view.go
+++ b/internal/api/contracts/movie_view.go
@@ -42,14 +42,16 @@ type MovieView struct {
 	RatingWarning string     `json:"rating_warning,omitempty"`
 
 	// Poster / cover (flattened from PosterState — no custom marshaler needed)
-	PosterURL                string `json:"poster_url"`
-	CoverURL                 string `json:"cover_url"`
-	CroppedPosterURL         string `json:"cropped_poster_url"`
-	ShouldCropPoster         bool   `json:"should_crop_poster"`
-	OriginalPosterURL        string `json:"original_poster_url"`
-	OriginalCroppedPosterURL string `json:"original_cropped_poster_url"`
-	OriginalShouldCropPoster *bool  `json:"original_should_crop_poster"`
-	OriginalCoverURL         string `json:"original_cover_url"`
+	PosterCropBounds         *models.CropBounds `json:"poster_crop_bounds,omitempty"`
+	PosterCropSourceFull     bool               `json:"poster_crop_source_full,omitempty"`
+	PosterURL                string             `json:"poster_url"`
+	CoverURL                 string             `json:"cover_url"`
+	CroppedPosterURL         string             `json:"cropped_poster_url"`
+	ShouldCropPoster         bool               `json:"should_crop_poster"`
+	OriginalPosterURL        string             `json:"original_poster_url"`
+	OriginalCroppedPosterURL string             `json:"original_cropped_poster_url"`
+	OriginalShouldCropPoster *bool              `json:"original_should_crop_poster"`
+	OriginalCoverURL         string             `json:"original_cover_url"`
 
 	// Media
 	TrailerURL       string   `json:"trailer_url"`
@@ -98,6 +100,8 @@ func MovieViewFromModel(m *models.Movie) *MovieView {
 		RatingScore:              m.RatingScore,
 		RatingVotes:              m.RatingVotes,
 		RatingWarning:            m.RatingWarning,
+		PosterCropBounds:         m.Poster.PosterCropBounds,
+		PosterCropSourceFull:     m.Poster.PosterCropSourceFull,
 		PosterURL:                m.Poster.PosterURL,
 		CoverURL:                 m.Poster.CoverURL,
 		CroppedPosterURL:         m.Poster.CroppedPosterURL,
@@ -157,6 +161,8 @@ func MovieViewToModel(v *MovieView) *models.Movie {
 	}
 	// Rebuild PosterState from the flattened MovieView fields.
 	m.Poster = models.PosterState{
+		PosterCropBounds:         v.PosterCropBounds,
+		PosterCropSourceFull:     v.PosterCropSourceFull,
 		PosterURL:                v.PosterURL,
 		CoverURL:                 v.CoverURL,
 		CroppedPosterURL:         v.CroppedPosterURL,

--- a/internal/downloader/media.go
+++ b/internal/downloader/media.go
@@ -156,23 +156,14 @@ func (d *Downloader) cropDownloadedPoster(tempPath, destPath string, bounds *mod
 		}
 	}
 
+	// Valid() guarantees unit-square containment, so no clamping is needed:
+	// rounding stays within [0,w]×[0,h] (the 1e-9 tolerance cannot edge over a
+	// pixel boundary) — only degenerate rounding needs a guard.
 	fw, fh := float64(w), float64(h)
 	left := int(math.Round(bounds.X * fw))
 	top := int(math.Round(bounds.Y * fh))
 	right := int(math.Round((bounds.X + bounds.Width) * fw))
 	bottom := int(math.Round((bounds.Y + bounds.Height) * fh))
-	if left < 0 {
-		left = 0
-	}
-	if top < 0 {
-		top = 0
-	}
-	if right > w {
-		right = w
-	}
-	if bottom > h {
-		bottom = h
-	}
 	if right <= left || bottom <= top {
 		logging.Warnf("downloadPoster: manual crop geometry collapses to empty rect; falling back")
 		return false

--- a/internal/downloader/media.go
+++ b/internal/downloader/media.go
@@ -46,10 +46,12 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 	bounds := movie.Poster.PosterCropBounds
 	geometryUsable := bounds != nil && movie.Poster.PosterCropSourceFull && bounds.Valid()
 
-	// Check if poster already exists — but a pending manual crop always wins:
-	// the user explicitly re-cropped on the review page, so organize replaces
-	// existing artwork with the manual crop (in-place/force-update flows).
-	if info, err := d.fs.Stat(destPath); err == nil && !geometryUsable {
+	// Check if poster already exists. Existing artwork is never replaced,
+	// even with pending manual crop geometry: downloaded paths feed the
+	// revert delete-list, so overwriting would leave NO poster after a
+	// revert. In-place artwork refresh needs overwrite tracking first
+	// (tracked in the follow-up issue).
+	if info, err := d.fs.Stat(destPath); err == nil {
 		// Already exists
 		return &DownloadResult{
 			Type:       MediaTypePoster,

--- a/internal/downloader/media.go
+++ b/internal/downloader/media.go
@@ -43,8 +43,13 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 	tmplCtx := d.buildTemplateContext(movie, multipart)
 	destPath := d.pathResolver.ResolvePosterPath(movie, nil, true, tmplCtx, destDir)
 
-	// Check if poster already exists
-	if info, err := d.fs.Stat(destPath); err == nil {
+	bounds := movie.Poster.PosterCropBounds
+	geometryUsable := bounds != nil && movie.Poster.PosterCropSourceFull && bounds.Valid()
+
+	// Check if poster already exists — but a pending manual crop always wins:
+	// the user explicitly re-cropped on the review page, so organize replaces
+	// existing artwork with the manual crop (in-place/force-update flows).
+	if info, err := d.fs.Stat(destPath); err == nil && !geometryUsable {
 		// Already exists
 		return &DownloadResult{
 			Type:       MediaTypePoster,
@@ -53,13 +58,6 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 			Downloaded: false,
 		}, nil
 	}
-
-	// Check if we need to crop the poster or use it directly. Manual
-	// review-page crop geometry takes precedence over the scraper's crop
-	// intent while it is still applyable; invalid geometry is dropped before
-	// any download so the pre-geometry paths below behave exactly as before.
-	bounds := movie.Poster.PosterCropBounds
-	geometryUsable := bounds != nil && movie.Poster.PosterCropSourceFull && bounds.Valid()
 	if !geometryUsable && !movie.Poster.ShouldCropPoster {
 		// High-quality poster - download directly without cropping
 		result, err := d.download(ctx, posterURL, destPath, MediaTypePoster)

--- a/internal/downloader/media.go
+++ b/internal/downloader/media.go
@@ -3,6 +3,7 @@ package downloader
 import (
 	"context"
 	"fmt"
+	"math"
 	"path/filepath"
 
 	"github.com/javinizer/javinizer-go/internal/imageutil"
@@ -53,14 +54,21 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 		}, nil
 	}
 
-	// Check if we need to crop the poster or use it directly
-	if !movie.Poster.ShouldCropPoster {
+	// Check if we need to crop the poster or use it directly. Manual
+	// review-page crop geometry takes precedence over the scraper's crop
+	// intent while it is still applyable; invalid geometry is dropped before
+	// any download so the pre-geometry paths below behave exactly as before.
+	bounds := movie.Poster.PosterCropBounds
+	geometryUsable := bounds != nil && movie.Poster.PosterCropSourceFull && bounds.Valid()
+	if !geometryUsable && !movie.Poster.ShouldCropPoster {
 		// High-quality poster - download directly without cropping
 		result, err := d.download(ctx, posterURL, destPath, MediaTypePoster)
 		return result, err
 	}
 
-	// Low-quality poster - download and crop from cover
+	// One GET feeds every poster-producing path below — fallback paths reuse
+	// the already-downloaded bytes instead of re-requesting the URL, so a
+	// single-use/signed poster URL cannot be consumed twice.
 	tempPath := destPath + ".full.tmp"
 	result, err := d.download(ctx, posterURL, tempPath, MediaTypePoster)
 	if err != nil || !result.Downloaded {
@@ -68,7 +76,32 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 		return result, err
 	}
 
-	// Crop the poster from the downloaded image
+	// Manual geometry first: reproduce the review-page crop on the downloaded
+	// source. Any inconsistency (undecodable, aspect drift, empty rect) falls
+	// through to the pre-geometry behavior with the temp file kept in place.
+	if geometryUsable && d.cropDownloadedPoster(tempPath, destPath, bounds) {
+		_ = d.fs.Remove(tempPath)
+		d.finalizePosterResult(result, destPath)
+		return result, nil
+	}
+
+	if !movie.Poster.ShouldCropPoster {
+		// Preserve the pre-geometry direct-download success: promote the
+		// already-downloaded bytes rather than re-requesting the URL.
+		if rerr := d.fs.Rename(tempPath, destPath); rerr != nil {
+			logging.Warnf("downloadPoster: failed to promote %s: %v", tempPath, rerr)
+			_ = d.fs.Remove(tempPath)
+			result.Downloaded = false
+			result.LocalPath = "" // never report the removed temp path
+			result.Size = 0
+			result.Error = fmt.Errorf("failed to finalize poster: %w", rerr)
+			return result, result.Error
+		}
+		d.finalizePosterResult(result, destPath)
+		return result, nil
+	}
+
+	// Low-quality poster - crop from the downloaded cover
 	if err := imageutil.CropPosterFromCover(d.fs, tempPath, destPath, d.config.MaxPosterHeight); err != nil {
 		_ = d.fs.Remove(tempPath) // Clean up temp file
 		result.Error = fmt.Errorf("failed to crop poster: %w", err)
@@ -86,6 +119,70 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 	}
 
 	return result, nil
+}
+
+// finalizePosterResult points result at the promoted poster, or clears the
+// location fields so a caller can never see a dangling (removed) temp path.
+func (d *Downloader) finalizePosterResult(result *DownloadResult, destPath string) {
+	result.LocalPath = ""
+	result.Size = 0
+	if info, err := d.fs.Stat(destPath); err == nil {
+		result.LocalPath = destPath
+		result.Size = info.Size()
+	}
+}
+
+// cropDownloadedPoster applies the normalized review-page geometry to an
+// already-downloaded full source image and writes the final poster.
+// Returns false when the geometry does not apply to this image (undecodable,
+// aspect drift, empty rect); the caller then falls back to the pre-geometry
+// behavior with the temp file still in place.
+func (d *Downloader) cropDownloadedPoster(tempPath, destPath string, bounds *models.CropBounds) bool {
+	w, h, derr := imageutil.ImageDimensions(d.fs, tempPath)
+	if derr != nil || w <= 0 || h <= 0 {
+		logging.Warnf("downloadPoster: cannot decode downloaded source for manual crop: %v", derr)
+		return false
+	}
+
+	// Aspect guard: the geometry was normalized against the review-time
+	// source; if the downloaded image no longer matches that aspect, the
+	// geometry targets a different image — refuse and fall back.
+	if bounds.SourceAspect > 0 {
+		got := float64(w) / float64(h)
+		diff := math.Abs(got - bounds.SourceAspect)
+		if diff > 0.01*bounds.SourceAspect {
+			logging.Warnf("downloadPoster: manual crop aspect mismatch (crop %.4f, downloaded %.4f); falling back", bounds.SourceAspect, got)
+			return false
+		}
+	}
+
+	fw, fh := float64(w), float64(h)
+	left := int(math.Round(bounds.X * fw))
+	top := int(math.Round(bounds.Y * fh))
+	right := int(math.Round((bounds.X + bounds.Width) * fw))
+	bottom := int(math.Round((bounds.Y + bounds.Height) * fh))
+	if left < 0 {
+		left = 0
+	}
+	if top < 0 {
+		top = 0
+	}
+	if right > w {
+		right = w
+	}
+	if bottom > h {
+		bottom = h
+	}
+	if right <= left || bottom <= top {
+		logging.Warnf("downloadPoster: manual crop geometry collapses to empty rect; falling back")
+		return false
+	}
+
+	if err := imageutil.CropPosterWithBounds(d.fs, tempPath, destPath, left, top, right, bottom, d.config.MaxPosterHeight); err != nil {
+		logging.Warnf("downloadPoster: manual crop failed: %v", err)
+		return false
+	}
+	return true
 }
 
 // downloadExtrafanart downloads screenshots to the extrafanart subdirectory.

--- a/internal/downloader/poster_crop_geometry_test.go
+++ b/internal/downloader/poster_crop_geometry_test.go
@@ -192,6 +192,41 @@ func TestDownloadPoster_PromoteFailureIsCleanError(t *testing.T) {
 	assert.Zero(t, result.Size)
 }
 
+// Existing destination + usable manual geometry: organize must REPLACE the
+// old artwork with the manual crop (the user explicitly re-cropped at review).
+func TestDownloadPoster_ExistingDestReplacedByManualCrop(t *testing.T) {
+	server := serveTwoToneSource(t)
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/dest/IPX-535-poster.jpg", []byte("old artwork"), 0o644))
+	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+	}, true)
+
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	require.NoError(t, err)
+	require.True(t, result.Downloaded, "existing poster must be replaced when manual geometry is pending")
+
+	img, w, _ := decodeResultPoster(t, fs, result.LocalPath)
+	assert.InDelta(t, 400, w, 2)
+	assert.Less(t, sampleLuma(img, 0.5, 0.5), 40.0)
+}
+
+// Existing destination without pending geometry keeps pre-change behavior:
+// the existing file is left untouched.
+func TestDownloadPoster_ExistingDestKeptWithoutGeometry(t *testing.T) {
+	server := serveTwoToneSource(t)
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/dest/IPX-535-poster.jpg", []byte("old artwork"), 0o644))
+	movie := geometryMovie(server.URL+"/cover.jpg", nil, true)
+
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	require.NoError(t, err)
+	assert.False(t, result.Downloaded, "no geometry: existing poster must be kept")
+	content, err := afero.ReadFile(fs, "/dest/IPX-535-poster.jpg")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("old artwork"), content)
+}
+
 // finalizePosterResult clears the location fields when the promoted file
 // cannot be stat'd, and points at the file with its size when it can.
 func TestFinalizePosterResult_StatFailClearsLocation(t *testing.T) {

--- a/internal/downloader/poster_crop_geometry_test.go
+++ b/internal/downloader/poster_crop_geometry_test.go
@@ -192,9 +192,11 @@ func TestDownloadPoster_PromoteFailureIsCleanError(t *testing.T) {
 	assert.Zero(t, result.Size)
 }
 
-// Existing destination + usable manual geometry: organize must REPLACE the
-// old artwork with the manual crop (the user explicitly re-cropped at review).
-func TestDownloadPoster_ExistingDestReplacedByManualCrop(t *testing.T) {
+// Existing destination + pending manual crop geometry: existing artwork is
+// still never replaced — replacement would break revert (downloaded paths are
+// deleted on revert, and the pre-existing poster would be gone). In-place
+// artwork refresh is follow-up work requiring overwrite tracking.
+func TestDownloadPoster_ExistingDestKeptWithGeometry(t *testing.T) {
 	server := serveTwoToneSource(t)
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "/dest/IPX-535-poster.jpg", []byte("old artwork"), 0o644))
@@ -204,11 +206,10 @@ func TestDownloadPoster_ExistingDestReplacedByManualCrop(t *testing.T) {
 
 	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
 	require.NoError(t, err)
-	require.True(t, result.Downloaded, "existing poster must be replaced when manual geometry is pending")
-
-	img, w, _ := decodeResultPoster(t, fs, result.LocalPath)
-	assert.InDelta(t, 400, w, 2)
-	assert.Less(t, sampleLuma(img, 0.5, 0.5), 40.0)
+	assert.False(t, result.Downloaded, "existing poster must be kept even with pending geometry")
+	content, err := afero.ReadFile(fs, "/dest/IPX-535-poster.jpg")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("old artwork"), content)
 }
 
 // Existing destination without pending geometry keeps pre-change behavior:

--- a/internal/downloader/poster_crop_geometry_test.go
+++ b/internal/downloader/poster_crop_geometry_test.go
@@ -1,0 +1,213 @@
+package downloader
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Two-tone 1000x600 source: left half black, right half white. The scraper's
+// auto-crop (CropPosterFromCover) takes the right ~47%% of a landscape cover,
+// so a manual LEFT crop producing black pixels proves the persisted geometry
+// beat the scraper default.
+func serveTwoToneSource(t *testing.T) *httptest.Server {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 1000, 600))
+	for y := 0; y < 600; y++ {
+		for x := 0; x < 1000; x++ {
+			if x < 500 {
+				img.Set(x, y, color.Black)
+			} else {
+				img.Set(x, y, color.White)
+			}
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_ = jpeg.Encode(w, img, &jpeg.Options{Quality: 95})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newGeometryDownloader(fs afero.Fs) *Downloader {
+	return NewDownloader(http.DefaultClient, fs, &Config{
+		DownloadPoster:  true,
+		MaxPosterHeight: 0,
+		MediaFormatConfig: organizer.MediaFormatConfig{
+			PosterFormat: "<ID>-poster.jpg",
+		},
+	}, nil)
+}
+
+func decodeResultPoster(t *testing.T, fs afero.Fs, path string) (image.Image, int, int) {
+	t.Helper()
+	f, err := fs.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	img, err := jpeg.Decode(f)
+	require.NoError(t, err, "poster at %s must decode as jpeg", path)
+	return img, img.Bounds().Dx(), img.Bounds().Dy()
+}
+
+// sampleLuma reads the luma at a fractional position, far from edges to
+// avoid JPEG edge-blend artifacts on the two-tone boundary.
+func sampleLuma(img image.Image, fx, fy float64) float64 {
+	b := img.Bounds()
+	x := b.Min.X + int(fx*float64(b.Dx()))
+	y := b.Min.Y + int(fy*float64(b.Dy()))
+	r, g, bl, _ := img.At(x, y).RGBA()
+	return 0.299*float64(r>>8) + 0.587*float64(g>>8) + 0.114*float64(bl>>8)
+}
+
+func geometryMovie(url string, bounds *models.CropBounds, autoCrop bool) *models.Movie {
+	m := &models.Movie{ID: "IPX-535", ContentID: "ipx00535", Title: "Crop"}
+	m.Poster.PosterURL = url
+	m.Poster.ShouldCropPoster = autoCrop
+	if bounds != nil {
+		m.Poster.PosterCropBounds = bounds
+		m.Poster.PosterCropSourceFull = true
+	}
+	return m
+}
+
+// The persisted manual crop geometry is applied to the downloaded source
+// instead of the scraper's default right-side auto-crop.
+func TestDownloadPoster_ManualGeometryApplied(t *testing.T) {
+	server := serveTwoToneSource(t)
+	fs := afero.NewMemMapFs()
+	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+	}, true)
+
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	require.NoError(t, err)
+	require.True(t, result.Downloaded)
+
+	img, w, h := decodeResultPoster(t, fs, result.LocalPath)
+	assert.InDelta(t, 400, w, 2, "manual crop width (0.4 of 1000px)")
+	assert.Equal(t, 600, h)
+	assert.Less(t, sampleLuma(img, 0.5, 0.5), 40.0,
+		"manual LEFT crop must keep the black half (auto-crop would have kept white)")
+}
+
+// Invalid geometry never fails organize: with should_crop_poster=true the
+// scraper auto-crop still runs.
+func TestDownloadPoster_InvalidGeometryFallsBackToAutoCrop(t *testing.T) {
+	server := serveTwoToneSource(t)
+	fs := afero.NewMemMapFs()
+	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
+		X: 0, Y: 0, Width: 1.5, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+	}, true)
+
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	require.NoError(t, err)
+	require.True(t, result.Downloaded)
+
+	img, w, _ := decodeResultPoster(t, fs, result.LocalPath)
+	assert.InDelta(t, 472, w, 3, "auto-crop keeps the right ~47.2%%")
+	assert.Greater(t, sampleLuma(img, 0.5, 0.5), 215.0, "auto-crop must keep the white half")
+}
+
+// With should_crop_poster=false the pre-geometry direct-download success path
+// is preserved even when geometry is present but invalid.
+func TestDownloadPoster_InvalidGeometryKeepsDirectDownloadSuccess(t *testing.T) {
+	server := serveTwoToneSource(t)
+	fs := afero.NewMemMapFs()
+	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
+		X: 0, Y: 0, Width: 0, Height: 0, SourceAspect: 1000.0 / 600.0,
+	}, false)
+
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	require.NoError(t, err)
+	require.True(t, result.Downloaded)
+
+	_, w, h := decodeResultPoster(t, fs, result.LocalPath)
+	assert.Equal(t, 1000, w)
+	assert.Equal(t, 600, h, "uncropped source must land unchanged")
+}
+
+// Geometry whose recorded aspect no longer matches the downloaded image is
+// stale (different image behind the same URL): refuse it and fall back —
+// reusing the one download already made (single-use URLs must not be re-GET).
+func TestDownloadPoster_AspectMismatchFallsBack(t *testing.T) {
+	var hits atomic.Int32
+	img := image.NewRGBA(image.Rect(0, 0, 1000, 600))
+	for y := 0; y < 600; y++ {
+		for x := 0; x < 1000; x++ {
+			img.Set(x, y, color.White)
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "image/jpeg")
+		_ = jpeg.Encode(w, img, &jpeg.Options{Quality: 95})
+	}))
+	t.Cleanup(srv.Close)
+	fs := afero.NewMemMapFs()
+	movie := geometryMovie(srv.URL+"/cover.jpg", &models.CropBounds{
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 378.0 / 529.0,
+	}, true)
+
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	require.NoError(t, err)
+	require.True(t, result.Downloaded)
+
+	got, _, _ := decodeResultPoster(t, fs, result.LocalPath)
+	assert.Greater(t, sampleLuma(got, 0.5, 0.5), 215.0, "stale aspect must fall back to white auto-crop")
+	assert.Equal(t, int32(1), hits.Load(), "auto-crop fallback must reuse the downloaded temp, not re-GET")
+}
+
+// An undecodable download with should_crop_poster=false keeps today's
+// direct-download success — a previously successful organize must not newly fail.
+func TestDownloadPoster_UndecodableKeepsDirectDownloadSuccess(t *testing.T) {
+	raw := []byte("not an image at all")
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write(raw)
+	}))
+	t.Cleanup(srv.Close)
+	fs := afero.NewMemMapFs()
+	movie := geometryMovie(srv.URL+"/poster.jpg", &models.CropBounds{
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 0.5,
+	}, false)
+
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	require.NoError(t, err)
+	require.True(t, result.Downloaded)
+
+	content, err := afero.ReadFile(fs, result.LocalPath)
+	require.NoError(t, err)
+	assert.Equal(t, raw, content, "direct download must deliver raw bytes unchanged")
+	assert.Equal(t, int32(1), hits.Load(), "direct fallback must reuse the downloaded temp, not re-GET")
+}
+
+// Geometry flagged as measured against the legacy already-cropped preview is
+// never applied — pre-geometry behavior exactly.
+func TestDownloadPoster_NonFullSourceGeometryIgnored(t *testing.T) {
+	server := serveTwoToneSource(t)
+	fs := afero.NewMemMapFs()
+	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+	}, true)
+	movie.Poster.PosterCropSourceFull = false
+
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	require.NoError(t, err)
+	require.True(t, result.Downloaded)
+
+	img, _, _ := decodeResultPoster(t, fs, result.LocalPath)
+	assert.Greater(t, sampleLuma(img, 0.5, 0.5), 215.0, "legacy geometry must be ignored (auto-crop white)")
+}

--- a/internal/downloader/poster_crop_geometry_test.go
+++ b/internal/downloader/poster_crop_geometry_test.go
@@ -2,11 +2,14 @@ package downloader
 
 import (
 	"context"
+	"errors"
 	"image"
 	"image/color"
 	"image/jpeg"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -84,6 +87,130 @@ func geometryMovie(url string, bounds *models.CropBounds, autoCrop bool) *models
 
 // The persisted manual crop geometry is applied to the downloaded source
 // instead of the scraper's default right-side auto-crop.
+// renameFailFs blocks only the final promote rename (dst = the poster
+// destination); the downloader's internal atomic ".tmp" staging is let
+// through — the promote step is the one under test.
+type renameFailFs struct {
+	afero.Fs
+}
+
+func (f renameFailFs) Rename(src, dst string) error {
+	if strings.HasSuffix(dst, "-poster.jpg") {
+		return errTestRenameFail
+	}
+	return f.Fs.Rename(src, dst)
+}
+
+var errTestRenameFail = errors.New("rename blocked")
+
+// Download failure with otherwise-applyable geometry: the error propagates
+// and nothing is left behind. Exactly one request is made.
+func TestDownloadPoster_GeometryDownloadFailurePropagates(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	fs := afero.NewMemMapFs()
+	movie := geometryMovie(srv.URL+"/cover.jpg", &models.CropBounds{
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+	}, true)
+
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	require.Error(t, err)
+	require.False(t, result.Downloaded)
+	assert.Equal(t, int32(1), hits.Load())
+	leftover, _ := afero.ReadDir(fs, "/dest")
+	assert.Empty(t, leftover, "no temp or dest file may survive a failed download")
+}
+
+// Dimensions decode fine (header intact) but pixel data is truncated: the
+// crop itself fails, and with scraper auto-crop intent the auto-crop attempt
+// fails identically — pre-change behavior for a broken source image.
+func TestDownloadPoster_GeometryCropFailureFallsToAutoCropError(t *testing.T) {
+	srv := serveTwoToneSource(t)
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	full, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	// Header survives DecodeConfig, pixels are gone.
+	trunc := full[:len(full)/3]
+	var hits atomic.Int32
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(trunc)
+	}))
+	t.Cleanup(ts2.Close)
+
+	fs := afero.NewMemMapFs()
+	movie := geometryMovie(ts2.URL+"/cover.jpg", &models.CropBounds{
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+	}, true)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	assert.Error(t, err, "broken source fails exactly like the pre-change auto-crop path")
+	require.False(t, result.Downloaded)
+	assert.Equal(t, int32(1), hits.Load())
+}
+
+// Geometry that rounds to an empty pixel rect falls back cleanly to the
+// scraper auto-crop.
+func TestDownloadPoster_DegenerateRectFallsBack(t *testing.T) {
+	server := serveTwoToneSource(t)
+	fs := afero.NewMemMapFs()
+	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
+		X: 0.5, Y: 0.5, Width: 0.0001, Height: 0.0001, SourceAspect: 1000.0 / 600.0,
+	}, true)
+
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	require.NoError(t, err)
+	require.True(t, result.Downloaded)
+	img, w, _ := decodeResultPoster(t, fs, result.LocalPath)
+	assert.InDelta(t, 472, w, 3, "degenerate geometry must fall back to auto-crop")
+	assert.Greater(t, sampleLuma(img, 0.5, 0.5), 215.0)
+}
+
+// Rename failure on the direct-promote fallback: clean error, no dangling
+// temp path in the result.
+func TestDownloadPoster_PromoteFailureIsCleanError(t *testing.T) {
+	fs := renameFailFs{afero.NewMemMapFs()}
+	// Undecodable payload: the geometry path bails to the direct-promote fallback.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("definitely not jpeg"))
+	}))
+	t.Cleanup(srv.Close)
+	movie := geometryMovie(srv.URL+"/poster.jpg", &models.CropBounds{
+		X: 0, Y: 0, Width: 0.4, Height: 1, SourceAspect: 1000.0 / 600.0,
+	}, false)
+
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	require.Error(t, err)
+	assert.False(t, result.Downloaded)
+	assert.Empty(t, result.LocalPath, "removed temp path must never leak into the result")
+	assert.Zero(t, result.Size)
+}
+
+// finalizePosterResult clears the location fields when the promoted file
+// cannot be stat'd, and points at the file with its size when it can.
+func TestFinalizePosterResult_StatFailClearsLocation(t *testing.T) {
+	d := newGeometryDownloader(afero.NewMemMapFs())
+	result := &DownloadResult{Downloaded: true, LocalPath: "/dest/X-poster.jpg.full.tmp", Size: 99}
+	d.finalizePosterResult(result, "/dest/X-poster.jpg")
+	assert.Empty(t, result.LocalPath, "missing destination must clear the temp path")
+	assert.Zero(t, result.Size)
+}
+
+func TestFinalizePosterResult_StatSuccessSetsLocation(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/dest/X-poster.jpg", []byte("img"), 0o644))
+	d := newGeometryDownloader(fs)
+	result := &DownloadResult{Downloaded: true}
+	d.finalizePosterResult(result, "/dest/X-poster.jpg")
+	assert.Equal(t, "/dest/X-poster.jpg", result.LocalPath)
+	assert.Equal(t, int64(3), result.Size)
+}
 func TestDownloadPoster_ManualGeometryApplied(t *testing.T) {
 	server := serveTwoToneSource(t)
 	fs := afero.NewMemMapFs()

--- a/internal/imageutil/crop.go
+++ b/internal/imageutil/crop.go
@@ -24,6 +24,21 @@ const (
 	LandscapeAspectRatioThreshold = 1.2
 )
 
+// ImageDimensions reads pixel dimensions from an image header without
+// decoding the pixel data.
+func ImageDimensions(fs afero.Fs, path string) (int, int, error) {
+	f, err := fs.Open(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer func() { _ = f.Close() }()
+	cfg, _, err := image.DecodeConfig(f)
+	if err != nil {
+		return 0, 0, err
+	}
+	return cfg.Width, cfg.Height, nil
+}
+
 // CropPosterFromCover intelligently crops a cover image to create a poster.
 //
 // Strategy:

--- a/internal/imageutil/image_dimensions_test.go
+++ b/internal/imageutil/image_dimensions_test.go
@@ -1,0 +1,52 @@
+package imageutil
+
+import (
+	"image"
+	"image/jpeg"
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+func TestImageDimensions(t *testing.T) {
+	t.Parallel()
+	fs := afero.NewMemMapFs()
+
+	img := image.NewRGBA(image.Rect(0, 0, 640, 480))
+	for i := range img.Pix {
+		img.Pix[i] = 128
+	}
+	f, err := fs.Create("/ok.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := jpeg.Encode(f, img, nil); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	t.Run("reads header-only dimensions", func(t *testing.T) {
+		w, h, err := ImageDimensions(fs, "/ok.jpg")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if w != 640 || h != 480 {
+			t.Fatalf("dims = %dx%d, want 640x480", w, h)
+		}
+	})
+
+	t.Run("missing file returns open error", func(t *testing.T) {
+		if _, _, err := ImageDimensions(fs, "/nope.jpg"); err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+
+	t.Run("undecodable content returns decode error", func(t *testing.T) {
+		if err := afero.WriteFile(fs, "/garbage.jpg", []byte("not an image"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := ImageDimensions(fs, "/garbage.jpg"); err == nil {
+			t.Fatal("expected decode error for garbage bytes")
+		}
+	})
+}

--- a/internal/mocks/worker/BatchJobInterface.go
+++ b/internal/mocks/worker/BatchJobInterface.go
@@ -1375,16 +1375,16 @@ func (_c *MockBatchJobInterface_UpdateMovie_Call) RunAndReturn(run func(ctx cont
 }
 
 // UpdatePosterCrop provides a mock function for the type MockBatchJobInterface
-func (_mock *MockBatchJobInterface) UpdatePosterCrop(movieID string, croppedURL string) error {
-	ret := _mock.Called(movieID, croppedURL)
+func (_mock *MockBatchJobInterface) UpdatePosterCrop(movieID string, croppedURL string, bounds *models.CropBounds, sourceFull bool) error {
+	ret := _mock.Called(movieID, croppedURL, bounds, sourceFull)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdatePosterCrop")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(movieID, croppedURL)
+	if returnFunc, ok := ret.Get(0).(func(string, string, *models.CropBounds, bool) error); ok {
+		r0 = returnFunc(movieID, croppedURL, bounds, sourceFull)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1399,11 +1399,13 @@ type MockBatchJobInterface_UpdatePosterCrop_Call struct {
 // UpdatePosterCrop is a helper method to define mock.On call
 //   - movieID string
 //   - croppedURL string
-func (_e *MockBatchJobInterface_Expecter) UpdatePosterCrop(movieID any, croppedURL any) *MockBatchJobInterface_UpdatePosterCrop_Call {
-	return &MockBatchJobInterface_UpdatePosterCrop_Call{Call: _e.mock.On("UpdatePosterCrop", movieID, croppedURL)}
+//   - bounds *models.CropBounds
+//   - sourceFull bool
+func (_e *MockBatchJobInterface_Expecter) UpdatePosterCrop(movieID any, croppedURL any, bounds any, sourceFull any) *MockBatchJobInterface_UpdatePosterCrop_Call {
+	return &MockBatchJobInterface_UpdatePosterCrop_Call{Call: _e.mock.On("UpdatePosterCrop", movieID, croppedURL, bounds, sourceFull)}
 }
 
-func (_c *MockBatchJobInterface_UpdatePosterCrop_Call) Run(run func(movieID string, croppedURL string)) *MockBatchJobInterface_UpdatePosterCrop_Call {
+func (_c *MockBatchJobInterface_UpdatePosterCrop_Call) Run(run func(movieID string, croppedURL string, bounds *models.CropBounds, sourceFull bool)) *MockBatchJobInterface_UpdatePosterCrop_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -1413,9 +1415,19 @@ func (_c *MockBatchJobInterface_UpdatePosterCrop_Call) Run(run func(movieID stri
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 *models.CropBounds
+		if args[2] != nil {
+			arg2 = args[2].(*models.CropBounds)
+		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -1426,7 +1438,7 @@ func (_c *MockBatchJobInterface_UpdatePosterCrop_Call) Return(err error) *MockBa
 	return _c
 }
 
-func (_c *MockBatchJobInterface_UpdatePosterCrop_Call) RunAndReturn(run func(movieID string, croppedURL string) error) *MockBatchJobInterface_UpdatePosterCrop_Call {
+func (_c *MockBatchJobInterface_UpdatePosterCrop_Call) RunAndReturn(run func(movieID string, croppedURL string, bounds *models.CropBounds, sourceFull bool) error) *MockBatchJobInterface_UpdatePosterCrop_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/mocks/worker/EditableJob.go
+++ b/internal/mocks/worker/EditableJob.go
@@ -862,16 +862,16 @@ func (_c *MockEditableJob_UpdateMovie_Call) RunAndReturn(run func(ctx context.Co
 }
 
 // UpdatePosterCrop provides a mock function for the type MockEditableJob
-func (_mock *MockEditableJob) UpdatePosterCrop(movieID string, croppedURL string) error {
-	ret := _mock.Called(movieID, croppedURL)
+func (_mock *MockEditableJob) UpdatePosterCrop(movieID string, croppedURL string, bounds *models.CropBounds, sourceFull bool) error {
+	ret := _mock.Called(movieID, croppedURL, bounds, sourceFull)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdatePosterCrop")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(movieID, croppedURL)
+	if returnFunc, ok := ret.Get(0).(func(string, string, *models.CropBounds, bool) error); ok {
+		r0 = returnFunc(movieID, croppedURL, bounds, sourceFull)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -886,11 +886,13 @@ type MockEditableJob_UpdatePosterCrop_Call struct {
 // UpdatePosterCrop is a helper method to define mock.On call
 //   - movieID string
 //   - croppedURL string
-func (_e *MockEditableJob_Expecter) UpdatePosterCrop(movieID any, croppedURL any) *MockEditableJob_UpdatePosterCrop_Call {
-	return &MockEditableJob_UpdatePosterCrop_Call{Call: _e.mock.On("UpdatePosterCrop", movieID, croppedURL)}
+//   - bounds *models.CropBounds
+//   - sourceFull bool
+func (_e *MockEditableJob_Expecter) UpdatePosterCrop(movieID any, croppedURL any, bounds any, sourceFull any) *MockEditableJob_UpdatePosterCrop_Call {
+	return &MockEditableJob_UpdatePosterCrop_Call{Call: _e.mock.On("UpdatePosterCrop", movieID, croppedURL, bounds, sourceFull)}
 }
 
-func (_c *MockEditableJob_UpdatePosterCrop_Call) Run(run func(movieID string, croppedURL string)) *MockEditableJob_UpdatePosterCrop_Call {
+func (_c *MockEditableJob_UpdatePosterCrop_Call) Run(run func(movieID string, croppedURL string, bounds *models.CropBounds, sourceFull bool)) *MockEditableJob_UpdatePosterCrop_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -900,9 +902,19 @@ func (_c *MockEditableJob_UpdatePosterCrop_Call) Run(run func(movieID string, cr
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 *models.CropBounds
+		if args[2] != nil {
+			arg2 = args[2].(*models.CropBounds)
+		}
+		var arg3 bool
+		if args[3] != nil {
+			arg3 = args[3].(bool)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -913,7 +925,7 @@ func (_c *MockEditableJob_UpdatePosterCrop_Call) Return(err error) *MockEditable
 	return _c
 }
 
-func (_c *MockEditableJob_UpdatePosterCrop_Call) RunAndReturn(run func(movieID string, croppedURL string) error) *MockEditableJob_UpdatePosterCrop_Call {
+func (_c *MockEditableJob_UpdatePosterCrop_Call) RunAndReturn(run func(movieID string, croppedURL string, bounds *models.CropBounds, sourceFull bool) error) *MockEditableJob_UpdatePosterCrop_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/models/movie.go
+++ b/internal/models/movie.go
@@ -295,16 +295,20 @@ func (m *Movie) Clone() *Movie {
 func (m Movie) MarshalJSON() ([]byte, error) {
 	type Alias Movie
 	aux := &struct {
-		PosterURL                string `json:"poster_url"`
-		CoverURL                 string `json:"cover_url"`
-		CroppedPosterURL         string `json:"cropped_poster_url"`
-		ShouldCropPoster         bool   `json:"should_crop_poster"`
-		OriginalPosterURL        string `json:"original_poster_url"`
-		OriginalCroppedPosterURL string `json:"original_cropped_poster_url"`
-		OriginalShouldCropPoster *bool  `json:"original_should_crop_poster"`
-		OriginalCoverURL         string `json:"original_cover_url"`
+		PosterCropBounds         *CropBounds `json:"poster_crop_bounds,omitempty"`
+		PosterCropSourceFull     bool        `json:"poster_crop_source_full,omitempty"`
+		PosterURL                string      `json:"poster_url"`
+		CoverURL                 string      `json:"cover_url"`
+		CroppedPosterURL         string      `json:"cropped_poster_url"`
+		ShouldCropPoster         bool        `json:"should_crop_poster"`
+		OriginalPosterURL        string      `json:"original_poster_url"`
+		OriginalCroppedPosterURL string      `json:"original_cropped_poster_url"`
+		OriginalShouldCropPoster *bool       `json:"original_should_crop_poster"`
+		OriginalCoverURL         string      `json:"original_cover_url"`
 		*Alias
 	}{
+		PosterCropBounds:         m.Poster.PosterCropBounds,
+		PosterCropSourceFull:     m.Poster.PosterCropSourceFull,
 		PosterURL:                m.Poster.PosterURL,
 		CoverURL:                 m.Poster.CoverURL,
 		CroppedPosterURL:         m.Poster.CroppedPosterURL,
@@ -323,14 +327,16 @@ func (m Movie) MarshalJSON() ([]byte, error) {
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type Alias Movie
 	aux := &struct {
-		PosterURL                string `json:"poster_url"`
-		CoverURL                 string `json:"cover_url"`
-		CroppedPosterURL         string `json:"cropped_poster_url"`
-		ShouldCropPoster         bool   `json:"should_crop_poster"`
-		OriginalPosterURL        string `json:"original_poster_url"`
-		OriginalCroppedPosterURL string `json:"original_cropped_poster_url"`
-		OriginalShouldCropPoster *bool  `json:"original_should_crop_poster"`
-		OriginalCoverURL         string `json:"original_cover_url"`
+		PosterCropBounds         *CropBounds `json:"poster_crop_bounds,omitempty"`
+		PosterCropSourceFull     bool        `json:"poster_crop_source_full,omitempty"`
+		PosterURL                string      `json:"poster_url"`
+		CoverURL                 string      `json:"cover_url"`
+		CroppedPosterURL         string      `json:"cropped_poster_url"`
+		ShouldCropPoster         bool        `json:"should_crop_poster"`
+		OriginalPosterURL        string      `json:"original_poster_url"`
+		OriginalCroppedPosterURL string      `json:"original_cropped_poster_url"`
+		OriginalShouldCropPoster *bool       `json:"original_should_crop_poster"`
+		OriginalCoverURL         string      `json:"original_cover_url"`
 		*Alias
 	}{
 		Alias: (*Alias)(m),
@@ -339,6 +345,8 @@ func (m *Movie) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	m.Poster = PosterState{
+		PosterCropBounds:         aux.PosterCropBounds,
+		PosterCropSourceFull:     aux.PosterCropSourceFull,
 		PosterURL:                aux.PosterURL,
 		CoverURL:                 aux.CoverURL,
 		CroppedPosterURL:         aux.CroppedPosterURL,

--- a/internal/models/poster_state.go
+++ b/internal/models/poster_state.go
@@ -1,11 +1,22 @@
 package models
 
+import "math"
+
 // PosterState groups the seven poster/cropping fields extracted from Movie.
 // Embedded in Movie with gorm:"embedded" so column names are preserved (zero-migration).
 // JSON serialization is handled by custom MarshalJSON/UnmarshalJSON on Movie to keep
 // the flat wire format — do NOT change the json tag on the Movie.Poster field from
 // json:"-" or poster fields will disappear from API responses.
 type PosterState struct {
+	// PosterCropBounds is the manual review-page crop geometry, normalized to
+	// 0–1 fractions of the full-size source image measured at crop time.
+	// Runtime-only (gorm:"-"): review intent is not library truth — no DB column.
+	// Nil when no manual crop is pending apply.
+	PosterCropBounds *CropBounds `json:"poster_crop_bounds,omitempty" gorm:"-"`
+	// PosterCropSourceFull records whether the bounds were measured against the
+	// full-size source (<id>-full.jpg). False (legacy already-cropped fallback)
+	// means the bounds are not applyable at organize time.
+	PosterCropSourceFull     bool   `json:"poster_crop_source_full,omitempty" gorm:"-"`
 	PosterURL                string `json:"poster_url"`
 	CoverURL                 string `json:"cover_url"`
 	CroppedPosterURL         string `json:"cropped_poster_url"`
@@ -19,9 +30,47 @@ type PosterState struct {
 // Clone returns a deep copy of the PosterState.
 func (p PosterState) Clone() PosterState {
 	cp := p
+	if p.PosterCropBounds != nil {
+		b := *p.PosterCropBounds
+		cp.PosterCropBounds = &b
+	}
 	if p.OriginalShouldCropPoster != nil {
 		b := *p.OriginalShouldCropPoster
 		cp.OriginalShouldCropPoster = &b
 	}
 	return cp
+}
+
+// CropBounds is a normalized poster crop rectangle. All components are 0–1
+// fractions of the full-size source image the crop was measured against, so
+// the geometry is resolution-stable across the maxPosterHeight downscale.
+type CropBounds struct {
+	X      float64 `json:"x"`
+	Y      float64 `json:"y"`
+	Width  float64 `json:"width"`
+	Height float64 `json:"height"`
+	// SourceAspect is the width/height ratio of the source image the crop was
+	// measured against. The apply phase refuses geometry whose aspect no
+	// longer matches the downloaded image, so same-URL source swaps fall back
+	// to pre-change behavior instead of cropping the wrong image.
+	SourceAspect float64 `json:"source_aspect,omitempty"`
+}
+
+// Valid reports whether the normalized crop geometry is applyable: every
+// component finite and within [0,1], strictly positive size, and the
+// rectangle contained in the unit square. The 1e-9 tolerance absorbs float
+// division error when pixel bounds land exactly on the source edge.
+func (b CropBounds) Valid() bool {
+	for _, v := range []float64{b.X, b.Y, b.Width, b.Height} {
+		if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 || v > 1 {
+			return false
+		}
+	}
+	// SourceAspect 0 = unset (no aspect guard); a negative or non-finite
+	// aspect is invalid — never "skip the guard" on corrupted geometry.
+	if b.SourceAspect < 0 || math.IsNaN(b.SourceAspect) || math.IsInf(b.SourceAspect, 0) {
+		return false
+	}
+	const tol = 1e-9
+	return b.Width > 0 && b.Height > 0 && b.X+b.Width <= 1+tol && b.Y+b.Height <= 1+tol
 }

--- a/internal/models/poster_state_test.go
+++ b/internal/models/poster_state_test.go
@@ -1,0 +1,92 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The manual review-page crop geometry must round-trip through Movie's custom
+// MarshalJSON/UnmarshalJSON — it is the only codec carrying poster fields.
+func TestPosterCropGeometryJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	movie := &Movie{
+		ContentID: "ipx00123",
+		Title:     "Crop Geometry",
+		Poster: PosterState{
+			PosterURL:            "https://example.com/poster.jpg",
+			ShouldCropPoster:     true,
+			PosterCropBounds:     &CropBounds{X: 0.0, Y: 0.1, Width: 0.4, Height: 0.8},
+			PosterCropSourceFull: true,
+		},
+	}
+
+	data, err := json.Marshal(movie)
+	require.NoError(t, err)
+
+	var wire map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &wire))
+	bounds, ok := wire["poster_crop_bounds"].(map[string]interface{})
+	require.True(t, ok, "poster_crop_bounds missing from marshaled movie")
+	assert.Equal(t, 0.4, bounds["width"])
+	assert.Equal(t, 0.1, bounds["y"])
+	assert.Equal(t, true, wire["poster_crop_source_full"])
+
+	var decoded Movie
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Poster.PosterCropBounds)
+	assert.Equal(t, *movie.Poster.PosterCropBounds, *decoded.Poster.PosterCropBounds)
+	assert.True(t, decoded.Poster.PosterCropSourceFull)
+	assert.Equal(t, "https://example.com/poster.jpg", decoded.Poster.PosterURL)
+	assert.True(t, decoded.Poster.ShouldCropPoster)
+}
+
+// Without pending geometry both fields must be omitted, keeping the wire
+// format byte-compatible with pre-change payloads (and golden files).
+func TestPosterCropGeometryJSONOmittedWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(&Movie{ContentID: "ipx00123"})
+	require.NoError(t, err)
+
+	var wire map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &wire))
+	_, hasBounds := wire["poster_crop_bounds"]
+	_, hasSourceFull := wire["poster_crop_source_full"]
+	assert.False(t, hasBounds, "poster_crop_bounds must be omitted when nil")
+	assert.False(t, hasSourceFull, "poster_crop_source_full must be omitted when false")
+}
+
+func TestCropBoundsValid(t *testing.T) {
+	t.Parallel()
+	valid := CropBounds{X: 0.1, Y: 0.05, Width: 0.4, Height: 0.9, SourceAspect: 1.667}
+	assert.True(t, valid.Valid())
+	assert.True(t, CropBounds{X: 0, Y: 0, Width: 1, Height: 1}.Valid(), "full-frame exact-edge crop is valid")
+	assert.True(t, (&CropBounds{X: 0.1, Y: 0.1, Width: 0.5, Height: 0.5, SourceAspect: 0}).Valid(), "unset aspect allowed (guard skipped)")
+	assert.False(t, (&CropBounds{Width: 0, Height: 0.5}).Valid(), "zero size")
+	assert.False(t, (&CropBounds{X: 0.9, Width: 0.5, Height: 1}).Valid(), "containment violated")
+	assert.False(t, (&CropBounds{Width: 0.5, Height: 0.5, SourceAspect: -1}).Valid(), "negative aspect must not silently disable the guard")
+}
+
+// Clone must deep-copy PosterCropBounds so mutating a clone cannot corrupt
+// the stored job result.
+func TestPosterStateCloneDeepCopiesCropBounds(t *testing.T) {
+	t.Parallel()
+
+	orig := PosterState{
+		PosterCropBounds:     &CropBounds{X: 0.1, Y: 0.2, Width: 0.3, Height: 0.4},
+		PosterCropSourceFull: true,
+	}
+	clone := orig.Clone()
+
+	require.NotNil(t, clone.PosterCropBounds)
+	assert.Equal(t, *orig.PosterCropBounds, *clone.PosterCropBounds)
+	assert.NotSame(t, orig.PosterCropBounds, clone.PosterCropBounds)
+	assert.True(t, clone.PosterCropSourceFull)
+
+	clone.PosterCropBounds.Width = 0.9
+	assert.Equal(t, 0.3, orig.PosterCropBounds.Width, "clone mutation leaked into original")
+}

--- a/internal/poster/manager.go
+++ b/internal/poster/manager.go
@@ -35,6 +35,14 @@ type cropResult struct {
 	FullPath string
 	// CroppedURL is the URL that serves the cropped poster via the API.
 	CroppedURL string
+	// SourceFull is true when the crop was measured against the full-size
+	// source image (<id>-full.jpg); false means the legacy already-cropped
+	// fallback (<id>.jpg) served as the source.
+	SourceFull bool
+	// SourceWidth/SourceHeight are the pixel dimensions of the image the crop
+	// was measured against; zero when they could not be decoded.
+	SourceWidth  int
+	SourceHeight int
 }
 
 // PosterManagerInterface defines the contract for poster operations.
@@ -97,10 +105,12 @@ func (pm *PosterManager) CropWithBounds(_ context.Context, jobID, posterID strin
 
 	tempPosterDir := filepath.Join(pm.tempDir, "posters", jobID)
 	sourcePath := filepath.Join(tempPosterDir, fmt.Sprintf("%s-full.jpg", posterID))
+	sourceIsFull := true
 
 	// Fallback for older jobs where the full image was cleaned up.
 	if _, err := pm.fs.Stat(sourcePath); err != nil {
 		sourcePath = filepath.Join(tempPosterDir, fmt.Sprintf("%s.jpg", posterID))
+		sourceIsFull = false
 	}
 
 	if _, err := pm.fs.Stat(sourcePath); err != nil {
@@ -128,11 +138,19 @@ func (pm *PosterManager) CropWithBounds(_ context.Context, jobID, posterID strin
 
 	croppedURL := fmt.Sprintf("/api/v1/temp/posters/%s/%s.jpg?v=%d", url.PathEscape(jobID), url.PathEscape(posterID), time.Now().UnixMilli())
 
-	return &cropResult{
+	result := &cropResult{
 		CroppedPath: croppedPath,
 		FullPath:    sourcePath,
 		CroppedURL:  croppedURL,
-	}, nil
+		SourceFull:  sourceIsFull,
+	}
+	// Record the source dimensions; a decode failure leaves them zero and the
+	// caller treats the geometry as not applyable (pre-change behavior).
+	if w, h, err := imageutil.ImageDimensions(pm.fs, sourcePath); err == nil {
+		result.SourceWidth = w
+		result.SourceHeight = h
+	}
+	return result, nil
 }
 
 // DownloadFromURL downloads a poster image from rawURL, validates the URL

--- a/internal/worker/batch_job_interface.go
+++ b/internal/worker/batch_job_interface.go
@@ -150,7 +150,7 @@ type JobReader interface {
 type JobEditor interface {
 	UpdateMovie(ctx context.Context, filePath string, movie *models.Movie) error
 	ExcludeFile(filePath string)
-	UpdatePosterCrop(movieID string, croppedURL string) error
+	UpdatePosterCrop(movieID string, croppedURL string, bounds *models.CropBounds, sourceFull bool) error
 	UpdatePosterFromURL(ctx context.Context, movieID string, posterURL string, croppedURL string) error
 
 	// ApplyFieldOverride cherry-picks a single field's value from the named
@@ -353,10 +353,20 @@ func (je *jobEditorImpl) UpdateMovie(ctx context.Context, filePath string, movie
 	// before persisting, so the cover/fanart reset survives server restarts
 	// and the DB/in-memory states stay in sync. Read-only pass: does not mutate
 	// the in-memory result, only populates movie.Poster.OriginalCoverURL.
+	var haveCurrent bool
+	var curPosterURL, curCoverURL string
+	var curShouldCrop bool
 	_ = je.store.AtomicUpdateFileResult(filePath, func(current *resultstore.MovieResult) (*resultstore.MovieResult, error) {
 		backupCoverOriginal(current.Movie, movie)
+		if current.Movie != nil {
+			haveCurrent = true
+			curPosterURL = current.Movie.Poster.PosterURL
+			curCoverURL = current.Movie.Poster.CoverURL
+			curShouldCrop = current.Movie.Poster.ShouldCropPoster
+		}
 		return current, nil
 	})
+	sanitizePosterCropGeometry(movie, haveCurrent, curPosterURL, curCoverURL, curShouldCrop)
 
 	// Apply explicit actress name edits before the movie upsert. The shared
 	// MovieUpserter only fills missing actress fields, which would discard a
@@ -423,8 +433,8 @@ func (je *jobEditorImpl) ExcludeFile(filePath string) {
 	}
 }
 
-func (je *jobEditorImpl) UpdatePosterCrop(movieID string, croppedURL string) error {
-	return je.posterEditor.UpdatePosterCrop(movieID, croppedURL)
+func (je *jobEditorImpl) UpdatePosterCrop(movieID string, croppedURL string, bounds *models.CropBounds, sourceFull bool) error {
+	return je.posterEditor.UpdatePosterCrop(movieID, croppedURL, bounds, sourceFull)
 }
 
 func (je *jobEditorImpl) UpdatePosterFromURL(ctx context.Context, movieID string, posterURL string, croppedURL string) error {

--- a/internal/worker/batch_job_miss2_test.go
+++ b/internal/worker/batch_job_miss2_test.go
@@ -32,7 +32,7 @@ func TestUpdatePosterCrop_Miss2_WithMovieResult(t *testing.T) {
 		},
 	})
 
-	err := job.posterEditor.UpdatePosterCrop("TEST-001", "https://example.com/cropped.jpg")
+	err := job.posterEditor.UpdatePosterCrop("TEST-001", "https://example.com/cropped.jpg", nil, false)
 	require.NoError(t, err)
 
 	result, err := job.results.GetMovieResult("/test/file.mp4")

--- a/internal/worker/batch_job_miss_test.go
+++ b/internal/worker/batch_job_miss_test.go
@@ -170,7 +170,7 @@ func TestUpdatePosterCrop_Miss_NoFilePaths(t *testing.T) {
 	jq := NewJobStore(nil, nil, nil, "", nil, nil)
 	job := jq.CreateJobBatch([]string{})
 
-	err := job.posterEditor.UpdatePosterCrop("NOFILE-001", "https://example.com/cropped.jpg")
+	err := job.posterEditor.UpdatePosterCrop("NOFILE-001", "https://example.com/cropped.jpg", nil, false)
 	assert.NoError(t, err)
 }
 

--- a/internal/worker/batch_job_partial_test.go
+++ b/internal/worker/batch_job_partial_test.go
@@ -21,7 +21,7 @@ func TestBatchJob_UpdatePosterCrop_NoMatchingFiles_Partial(t *testing.T) {
 		},
 	})
 	// No results set for any file — UpdatePosterCrop should return nil
-	err := job.posterEditor.UpdatePosterCrop("NONEXISTENT-001", "cropped.jpg")
+	err := job.posterEditor.UpdatePosterCrop("NONEXISTENT-001", "cropped.jpg", nil, false)
 	assert.NoError(t, err, "should return nil when no matching files")
 }
 
@@ -40,7 +40,7 @@ func TestBatchJob_UpdatePosterCrop_NilMovie_Partial(t *testing.T) {
 		Movie:         nil,
 	})
 
-	err := job.posterEditor.UpdatePosterCrop("ABC-001", "cropped.jpg")
+	err := job.posterEditor.UpdatePosterCrop("ABC-001", "cropped.jpg", nil, false)
 	assert.NoError(t, err, "should skip files with nil Movie")
 }
 
@@ -76,7 +76,7 @@ func TestBatchJob_UpdatePosterCrop_MultipleFiles_Miss(t *testing.T) {
 		},
 	})
 
-	err := job.posterEditor.UpdatePosterCrop("ABC-001", "cropped.jpg")
+	err := job.posterEditor.UpdatePosterCrop("ABC-001", "cropped.jpg", nil, false)
 	require.NoError(t, err)
 
 	// Both files should be updated

--- a/internal/worker/batch_job_test.go
+++ b/internal/worker/batch_job_test.go
@@ -592,6 +592,35 @@ func TestBatchJob_UpdatePosterCrop(t *testing.T) {
 		assert.False(t, result.Movie.Poster.ShouldCropPoster)
 	})
 
+	t.Run("cover-fallback movie: second crop preserves the first baseline", func(t *testing.T) {
+		// Cover-fallback: the scraped movie has no poster_url, so the scraped
+		// baseline legitimately holds OriginalPosterURL == "" and possibly a
+		// nil OriginalShouldCropPoster — the "baseline exists" sentinel must
+		// not read that as absent on crop #2, or the first manual crop becomes
+		// the baseline and Reset can never return to the scraped state.
+		jq := NewJobStore(nil, nil, nil, t.TempDir(), nil, nil)
+		job := jq.CreateJobBatch([]string{"/tmp/COFB-001.mp4"})
+		job.SetResultDirect("/tmp/COFB-001.mp4", &resultstore.MovieResult{
+			FileMatchInfo: models.FileMatchInfo{Path: "/tmp/COFB-001.mp4", MovieID: "COFB-001"},
+			Status:        models.JobStatusCompleted,
+			Movie: &models.Movie{ID: "COFB-001", Poster: models.PosterState{
+				CoverURL:         "https://cdn.example/cover.jpg",
+				ShouldCropPoster: true,
+			}},
+		})
+
+		require.NoError(t, job.posterEditor.UpdatePosterCrop("COFB-001", "/tmp/c1.jpg", nil, false))
+		result := job.snap().Results["/tmp/COFB-001.mp4"]
+		assert.Equal(t, "", result.Movie.Poster.OriginalPosterURL)
+		require.NotNil(t, result.Movie.Poster.OriginalShouldCropPoster)
+		assert.True(t, *result.Movie.Poster.OriginalShouldCropPoster)
+
+		require.NoError(t, job.posterEditor.UpdatePosterCrop("COFB-001", "/tmp/c2.jpg", nil, false))
+		result = job.snap().Results["/tmp/COFB-001.mp4"]
+		require.NotNil(t, result.Movie.Poster.OriginalShouldCropPoster)
+		assert.True(t, *result.Movie.Poster.OriginalShouldCropPoster, "baseline must still be the scraped intent")
+		assert.Equal(t, "", result.Movie.Poster.OriginalPosterURL)
+	})
 	t.Run("does not overwrite backup on second crop", func(t *testing.T) {
 		jq := NewJobStore(nil, nil, nil, t.TempDir(), nil, nil)
 		job := jq.CreateJobBatch([]string{"/tmp/ABC-001.mp4"})

--- a/internal/worker/batch_job_test.go
+++ b/internal/worker/batch_job_test.go
@@ -580,7 +580,7 @@ func TestBatchJob_UpdatePosterCrop(t *testing.T) {
 			Movie:         &models.Movie{ID: "ABC-001", Poster: models.PosterState{PosterURL: "original.jpg", CroppedPosterURL: "original-crop.jpg", ShouldCropPoster: true}},
 		})
 
-		err := job.posterEditor.UpdatePosterCrop("ABC-001", "new-crop.jpg")
+		err := job.posterEditor.UpdatePosterCrop("ABC-001", "new-crop.jpg", nil, false)
 		require.NoError(t, err)
 
 		result := job.snap().Results["/tmp/ABC-001.mp4"]
@@ -601,9 +601,9 @@ func TestBatchJob_UpdatePosterCrop(t *testing.T) {
 			Movie:         &models.Movie{ID: "ABC-001", Poster: models.PosterState{PosterURL: "original.jpg", ShouldCropPoster: true}},
 		})
 
-		err := job.posterEditor.UpdatePosterCrop("ABC-001", "crop1.jpg")
+		err := job.posterEditor.UpdatePosterCrop("ABC-001", "crop1.jpg", nil, false)
 		require.NoError(t, err)
-		err = job.posterEditor.UpdatePosterCrop("ABC-001", "crop2.jpg")
+		err = job.posterEditor.UpdatePosterCrop("ABC-001", "crop2.jpg", nil, false)
 		require.NoError(t, err)
 
 		result := job.snap().Results["/tmp/ABC-001.mp4"]
@@ -623,7 +623,7 @@ func TestBatchJob_UpdatePosterCrop(t *testing.T) {
 			Movie:         &models.Movie{ID: "ABC-001", Poster: models.PosterState{PosterURL: "poster.jpg"}},
 		})
 
-		err := job.posterEditor.UpdatePosterCrop("ABC-001", "new-crop.jpg")
+		err := job.posterEditor.UpdatePosterCrop("ABC-001", "new-crop.jpg", nil, false)
 		require.NoError(t, err)
 
 		assert.Equal(t, "new-crop.jpg", job.snap().Results["/tmp/ABC-001-cd1.mp4"].Movie.Poster.CroppedPosterURL)
@@ -638,7 +638,7 @@ func TestBatchJob_UpdatePosterCrop(t *testing.T) {
 			Movie:         nil,
 		})
 
-		err := job.posterEditor.UpdatePosterCrop("ABC-001", "crop.jpg")
+		err := job.posterEditor.UpdatePosterCrop("ABC-001", "crop.jpg", nil, false)
 		require.NoError(t, err)
 	})
 
@@ -650,7 +650,7 @@ func TestBatchJob_UpdatePosterCrop(t *testing.T) {
 			Movie:         &models.Movie{ID: "ABC-001", Poster: models.PosterState{PosterURL: "poster.jpg", ShouldCropPoster: true}},
 		})
 
-		err := job.posterEditor.UpdatePosterCrop("ABC-001", "crop.jpg")
+		err := job.posterEditor.UpdatePosterCrop("ABC-001", "crop.jpg", nil, false)
 		require.NoError(t, err)
 
 		result := job.snap().Results["/tmp/ABC-001.mp4"]

--- a/internal/worker/field_override.go
+++ b/internal/worker/field_override.go
@@ -147,7 +147,12 @@ func applyFieldOverride(movie *models.Movie, prov *resultstore.ProvenanceData, f
 	case "cover_url":
 		movie.Poster.CoverURL = result.CoverURL
 		setFieldSource("cover_url")
-		clearPosterCropGeometry(movie) // cover is the fallback poster source
+		// Only clears when the cover IS the effective poster source
+		// (poster_url empty): swapping fanart under an explicit poster must
+		// keep a still-valid manual crop.
+		if movie.Poster.PosterURL == "" {
+			clearPosterCropGeometry(movie)
+		}
 	case "trailer_url":
 		movie.TrailerURL = result.TrailerURL
 		setFieldSource("trailer_url")

--- a/internal/worker/field_override.go
+++ b/internal/worker/field_override.go
@@ -143,15 +143,18 @@ func applyFieldOverride(movie *models.Movie, prov *resultstore.ProvenanceData, f
 	case "poster_url":
 		movie.Poster.PosterURL = result.PosterURL
 		setFieldSource("poster_url")
+		clearPosterCropGeometry(movie) // new source: stored geometry is stale
 	case "cover_url":
 		movie.Poster.CoverURL = result.CoverURL
 		setFieldSource("cover_url")
+		clearPosterCropGeometry(movie) // cover is the fallback poster source
 	case "trailer_url":
 		movie.TrailerURL = result.TrailerURL
 		setFieldSource("trailer_url")
 	case "should_crop_poster":
 		movie.Poster.ShouldCropPoster = result.ShouldCropPoster
 		setFieldSource("should_crop_poster")
+		clearPosterCropGeometry(movie) // intent change invalidates geometry
 	default:
 		return fmt.Errorf("unhandled field: %s", fieldKey)
 	}

--- a/internal/worker/miss3_test.go
+++ b/internal/worker/miss3_test.go
@@ -280,7 +280,7 @@ func TestStandaloneJob_UpdatePosterCrop(t *testing.T) {
 
 	ej, ok := jq.GetJobForEdit(job.ID.String())
 	require.True(t, ok)
-	err := ej.UpdatePosterCrop("UPC-001", "https://example.com/cropped.jpg")
+	err := ej.UpdatePosterCrop("UPC-001", "https://example.com/cropped.jpg", nil, false)
 	require.NoError(t, err)
 
 	result, _ := job.results.GetMovieResult("file1.mp4")

--- a/internal/worker/poster_crop_geometry_test.go
+++ b/internal/worker/poster_crop_geometry_test.go
@@ -1,0 +1,261 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/scrape"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cropGeometryFixture() *models.CropBounds {
+	return &models.CropBounds{X: 0.1, Y: 0.05, Width: 0.4, Height: 0.9, SourceAspect: 1.667}
+}
+
+func newCropGeometryJob(t *testing.T) (*BatchJob, string) {
+	t.Helper()
+	const filePath = "/tmp/CROPGEO-001.mp4"
+	jq := NewJobStore(nil, nil, nil, t.TempDir(), nil, nil)
+	job := jq.CreateJobBatch([]string{filePath})
+	job.results.UpdateFileResult(filePath, &resultstore.MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: filePath, MovieID: "CROPGEO-001"},
+		Status:        models.JobStatusCompleted,
+		Movie: &models.Movie{
+			ID:    "CROPGEO-001",
+			Title: "Subject",
+			Poster: models.PosterState{
+				PosterURL:        "https://cdn.example/poster.jpg",
+				CoverURL:         "https://cdn.example/cover.jpg",
+				ShouldCropPoster: true,
+			},
+		},
+		StartedAt: time.Now(),
+	})
+	return job, filePath
+}
+
+func storedPosterState(t *testing.T, job *BatchJob, filePath string) models.PosterState {
+	t.Helper()
+	res, err := job.results.GetMovieResult(filePath)
+	require.NoError(t, err)
+	require.NotNil(t, res.Movie)
+	return res.Movie.Poster
+}
+
+// The crop endpoint's editor call stores normalized geometry next to the
+// cropped preview URL for every file of the movie.
+func TestUpdatePosterCrop_StoresGeometry(t *testing.T) {
+	job, filePath := newCropGeometryJob(t)
+
+	err := job.posterEditor.UpdatePosterCrop("CROPGEO-001", "/api/v1/temp/posters/job/CROPGEO-001.jpg?v=1", cropGeometryFixture(), true)
+	require.NoError(t, err)
+
+	poster := storedPosterState(t, job, filePath)
+	require.NotNil(t, poster.PosterCropBounds)
+	assert.Equal(t, *cropGeometryFixture(), *poster.PosterCropBounds)
+	assert.True(t, poster.PosterCropSourceFull)
+	assert.Equal(t, "/api/v1/temp/posters/job/CROPGEO-001.jpg?v=1", poster.CroppedPosterURL)
+	assert.False(t, poster.ShouldCropPoster)
+}
+
+// A crop measured against the legacy already-cropped preview stores nothing
+// applyable — and clears any previously stored geometry.
+func TestUpdatePosterCrop_LegacyClearsGeometry(t *testing.T) {
+	job, filePath := newCropGeometryJob(t)
+	require.NoError(t, job.posterEditor.UpdatePosterCrop("CROPGEO-001", "/tmp/c1.jpg", cropGeometryFixture(), true))
+	require.NotNil(t, storedPosterState(t, job, filePath).PosterCropBounds)
+
+	require.NoError(t, job.posterEditor.UpdatePosterCrop("CROPGEO-001", "/tmp/c2.jpg", nil, false))
+
+	poster := storedPosterState(t, job, filePath)
+	assert.Nil(t, poster.PosterCropBounds)
+	assert.False(t, poster.PosterCropSourceFull)
+	assert.Equal(t, "/tmp/c2.jpg", poster.CroppedPosterURL)
+}
+
+// Poster-from-URL replaces the poster source: stored geometry is stale.
+func TestUpdatePosterFromURL_ClearsGeometry(t *testing.T) {
+	job, filePath := newCropGeometryJob(t)
+	require.NoError(t, job.posterEditor.UpdatePosterCrop("CROPGEO-001", "/tmp/c1.jpg", cropGeometryFixture(), true))
+
+	require.NoError(t, job.posterEditor.UpdatePosterFromURL(context.Background(), "CROPGEO-001",
+		"https://cdn.example/new-poster.jpg", "/tmp/new-crop.jpg"))
+
+	poster := storedPosterState(t, job, filePath)
+	assert.Equal(t, "https://cdn.example/new-poster.jpg", poster.PosterURL)
+	assert.Nil(t, poster.PosterCropBounds, "new poster source invalidates stored geometry")
+	assert.False(t, poster.PosterCropSourceFull)
+}
+
+// Per-scraper field overrides that touch the poster source or crop intent
+// clear stored geometry.
+func TestApplyFieldOverridePosterKeys_ClearGeometry(t *testing.T) {
+	for _, key := range []string{"poster_url", "cover_url", "should_crop_poster"} {
+		t.Run(key, func(t *testing.T) {
+			movie, prov := overrideFixture()
+			movie.Poster.PosterCropBounds = cropGeometryFixture()
+			movie.Poster.PosterCropSourceFull = true
+
+			require.NoError(t, applyFieldOverride(movie, prov, key, "dmm"))
+			assert.Nil(t, movie.Poster.PosterCropBounds, "%s override must clear geometry", key)
+			assert.False(t, movie.Poster.PosterCropSourceFull)
+		})
+	}
+}
+
+// sanitizePosterCropGeometry: stored-geometry contract on whole-movie saves.
+func TestSanitizePosterCropGeometry(t *testing.T) {
+	const (
+		curPoster = "https://cdn.example/poster.jpg"
+		curCover  = "https://cdn.example/cover.jpg"
+	)
+	mk := func() *models.Movie {
+		m := &models.Movie{ID: "CROPGEO-001"}
+		m.Poster.PosterURL = curPoster
+		m.Poster.CoverURL = curCover
+		m.Poster.PosterCropBounds = cropGeometryFixture()
+		m.Poster.PosterCropSourceFull = true
+		return m
+	}
+
+	t.Run("unchanged source and intent keeps geometry", func(t *testing.T) {
+		next := mk()
+		sanitizePosterCropGeometry(next, true, curPoster, curCover, false)
+		require.NotNil(t, next.Poster.PosterCropBounds)
+	})
+	t.Run("poster_url change clears", func(t *testing.T) {
+		next := mk()
+		next.Poster.PosterURL = "https://cdn.example/other.jpg"
+		sanitizePosterCropGeometry(next, true, curPoster, curCover, false)
+		assert.Nil(t, next.Poster.PosterCropBounds)
+	})
+	t.Run("cover_url change clears", func(t *testing.T) {
+		next := mk()
+		next.Poster.CoverURL = "https://cdn.example/other-cover.jpg"
+		sanitizePosterCropGeometry(next, true, curPoster, curCover, false)
+		assert.Nil(t, next.Poster.PosterCropBounds)
+	})
+	t.Run("intent change clears", func(t *testing.T) {
+		next := mk()
+		next.Poster.ShouldCropPoster = true
+		sanitizePosterCropGeometry(next, true, curPoster, curCover, false)
+		assert.Nil(t, next.Poster.PosterCropBounds)
+	})
+	t.Run("invalid geometry dropped", func(t *testing.T) {
+		next := mk()
+		next.Poster.PosterCropBounds = &models.CropBounds{X: 0.9, Y: 0, Width: 0.5, Height: 1}
+		sanitizePosterCropGeometry(next, true, curPoster, curCover, false)
+		assert.Nil(t, next.Poster.PosterCropBounds)
+		assert.False(t, next.Poster.PosterCropSourceFull)
+	})
+	t.Run("no stored current keeps geometry", func(t *testing.T) {
+		next := mk()
+		sanitizePosterCropGeometry(next, false, "", "", false)
+		require.NotNil(t, next.Poster.PosterCropBounds)
+	})
+	t.Run("absent geometry normalizes flag", func(t *testing.T) {
+		next := mk()
+		next.Poster.PosterCropBounds = nil
+		next.Poster.PosterCropSourceFull = true
+		sanitizePosterCropGeometry(next, true, curPoster, curCover, false)
+		assert.False(t, next.Poster.PosterCropSourceFull)
+	})
+}
+
+// UpdateMovie (the review-page save) clears geometry when the poster source
+// changes and preserves it for unrelated edits when the handler has resolved
+// the omitted field onto the payload.
+func TestJobEditorUpdateMovie_SourceChangeClearsGeometry(t *testing.T) {
+	const filePath = "test.mp4"
+	tracker := resultstore.New(1, []string{filePath})
+	existing := &models.Movie{ID: "CROPGEO-001", Title: "Subject"}
+	existing.Poster.PosterURL = "https://cdn.example/poster.jpg"
+	existing.Poster.ShouldCropPoster = false
+	existing.Poster.PosterCropBounds = cropGeometryFixture()
+	existing.Poster.PosterCropSourceFull = true
+	tracker.UpdateFileResult(filePath, &resultstore.MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: filePath, MovieID: existing.ID},
+		Movie:         existing,
+		Status:        models.JobStatusCompleted,
+	})
+	je := &jobEditorImpl{store: tracker}
+
+	t.Run("source change clears", func(t *testing.T) {
+		next := existing.Clone()
+		next.Poster.PosterURL = "https://cdn.example/new.jpg"
+		require.NoError(t, je.UpdateMovie(context.Background(), filePath, next))
+		stored, err := tracker.GetMovieResult(filePath)
+		require.NoError(t, err)
+		assert.Nil(t, stored.Movie.Poster.PosterCropBounds)
+	})
+
+	t.Run("unrelated edit preserves", func(t *testing.T) {
+		// Re-seed geometry (previous subtest cleared it).
+		existing.Poster.PosterCropBounds = cropGeometryFixture()
+		existing.Poster.PosterCropSourceFull = true
+		tracker.UpdateFileResult(filePath, &resultstore.MovieResult{
+			FileMatchInfo: models.FileMatchInfo{Path: filePath, MovieID: existing.ID},
+			Movie:         existing,
+			Status:        models.JobStatusCompleted,
+		})
+
+		next := existing.Clone()
+		next.Title = "Renamed"
+		require.NoError(t, je.UpdateMovie(context.Background(), filePath, next))
+		stored, err := tracker.GetMovieResult(filePath)
+		require.NoError(t, err)
+		require.NotNil(t, stored.Movie.Poster.PosterCropBounds, "unchanged source/intent keeps geometry")
+		assert.Equal(t, "Renamed", stored.Movie.Title)
+	})
+}
+
+// Rescrape clears persisted geometry even when the refreshed poster URL is
+// unchanged — the new scrape's source image may differ from what the crop
+// was measured against.
+func TestRescrape_ClearsPosterCropGeometry(t *testing.T) {
+	wf := &stubRescrapeWorkflow{
+		scrapeResult: &scrape.ScrapeResult{
+			Status: scrape.StatusCompleted,
+			Movie: &models.Movie{
+				ID:    "CROPGEO-001",
+				Title: "Rescraped",
+				Poster: models.PosterState{
+					PosterURL: "https://cdn.example/poster.jpg", // same URL refresh
+					CoverURL:  "https://cdn.example/cover.jpg",
+				},
+			},
+		},
+	}
+	const filePath = "f1.mp4"
+	rt := resultstore.New(1, []string{filePath})
+	existing := &models.Movie{ID: "CROPGEO-001", Title: "Subject"}
+	existing.Poster.PosterURL = "https://cdn.example/poster.jpg"
+	existing.Poster.PosterCropBounds = cropGeometryFixture()
+	existing.Poster.PosterCropSourceFull = true
+	rt.UpdateFileResult(filePath, &resultstore.MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: filePath, MovieID: existing.ID},
+		Movie:         existing,
+		Status:        models.JobStatusCompleted,
+	})
+	inputs := rescrapePhaseInputs{
+		WF:        wf,
+		ResultMap: rt,
+		Finder:    rt,
+		JobID:     models.NewJobID(),
+	}
+
+	phase := NewRescrapePhase()
+	result, err := phase.Rescrape(context.Background(), inputs, RescrapeCmd{MovieID: "CROPGEO-001", FilePath: filePath})
+	require.NoError(t, err)
+	require.Equal(t, models.RescrapeStatusSuccess, result.Status)
+
+	stored, gErr := rt.GetMovieResult(filePath)
+	require.NoError(t, gErr)
+	require.NotNil(t, stored.Movie)
+	assert.Nil(t, stored.Movie.Poster.PosterCropBounds, "rescrape must clear stored geometry")
+	assert.False(t, stored.Movie.Poster.PosterCropSourceFull)
+}

--- a/internal/worker/poster_crop_geometry_test.go
+++ b/internal/worker/poster_crop_geometry_test.go
@@ -112,6 +112,17 @@ func TestApplyFieldOverridePosterKeys_ClearGeometry(t *testing.T) {
 			assert.False(t, movie.Poster.PosterCropSourceFull)
 		})
 	}
+
+	t.Run("cover_url with an explicit poster keeps geometry", func(t *testing.T) {
+		movie, prov := overrideFixture()
+		movie.Poster.PosterURL = "https://cdn.example/explicit-poster.jpg" // poster is the effective source
+		movie.Poster.PosterCropBounds = cropGeometryFixture()
+		movie.Poster.PosterCropSourceFull = true
+
+		require.NoError(t, applyFieldOverride(movie, prov, "cover_url", "dmm"))
+		require.NotNil(t, movie.Poster.PosterCropBounds, "fanart override under explicit poster must not discard the crop")
+		assert.True(t, movie.Poster.PosterCropSourceFull)
+	})
 }
 
 // sanitizePosterCropGeometry: stored-geometry contract on whole-movie saves.
@@ -140,10 +151,17 @@ func TestSanitizePosterCropGeometry(t *testing.T) {
 		sanitizePosterCropGeometry(next, true, curPoster, curCover, false)
 		assert.Nil(t, next.Poster.PosterCropBounds)
 	})
-	t.Run("cover_url change clears", func(t *testing.T) {
+	t.Run("cover_url change alone preserves (poster is the effective source)", func(t *testing.T) {
 		next := mk()
 		next.Poster.CoverURL = "https://cdn.example/other-cover.jpg"
 		sanitizePosterCropGeometry(next, true, curPoster, curCover, false)
+		require.NotNil(t, next.Poster.PosterCropBounds, "fanart churn must not discard a still-valid crop")
+	})
+	t.Run("cover change clears when cover is the effective source", func(t *testing.T) {
+		next := mk()
+		next.Poster.PosterURL = ""
+		next.Poster.CoverURL = "https://cdn.example/other-cover.jpg"
+		sanitizePosterCropGeometry(next, true, "", curCover, false)
 		assert.Nil(t, next.Poster.PosterCropBounds)
 	})
 	t.Run("intent change clears", func(t *testing.T) {

--- a/internal/worker/poster_crop_geometry_test.go
+++ b/internal/worker/poster_crop_geometry_test.go
@@ -48,6 +48,13 @@ func storedPosterState(t *testing.T, job *BatchJob, filePath string) models.Post
 
 // The crop endpoint's editor call stores normalized geometry next to the
 // cropped preview URL for every file of the movie.
+// Nil-receiver guards on the geometry helpers: defensive branches must hold
+// without touching state.
+func TestCropGeometryHelpers_NilGuards(t *testing.T) {
+	t.Parallel()
+	clearPosterCropGeometry(nil)                           // no panic
+	sanitizePosterCropGeometry(nil, true, "a", "b", false) // no panic
+}
 func TestUpdatePosterCrop_StoresGeometry(t *testing.T) {
 	job, filePath := newCropGeometryJob(t)
 

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -36,8 +36,12 @@ func NewPosterEditor(lookup resultstore.ResultReadFacade, updater resultstore.Re
 	return &PosterEditor{lookup: lookup, updater: updater, movieRepo: movieRepo}
 }
 
-// UpdatePosterCrop updates the cropped poster URL for all files matching movieID.
-func (pe *PosterEditor) UpdatePosterCrop(movieID string, croppedURL string) error {
+// UpdatePosterCrop updates the cropped poster URL and the manual crop
+// geometry for all files matching movieID. bounds is nil (and sourceFull
+// false) when the crop was measured against a legacy already-cropped
+// preview — no applyable geometry exists, so any stored geometry is cleared
+// and the job keeps pre-change behavior.
+func (pe *PosterEditor) UpdatePosterCrop(movieID string, croppedURL string, bounds *models.CropBounds, sourceFull bool) error {
 	filePaths := pe.lookup.FindFilePathsForMovieID(movieID)
 	for _, filePath := range filePaths {
 		err := pe.updater.AtomicUpdateFileResult(filePath, func(current *resultstore.MovieResult) (*resultstore.MovieResult, error) {
@@ -48,6 +52,8 @@ func (pe *PosterEditor) UpdatePosterCrop(movieID string, croppedURL string) erro
 			backupPosterOriginals(movie)
 			movie.Poster.CroppedPosterURL = croppedURL
 			movie.Poster.ShouldCropPoster = false
+			movie.Poster.PosterCropBounds = bounds
+			movie.Poster.PosterCropSourceFull = sourceFull
 			current.Movie = movie
 			current.FileMatchInfo.MovieID = movie.ID
 			return current, nil
@@ -74,6 +80,7 @@ func (pe *PosterEditor) UpdatePosterFromURL(ctx context.Context, movieID string,
 			movie.Poster.PosterURL = posterURL
 			movie.Poster.CroppedPosterURL = croppedURL
 			movie.Poster.ShouldCropPoster = false
+			clearPosterCropGeometry(movie) // new source: stored geometry is stale
 			current.Movie = movie
 			current.FileMatchInfo.MovieID = movie.ID
 			return current, nil
@@ -103,6 +110,45 @@ func (pe *PosterEditor) UpdatePosterFromURL(ctx context.Context, movieID string,
 	}
 
 	return nil
+}
+
+// clearPosterCropGeometry drops persisted manual crop geometry from m.
+// Called at every flow that replaces the poster source or crop intent so a
+// stale crop can never be applied to a different image.
+func clearPosterCropGeometry(m *models.Movie) {
+	if m == nil {
+		return
+	}
+	m.Poster.PosterCropBounds = nil
+	m.Poster.PosterCropSourceFull = false
+}
+
+// sanitizePosterCropGeometry enforces the manual-crop invalidation contract
+// when a whole movie is stored (UpdateMovie): carried geometry survives only
+// if it is valid AND the stored poster source (poster_url/cover_url) and crop
+// intent are unchanged. A nil next-bounds means "no geometry" (the batch
+// PATCH handler resolves omitted-vs-explicit-null upstream) — only normalize
+// the flag in that case.
+func sanitizePosterCropGeometry(next *models.Movie, haveCurrent bool, curPosterURL, curCoverURL string, curShouldCrop bool) {
+	if next == nil {
+		return
+	}
+	if next.Poster.PosterCropBounds == nil {
+		next.Poster.PosterCropSourceFull = false
+		return
+	}
+	if !next.Poster.PosterCropBounds.Valid() {
+		clearPosterCropGeometry(next)
+		return
+	}
+	if !haveCurrent {
+		return
+	}
+	if next.Poster.PosterURL != curPosterURL ||
+		next.Poster.CoverURL != curCoverURL ||
+		next.Poster.ShouldCropPoster != curShouldCrop {
+		clearPosterCropGeometry(next)
+	}
 }
 
 // backupPosterOriginals preserves the original poster URLs before they are overwritten.

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -125,10 +125,12 @@ func clearPosterCropGeometry(m *models.Movie) {
 
 // sanitizePosterCropGeometry enforces the manual-crop invalidation contract
 // when a whole movie is stored (UpdateMovie): carried geometry survives only
-// if it is valid AND the stored poster source (poster_url/cover_url) and crop
-// intent are unchanged. A nil next-bounds means "no geometry" (the batch
-// PATCH handler resolves omitted-vs-explicit-null upstream) — only normalize
-// the flag in that case.
+// if it is valid AND the movie's EFFECTIVE poster source (poster_url, falling
+// back to cover_url — the same selection the downloader and the apply boundary
+// use) and crop intent are unchanged. A fanart-only edit (cover_url changes
+// while poster_url selects the source) must not discard a still-valid crop.
+// A nil next-bounds means "no geometry" (the batch PATCH handler resolves
+// omitted-vs-explicit-null upstream) — only normalize the flag in that case.
 func sanitizePosterCropGeometry(next *models.Movie, haveCurrent bool, curPosterURL, curCoverURL string, curShouldCrop bool) {
 	if next == nil {
 		return
@@ -144,11 +146,19 @@ func sanitizePosterCropGeometry(next *models.Movie, haveCurrent bool, curPosterU
 	if !haveCurrent {
 		return
 	}
-	if next.Poster.PosterURL != curPosterURL ||
-		next.Poster.CoverURL != curCoverURL ||
+	if effectivePosterSourceOf(next.Poster.PosterURL, next.Poster.CoverURL) != effectivePosterSourceOf(curPosterURL, curCoverURL) ||
 		next.Poster.ShouldCropPoster != curShouldCrop {
 		clearPosterCropGeometry(next)
 	}
+}
+
+// effectivePosterSourceOf mirrors the downloader's poster source selection:
+// poster_url when present, otherwise cover_url.
+func effectivePosterSourceOf(posterURL, coverURL string) string {
+	if posterURL != "" {
+		return posterURL
+	}
+	return coverURL
 }
 
 // backupPosterOriginals preserves the original poster URLs before they are overwritten.

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -162,8 +162,15 @@ func effectivePosterSourceOf(posterURL, coverURL string) string {
 }
 
 // backupPosterOriginals preserves the original poster URLs before they are overwritten.
+//
+// The sentinel for "baseline already captured" is EITHER field present:
+// — OriginalPosterURL non-empty covers legacy envelopes (URL-only backups
+// predate the eager baseline) — while OriginalShouldCropPoster non-nil covers
+// cover-fallback movies whose baseline legitimately has an empty poster URL;
+// URL-only sentinel would re-snapshot on the SECOND crop of such a movie and
+// store the first manual crop as the "original".
 func backupPosterOriginals(movie *models.Movie) {
-	if movie.Poster.OriginalPosterURL == "" {
+	if movie.Poster.OriginalPosterURL == "" && movie.Poster.OriginalShouldCropPoster == nil {
 		shouldCrop := movie.Poster.ShouldCropPoster
 		movie.Poster.OriginalPosterURL = movie.Poster.PosterURL
 		movie.Poster.OriginalCroppedPosterURL = movie.Poster.CroppedPosterURL

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -383,6 +383,12 @@ func (p *rescrapePhase) Rescrape(ctx context.Context, inputs rescrapePhaseInputs
 			establishScrapedBaseline(movieResult.Movie, movieResult.Movie)
 		}
 
+		// A rescrape refreshes the poster source: any manual crop geometry
+		// measured against the previous source is stale. Clear it explicitly
+		// (including same-URL refreshes) rather than relying on the merge
+		// engine incidentally dropping the runtime-only field.
+		clearPosterCropGeometry(movieResult.Movie)
+
 		// Commit result
 		outcome, commitErr := p.CompleteRescrape(inputs, lookup.FilePath, movieResult, lookup.CapturedRevision, newMovieID, lookup.OldMovieID)
 		if commitErr != nil {

--- a/internal/worker/resultstore/movie_result_test.go
+++ b/internal/worker/resultstore/movie_result_test.go
@@ -1,6 +1,7 @@
 package resultstore
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -72,6 +73,53 @@ func TestMovieResultClone_PointerFields_Independent(t *testing.T) {
 	}
 	if *orig.TranslationWarning != "translation incomplete" {
 		t.Errorf("original TranslationWarning changed: got %q, want %q", *orig.TranslationWarning, "translation incomplete")
+	}
+}
+
+// The job envelope persists MovieResult via encoding/json; manual poster crop
+// geometry on Movie must survive the marshal/unmarshal round-trip so the
+// review-page crop is still available at organize time after a reload.
+func TestMovieResultEnvelopeRoundTrip_PreservesPosterCropGeometry(t *testing.T) {
+	t.Parallel()
+
+	orig := &MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: "/path/to/file.mp4", MovieID: "ABCD-123"},
+		Movie: &models.Movie{
+			ContentID: "ABCD-123",
+			Poster: models.PosterState{
+				PosterURL:            "https://example.com/poster.jpg",
+				CoverURL:             "https://example.com/cover.jpg",
+				CroppedPosterURL:     "/tmp/crop-abcd123.jpg",
+				ShouldCropPoster:     true,
+				PosterCropBounds:     &models.CropBounds{X: 0, Y: 0.05, Width: 0.42, Height: 0.9},
+				PosterCropSourceFull: true,
+			},
+		},
+		Revision: 3,
+		Status:   models.JobStatusCompleted,
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	var reloaded MovieResult
+	if err := json.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+
+	got := reloaded.Movie.Poster
+	if got.PosterCropBounds == nil {
+		t.Fatal("poster crop bounds lost in job-envelope round-trip")
+	}
+	if *got.PosterCropBounds != *orig.Movie.Poster.PosterCropBounds {
+		t.Errorf("poster crop bounds: got %+v, want %+v", *got.PosterCropBounds, *orig.Movie.Poster.PosterCropBounds)
+	}
+	if !got.PosterCropSourceFull {
+		t.Error("poster_crop_source_full lost in job-envelope round-trip")
+	}
+	if got.CroppedPosterURL != orig.Movie.Poster.CroppedPosterURL {
+		t.Errorf("cropped poster url: got %q, want %q", got.CroppedPosterURL, orig.Movie.Poster.CroppedPosterURL)
 	}
 }
 

--- a/internal/workflow/apply_orchestrator.go
+++ b/internal/workflow/apply_orchestrator.go
@@ -291,6 +291,16 @@ func (o *applyOrchImpl) stepMerge(cmd ApplyCmd, state *applyPipelineState, steps
 		steps.Merged = true
 		return nil
 	}
+	// Capture the manual review-page crop geometry before the merge: the
+	// merger rebuilds a fresh Movie and does not know about the runtime-only
+	// geometry, so carry/clear is decided here at the apply boundary.
+	preSource := effectivePosterSource(state.movie)
+	var preBounds *models.CropBounds
+	var preFull bool
+	if state.movie != nil {
+		preBounds = state.movie.Poster.PosterCropBounds
+		preFull = state.movie.Poster.PosterCropSourceFull
+	}
 	mergeRes := o.nfo.MergeWithExistingNFO(state.movie, nfo.MergeWithExistingOptions{
 		Match:          cmd.Match,
 		ForceOverwrite: cmd.Merge.ForceOverwrite,
@@ -299,10 +309,42 @@ func (o *applyOrchImpl) stepMerge(cmd ApplyCmd, state *applyPipelineState, steps
 		ArrayStrategy:  cmd.Merge.ArrayStrategy,
 	})
 	state.movie = mergeRes.Movie
+	carryPosterCropAcrossMerge(state.movie, preSource, preBounds, preFull)
 	state.merged = mergeRes.Merged
 	state.foundNFOPath = mergeRes.FoundNFOPath
 	steps.Merged = true
 	return nil
+}
+
+// effectivePosterSource mirrors the downloader's poster source selection:
+// PosterURL when present, otherwise CoverURL.
+func effectivePosterSource(m *models.Movie) string {
+	if m == nil {
+		return ""
+	}
+	if m.Poster.PosterURL != "" {
+		return m.Poster.PosterURL
+	}
+	return m.Poster.CoverURL
+}
+
+// carryPosterCropAcrossMerge retains manual crop geometry across the
+// pre-organize merge only when the merge left the effective poster source
+// unchanged; any source change (or absent/non-full-source geometry) clears
+// it so a stale crop can never be applied to a different image. Runs at the
+// apply boundary only — the generic NFO merger never sees the field.
+func carryPosterCropAcrossMerge(merged *models.Movie, preSource string, preBounds *models.CropBounds, preFull bool) {
+	if merged == nil {
+		return
+	}
+	if preBounds != nil && preFull && preSource != "" && effectivePosterSource(merged) == preSource {
+		b := *preBounds
+		merged.Poster.PosterCropBounds = &b
+		merged.Poster.PosterCropSourceFull = true
+		return
+	}
+	merged.Poster.PosterCropBounds = nil
+	merged.Poster.PosterCropSourceFull = false
 }
 
 // stepDisplayTitle applies the display title template or falls back to Title.

--- a/internal/workflow/apply_orchestrator_crop_test.go
+++ b/internal/workflow/apply_orchestrator_crop_test.go
@@ -1,0 +1,205 @@
+package workflow
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/downloader"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/nfo"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubNFOFileMerger emulates MergeWithExistingNFO returning a freshly merged
+// movie (the real merger rebuilds a new Movie and never sees the runtime-only
+// crop geometry).
+type stubNFOFileMerger struct {
+	result nfo.MergeWithExistingResult
+}
+
+func (s *stubNFOFileMerger) MergeWithExistingNFO(_ *models.Movie, _ nfo.MergeWithExistingOptions) nfo.MergeWithExistingResult {
+	return s.result
+}
+
+// stubOrganizerToDest skips real file organization and points the pipeline
+// at the requested destination dir, so the integrated crop test exercises
+// merge boundary + download steps with real side effects and no moves.
+type stubOrganizerToDest struct{}
+
+func (stubOrganizerToDest) Organize(_ context.Context, cmd organizer.OrganizeCmd) (*organizer.OrganizeResult, error) {
+	return &organizer.OrganizeResult{FolderPath: cmd.DestDir}, nil
+}
+
+// Integrated reported-regression check: a movie carrying manual crop geometry
+// through Execute comes out on disk cropped per the manual geometry, not the
+// scraper default (scraper auto-crop of a landscape cover keeps the RIGHT
+// half — white — while the manual geometry takes the LEFT half — black).
+func TestApplyExecute_ManualCropGeometryReachesDisk(t *testing.T) {
+	// Two-tone source: left half black, right half white.
+	src := image.NewRGBA(image.Rect(0, 0, 1000, 600))
+	for y := 0; y < 600; y++ {
+		for x := 0; x < 1000; x++ {
+			if x < 500 {
+				src.Set(x, y, color.Black)
+			} else {
+				src.Set(x, y, color.White)
+			}
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_ = jpeg.Encode(w, src, &jpeg.Options{Quality: 95})
+	}))
+	t.Cleanup(srv.Close)
+
+	fs := afero.NewMemMapFs()
+	dl := downloader.NewDownloader(http.DefaultClient, fs, &downloader.Config{
+		DownloadPoster:  true,
+		MaxPosterHeight: 0,
+		MediaFormatConfig: organizer.MediaFormatConfig{
+			PosterFormat: "<ID>-poster.jpg",
+		},
+	}, nil)
+
+	movie := &models.Movie{ID: "ABF-346", ContentID: "abf00346", Title: "Integrated Crop"}
+	movie.Poster.PosterURL = srv.URL + "/cover.jpg"
+	movie.Poster.ShouldCropPoster = true // scraper intent: auto-crop (white)
+	movie.Poster.PosterCropBounds = &models.CropBounds{X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0}
+	movie.Poster.PosterCropSourceFull = true
+
+	orch := &applyOrchImpl{
+		fs:         fs,
+		organizer:  stubOrganizerToDest{},
+		downloader: dl,
+		// nfo nil: merge step is a pass-through for this scenario
+		revertLog: noOpRevertLog{},
+	}
+	result, err := orch.Execute(context.Background(), ApplyCmd{
+		Movie:    movie,
+		Match:    models.FileMatchInfo{Path: "/src/ABF-346.mp4"},
+		DestPath: "/dest",
+		Download: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	f, err := fs.Open("/dest/ABF-346-poster.jpg")
+	require.NoError(t, err, "poster must land in the destination dir")
+	defer func() { _ = f.Close() }()
+	img, err := jpeg.Decode(f)
+	require.NoError(t, err)
+	assert.InDelta(t, 400, img.Bounds().Dx(), 2, "manual crop width (0.4 of 1000px)")
+	b := img.Bounds()
+	x := b.Min.X + b.Dx()/2
+	y := b.Min.Y + b.Dy()/2
+	r, g, bl, _ := img.At(x, y).RGBA()
+	luma := 0.299*float64(r>>8) + 0.587*float64(g>>8) + 0.114*float64(bl>>8)
+	assert.Less(t, luma, 40.0, "on-disk poster must be the manual LEFT crop (black), not the scraper right crop (white)")
+}
+
+func cropBoundsFixture() *models.CropBounds {
+	return &models.CropBounds{X: 0.1, Y: 0.05, Width: 0.4, Height: 0.9, SourceAspect: 1.5}
+}
+
+// A merge that leaves the effective poster source unchanged carries the
+// manual crop geometry across — including onto a freshly built merged movie.
+func TestApplyMergeBoundary_SourceUnchangedKeepsGeometry(t *testing.T) {
+	pre := &models.Movie{ID: "IPX-535"}
+	pre.Poster.PosterURL = "https://cdn/p.jpg"
+	pre.Poster.PosterCropBounds = cropBoundsFixture()
+	pre.Poster.PosterCropSourceFull = true
+
+	freshMerged := &models.Movie{ID: "IPX-535"}
+	freshMerged.Poster.PosterURL = "https://cdn/p.jpg"
+
+	orch := &applyOrchImpl{nfo: &stubNFOFileMerger{result: nfo.MergeWithExistingResult{Movie: freshMerged, Merged: true}}}
+	state := &applyPipelineState{movie: pre}
+	steps := &stepCompletion{}
+
+	require.NoError(t, orch.stepMerge(ApplyCmd{}, state, steps))
+	require.True(t, steps.Merged)
+	require.Same(t, freshMerged, state.movie)
+	require.NotNil(t, state.movie.Poster.PosterCropBounds, "geometry must be carried across the merge")
+	assert.Equal(t, *cropBoundsFixture(), *state.movie.Poster.PosterCropBounds)
+	assert.True(t, state.movie.Poster.PosterCropSourceFull)
+	assert.NotSame(t, pre.Poster.PosterCropBounds, state.movie.Poster.PosterCropBounds, "carry must copy, not alias")
+}
+
+// A merge that changes the effective poster source clears the geometry so a
+// crop measured against the old image is never applied to the new one.
+func TestApplyMergeBoundary_SourceChangedClearsGeometry(t *testing.T) {
+	pre := &models.Movie{ID: "IPX-535"}
+	pre.Poster.PosterURL = "https://cdn/old.jpg"
+	pre.Poster.PosterCropBounds = cropBoundsFixture()
+	pre.Poster.PosterCropSourceFull = true
+
+	freshMerged := &models.Movie{ID: "IPX-535"}
+	freshMerged.Poster.PosterURL = "https://cdn/new.jpg"
+
+	orch := &applyOrchImpl{nfo: &stubNFOFileMerger{result: nfo.MergeWithExistingResult{Movie: freshMerged, Merged: true}}}
+	state := &applyPipelineState{movie: pre}
+
+	require.NoError(t, orch.stepMerge(ApplyCmd{}, state, &stepCompletion{}))
+	assert.Nil(t, state.movie.Poster.PosterCropBounds)
+	assert.False(t, state.movie.Poster.PosterCropSourceFull)
+}
+
+// CoverURL is the fallback poster source: changing it while PosterURL is
+// empty is also a source change.
+func TestApplyMergeBoundary_CoverChangedClearsGeometry(t *testing.T) {
+	pre := &models.Movie{ID: "IPX-535"}
+	pre.Poster.CoverURL = "https://cdn/old-cover.jpg"
+	pre.Poster.PosterCropBounds = cropBoundsFixture()
+	pre.Poster.PosterCropSourceFull = true
+
+	freshMerged := &models.Movie{ID: "IPX-535"}
+	freshMerged.Poster.CoverURL = "https://cdn/new-cover.jpg"
+
+	orch := &applyOrchImpl{nfo: &stubNFOFileMerger{result: nfo.MergeWithExistingResult{Movie: freshMerged, Merged: true}}}
+	state := &applyPipelineState{movie: pre}
+
+	require.NoError(t, orch.stepMerge(ApplyCmd{}, state, &stepCompletion{}))
+	assert.Nil(t, state.movie.Poster.PosterCropBounds, "cover source change must clear geometry")
+}
+
+// Legacy (non-full-source) geometry is never applied — it does not survive
+// the boundary either.
+func TestApplyMergeBoundary_NonFullSourceGeometryDropped(t *testing.T) {
+	pre := &models.Movie{ID: "IPX-535"}
+	pre.Poster.PosterURL = "https://cdn/p.jpg"
+	pre.Poster.PosterCropBounds = cropBoundsFixture()
+	pre.Poster.PosterCropSourceFull = false
+
+	freshMerged := &models.Movie{ID: "IPX-535"}
+	freshMerged.Poster.PosterURL = "https://cdn/p.jpg"
+
+	orch := &applyOrchImpl{nfo: &stubNFOFileMerger{result: nfo.MergeWithExistingResult{Movie: freshMerged, Merged: true}}}
+	state := &applyPipelineState{movie: pre}
+
+	require.NoError(t, orch.stepMerge(ApplyCmd{}, state, &stepCompletion{}))
+	assert.Nil(t, state.movie.Poster.PosterCropBounds)
+}
+
+// Without an NFO merger enabled the merge step is a pass-through: the movie
+// (and any geometry) is untouched.
+func TestApplyMergeBoundary_NoMergerPassesThrough(t *testing.T) {
+	pre := &models.Movie{ID: "IPX-535"}
+	pre.Poster.PosterURL = "https://cdn/p.jpg"
+	pre.Poster.PosterCropBounds = cropBoundsFixture()
+	pre.Poster.PosterCropSourceFull = true
+
+	orch := &applyOrchImpl{}
+	state := &applyPipelineState{movie: pre}
+
+	require.NoError(t, orch.stepMerge(ApplyCmd{}, state, &stepCompletion{}))
+	require.Same(t, pre, state.movie)
+	assert.NotNil(t, state.movie.Poster.PosterCropBounds)
+}

--- a/internal/workflow/apply_orchestrator_crop_test.go
+++ b/internal/workflow/apply_orchestrator_crop_test.go
@@ -133,6 +133,31 @@ func TestApplyMergeBoundary_SourceUnchangedKeepsGeometry(t *testing.T) {
 	assert.NotSame(t, pre.Poster.PosterCropBounds, state.movie.Poster.PosterCropBounds, "carry must copy, not alias")
 }
 
+// Edge branches of the boundary carry/clear: nil merged movie is a no-op;
+// absent, non-full-source, or source-less geometry never applies.
+func TestApplyMergeBoundary_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	carryPosterCropAcrossMerge(nil, "https://cdn/p.jpg", cropBoundsFixture(), true) // no panic
+
+	// No pre-merge geometry: merged movie gains nothing.
+	merged := &models.Movie{}
+	merged.Poster.PosterURL = "https://cdn/p.jpg"
+	carryPosterCropAcrossMerge(merged, "", nil, false)
+	assert.Nil(t, merged.Poster.PosterCropBounds)
+	assert.False(t, merged.Poster.PosterCropSourceFull)
+
+	// Geometry without a poster source is meaningless: never carried.
+	merged2 := &models.Movie{}
+	carryPosterCropAcrossMerge(merged2, "", cropBoundsFixture(), true)
+	assert.Nil(t, merged2.Poster.PosterCropBounds)
+
+	assert.Equal(t, "", effectivePosterSource(nil))
+	withCover := &models.Movie{}
+	withCover.Poster.CoverURL = "https://cdn/c.jpg"
+	assert.Equal(t, "https://cdn/c.jpg", effectivePosterSource(withCover))
+}
+
 // A merge that changes the effective poster source clears the geometry so a
 // crop measured against the old image is never applied to the new one.
 func TestApplyMergeBoundary_SourceChangedClearsGeometry(t *testing.T) {

--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -96,8 +96,21 @@ export interface PosterCropRequest {
 	max_poster_height?: number;
 }
 
+// Normalized manual poster crop geometry (0–1 fractions of the
+// full-size source image), or null when no applyable crop is stored.
+export interface CropBounds {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	source_aspect?: number;
+}
+
 export interface PosterCropResponse {
 	cropped_poster_url: string;
+	poster_crop_bounds: CropBounds | null;
+	poster_crop_source_full: boolean;
+	should_crop_poster: boolean;
 }
 
 export interface PosterFromURLRequest {
@@ -433,6 +446,8 @@ export interface Movie {
 	poster_url?: string;
 	cropped_poster_url?: string;
 	should_crop_poster?: boolean;
+	poster_crop_bounds?: CropBounds | null;
+	poster_crop_source_full?: boolean;
 	original_poster_url?: string;
 	original_cropped_poster_url?: string;
 	original_should_crop_poster?: boolean | null;

--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -111,6 +111,9 @@ export interface PosterCropResponse {
 	poster_crop_bounds: CropBounds | null;
 	poster_crop_source_full: boolean;
 	should_crop_poster: boolean;
+	original_poster_url?: string;
+	original_cropped_poster_url?: string;
+	original_should_crop_poster?: boolean | null;
 }
 
 export interface PosterFromURLRequest {

--- a/web/frontend/src/routes/review/[jobId]/stores/overlay-field-override.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/overlay-field-override.ts
@@ -15,7 +15,6 @@ export function overlayFieldOverride(target: Movie, field: string, src: Movie): 
 			target.release_year = src.release_year;
 			break;
 		case 'poster_url':
-		case 'cover_url':
 		case 'should_crop_poster':
 			(target as unknown as Record<string, unknown>)[field] =
 				(src as unknown as Record<string, unknown>)[field];
@@ -24,6 +23,16 @@ export function overlayFieldOverride(target: Movie, field: string, src: Movie): 
 			// save cannot re-upload geometry measured against the superseded image.
 			target.poster_crop_bounds = src.poster_crop_bounds ?? null;
 			target.poster_crop_source_full = src.poster_crop_source_full ?? false;
+			break;
+		case 'cover_url':
+			(target as unknown as Record<string, unknown>)[field] =
+				(src as unknown as Record<string, unknown>)[field];
+			// Cover is only the effective poster source when poster_url is
+			// empty — fanart churn under an explicit poster keeps the crop.
+			if (!target.poster_url) {
+				target.poster_crop_bounds = src.poster_crop_bounds ?? null;
+				target.poster_crop_source_full = src.poster_crop_source_full ?? false;
+			}
 			break;
 		default:
 			(target as unknown as Record<string, unknown>)[field] =

--- a/web/frontend/src/routes/review/[jobId]/stores/overlay-field-override.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/overlay-field-override.ts
@@ -14,6 +14,17 @@ export function overlayFieldOverride(target: Movie, field: string, src: Movie): 
 			target.release_date = src.release_date;
 			target.release_year = src.release_year;
 			break;
+		case 'poster_url':
+		case 'cover_url':
+		case 'should_crop_poster':
+			(target as unknown as Record<string, unknown>)[field] =
+				(src as unknown as Record<string, unknown>)[field];
+			// Poster source/intent overrides clear stored manual crop geometry
+			// server-side — mirror that in the pending-edit overlay so the next
+			// save cannot re-upload geometry measured against the superseded image.
+			target.poster_crop_bounds = src.poster_crop_bounds ?? null;
+			target.poster_crop_source_full = src.poster_crop_source_full ?? false;
+			break;
 		default:
 			(target as unknown as Record<string, unknown>)[field] =
 				(src as unknown as Record<string, unknown>)[field];

--- a/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.test.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import type { Movie } from '$lib/api/types';
+import { buildMovieToSave } from './save-helpers';
+import { applyCropEcho, clearCropGeometry, siblingResultFilePaths } from './poster-crop-sync';
+
+function makeMovie(overrides: Partial<Movie> = {}): Movie {
+	return {
+		id: 'ABC-001',
+		code: 'ABC-001',
+		title: 'Subject',
+		poster_url: 'https://cdn.example/poster.jpg',
+		cover_url: 'https://cdn.example/cover.jpg',
+		should_crop_poster: true,
+		cropped_poster_url: '/api/v1/temp/posters/job/ABC-001.jpg?v=1',
+		...overrides,
+	};
+}
+
+const BOUNDS = { x: 0.1, y: 0.05, width: 0.4, height: 0.9, source_aspect: 1.667 };
+
+describe('applyCropEcho', () => {
+	it('writes the server-echoed geometry and resulting intent onto the movie', () => {
+		const synced = applyCropEcho(makeMovie(), {
+			cropped_poster_url: '/api/v1/temp/posters/job/ABC-001.jpg?v=2',
+			should_crop_poster: false,
+			poster_crop_bounds: BOUNDS,
+			poster_crop_source_full: true,
+		});
+		expect(synced.poster_crop_bounds).toEqual(BOUNDS);
+		expect(synced.poster_crop_source_full).toBe(true);
+		expect(synced.should_crop_poster).toBe(false);
+		expect(synced.cropped_poster_url).toContain('v=2');
+	});
+
+	it('drops both geometry keys on a null (legacy fallback) echo', () => {
+		const synced = applyCropEcho(
+			makeMovie({ poster_crop_bounds: BOUNDS, poster_crop_source_full: true }),
+			{
+				cropped_poster_url: '/api/v1/temp/posters/job/ABC-001.jpg?v=3',
+				should_crop_poster: false,
+				poster_crop_bounds: null,
+				poster_crop_source_full: false,
+			},
+		);
+		expect('poster_crop_bounds' in synced).toBe(false);
+		expect('poster_crop_source_full' in synced).toBe(false);
+		expect(synced.should_crop_poster).toBe(false);
+	});
+
+	it('saveAllEdits payload carries the post-crop state (amplifier regression)', () => {
+		// The pre-organize saveAllEdits() PATCHes buildMovieToSave(overlayMovie);
+		// the synced overlay must serialize the crop state so the save cannot
+		// re-upload stale pre-crop intent.
+		const overlayMovie = applyCropEcho(makeMovie(), {
+			cropped_poster_url: '/api/v1/temp/posters/job/ABC-001.jpg?v=2',
+			should_crop_poster: false,
+			poster_crop_bounds: BOUNDS,
+			poster_crop_source_full: true,
+		});
+		const wire = JSON.parse(JSON.stringify(buildMovieToSave(overlayMovie)));
+		expect(wire.poster_crop_bounds).toEqual(BOUNDS);
+		// the apply gate refuses geometry whose full-source flag is lost in transit
+		expect(wire.poster_crop_source_full).toBe(true);
+		expect(wire.should_crop_poster).toBe(false);
+	});
+});
+
+describe('siblingResultFilePaths', () => {
+	const results = {
+		'/a/IPX-535.mp4': { result_id: 'r1', movie_id: 'IPX-535' },
+		'/a/IPX-535-cd2.mp4': { result_id: 'r2', movie_id: 'IPX-535' },
+		'/a/OTHER-1.mp4': { result_id: 'r3', movie_id: 'OTHER-1' },
+	};
+
+	it('returns every part of the same movie (multipart overlay sync)', () => {
+		expect(siblingResultFilePaths(results, 'r1')).toEqual(['/a/IPX-535.mp4', '/a/IPX-535-cd2.mp4']);
+	});
+
+	it('is empty for an unknown resultId', () => {
+		expect(siblingResultFilePaths(results, 'nope')).toEqual([]);
+		expect(siblingResultFilePaths(undefined, 'r1')).toEqual([]);
+	});
+});
+
+describe('clearCropGeometry', () => {
+	it('marks geometry for explicit clear on the next save', () => {
+		const cleared = clearCropGeometry(makeMovie({ poster_crop_bounds: BOUNDS }));
+		expect(cleared.poster_crop_bounds).toBeNull();
+		const wire = JSON.parse(JSON.stringify(buildMovieToSave(cleared)));
+		expect(wire).toHaveProperty('poster_crop_bounds', null);
+	});
+
+	it('preserves unrelated pending edits', () => {
+		const cleared = clearCropGeometry(makeMovie({ title: 'Edited', poster_crop_bounds: BOUNDS }));
+		expect(cleared.title).toBe('Edited');
+		expect(cleared.poster_url).toBe('https://cdn.example/poster.jpg');
+	});
+});

--- a/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.test.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import type { Movie } from '$lib/api/types';
 import { buildMovieToSave } from './save-helpers';
-import { applyCropEcho, clearCropGeometry, siblingResultFilePaths } from './poster-crop-sync';
+import {
+	applyCropEcho,
+	clearCropGeometry,
+	rescrapeClearedMovieKeys,
+	siblingResultFilePaths,
+} from './poster-crop-sync';
 
 function makeMovie(overrides: Partial<Movie> = {}): Movie {
 	return {
@@ -122,6 +127,24 @@ describe('siblingResultFilePaths', () => {
 	it('is empty for an unknown resultId', () => {
 		expect(siblingResultFilePaths(results, 'nope')).toEqual([]);
 		expect(siblingResultFilePaths(undefined, 'r1')).toEqual([]);
+	});
+});
+
+describe('rescrapeClearedMovieKeys', () => {
+	it('keys successful rescrapes by requested ID and corrected content ID', () => {
+		const keys = rescrapeClearedMovieKeys([
+			{ movie_id: 'OLD-001', status: 'success', movie: { id: 'NEW-001' } },
+			{ movie_id: 'KEEP-002', status: 'success', movie: { id: 'KEEP-002' } },
+			{ movie_id: 'FAIL-003', status: 'failed' },
+		]);
+		expect(keys.has('OLD-001')).toBe(true);
+		expect(keys.has('NEW-001')).toBe(true);
+		expect(keys.has('KEEP-002')).toBe(true);
+		expect(keys.has('FAIL-003')).toBe(false);
+	});
+
+	it('empty results clear nothing', () => {
+		expect(rescrapeClearedMovieKeys([]).size).toBe(0);
 	});
 });
 

--- a/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.test.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.test.ts
@@ -63,6 +63,49 @@ describe('applyCropEcho', () => {
 		expect(wire.poster_crop_source_full).toBe(true);
 		expect(wire.should_crop_poster).toBe(false);
 	});
+
+	it('adopts the server-echoed pre-crop baseline verbatim', () => {
+		const synced = applyCropEcho(makeMovie(), {
+			cropped_poster_url: '/api/v1/temp/posters/job/ABC-001.jpg?v=2',
+			should_crop_poster: false,
+			poster_crop_bounds: BOUNDS,
+			poster_crop_source_full: true,
+			original_poster_url: 'https://cdn.example/scraped.jpg',
+			original_cropped_poster_url: 'https://cdn.example/scraped-crop.jpg',
+			original_should_crop_poster: true,
+		});
+		expect(synced.original_poster_url).toBe('https://cdn.example/scraped.jpg');
+		expect(synced.original_cropped_poster_url).toContain('scraped-crop');
+		expect(synced.original_should_crop_poster).toBe(true);
+	});
+
+	it('never invents a baseline when the echo carries none', () => {
+		const synced = applyCropEcho(makeMovie(), {
+			cropped_poster_url: '/api/v1/temp/posters/job/ABC-001.jpg?v=2',
+			should_crop_poster: false,
+			poster_crop_bounds: BOUNDS,
+			poster_crop_source_full: true,
+		});
+		expect(synced.original_poster_url).toBeUndefined();
+	});
+
+	it('existing scraped baseline is never clobbered by the echo', () => {
+		const synced = applyCropEcho(
+			makeMovie({
+				original_poster_url: 'https://cdn.example/original.jpg',
+				original_cropped_poster_url: 'https://cdn.example/original-crop.jpg',
+				original_should_crop_poster: true,
+			}),
+			{
+				cropped_poster_url: '/api/v1/temp/posters/job/ABC-001.jpg?v=2',
+				should_crop_poster: false,
+				poster_crop_bounds: BOUNDS,
+				poster_crop_source_full: true,
+			},
+		);
+		expect(synced.original_poster_url).toBe('https://cdn.example/original.jpg');
+		expect(synced.original_cropped_poster_url).toContain('original-crop');
+	});
 });
 
 describe('siblingResultFilePaths', () => {

--- a/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.test.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.test.ts
@@ -84,6 +84,23 @@ describe('applyCropEcho', () => {
 		expect(synced.original_should_crop_poster).toBe(true);
 	});
 
+	it('empty original_poster_url is still a baseline (cover-fallback movies)', () => {
+		// Cover-fallback movie that originally required auto-crop: the server
+		// echoes an empty poster URL with the pre-crop crop/intent baseline.
+		const synced = applyCropEcho(makeMovie({ poster_url: '' }), {
+			cropped_poster_url: '/api/v1/temp/posters/job/ABC-001.jpg?v=2',
+			should_crop_poster: false,
+			poster_crop_bounds: BOUNDS,
+			poster_crop_source_full: true,
+			original_poster_url: '',
+			original_cropped_poster_url: 'https://cdn.example/scraped-crop.jpg',
+			original_should_crop_poster: true,
+		});
+		expect(synced.original_poster_url).toBe('');
+		expect(synced.original_cropped_poster_url).toContain('scraped-crop');
+		expect(synced.original_should_crop_poster).toBe(true);
+	});
+
 	it('never invents a baseline when the echo carries none', () => {
 		const synced = applyCropEcho(makeMovie(), {
 			cropped_poster_url: '/api/v1/temp/posters/job/ABC-001.jpg?v=2',

--- a/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.ts
@@ -7,6 +7,11 @@ export interface CropEcho {
 	should_crop_poster: boolean;
 	poster_crop_bounds: CropBounds | null;
 	poster_crop_source_full: boolean;
+	// server-side pre-edit poster baseline (backupPosterOriginals); echoed so
+	// the client reset baseline is authoritative, never guessed.
+	original_poster_url?: string;
+	original_cropped_poster_url?: string;
+	original_should_crop_poster?: boolean | null;
 }
 
 // applyCropEcho merges the server-echoed crop state into a movie — used for
@@ -18,10 +23,21 @@ export interface CropEcho {
 // stored server-side) drops the key entirely so the overlay round-trips as
 // "no geometry", matching server state and avoiding phantom dirty diffs.
 export function applyCropEcho(movie: Movie, echo: CropEcho): Movie {
+	// Adopt the server-side pre-edit baseline verbatim (set on the first
+	// poster edit via backupPosterOriginals). Never derive it from the current
+	// movie: by the time the echo arrives the crop fields are already
+	// post-edit, and a partially-populated legacy baseline would guess wrong.
 	const base: Movie = {
 		...movie,
 		cropped_poster_url: echo.cropped_poster_url,
 		should_crop_poster: echo.should_crop_poster,
+		...(echo.original_poster_url
+			? {
+					original_poster_url: echo.original_poster_url,
+					original_cropped_poster_url: echo.original_cropped_poster_url,
+					original_should_crop_poster: echo.original_should_crop_poster ?? movie.original_should_crop_poster,
+				}
+			: {}),
 	};
 	delete base.poster_crop_bounds;
 	delete base.poster_crop_source_full;

--- a/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.ts
@@ -31,11 +31,14 @@ export function applyCropEcho(movie: Movie, echo: CropEcho): Movie {
 		...movie,
 		cropped_poster_url: echo.cropped_poster_url,
 		should_crop_poster: echo.should_crop_poster,
-		...(echo.original_poster_url
+		// Presence, not truthiness: a cover-fallback movie legitimately echoes
+		// an EMPTY original_poster_url with the pre-crop crop/intent baseline,
+		// and that baseline is exactly what Reset must restore.
+		...(echo.original_poster_url !== undefined
 			? {
 					original_poster_url: echo.original_poster_url,
 					original_cropped_poster_url: echo.original_cropped_poster_url,
-					original_should_crop_poster: echo.original_should_crop_poster ?? movie.original_should_crop_poster,
+					original_should_crop_poster: echo.original_should_crop_poster ?? null,
 				}
 			: {}),
 	};

--- a/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.ts
@@ -71,6 +71,23 @@ export function siblingResultFilePaths(
 		.map(([filePath]) => filePath);
 }
 
+// rescrapeClearedMovieKeys returns the movie IDs whose stored crop state a
+// bulk rescrape actually cleared (success only). A rescrape that corrects
+// the content ID reports the requested (old) ID on the result row while the
+// job results and the echoed movie carry the corrected ID — so both the old
+// request ID and the echoed new ID count as cleared.
+export function rescrapeClearedMovieKeys(
+	results: ReadonlyArray<{ movie_id: string; status: string; movie?: { id?: string } }>,
+): Set<string> {
+	const keys = new Set<string>();
+	for (const r of results) {
+		if (r.status !== 'success') continue;
+		keys.add(r.movie_id);
+		if (r.movie?.id) keys.add(r.movie.id);
+	}
+	return keys;
+}
+
 // clearCropGeometry marks pending crop geometry for server-side clearing on
 // the next save: an explicit null rides the movie PATCH as "clear", whereas
 // an omitted key would preserve stored geometry. Used when the poster source

--- a/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/poster-crop-sync.ts
@@ -1,0 +1,64 @@
+import type { CropBounds, Movie } from '$lib/api/types';
+
+// CropEcho is the server-echoed crop state returned by the poster-crop
+// endpoint after a successful manual crop.
+export interface CropEcho {
+	cropped_poster_url: string;
+	should_crop_poster: boolean;
+	poster_crop_bounds: CropBounds | null;
+	poster_crop_source_full: boolean;
+}
+
+// applyCropEcho merges the server-echoed crop state into a movie — used for
+// both the visible job-result state and the pending editedMovies overlay — so
+// a pre-organize saveAllEdits() uploads crop-consistent data instead of
+// clobbering the crop with stale pre-crop intent.
+//
+// A null bounds echo (legacy already-cropped source — nothing applyable is
+// stored server-side) drops the key entirely so the overlay round-trips as
+// "no geometry", matching server state and avoiding phantom dirty diffs.
+export function applyCropEcho(movie: Movie, echo: CropEcho): Movie {
+	const base: Movie = {
+		...movie,
+		cropped_poster_url: echo.cropped_poster_url,
+		should_crop_poster: echo.should_crop_poster,
+	};
+	delete base.poster_crop_bounds;
+	delete base.poster_crop_source_full;
+	if (echo.poster_crop_bounds == null) {
+		return base;
+	}
+	return {
+		...base,
+		poster_crop_bounds: echo.poster_crop_bounds,
+		// must round-trip with the bounds: the apply gate refuses geometry
+		// whose full-source flag did not survive the overlay save
+		poster_crop_source_full: echo.poster_crop_source_full,
+	};
+}
+
+// siblingResultFilePaths returns every result file path belonging to the
+// same movie as resultId. The crop endpoint applies poster state to ALL parts
+// of a multipart movie (same geometry per part), so the job-state/overlay
+// sync must cover siblings too — a stale sibling overlay would re-upload
+// pre-crop intent on the next save and wipe the stored geometry.
+export function siblingResultFilePaths(
+	results: Record<string, { result_id?: string; movie_id?: string }> | undefined,
+	resultId: string,
+): string[] {
+	if (!results) return [];
+	const entry = Object.values(results).find((r) => r?.result_id === resultId);
+	const movieId = entry?.movie_id;
+	if (!movieId) return [];
+	return Object.entries(results)
+		.filter(([, r]) => r?.movie_id === movieId)
+		.map(([filePath]) => filePath);
+}
+
+// clearCropGeometry marks pending crop geometry for server-side clearing on
+// the next save: an explicit null rides the movie PATCH as "clear", whereas
+// an omitted key would preserve stored geometry. Used when the poster source
+// is replaced (poster-from-URL) or the poster is reset to its baseline.
+export function clearCropGeometry(movie: Movie): Movie {
+	return { ...movie, poster_crop_bounds: null };
+}

--- a/web/frontend/src/routes/review/[jobId]/stores/review-mutations.overlay.test.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-mutations.overlay.test.ts
@@ -47,6 +47,39 @@ describe('overlayFieldOverride', () => {
 		expect(target.maker).toBe('New Maker');
 	});
 
+	it('poster source override clears pending crop geometry (mirrors backend)', () => {
+		const target = makeMovie({
+			poster_url: 'https://old/poster.jpg',
+			poster_crop_bounds: { x: 0.1, y: 0.1, width: 0.4, height: 0.9 },
+			poster_crop_source_full: true,
+		});
+		const src = makeMovie({ poster_url: 'https://new/poster.jpg' });
+		overlayFieldOverride(target, 'poster_url', src);
+		expect(target.poster_url).toBe('https://new/poster.jpg');
+		expect(target.poster_crop_bounds).toBeNull();
+		expect(target.poster_crop_source_full).toBe(false);
+	});
+
+	it('should_crop_poster override clears pending crop geometry', () => {
+		const target = makeMovie({
+			poster_crop_bounds: { x: 0.1, y: 0.1, width: 0.4, height: 0.9 },
+			poster_crop_source_full: true,
+		});
+		const src = makeMovie({ should_crop_poster: true });
+		overlayFieldOverride(target, 'should_crop_poster', src);
+		expect(target.should_crop_poster).toBe(true);
+		expect(target.poster_crop_bounds).toBeNull();
+	});
+
+	it('non-poster overrides keep pending crop geometry', () => {
+		const target = makeMovie({
+			poster_crop_bounds: { x: 0.1, y: 0.1, width: 0.4, height: 0.9 },
+		});
+		const src = makeMovie({ maker: 'New Maker' });
+		overlayFieldOverride(target, 'maker', src);
+		expect(target.poster_crop_bounds).toEqual({ x: 0.1, y: 0.1, width: 0.4, height: 0.9 });
+	});
+
 	it('unrelated fields on target are preserved when overriding maker', () => {
 		const target = makeMovie({ director: 'Orig Director', maker: 'Orig Maker' });
 		const src = makeMovie({ maker: 'New Maker', director: 'Src Director' });

--- a/web/frontend/src/routes/review/[jobId]/stores/review-mutations.overlay.test.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-mutations.overlay.test.ts
@@ -71,6 +71,28 @@ describe('overlayFieldOverride', () => {
 		expect(target.poster_crop_bounds).toBeNull();
 	});
 
+	it('cover_url override keeps geometry when an explicit poster exists', () => {
+		const target = makeMovie({
+			poster_url: 'https://cdn.example/explicit.jpg',
+			poster_crop_bounds: { x: 0.1, y: 0.1, width: 0.4, height: 0.9 },
+			poster_crop_source_full: true,
+		});
+		const src = makeMovie({ cover_url: 'https://cdn.example/new-cover.jpg' });
+		overlayFieldOverride(target, 'cover_url', src);
+		expect(target.cover_url).toBe('https://cdn.example/new-cover.jpg');
+		expect(target.poster_crop_bounds).toEqual({ x: 0.1, y: 0.1, width: 0.4, height: 0.9 });
+	});
+
+	it('cover_url override clears geometry when cover is the poster source', () => {
+		const target = makeMovie({
+			poster_url: '',
+			poster_crop_bounds: { x: 0.1, y: 0.1, width: 0.4, height: 0.9 },
+		});
+		const src = makeMovie({ cover_url: 'https://cdn.example/new-cover.jpg' });
+		overlayFieldOverride(target, 'cover_url', src);
+		expect(target.poster_crop_bounds).toBeNull();
+	});
+
 	it('non-poster overrides keep pending crop geometry', () => {
 		const target = makeMovie({
 			poster_crop_bounds: { x: 0.1, y: 0.1, width: 0.4, height: 0.9 },

--- a/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
@@ -21,6 +21,7 @@ import {
 	type PosterCropMetrics,
 } from '../review-utils';
 import { overlayFieldOverride } from './overlay-field-override';
+import { applyCropEcho, clearCropGeometry, siblingResultFilePaths } from './poster-crop-sync';
 import { buildMovieToSave } from './save-helpers';
 import * as m from '$lib/paraglide/messages';
 
@@ -96,37 +97,38 @@ export function createReviewMutations(deps: ReviewMutationsDeps) {
 		onSuccess: (data: PosterFromURLResponse, { resultId }) => {
 			const currentJob = deps.getJob();
 			if (currentJob) {
+				// The backend applies the new poster to every part of the movie —
+				// sync siblings too, or a stale sibling overlay would re-upload the
+				// old poster (and crop state) on the next save.
+				const partPaths = siblingResultFilePaths(
+					currentJob.results as Record<string, FileResult>,
+					resultId,
+				);
+				const fromUrlEcho = (movie: Movie): Movie =>
+					clearCropGeometry({
+						...movie,
+						poster_url: data.poster_url,
+						cropped_poster_url: data.cropped_poster_url,
+						should_crop_poster: false,
+					});
 				const updatedJob: BatchJobResponse = {
 					...currentJob,
 					results: { ...currentJob.results },
 				};
-				for (const [filePath, result] of Object.entries(updatedJob.results)) {
-					const r = result as FileResult;
-					if (r.result_id === resultId && r.movie) {
-						updatedJob.results[filePath] = {
-							...r,
-							movie: {
-								...r.movie,
-								poster_url: data.poster_url,
-								cropped_poster_url: data.cropped_poster_url,
-								should_crop_poster: false,
-							},
-						};
+				for (const filePath of partPaths) {
+					const r = updatedJob.results[filePath] as FileResult;
+					if (r?.movie) {
+						updatedJob.results[filePath] = { ...r, movie: fromUrlEcho(r.movie) };
 					}
 				}
 				deps.skipJobSync();
 				deps.setJob(updatedJob);
 
 				const editedMovies = deps.getEditedMovies();
-				for (const [filePath, movie] of editedMovies) {
-					const editedResultId = currentJob.results?.[filePath]?.result_id;
-					if (editedResultId === resultId) {
-						editedMovies.set(filePath, {
-							...movie,
-							poster_url: data.poster_url,
-							cropped_poster_url: data.cropped_poster_url,
-							should_crop_poster: false,
-						});
+				for (const filePath of partPaths) {
+					const movie = editedMovies.get(filePath);
+					if (movie) {
+						editedMovies.set(filePath, fromUrlEcho(movie));
 					}
 				}
 			}
@@ -233,7 +235,39 @@ export function createReviewMutations(deps: ReviewMutationsDeps) {
 		}) => {
 			return deps.updateBatchMoviePosterCrop(mutationJobId, resultId, crop, maxPosterHeight);
 		},
-		onSuccess: (response: PosterCropResponse) => {
+		onSuccess: (response: PosterCropResponse, { resultId }) => {
+			// Sync the server-echoed crop state into the visible job-result state
+			// and the pending editedMovies overlay, so a pre-organize saveAllEdits()
+			// cannot re-upload stale pre-crop intent (should_crop_poster=true) and
+			// clobber the crop. A null echo (legacy already-cropped source) drops
+			// the key — the server holds no applyable geometry either.
+			const job = deps.getJob();
+			if (job) {
+				// Same movie ID = same poster: the server applied the crop to every
+				// part, so sync every part here (multipart; see siblingResultFilePaths).
+				const partPaths = siblingResultFilePaths(
+					job.results as Record<string, FileResult>,
+					resultId,
+				);
+				const updatedJob: BatchJobResponse = { ...job, results: { ...job.results } };
+				for (const filePath of partPaths) {
+					const r = updatedJob.results[filePath] as FileResult;
+					if (r?.movie) {
+						updatedJob.results[filePath] = { ...r, movie: applyCropEcho(r.movie, response) };
+					}
+				}
+				deps.skipJobSync();
+				deps.setJob(updatedJob);
+
+				const editedMovies = deps.getEditedMovies();
+				for (const filePath of partPaths) {
+					const movie = editedMovies.get(filePath);
+					if (movie) {
+						editedMovies.set(filePath, applyCropEcho(movie, response));
+					}
+				}
+			}
+
 			const currentResultVal = deps.getCurrentResult();
 			if (currentResultVal) {
 				deps.getPosterPreviewOverrides().set(currentResultVal.file_path, {

--- a/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
@@ -21,7 +21,12 @@ import {
 	type PosterCropMetrics,
 } from '../review-utils';
 import { overlayFieldOverride } from './overlay-field-override';
-import { applyCropEcho, clearCropGeometry, siblingResultFilePaths } from './poster-crop-sync';
+import {
+	applyCropEcho,
+	clearCropGeometry,
+	rescrapeClearedMovieKeys,
+	siblingResultFilePaths,
+} from './poster-crop-sync';
 import { buildMovieToSave } from './save-helpers';
 import * as m from '$lib/paraglide/messages';
 
@@ -365,9 +370,7 @@ export function createReviewMutations(deps: ReviewMutationsDeps) {
 			// pending overlays so a later save cannot re-upload pre-rescrape
 			// bounds. Only movies that actually succeeded — a failed rescrape kept
 			// its server-side geometry, and an explicit null here would clear it.
-			const succeededIds = new Set(
-				(data.results ?? []).filter((r) => r.status === 'success').map((r) => r.movie_id),
-			);
+			const succeededIds = rescrapeClearedMovieKeys(data.results ?? []);
 			const jobSnapshot = data.job ?? deps.getJob();
 			if (jobSnapshot && succeededIds.size > 0) {
 				const editedMovies = deps.getEditedMovies();

--- a/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
@@ -355,10 +355,28 @@ export function createReviewMutations(deps: ReviewMutationsDeps) {
 				array_strategy: arrayStrategy as 'merge' | 'replace' | undefined,
 			});
 		},
-		onSuccess: (data) => {
+		onSuccess: (data, { movieIds }) => {
 			if (data.job) {
 				deps.skipJobSync();
 				deps.setJob(data.job);
+			}
+
+			// Rescrape clears stored crop geometry server-side; mirror that into
+			// pending overlays so a later save cannot re-upload pre-rescrape
+			// bounds. (Clearing a failed movie's entry is safe either way: an
+			// omitted geometry key preserves the still-stored geometry.)
+			const jobSnapshot = data.job ?? deps.getJob();
+			if (jobSnapshot) {
+				const requested = new Set(movieIds);
+				const editedMovies = deps.getEditedMovies();
+				for (const [filePath, result] of Object.entries(jobSnapshot.results ?? {})) {
+					const fr = result as FileResult;
+					if (!requested.has(fr.movie_id)) continue;
+					const pending = editedMovies.get(filePath);
+					if (pending && (pending.poster_crop_bounds != null || pending.poster_crop_source_full)) {
+						editedMovies.set(filePath, clearCropGeometry(pending));
+					}
+				}
 			}
 
 			if (data.failed > 0) {

--- a/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-mutations.svelte.ts
@@ -363,15 +363,17 @@ export function createReviewMutations(deps: ReviewMutationsDeps) {
 
 			// Rescrape clears stored crop geometry server-side; mirror that into
 			// pending overlays so a later save cannot re-upload pre-rescrape
-			// bounds. (Clearing a failed movie's entry is safe either way: an
-			// omitted geometry key preserves the still-stored geometry.)
+			// bounds. Only movies that actually succeeded — a failed rescrape kept
+			// its server-side geometry, and an explicit null here would clear it.
+			const succeededIds = new Set(
+				(data.results ?? []).filter((r) => r.status === 'success').map((r) => r.movie_id),
+			);
 			const jobSnapshot = data.job ?? deps.getJob();
-			if (jobSnapshot) {
-				const requested = new Set(movieIds);
+			if (jobSnapshot && succeededIds.size > 0) {
 				const editedMovies = deps.getEditedMovies();
 				for (const [filePath, result] of Object.entries(jobSnapshot.results ?? {})) {
 					const fr = result as FileResult;
-					if (!requested.has(fr.movie_id)) continue;
+					if (!succeededIds.has(fr.movie_id)) continue;
 					const pending = editedMovies.get(filePath);
 					if (pending && (pending.poster_crop_bounds != null || pending.poster_crop_source_full)) {
 						editedMovies.set(filePath, clearCropGeometry(pending));

--- a/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
@@ -49,6 +49,7 @@ import { calculateCompleteness, type CompletenessTier } from '$lib/utils/complet
 import { nextOrganizeProgress } from '$lib/utils/job-progress';
 import { createReviewMutations } from './review-mutations.svelte';
 import { buildMovieOverride } from './save-helpers';
+import { clearCropGeometry } from './poster-crop-sync';
 import * as m from '$lib/paraglide/messages';
 
 interface MovieGroup {
@@ -681,7 +682,10 @@ export function createReviewState(pageStore: Page) {
 		return (
 			currentMovie.poster_url !== original.poster_url ||
 			currentMovie.cropped_poster_url !== original.cropped_poster_url ||
-			currentMovie.should_crop_poster !== original.should_crop_poster
+			currentMovie.should_crop_poster !== original.should_crop_poster ||
+			// pending manual crop geometry is drift from the baseline even when
+			// URL/intent fields happen to match it
+			currentMovie.poster_crop_bounds != null
 		);
 	});
 
@@ -701,17 +705,22 @@ export function createReviewState(pageStore: Page) {
 		const posterChanged =
 			currentMovie.poster_url !== original.poster_url ||
 			currentMovie.cropped_poster_url !== original.cropped_poster_url ||
-			currentMovie.should_crop_poster !== original.should_crop_poster;
+			currentMovie.should_crop_poster !== original.should_crop_poster ||
+			currentMovie.poster_crop_bounds != null;
 		if (!posterChanged) return;
 
 		if (original.poster_url !== currentMovie.poster_url) {
 			mutations.applyPosterFromUrl(currentResult!.result_id, original.poster_url);
 		} else {
-			updateCurrentMovie({
-				...currentMovie,
-				cropped_poster_url: original.cropped_poster_url,
-				should_crop_poster: original.should_crop_poster,
-			});
+			updateCurrentMovie(
+				// explicit null: the next save clears stored crop geometry on the
+				// server (an omitted key would preserve it)
+				clearCropGeometry({
+					...currentMovie,
+					cropped_poster_url: original.cropped_poster_url,
+					should_crop_poster: original.should_crop_poster,
+				}),
+			);
 			clearPosterPreviewOverride();
 		}
 	}

--- a/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
@@ -678,7 +678,12 @@ export function createReviewState(pageStore: Page) {
 	const canResetPoster = $derived.by(() => {
 		if (!currentResult || !currentMovie) return false;
 		const original = posterBaseline;
-		if (!original || !original.poster_url) return false;
+		if (!original) return false;
+		// No scraped poster baseline AND no pending crop: nothing to restore.
+		// Pending geometry alone makes Reset meaningful even for cover-fallback
+		// movies (empty baseline poster_url) — it restores the scraped intent
+		// and clears the crop.
+		if (!original.poster_url && currentMovie.poster_crop_bounds == null) return false;
 		return (
 			currentMovie.poster_url !== original.poster_url ||
 			currentMovie.cropped_poster_url !== original.cropped_poster_url ||
@@ -700,7 +705,9 @@ export function createReviewState(pageStore: Page) {
 		if (!currentResult || !currentMovie) return;
 
 		const original = posterBaseline;
-		if (!original || !original.poster_url) return;
+		if (!original) return;
+		// see canResetPoster: pending geometry alone makes Reset meaningful
+		if (!original.poster_url && currentMovie.poster_crop_bounds == null) return;
 
 		const posterChanged =
 			currentMovie.poster_url !== original.poster_url ||
@@ -709,7 +716,8 @@ export function createReviewState(pageStore: Page) {
 			currentMovie.poster_crop_bounds != null;
 		if (!posterChanged) return;
 
-		if (original.poster_url !== currentMovie.poster_url) {
+		// No restorable URL when the baseline is empty (cover-only fallback).
+		if (original.poster_url !== '' && original.poster_url !== currentMovie.poster_url) {
 			mutations.applyPosterFromUrl(currentResult!.result_id, original.poster_url);
 		} else {
 			updateCurrentMovie(

--- a/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
+++ b/web/frontend/src/routes/review/[jobId]/stores/review-state.svelte.ts
@@ -49,7 +49,7 @@ import { calculateCompleteness, type CompletenessTier } from '$lib/utils/complet
 import { nextOrganizeProgress } from '$lib/utils/job-progress';
 import { createReviewMutations } from './review-mutations.svelte';
 import { buildMovieOverride } from './save-helpers';
-import { clearCropGeometry } from './poster-crop-sync';
+import { clearCropGeometry, siblingResultFilePaths } from './poster-crop-sync';
 import * as m from '$lib/paraglide/messages';
 
 interface MovieGroup {
@@ -729,6 +729,24 @@ export function createReviewState(pageStore: Page) {
 					should_crop_poster: original.should_crop_poster,
 				}),
 			);
+			// Multipart: poster state is movie-wide and each part's save PATCHes
+			// all parts — propagate the reset into sibling overlays too, or a
+			// sibling's pending edit can out-race this part's save and restore
+			// the geometry that was just cleared.
+			if (job) {
+				for (const fp of siblingResultFilePaths(job.results as Record<string, FileResult>, currentResult!.result_id)) {
+					if (fp === currentResult!.file_path) continue;
+					const sibling = editedMovies.get(fp);
+					if (sibling) {
+						editedMovies.set(fp, clearCropGeometry({
+							...sibling,
+							poster_url: original.poster_url,
+							cropped_poster_url: original.cropped_poster_url,
+							should_crop_poster: original.should_crop_poster,
+						}));
+					}
+				}
+			}
 			clearPosterPreviewOverride();
 		}
 	}


### PR DESCRIPTION
## What

Fixes the reported bug (Discord, Homer): on a 50-file batch, re-cropping jobs on the review page showed the crop in every preview, but **Organize wrote the scraper's default auto-crop (or the full uncropped image) to disk**. The manual crop was silently lost.

This is the deliberately minimal redo of the abandoned #178 approach — fix the reported bug and nothing else. Deferred hardening is tracked in #186.

## Root causes

1. **Geometry was never stored** — the crop endpoint cropped the temp preview and kept only the resulting URL; the bounds were discarded.
2. **Apply only knew a boolean** — `downloadPoster` used `should_crop_poster`: full image or hard-coded right-side auto-crop; manual geometry never consulted.
3. **The amplifier** — the Organize button runs `saveAllEdits()` first, PATCHing the whole movie from the `editedMovies` overlay; the crop mutation never updated the overlay, so the save re-uploaded stale `should_crop_poster=true` and clobbered the crop.

## Changes

**Persistence** — `models.CropBounds` (normalized 0–1 fractions + `source_aspect`) and `PosterCropSourceFull`, runtime-only (`gorm:"-"`, no DB migration), wired through the explicit serializers (`Movie.Marshal/UnmarshalJSON`, `PosterState.Clone`, `MovieView` mappings, job envelope). Crop endpoint validates pixel-space containment (400), stores bounds via the extended `UpdatePosterCrop`, echoes `poster_crop_bounds` (null for legacy already-cropped source) + `should_crop_poster` + `poster_crop_source_full`, and persists the job envelope.

**Apply** — merge boundary carries geometry across `stepMerge` only when the effective poster source is unchanged (generic NFO merger untouched). `downloadPoster`: one GET feeds all paths; valid + aspect-consistent full-source geometry is applied to the downloaded source; any inconsistency (invalid/decode-failure/aspect-mismatch) falls back to exact pre-change behavior reusing the downloaded temp — **a previously-successful organize can never newly fail**.

**Invalidation** — geometry cleared on any poster source/intent change: poster-from-URL, `poster_url`/`cover_url`/`should_crop_poster` overrides, source- or intent-changing PATCH, rescrape (incl. same-URL refresh). PATCH that *omits* the field preserves geometry (presence-tracked request DTO); explicit `null` clears.

**Frontend (amplifier fix)** — crop success writes the server echo into the visible job state *and* the pending-edits overlay for **all multipart parts**; poster-from-URL and poster reset clear geometry in both places. `organize-controller.ts` untouched.

## Testing

- Pixel-level: two-tone 1000×600 source — integrated `Execute` run asserts the on-disk poster is the manual **left** crop, not the scraper's right-side auto-crop; downloader fallback ladder keeps single-GET (hit-count asserted), undecodable/direct-download success preserved
- Codec + job-envelope round-trip; PATCH presence (omitted preserves / explicit null clears / synced overlay survives save); merge-boundary carry/clear; invalidation per call site incl. rescrape; frontend overlay sync + wire-shape tests
- Gates: full short Go suite (114 pkgs), `golangci-lint` 0 issues, frontend 480 tests + `svelte-check` 0 errors, swagger + mocks regenerated

## Explicit non-goals (→ #186)

No new locking, rollback/compensation, staged installs or crash-recovery machinery, unrelated validations, or multipart hardening beyond same-geometry-per-part. Concurrent crop/organize interleaving is a documented **pre-existing** race (the reported repro is strictly sequential) — tracked in #186 along with the #178 branch as quarry.

## Review history

Two local sub-agent review rounds (kimi-k3 and gpt-5.6-luna, max effort) plus a local CI-parity Codex review — all in-scope findings fixed before push (overlay round-trip of the full-source flag, multipart sibling sync, single-GET fallbacks, result-field consistency, aspect validity, envelope persistence). Both Codex P1s belonging to the deferred categories are logged in #186.