### PR TITLE
fix(matcher): detect letter+quality-tag multipart suffixes

### DIFF
--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -122,6 +122,26 @@ func (m *Matcher) matchWithRegex(file models.FileMatchInfo, filename string, pat
 	// First capture group is the ID.
 	result.ID = strings.ToUpper(id)
 
+	// The built-in ID pattern optionally consumes a trailing E or Z as a catalog
+	// suffix (e.g. IPX-535Z). When that letter immediately precedes a digit-first
+	// quality tag (the letter+trailing part form, e.g. "SVFLA-001e-4k" where 'e' is
+	// part E, not a catalog suffix), strip it from the ID so the part letter is
+	// detected. A bare E/Z without a trailing tag is a legitimate catalog suffix
+	// (e.g. IPX-535Z) and is preserved.
+	if n := len(result.ID); n > 1 && (result.ID[n-1] == 'E' || result.ID[n-1] == 'Z') {
+		baseID := result.ID[:n-1]
+		num, suffix, patternType, trailingPrefix := DetectPartSuffix(filename, baseID)
+		if patternType == PatternLetter && trailingPrefix != "" {
+			result.ID = baseID
+			result.PartNumber = num
+			result.PartSuffix = suffix
+			result.MultipartPattern = patternType
+			result.TrailingPrefix = trailingPrefix
+			result.IsMultiPart = false
+			return result
+		}
+	}
+
 	// Detect part suffix from the rest of the filename
 	num, suffix, patternType, trailingPrefix := DetectPartSuffix(filename, result.ID)
 	result.PartNumber = num

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -178,7 +178,19 @@ func (m *Matcher) MatchString(s string) string {
 	// Try built-in pattern
 	matches := m.builtinPattern.FindStringSubmatch(s)
 	if len(matches) > 1 {
-		return strings.ToUpper(matches[1])
+		id := strings.ToUpper(matches[1])
+		// Apply the same E/Z catalog-suffix stripping as matchWithRegex so MatchString
+		// stays consistent with MatchFile for downstream re-match callers (e.g. the
+		// scrape phase re-deriving a movie ID from a filename). A bare E/Z without a
+		// trailing digit-first quality tag is a legitimate catalog suffix and preserved.
+		if n := len(id); n > 1 && (id[n-1] == 'E' || id[n-1] == 'Z') {
+			baseID := id[:n-1]
+			_, _, patternType, trailingPrefix := DetectPartSuffix(s, baseID)
+			if patternType == PatternLetter && trailingPrefix != "" {
+				return baseID
+			}
+		}
+		return id
 	}
 
 	return ""

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -128,19 +128,24 @@ func (m *Matcher) matchWithRegex(file models.FileMatchInfo, filename string, pat
 	// quality tag (the letter+trailing part form, e.g. "SVFLA-001e-4k" where 'e' is
 	// part E, not a catalog suffix), strip it from the ID so the part letter is
 	// detected. A bare E/Z without a trailing tag is a legitimate catalog suffix
-	// (e.g. IPX-535Z) and is preserved.
-	if n := len(result.ID); n > 1 && (result.ID[n-1] == 'E' || result.ID[n-1] == 'Z') {
-		baseID := result.ID[:n-1]
-		num, suffix, patternType, trailingPrefix := DetectPartSuffix(filename, baseID)
-		if patternType == PatternLetter && trailingPrefix != "" {
-			result.strippedSuffix = string(result.ID[n-1])
-			result.ID = baseID
-			result.PartNumber = num
-			result.PartSuffix = suffix
-			result.MultipartPattern = patternType
-			result.TrailingPrefix = trailingPrefix
-			result.IsMultiPart = false
-			return result
+	// (e.g. IPX-535Z) and is preserved. Only the built-in pattern applies this
+	// heuristic; a custom regex that explicitly captures an E/Z-suffixed ID is
+	// authoritative and must not be overridden.
+	if matchType == "builtin" {
+		n := len(result.ID)
+		if n > 1 && (result.ID[n-1] == 'E' || result.ID[n-1] == 'Z') {
+			baseID := result.ID[:n-1]
+			num, suffix, patternType, trailingPrefix := DetectPartSuffix(filename, baseID)
+			if patternType == PatternLetter && trailingPrefix != "" {
+				result.strippedSuffix = string(result.ID[n-1])
+				result.ID = baseID
+				result.PartNumber = num
+				result.PartSuffix = suffix
+				result.MultipartPattern = patternType
+				result.TrailingPrefix = trailingPrefix
+				result.IsMultiPart = false
+				return result
+			}
 		}
 	}
 

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -276,6 +276,18 @@ func ValidateMultipartInDirectory(results []MatchResult) []MatchResult {
 			if len(set) < 2 {
 				return
 			}
+			// Exclude files whose letter was a stripped E/Z catalog suffix — they are not
+			// genuine part letters and must not confirm each other as multipart.
+			genuine := make([]int, 0, len(set))
+			for _, idx := range set {
+				if validated[idx].strippedSuffix == "" {
+					genuine = append(genuine, idx)
+				}
+			}
+			if len(genuine) < 2 {
+				return
+			}
+			set = genuine
 			countByPart := make(map[int]int)
 			for _, idx := range set {
 				countByPart[validated[idx].PartNumber]++

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -25,6 +25,7 @@ type MatchResult struct {
 	MatchedBy        string // "regex" or "builtin"
 	MultipartPattern string // Pattern type: "explicit", "letter", "trailing", or "" (see PatternExplicit, PatternLetter, PatternTrailing, PatternNone)
 	TrailingPrefix   string // For PatternTrailing: noise portion before the part number (e.g., "-un-javgg.net")
+	strippedSuffix   string // E/Z catalog suffix stripped from the ID at match time; restored by ValidateMultipartInDirectory if the part does not confirm
 }
 
 // NewMatcher creates a new file matcher
@@ -132,6 +133,7 @@ func (m *Matcher) matchWithRegex(file models.FileMatchInfo, filename string, pat
 		baseID := result.ID[:n-1]
 		num, suffix, patternType, trailingPrefix := DetectPartSuffix(filename, baseID)
 		if patternType == PatternLetter && trailingPrefix != "" {
+			result.strippedSuffix = string(result.ID[n-1])
 			result.ID = baseID
 			result.PartNumber = num
 			result.PartSuffix = suffix
@@ -311,6 +313,10 @@ func ValidateMultipartInDirectory(results []MatchResult) []MatchResult {
 
 	for i := range validated {
 		if validated[i].MultipartPattern == PatternLetter && !validated[i].IsMultiPart {
+			if validated[i].strippedSuffix != "" {
+				validated[i].ID += validated[i].strippedSuffix
+				validated[i].strippedSuffix = ""
+			}
 			validated[i].PartNumber = 0
 			validated[i].PartSuffix = ""
 		}

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -276,18 +276,19 @@ func ValidateMultipartInDirectory(results []MatchResult) []MatchResult {
 			if len(set) < 2 {
 				return
 			}
-			// Exclude files whose letter was a stripped E/Z catalog suffix — they are not
-			// genuine part letters and must not confirm each other as multipart.
-			genuine := make([]int, 0, len(set))
+			// A stripped E/Z catalog suffix is a genuine part letter only when it has a
+			// non-stripped sibling to confirm with (e.g. d-4k + e-4k). When ALL candidates
+			// are stripped (e.g. E-4k + Z-4k, distinct catalog IDs), none are genuine parts;
+			// exclude the whole group so they restore their original catalog IDs.
+			genuineCount := 0
 			for _, idx := range set {
 				if validated[idx].strippedSuffix == "" {
-					genuine = append(genuine, idx)
+					genuineCount++
 				}
 			}
-			if len(genuine) < 2 {
+			if genuineCount == 0 {
 				return
 			}
-			set = genuine
 			countByPart := make(map[int]int)
 			for _, idx := range set {
 				countByPart[validated[idx].PartNumber]++

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -54,11 +54,7 @@ func NewMatcher(cfg *Config) (*Matcher, error) {
 	//      (prevents partial matches like "PPV1234" from "FC2PPV123456")
 	//   5. Hyphen format: letters + hyphen + digits (standard JAV)
 	builtinPattern := `(?i)((?:h_\d+[a-z]+\d+)|(?:\b\d{6}[-_]\d{2,3}-(?:1PON|10MU|CARIB)\b)|(?:\b[A-Za-z]{1,2}\d{3,5}\b)|(?:\b[A-Za-z]{3,6}\d{3,4}\b)|(?:(?:[A-Za-z]+|T28)-\d+(?:[ZE])?))`
-	compiled, err := regexp.Compile(builtinPattern)
-	if err != nil {
-		return nil, err
-	}
-	m.builtinPattern = compiled
+	m.builtinPattern = regexp.MustCompile(builtinPattern)
 
 	// Compile custom regex if enabled
 	if cfg.RegexEnabled && cfg.RegexPattern != "" {
@@ -166,13 +162,23 @@ func (m *Matcher) MatchString(s string) string {
 // directory with the same ID.
 //
 // Validation rules:
-//   - PatternLetter: 2+ letter-pattern files with the same ID in the same directory
+//   - PatternLetter (bare, e.g. "ABW-121-C"): 2+ bare-letter files with the same ID in
+//     the same directory, all with distinct part numbers (no duplicate encodes).
+//   - PatternLetter (tagged, e.g. "a-4k"): 2+ tagged-letter files with the same ID, all
+//     with distinct part numbers; the trailing content must be a digit-first resolution
+//     tag (e.g. -4k, -1080p) and is irrelevant to part identity (the letter is the part).
+//   - Bare and tagged letter conventions do NOT cross-validate for sibling confirmation,
+//     but a confirmed set's part numbers block the other convention to avoid colliding
+//     -pt1/-pt2 targets.
 //   - PatternTrailing: 2+ trailing-pattern files with the same ID, same directory,
-//     AND same TrailingPrefix (the noise portion before the part number must match)
-//   - PatternLetter and PatternTrailing do NOT cross-validate — they are separate conventions
+//     AND same TrailingPrefix.
+//   - Any letter file not confirmed has PartNumber/PartSuffix cleared.
+//   - Letter part numbers must not collide with explicit/trailing-confirmed parts.
 //
 // This prevents false positives for:
 //   - "ABW-121-C.mp4" where -C means Chinese subtitles, not part 3
+//   - "a-4k.mp4" + "a-4k.mkv" (duplicate encodes of the same part)
+//   - "a-4k" + "a-1080p" (same part, different quality)
 //   - "IPX-535-uncen-1.mp4" alone where -1 is not a part number
 //   - "IPX-535-uncen-1.mp4" + "IPX-535-C.mp4" which are different variants, not parts
 func ValidateMultipartInDirectory(results []MatchResult) []MatchResult {
@@ -201,20 +207,9 @@ func ValidateMultipartInDirectory(results []MatchResult) []MatchResult {
 			continue
 		}
 
-		// Validate letter patterns: 2+ letter-pattern files with same ID = multipart
-		letterIndices := []int{}
-		for _, idx := range indices {
-			if validated[idx].MultipartPattern == PatternLetter {
-				letterIndices = append(letterIndices, idx)
-			}
-		}
-		if len(letterIndices) >= 2 {
-			for _, idx := range letterIndices {
-				validated[idx].IsMultiPart = true
-			}
-		}
-
-		// Validate trailing patterns: group by prefix, 2+ with same prefix = multipart
+		// Validate trailing patterns first: group by prefix, 2+ with the same prefix
+		// confirm as multipart. Doing this before the letter check lets the letter
+		// overlap guard see already-confirmed trailing part numbers.
 		prefixGroups := make(map[string][]int)
 		for _, idx := range indices {
 			if validated[idx].MultipartPattern == PatternTrailing {
@@ -228,6 +223,76 @@ func ValidateMultipartInDirectory(results []MatchResult) []MatchResult {
 					validated[idx].IsMultiPart = true
 				}
 			}
+		}
+
+		// Validate letter patterns. The part identity is the LETTER (A/B/C...), not any
+		// trailing quality tag: two files are the same part iff they share the same letter;
+		// different letters are different parts. Bare letters (no trailing content, e.g.
+		// "ABW-121-C") and tagged letters (trailing content, e.g. "a-4k") are separate
+		// conventions and do NOT cross-validate for sibling confirmation — a bare subtitle
+		// marker like -C must not be pulled into multipart by a tagged sibling. Within a
+		// convention, confirm the set as multipart only when every letter occurs exactly once
+		// (no duplicate encodes, e.g. a-4k.mp4 + a-4k.mkv or A/A/B) AND no part number
+		// collides with a part already confirmed by explicit or trailing patterns or by the
+		// OTHER letter convention (both would render the same -pt1/-pt2 targets). Trailing
+		// content (e.g. -4k vs -1080p) is irrelevant to part identity, so a-4k + b-1080p
+		// confirm as parts 1 and 2. Files not confirmed have their letter-part fields cleared
+		// so a lone unconfirmed file does not render part metadata.
+		bareLetterIndices := []int{}
+		taggedLetterIndices := []int{}
+		for _, idx := range indices {
+			if validated[idx].MultipartPattern == PatternLetter {
+				if validated[idx].TrailingPrefix == "" {
+					bareLetterIndices = append(bareLetterIndices, idx)
+				} else {
+					taggedLetterIndices = append(taggedLetterIndices, idx)
+				}
+			}
+		}
+		confirmedLetterParts := make(map[int]struct{})
+		confirmLetterSet := func(set []int) {
+			if len(set) < 2 {
+				return
+			}
+			countByPart := make(map[int]int)
+			for _, idx := range set {
+				countByPart[validated[idx].PartNumber]++
+			}
+			for _, c := range countByPart {
+				if c > 1 {
+					return
+				}
+			}
+			for _, idx := range indices {
+				if validated[idx].MultipartPattern != PatternLetter && validated[idx].IsMultiPart {
+					if countByPart[validated[idx].PartNumber] > 0 {
+						return
+					}
+				}
+			}
+			// Reject if any part number was already confirmed by the other letter convention
+			// (bare vs tagged), since both would render the same -pt1/-pt2 targets.
+			for pn := range countByPart {
+				if _, ok := confirmedLetterParts[pn]; ok {
+					return
+				}
+			}
+			for _, idx := range set {
+				validated[idx].IsMultiPart = true
+			}
+			for pn := range countByPart {
+				confirmedLetterParts[pn] = struct{}{}
+			}
+		}
+		confirmLetterSet(bareLetterIndices)
+		confirmLetterSet(taggedLetterIndices)
+
+	}
+
+	for i := range validated {
+		if validated[i].MultipartPattern == PatternLetter && !validated[i].IsMultiPart {
+			validated[i].PartNumber = 0
+			validated[i].PartSuffix = ""
 		}
 	}
 

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -2674,6 +2674,44 @@ func TestValidateMultipartInDirectory_NonQualityTrailingEndToEnd(t *testing.T) {
 	}
 }
 
+// TestValidateMultipartInDirectory_LetterQualityTagFpsShorthandEndToEnd verifies that
+// a numeric quality component (e.g. -60 fps shorthand in "a-4k-60") does not get consumed as
+// a trailing part number, so two letter+quality+fps siblings confirm as multipart.
+func TestValidateMultipartInDirectory_LetterQualityTagFpsShorthandEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535a-4k-60.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-4k-60.mp4"},
+		{Name: "IPX-535b-4k-60.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535b-4k-60.mp4"},
+	}
+
+	results := matcher.Match(files)
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 results, got %d", len(results))
+	}
+	for _, r := range results {
+		if r.MultipartPattern != PatternLetter {
+			t.Errorf("%s: expected PatternLetter, got %q", r.File.Name, r.MultipartPattern)
+		}
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	confirmed := 0
+	for _, r := range validated {
+		if r.IsMultiPart {
+			confirmed++
+		}
+	}
+	if confirmed != 2 {
+		t.Errorf("expected both fps-shorthand siblings to confirm multipart, got %d", confirmed)
+	}
+}
+
 // TestValidateMultipartInDirectory_SGKI071EndToEnd tests the specific regression case
 // that motivated the PatternTrailing implementation: SGKI-071-un-javgg.net-{1,2}.mp4
 // producing duplicate filenames in the preview.

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -2778,6 +2778,66 @@ func TestValidateMultipartInDirectory_LetterPrefixTrailingNumberEndToEnd(t *test
 	}
 }
 
+// TestValidateMultipartInDirectory_CompoundQualitySuffixEndToEnd verifies that a
+// compound quality suffix (e.g. 4k-HDR, 4k-h265) after the letter part marker is detected
+// as letter+trailing, so two such siblings confirm as multipart.
+func TestValidateMultipartInDirectory_CompoundQualitySuffixEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+	m, err := NewMatcher(cfg)
+	require.NoError(t, err)
+
+	files := []models.FileMatchInfo{
+		{Name: "SVFLA-001a-4k-HDR.mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001a-4k-HDR.mp4"},
+		{Name: "SVFLA-001b-4k-HDR.mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001b-4k-HDR.mp4"},
+	}
+	results := m.Match(files)
+	require.Len(t, results, 2)
+	for _, r := range results {
+		require.Equal(t, PatternLetter, r.MultipartPattern)
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	confirmed := 0
+	for _, r := range validated {
+		if r.IsMultiPart {
+			confirmed++
+		}
+	}
+	require.Equal(t, 2, confirmed, "both compound-quality siblings should confirm multipart")
+}
+
+// TestValidateMultipartInDirectory_StrippedEZWithGenuineSibling confirms that a
+// stripped E/Z part letter confirms when it has a genuine non-stripped sibling, so
+// SVFLA-001d-4k + SVFLA-001e-4k both confirm as multipart parts D and E (E is a genuine
+// part here, not a lone catalog suffix).
+func TestValidateMultipartInDirectory_StrippedEZWithGenuineSibling(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+	m, err := NewMatcher(cfg)
+	require.NoError(t, err)
+
+	files := []models.FileMatchInfo{
+		{Name: "SVFLA-001d-4k.mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001d-4k.mp4"},
+		{Name: "SVFLA-001e-4k.mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001e-4k.mp4"},
+	}
+	results := m.Match(files)
+	require.Len(t, results, 2)
+
+	validated := ValidateMultipartInDirectory(results)
+	confirmed := 0
+	for i, r := range validated {
+		if r.IsMultiPart {
+			confirmed++
+		}
+		wantID := "SVFLA-001"
+		if r.ID != wantID {
+			t.Errorf("result %d: expected ID %q, got %q", i, wantID, r.ID)
+		}
+	}
+	if confirmed != 2 {
+		t.Errorf("expected both d-4k + e-4k to confirm multipart, got %d", confirmed)
+	}
+}
+
 // TestValidateMultipartInDirectory_StrippedEZDoNotConfirmEachOther verifies that two
 // E/Z-stripped catalog IDs (e.g. IPX-535E-4k + IPX-535Z-4k) do NOT confirm each other as
 // multipart: E and Z are catalog suffixes, not part letters, so both restore their original IDs.

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -627,6 +627,31 @@ func TestMatcher_MatchFile_CustomRegexEmptyCapture(t *testing.T) {
 	assert.Nil(t, result, "custom regex with empty capture group must yield no match (falls back to builtin, which also misses '123')")
 }
 
+func TestMatcher_EZ_CatalogSuffix_StrippedForLetterQuality(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+	m, err := NewMatcher(cfg)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		filename string
+		wantID   string
+	}{
+		{"part e + 4k tag", "SVFLA-001e-4k.mp4", "SVFLA-001"},
+		{"part d + 4k tag", "SVFLA-001d-4k.mp4", "SVFLA-001"},
+		{"part z + 1080p tag", "ABC-123z-1080p.mp4", "ABC-123"},
+		{"catalog suffix Z (no tag)", "IPX-535Z.mp4", "IPX-535Z"},
+		{"catalog suffix E (no tag)", "IPX-535E.mp4", "IPX-535E"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := m.MatchFile(models.FileMatchInfo{Name: tt.filename, Extension: ".mp4"})
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantID, result.ID)
+		})
+	}
+}
+
 func TestMatcher_PartSuffixVariations(t *testing.T) {
 	cfg := &Config{
 		RegexEnabled: false,

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -2815,6 +2815,34 @@ func TestValidateMultipartInDirectory_LetterPrefixTrailingNumberEndToEnd(t *test
 	}
 }
 
+// TestValidateMultipartInDirectory_NumericOnlyResolutionEndToEnd verifies that a
+// numeric-only resolution tag (e.g. -1080, -2160, -720) is detected as letter+trailing,
+// so two such siblings confirm as multipart.
+func TestValidateMultipartInDirectory_NumericOnlyResolutionEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+	m, err := NewMatcher(cfg)
+	require.NoError(t, err)
+
+	files := []models.FileMatchInfo{
+		{Name: "SVFLA-001a-1080.mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001a-1080.mp4"},
+		{Name: "SVFLA-001b-1080.mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001b-1080.mp4"},
+	}
+	results := m.Match(files)
+	require.Len(t, results, 2)
+	for _, r := range results {
+		require.Equal(t, PatternLetter, r.MultipartPattern)
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	confirmed := 0
+	for _, r := range validated {
+		if r.IsMultiPart {
+			confirmed++
+		}
+	}
+	require.Equal(t, 2, confirmed)
+}
+
 // TestValidateMultipartInDirectory_CompoundQualitySuffixEndToEnd verifies that a
 // compound quality suffix (e.g. 4k-HDR, 4k-h265) after the letter part marker is detected
 // as letter+trailing, so two such siblings confirm as multipart.

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMatcher_MatchFile(t *testing.T) {
@@ -615,6 +617,16 @@ func TestMatcher_LongStudioCodes(t *testing.T) {
 }
 
 // TestMatcher_PartSuffixVariations tests various multi-part suffix formats
+func TestMatcher_MatchFile_CustomRegexEmptyCapture(t *testing.T) {
+	cfg := &Config{RegexEnabled: true, RegexPattern: "([A-Z]*)"}
+	m, err := NewMatcher(cfg)
+	require.NoError(t, err)
+
+	file := models.FileMatchInfo{Name: "123.mp4", Extension: ".mp4"}
+	result := m.MatchFile(file)
+	assert.Nil(t, result, "custom regex with empty capture group must yield no match (falls back to builtin, which also misses '123')")
+}
+
 func TestMatcher_PartSuffixVariations(t *testing.T) {
 	cfg := &Config{
 		RegexEnabled: false,
@@ -639,6 +651,10 @@ func TestMatcher_PartSuffixVariations(t *testing.T) {
 		{"Letter B", "IPX-535-B.mp4", "IPX-535", 2, false, PatternLetter},
 		{"Letter C", "IPX-535-C.mp4", "IPX-535", 3, false, PatternLetter},
 		{"Lowercase letter", "IPX-535-a.mp4", "IPX-535", 1, false, PatternLetter},
+
+		// Letter + trailing content (quality/resolution tag) - ambiguous, require directory validation
+		{"Letter a + 4k tag (no sep)", "IPX-535a-4k.mp4", "IPX-535", 1, false, PatternLetter},
+		{"Letter b + 1080p tag (dash sep)", "IPX-535-b-1080p.mp4", "IPX-535", 2, false, PatternLetter},
 
 		// Numeric suffixes - explicit, always multipart
 		{"pt1", "IPX-535-pt1.mp4", "IPX-535", 1, true, PatternExplicit},
@@ -1177,7 +1193,7 @@ func TestMatcher_PartSuffixEdgeCases(t *testing.T) {
 
 		// Parts with extra text (the regex is flexible and still detects these)
 		{"Part with text after", "IPX-535-part1-extra.mp4", "IPX-535", 1, "-part1", true, PatternExplicit},
-		{"Letter with text after", "IPX-535-A-extra.mp4", "IPX-535", 0, "", false, PatternNone}, // Extra text prevents letter detection
+		{"Letter with text after", "IPX-535-A-extra.mp4", "IPX-535", 0, "", false, PatternNone}, // -extra is not a resolution tag, so not a letter+trailing part
 
 		// ID ending in letter ABC-123A (letter pattern - needs validation)
 		{"ID ending in letter ABC-123A (letter pattern - needs validation)", "ABC-123A.mp4", "ABC-123", 1, "-A", false, PatternLetter},
@@ -1335,6 +1351,334 @@ func TestValidateMultipartInDirectory(t *testing.T) {
 			},
 			expectedMulti: []bool{true, true},
 			desc:          "Two files with same ID and letter suffixes should be detected as multipart",
+		},
+		{
+			name: "two letter+quality-tag files same ID - IS multipart",
+			results: []MatchResult{
+				{
+					ID:               "SVFLA-001",
+					PartNumber:       1,
+					PartSuffix:       "-A",
+					MultipartPattern: PatternLetter,
+					IsMultiPart:      false,
+					File:             models.FileMatchInfo{Path: "/videos/SVFLA-001a-4k.mp4"},
+				},
+				{
+					ID:               "SVFLA-001",
+					PartNumber:       2,
+					PartSuffix:       "-B",
+					MultipartPattern: PatternLetter,
+					IsMultiPart:      false,
+					File:             models.FileMatchInfo{Path: "/videos/SVFLA-001b-4k.mp4"},
+				},
+			},
+			expectedMulti: []bool{true, true},
+			desc:          "Two letter+quality-tag files with same ID should be detected as multipart",
+		},
+		{
+			name: "single letter+quality-tag file - NOT multipart",
+			results: []MatchResult{
+				{
+					ID:               "SVFLA-001",
+					PartNumber:       1,
+					PartSuffix:       "-A",
+					MultipartPattern: PatternLetter,
+					IsMultiPart:      false,
+					File:             models.FileMatchInfo{Path: "/videos/SVFLA-001a-4k.mp4"},
+				},
+			},
+			expectedMulti: []bool{false},
+			desc:          "Single letter+quality-tag file should NOT be treated as multipart",
+		},
+		{
+			name: "same letter, different quality tag - NOT multipart (same part, different encode)",
+			results: []MatchResult{
+				{
+					ID:               "IPX-535",
+					PartNumber:       1,
+					PartSuffix:       "-A",
+					MultipartPattern: PatternLetter,
+					IsMultiPart:      false,
+					TrailingPrefix:   "-4k",
+					File:             models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mp4"},
+				},
+				{
+					ID:               "IPX-535",
+					PartNumber:       1,
+					PartSuffix:       "-A",
+					MultipartPattern: PatternLetter,
+					IsMultiPart:      false,
+					TrailingPrefix:   "-1080p",
+					File:             models.FileMatchInfo{Path: "/videos/IPX-535a-1080p.mp4"},
+				},
+			},
+			expectedMulti: []bool{false, false},
+			desc:          "Two files with same part letter but different quality tags are the same part (duplicate encodes), not two parts",
+		},
+		{
+			name: "same letter, same trailing tag, different container - NOT multipart (same part)",
+			results: []MatchResult{
+				{
+					ID:               "IPX-535",
+					PartNumber:       1,
+					PartSuffix:       "-A",
+					MultipartPattern: PatternLetter,
+					IsMultiPart:      false,
+					TrailingPrefix:   "-4k",
+					File:             models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mp4"},
+				},
+				{
+					ID:               "IPX-535",
+					PartNumber:       1,
+					PartSuffix:       "-A",
+					MultipartPattern: PatternLetter,
+					IsMultiPart:      false,
+					TrailingPrefix:   "-4k",
+					File:             models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mkv"},
+				},
+			},
+			expectedMulti: []bool{false, false},
+			desc:          "Two files with the same part letter and same trailing tag (e.g. mp4 + mkv encodes) are the same part, not two parts",
+		},
+		{
+			name: "letter + non-quality trailing word - NOT multipart (edition variant)",
+			results: []MatchResult{
+				{
+					ID: "IPX-535", PartNumber: 0, PartSuffix: "", MultipartPattern: PatternNone, IsMultiPart: false,
+					File: models.FileMatchInfo{Path: "/videos/IPX-535-A-extra.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 0, PartSuffix: "", MultipartPattern: PatternNone, IsMultiPart: false,
+					File: models.FileMatchInfo{Path: "/videos/IPX-535-B-extra.mp4"},
+				},
+			},
+			expectedMulti: []bool{false, false},
+			desc:          "Letter + a non-quality trailing word (e.g. -extra) is an edition/variant, not a part; the regex only accepts digit-first resolution tags as trailing content",
+		},
+		{
+			name: "bare A/B and tagged A/B-4k overlap - only one set confirms",
+			results: []MatchResult{
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "", File: models.FileMatchInfo{Path: "/videos/IPX-535-A.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "", File: models.FileMatchInfo{Path: "/videos/IPX-535-B.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535b-4k.mp4"},
+				},
+			},
+			expectedMulti: []bool{true, true, false, false},
+			desc:          "Bare A/B and tagged A/B-4k both render -pt1/-pt2; the bare set confirms first and the tagged set is rejected to avoid the collision (duplicate targets left to the organize layer)",
+		},
+		{
+			name: "bare letter and tagged letter do NOT cross-validate",
+			results: []MatchResult{
+				{
+					ID: "ABW-121", PartNumber: 3, PartSuffix: "-C", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "", File: models.FileMatchInfo{Path: "/videos/ABW-121-C.mp4"},
+				},
+				{
+					ID: "ABW-121", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/ABW-121-A-4k.mp4"},
+				},
+				{
+					ID: "ABW-121", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/ABW-121-B-4k.mp4"},
+				},
+			},
+			expectedMulti: []bool{false, true, true},
+			desc:          "Bare letter C (subtitle variant) does not cross-validate with tagged letters A/B-4k; the tagged pair confirms among themselves, the bare C stays single-part",
+		},
+		{
+			name: "different letters, different trailing tags - both confirm (distinct parts)",
+			results: []MatchResult{
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-1080p", File: models.FileMatchInfo{Path: "/videos/IPX-535b-1080p.mp4"},
+				},
+			},
+			expectedMulti: []bool{true, true},
+			desc:          "a-4k and b-1080p are distinct parts (letters A and B); differing trailing tags do not change the part identity, so both confirm as parts 1 and 2",
+		},
+		{
+			name: "transitive overlap via shared part - later candidate NOT confirmed (order-independent)",
+			results: []MatchResult{
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535b-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-1080p", File: models.FileMatchInfo{Path: "/videos/IPX-535a-1080p.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-2160p", File: models.FileMatchInfo{Path: "/videos/IPX-535b-2160p.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 3, PartSuffix: "-C", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-2160p", File: models.FileMatchInfo{Path: "/videos/IPX-535c-2160p.mp4"},
+				},
+			},
+			expectedMulti: []bool{false, false, false, false, false},
+			desc:          "X={1,2}-4k, Y={1}-1080p, Z={2,3}-2160p: Z shares part 2 with the invalidated X, so Z must NOT confirm regardless of map iteration order (part 2 would collide)",
+		},
+		{
+			name: "part number shared across letter groups - candidate NOT confirmed",
+			results: []MatchResult{
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535b-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-1080p", File: models.FileMatchInfo{Path: "/videos/IPX-535a-1080p.mp4"},
+				},
+			},
+			expectedMulti: []bool{false, false, false},
+			desc:          "Part number 1 appears in both the -4k and -1080p letter groups, so the -4k candidate is not confirmed (a-1080p would otherwise be misclassified as the single-part ID.mp4); duplicate targets left to the organize layer",
+		},
+		{
+			name: "letter group overlapping trailing group - letter group NOT confirmed",
+			results: []MatchResult{
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535b-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-1", MultipartPattern: PatternTrailing, IsMultiPart: false,
+					TrailingPrefix: "-HD", File: models.FileMatchInfo{Path: "/videos/IPX-535-HD-1.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-2", MultipartPattern: PatternTrailing, IsMultiPart: false,
+					TrailingPrefix: "-HD", File: models.FileMatchInfo{Path: "/videos/IPX-535-HD-2.mp4"},
+				},
+			},
+			expectedMulti: []bool{false, false, true, true},
+			desc:          "Letter group parts 1/2 overlap a trailing group parts 1/2, so the letter group is not confirmed (would collide on -pt1/-pt2); trailing group still confirms",
+		},
+		{
+			name: "letter group overlapping explicit part - letter group NOT confirmed",
+			results: []MatchResult{
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-pt1", MultipartPattern: PatternExplicit, IsMultiPart: true,
+					File: models.FileMatchInfo{Path: "/videos/IPX-535-pt1.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535b-4k.mp4"},
+				},
+			},
+			expectedMulti: []bool{true, false, false},
+			desc:          "Letter group parts 1/2 overlap explicit pt1 on part 1, so the letter group is not confirmed (would collide on -pt1); explicit stays multipart",
+		},
+		{
+			name: "disjoint quality-tag groups - both confirm (no part-number overlap)",
+			results: []MatchResult{
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535b-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 3, PartSuffix: "-C", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-1080p", File: models.FileMatchInfo{Path: "/videos/IPX-535c-1080p.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 4, PartSuffix: "-D", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-1080p", File: models.FileMatchInfo{Path: "/videos/IPX-535d-1080p.mp4"},
+				},
+			},
+			expectedMulti: []bool{true, true, true, true},
+			desc:          "Two quality-tag groups with disjoint part numbers (1-2 and 3-4) produce distinct -pt1/-pt2/-pt3/-pt4 targets, so both confirm",
+		},
+		{
+			name: "two quality-tag groups same ID - NOT multipart (would collide on -pt1/-pt2)",
+			results: []MatchResult{
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-4k", File: models.FileMatchInfo{Path: "/videos/IPX-535b-4k.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 1, PartSuffix: "-A", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-1080p", File: models.FileMatchInfo{Path: "/videos/IPX-535a-1080p.mp4"},
+				},
+				{
+					ID: "IPX-535", PartNumber: 2, PartSuffix: "-B", MultipartPattern: PatternLetter, IsMultiPart: false,
+					TrailingPrefix: "-1080p", File: models.FileMatchInfo{Path: "/videos/IPX-535b-1080p.mp4"},
+				},
+			},
+			expectedMulti: []bool{false, false, false, false},
+			desc:          "Two distinct quality-tag groups (4k and 1080p) for the same ID would both render ID-pt1/pt2 targets and collide under concurrent apply, so neither group confirms; duplicate single-part targets are left to the organize layer's conflict detection",
+		},
+		{
+			name: "A/A/B same tag - NOT multipart (duplicate part number A)",
+			results: []MatchResult{
+				{
+					ID:               "IPX-535",
+					PartNumber:       1,
+					PartSuffix:       "-A",
+					MultipartPattern: PatternLetter,
+					IsMultiPart:      false,
+					TrailingPrefix:   "-4k",
+					File:             models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mp4"},
+				},
+				{
+					ID:               "IPX-535",
+					PartNumber:       1,
+					PartSuffix:       "-A",
+					MultipartPattern: PatternLetter,
+					IsMultiPart:      false,
+					TrailingPrefix:   "-4k",
+					File:             models.FileMatchInfo{Path: "/videos/IPX-535a-4k.mkv"},
+				},
+				{
+					ID:               "IPX-535",
+					PartNumber:       2,
+					PartSuffix:       "-B",
+					MultipartPattern: PatternLetter,
+					IsMultiPart:      false,
+					TrailingPrefix:   "-4k",
+					File:             models.FileMatchInfo{Path: "/videos/IPX-535b-4k.mp4"},
+				},
+			},
+			expectedMulti: []bool{false, false, false},
+			desc:          "A/A/B with a shared tag has a duplicate part number (A), so none are confirmed multipart — no colliding -pt1 names",
 		},
 		{
 			name: "explicit pattern stays multipart regardless of sibling count",
@@ -1959,6 +2303,373 @@ func TestValidateMultipartInDirectory_ActualMultipart(t *testing.T) {
 	for i, r := range validated {
 		if r.IsMultiPart != true {
 			t.Errorf("Result %d: expected IsMultiPart=true after validation, got false", i)
+		}
+	}
+}
+
+// TestValidateMultipartInDirectory_LetterQualityTagEndToEnd tests the regression case
+// where a single-letter part marker is followed by a quality/resolution tag
+// (e.g. SVFLA-001a-4k.mp4 + SVFLA-001b-4k.mp4), which previously fell through to
+// PatternNone and produced identical <ID> filenames that collided on disk.
+func TestValidateMultipartInDirectory_LetterQualityTagEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "SVFLA-001a-4k.mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001a-4k.mp4"},
+		{Name: "SVFLA-001b-4k.mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001b-4k.mp4"},
+	}
+
+	results := matcher.Match(files)
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 results, got %d", len(results))
+	}
+
+	wantParts := map[string]int{"SVFLA-001a-4k.mp4": 1, "SVFLA-001b-4k.mp4": 2}
+	wantSuffix := map[string]string{"SVFLA-001a-4k.mp4": "-A", "SVFLA-001b-4k.mp4": "-B"}
+	for _, r := range results {
+		if r.MultipartPattern != PatternLetter {
+			t.Errorf("%s: expected MultipartPattern %s, got %s", r.File.Name, PatternLetter, r.MultipartPattern)
+		}
+		if r.IsMultiPart != false {
+			t.Errorf("%s: expected IsMultiPart=false before validation, got true", r.File.Name)
+		}
+		if r.PartNumber != wantParts[r.File.Name] {
+			t.Errorf("%s: expected PartNumber %d, got %d", r.File.Name, wantParts[r.File.Name], r.PartNumber)
+		}
+		if r.PartSuffix != wantSuffix[r.File.Name] {
+			t.Errorf("%s: expected PartSuffix %s, got %s", r.File.Name, wantSuffix[r.File.Name], r.PartSuffix)
+		}
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	for _, r := range validated {
+		if r.IsMultiPart != true {
+			t.Errorf("%s: expected IsMultiPart=true after validation, got false", r.File.Name)
+		}
+		if r.PartNumber != wantParts[r.File.Name] {
+			t.Errorf("%s: expected PartNumber %d after validation, got %d", r.File.Name, wantParts[r.File.Name], r.PartNumber)
+		}
+	}
+}
+
+// TestValidateMultipartInDirectory_LetterSamePartDifferentQualityEndToEnd verifies that
+// two encodes of the SAME part (same letter, different quality tag) are NOT confirmed as
+// multipart through the real Match -> Validate pipeline, so they do not both render -pt1.
+func TestValidateMultipartInDirectory_LetterSamePartDifferentQualityEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535a-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-4k.mp4"},
+		{Name: "IPX-535a-1080p.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-1080p.mp4"},
+	}
+
+	results := matcher.Match(files)
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 results, got %d", len(results))
+	}
+	for _, r := range results {
+		if r.MultipartPattern != PatternLetter {
+			t.Errorf("%s: expected MultipartPattern %s, got %s", r.File.Name, PatternLetter, r.MultipartPattern)
+		}
+		if r.TrailingPrefix == "" {
+			t.Errorf("%s: expected non-empty TrailingPrefix for letter+trailing match", r.File.Name)
+		}
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	for _, r := range validated {
+		if r.IsMultiPart {
+			t.Errorf("%s: same-part-different-quality must NOT be confirmed multipart, got IsMultiPart=true", r.File.Name)
+		}
+	}
+}
+
+// TestValidateMultipartInDirectory_LetterSamePartSameTrailingEndToEnd verifies that
+// two encodes of the SAME part in different containers (e.g. .mp4 + .mkv, both "a-4k")
+// are NOT confirmed as multipart through the real Match -> Validate pipeline: they share
+// both the part letter and the trailing tag, so they must not render a colliding -pt1.
+func TestValidateMultipartInDirectory_LetterSamePartSameTrailingEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535a-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-4k.mp4"},
+		{Name: "IPX-535a-4k.mkv", Extension: ".mkv", Path: "/media/JAV/IPX-535a-4k.mkv"},
+	}
+
+	results := matcher.Match(files)
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 results, got %d", len(results))
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	for _, r := range validated {
+		if r.IsMultiPart {
+			t.Errorf("%s: same-part-same-trailing must NOT be confirmed multipart, got IsMultiPart=true", r.File.Name)
+		}
+	}
+}
+
+// TestValidateMultipartInDirectory_TwoQualityTagGroupsEndToEnd verifies that two
+// distinct quality-tag groups (a/b-4k + a/b-1080p) for the same ID are NOT confirmed
+// multipart through the real Match -> Validate pipeline, so neither renders the
+// colliding -pt1/-pt2 names that concurrent apply could overwrite.
+func TestValidateMultipartInDirectory_TwoQualityTagGroupsEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535a-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-4k.mp4"},
+		{Name: "IPX-535b-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535b-4k.mp4"},
+		{Name: "IPX-535a-1080p.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-1080p.mp4"},
+		{Name: "IPX-535b-1080p.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535b-1080p.mp4"},
+	}
+
+	results := matcher.Match(files)
+	if len(results) != 4 {
+		t.Fatalf("Expected 4 results, got %d", len(results))
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	for _, r := range validated {
+		if r.IsMultiPart {
+			t.Errorf("%s: two quality-tag groups must not both confirm multipart (would collide on -pt1/-pt2), got IsMultiPart=true", r.File.Name)
+		}
+	}
+}
+
+// TestValidateMultipartInDirectory_DisjointQualityTagGroupsEndToEnd verifies that
+// two quality-tag groups with disjoint part numbers (a/b-4k parts 1-2 + c/d-1080p parts 3-4)
+// both confirm multipart through the real Match -> Validate pipeline, producing distinct
+// -pt1/-pt2/-pt3/-pt4 targets with no collision.
+func TestValidateMultipartInDirectory_DisjointQualityTagGroupsEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535a-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-4k.mp4"},
+		{Name: "IPX-535b-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535b-4k.mp4"},
+		{Name: "IPX-535c-1080p.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535c-1080p.mp4"},
+		{Name: "IPX-535d-1080p.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535d-1080p.mp4"},
+	}
+
+	results := matcher.Match(files)
+	if len(results) != 4 {
+		t.Fatalf("Expected 4 results, got %d", len(results))
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	confirmed := 0
+	for _, r := range validated {
+		if r.IsMultiPart {
+			confirmed++
+		}
+	}
+	if confirmed != 4 {
+		t.Errorf("expected all 4 disjoint-group files to confirm multipart, got %d", confirmed)
+	}
+}
+
+// TestValidateMultipartInDirectory_LetterGroupOverlappingExplicitEndToEnd verifies that
+// a letter quality-tag group whose part numbers overlap an existing explicit -pt1 part is
+// NOT confirmed through the real Match -> Validate pipeline, preventing a colliding -pt1
+// target (explicit pt1 vs letter part A both render ID-pt1).
+func TestValidateMultipartInDirectory_LetterGroupOverlappingExplicitEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535-pt1.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535-pt1.mp4"},
+		{Name: "IPX-535a-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-4k.mp4"},
+		{Name: "IPX-535b-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535b-4k.mp4"},
+	}
+
+	results := matcher.Match(files)
+	if len(results) != 3 {
+		t.Fatalf("Expected 3 results, got %d", len(results))
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	explicitConfirmed := 0
+	letterConfirmed := 0
+	for _, r := range validated {
+		if r.MultipartPattern == PatternExplicit && r.IsMultiPart {
+			explicitConfirmed++
+		}
+		if r.MultipartPattern == PatternLetter && r.IsMultiPart {
+			letterConfirmed++
+			t.Errorf("%s: letter group overlapping an explicit part must not be confirmed multipart", r.File.Name)
+		}
+	}
+	if explicitConfirmed != 1 {
+		t.Errorf("expected the explicit pt1 to stay multipart, got %d confirmed", explicitConfirmed)
+	}
+	if letterConfirmed != 0 {
+		t.Errorf("expected no letter-group file confirmed, got %d", letterConfirmed)
+	}
+}
+
+// TestValidateMultipartInDirectory_LetterGroupOverlappingTrailingEndToEnd verifies
+// that a letter quality-tag group whose part numbers overlap a trailing-number group
+// (PatternTrailing) is NOT confirmed through the real Match -> Validate pipeline, even
+// though trailing parts start with IsMultiPart=false, because trailing confirmation runs
+// before the letter overlap check.
+func TestValidateMultipartInDirectory_LetterGroupOverlappingTrailingEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535a-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-4k.mp4"},
+		{Name: "IPX-535b-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535b-4k.mp4"},
+		{Name: "IPX-535-HD-1.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535-HD-1.mp4"},
+		{Name: "IPX-535-HD-2.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535-HD-2.mp4"},
+	}
+
+	results := matcher.Match(files)
+	if len(results) != 4 {
+		t.Fatalf("Expected 4 results, got %d", len(results))
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	letterConfirmed := 0
+	trailingConfirmed := 0
+	for _, r := range validated {
+		if r.MultipartPattern == PatternLetter && r.IsMultiPart {
+			letterConfirmed++
+			t.Errorf("%s: letter group overlapping a trailing group must not be confirmed multipart", r.File.Name)
+		}
+		if r.MultipartPattern == PatternTrailing && r.IsMultiPart {
+			trailingConfirmed++
+		}
+	}
+	if letterConfirmed != 0 {
+		t.Errorf("expected no letter-group file confirmed, got %d", letterConfirmed)
+	}
+	if trailingConfirmed != 2 {
+		t.Errorf("expected both trailing files confirmed, got %d", trailingConfirmed)
+	}
+}
+
+// TestValidateMultipartInDirectory_PartSharedAcrossLetterGroupsEndToEnd verifies that
+// a candidate letter group sharing a part number with any other letter group (candidate or
+// not) is NOT confirmed through the real Match -> Validate pipeline. With a/b-4k (parts 1-2)
+// plus a lone a-1080p (part 1), the -4k group would misclassify a-1080p as the single-part
+// <ID>.mp4, so neither confirms.
+func TestValidateMultipartInDirectory_PartSharedAcrossLetterGroupsEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535a-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-4k.mp4"},
+		{Name: "IPX-535b-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535b-4k.mp4"},
+		{Name: "IPX-535a-1080p.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-1080p.mp4"},
+	}
+
+	results := matcher.Match(files)
+	if len(results) != 3 {
+		t.Fatalf("Expected 3 results, got %d", len(results))
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	for _, r := range validated {
+		if r.IsMultiPart {
+			t.Errorf("%s: part shared across letter groups must not confirm multipart, got IsMultiPart=true", r.File.Name)
+		}
+	}
+}
+
+// TestValidateMultipartInDirectory_LoneLetterTagCleared verifies that a lone
+// letter+trailing file (no siblings) has PartNumber/PartSuffix cleared after validation so
+// it does not render part metadata as a single-part file.
+func TestValidateMultipartInDirectory_LoneLetterTagCleared(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "SVFLA-001a-4k.mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001a-4k.mp4"},
+	}
+
+	results := matcher.Match(files)
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 result, got %d", len(results))
+	}
+	if results[0].MultipartPattern != PatternLetter {
+		t.Fatalf("expected PatternLetter pre-validation, got %q", results[0].MultipartPattern)
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	if validated[0].IsMultiPart {
+		t.Error("lone file must not be multipart")
+	}
+	if validated[0].PartNumber != 0 {
+		t.Errorf("lone unconfirmed letter file must have PartNumber cleared, got %d", validated[0].PartNumber)
+	}
+	if validated[0].PartSuffix != "" {
+		t.Errorf("lone unconfirmed letter file must have PartSuffix cleared, got %q", validated[0].PartSuffix)
+	}
+}
+
+// TestValidateMultipartInDirectory_NonQualityTrailingEndToEnd verifies that letter +
+// non-resolution trailing content (e.g. -extra) is NOT detected as a letter+trailing part
+// through the real Match -> Validate pipeline, so edition variants are not misclassified.
+func TestValidateMultipartInDirectory_NonQualityTrailingEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535-A-extra.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535-A-extra.mp4"},
+		{Name: "IPX-535-B-extra.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535-B-extra.mp4"},
+	}
+
+	results := matcher.Match(files)
+	for _, r := range results {
+		if r.MultipartPattern != PatternNone {
+			t.Errorf("%s: expected PatternNone for non-resolution trailing content, got %q", r.File.Name, r.MultipartPattern)
+		}
+		if r.IsMultiPart {
+			t.Errorf("%s: edition variant must not be multipart, got IsMultiPart=true", r.File.Name)
 		}
 	}
 }

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -627,6 +627,19 @@ func TestMatcher_MatchFile_CustomRegexEmptyCapture(t *testing.T) {
 	assert.Nil(t, result, "custom regex with empty capture group must yield no match (falls back to builtin, which also misses '123')")
 }
 
+func TestMatcher_EZ_CatalogSuffix_CustomRegexNotStripped(t *testing.T) {
+	// A custom regex that explicitly captures an E-suffixed catalog ID must not have
+	// the E/Z stripping heuristic override it (only built-in matches strip).
+	cfg := &Config{RegexEnabled: true, RegexPattern: "([A-Z]+-\\d+E)"}
+	m, err := NewMatcher(cfg)
+	require.NoError(t, err)
+
+	result := m.MatchFile(models.FileMatchInfo{Name: "IPX-535E-4k.mp4", Extension: ".mp4"})
+	require.NotNil(t, result)
+	assert.Equal(t, "IPX-535E", result.ID, "custom-regex E-suffixed capture must be preserved")
+	assert.Equal(t, "regex", result.MatchedBy)
+}
+
 func TestMatcher_EZ_CatalogSuffix_StrippedForLetterQuality(t *testing.T) {
 	cfg := &Config{RegexEnabled: false}
 	m, err := NewMatcher(cfg)

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -627,6 +627,30 @@ func TestMatcher_MatchFile_CustomRegexEmptyCapture(t *testing.T) {
 	assert.Nil(t, result, "custom regex with empty capture group must yield no match (falls back to builtin, which also misses '123')")
 }
 
+func TestMatcher_EZ_CatalogSuffix_MatchStringConsistent(t *testing.T) {
+	// MatchString must apply the same E/Z stripping as MatchFile for built-in matches
+	// so downstream re-match (e.g. scrape_phase buildScrapeCmd) stays consistent.
+	cfg := &Config{RegexEnabled: false}
+	m, err := NewMatcher(cfg)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"part e + 4k tag", "SVFLA-001e-4k.mp4", "SVFLA-001"},
+		{"part d + 4k tag", "SVFLA-001d-4k.mp4", "SVFLA-001"},
+		{"catalog suffix E (no tag)", "IPX-535E.mp4", "IPX-535E"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := m.MatchString(tt.in)
+			assert.Equal(t, tt.want, got, "MatchString must match MatchFile's E/Z stripping")
+		})
+	}
+}
+
 func TestMatcher_EZ_CatalogSuffix_CustomRegexNotStripped(t *testing.T) {
 	// A custom regex that explicitly captures an E-suffixed catalog ID must not have
 	// the E/Z stripping heuristic override it (only built-in matches strip).

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -2778,6 +2778,33 @@ func TestValidateMultipartInDirectory_LetterPrefixTrailingNumberEndToEnd(t *test
 	}
 }
 
+// TestValidateMultipartInDirectory_StrippedEZDoNotConfirmEachOther verifies that two
+// E/Z-stripped catalog IDs (e.g. IPX-535E-4k + IPX-535Z-4k) do NOT confirm each other as
+// multipart: E and Z are catalog suffixes, not part letters, so both restore their original IDs.
+func TestValidateMultipartInDirectory_StrippedEZDoNotConfirmEachOther(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+	m, err := NewMatcher(cfg)
+	require.NoError(t, err)
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535E-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535E-4k.mp4"},
+		{Name: "IPX-535Z-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535Z-4k.mp4"},
+	}
+	results := m.Match(files)
+	require.Len(t, results, 2)
+
+	validated := ValidateMultipartInDirectory(results)
+	for i, r := range validated {
+		if r.IsMultiPart {
+			t.Errorf("result %d: stripped E/Z catalog IDs must not confirm as multipart", i)
+		}
+		wantID := "IPX-535" + map[int]string{0: "E", 1: "Z"}[i]
+		if r.ID != wantID {
+			t.Errorf("result %d: expected ID %q, got %q", i, wantID, r.ID)
+		}
+	}
+}
+
 // TestValidateMultipartInDirectory_LoneEZCatalogSuffixRestored verifies that a lone
 // E/Z-suffixed catalog ID with a quality tag (e.g. IPX-535E-4k) has its ID restored to
 // IPX-535E after validation, since E is a catalog suffix (not a part letter) when there

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -2712,6 +2712,45 @@ func TestValidateMultipartInDirectory_LetterQualityTagFpsShorthandEndToEnd(t *te
 	}
 }
 
+// TestValidateMultipartInDirectory_LetterPrefixTrailingNumberEndToEnd verifies that
+// a one-letter noise prefix followed by a trailing part number (e.g. IPX-535-C-1 + -C-2) is
+// detected as PatternTrailing parts 1 and 2, NOT misclassified as letter part C (which would
+// collapse both to a duplicate and clear their multipart metadata).
+func TestValidateMultipartInDirectory_LetterPrefixTrailingNumberEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+
+	matcher, err := NewMatcher(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create matcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535-C-1.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535-C-1.mp4"},
+		{Name: "IPX-535-C-2.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535-C-2.mp4"},
+	}
+
+	results := matcher.Match(files)
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 results, got %d", len(results))
+	}
+	for _, r := range results {
+		if r.MultipartPattern != PatternTrailing {
+			t.Errorf("%s: expected PatternTrailing, got %q", r.File.Name, r.MultipartPattern)
+		}
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	confirmed := 0
+	for _, r := range validated {
+		if r.IsMultiPart {
+			confirmed++
+		}
+	}
+	if confirmed != 2 {
+		t.Errorf("expected both trailing-number siblings to confirm multipart, got %d", confirmed)
+	}
+}
+
 // TestValidateMultipartInDirectory_SGKI071EndToEnd tests the specific regression case
 // that motivated the PatternTrailing implementation: SGKI-071-un-javgg.net-{1,2}.mp4
 // producing duplicate filenames in the preview.

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -2815,6 +2815,34 @@ func TestValidateMultipartInDirectory_LetterPrefixTrailingNumberEndToEnd(t *test
 	}
 }
 
+// TestValidateMultipartInDirectory_BracketedQualityTagEndToEnd verifies that a
+// bracket-wrapped quality tag (e.g. [4k]) after the letter part marker is detected as
+// letter+trailing, so two such siblings confirm as multipart.
+func TestValidateMultipartInDirectory_BracketedQualityTagEndToEnd(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+	m, err := NewMatcher(cfg)
+	require.NoError(t, err)
+
+	files := []models.FileMatchInfo{
+		{Name: "SVFLA-001a-[4k].mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001a-[4k].mp4"},
+		{Name: "SVFLA-001b-[4k].mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001b-[4k].mp4"},
+	}
+	results := m.Match(files)
+	require.Len(t, results, 2)
+	for _, r := range results {
+		require.Equal(t, PatternLetter, r.MultipartPattern)
+	}
+
+	validated := ValidateMultipartInDirectory(results)
+	confirmed := 0
+	for _, r := range validated {
+		if r.IsMultiPart {
+			confirmed++
+		}
+	}
+	require.Equal(t, 2, confirmed)
+}
+
 // TestValidateMultipartInDirectory_NumericOnlyResolutionEndToEnd verifies that a
 // numeric-only resolution tag (e.g. -1080, -2160, -720) is detected as letter+trailing,
 // so two such siblings confirm as multipart.

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -642,6 +642,8 @@ func TestMatcher_EZ_CatalogSuffix_StrippedForLetterQuality(t *testing.T) {
 		{"part z + 1080p tag", "ABC-123z-1080p.mp4", "ABC-123"},
 		{"catalog suffix Z (no tag)", "IPX-535Z.mp4", "IPX-535Z"},
 		{"catalog suffix E (no tag)", "IPX-535E.mp4", "IPX-535E"},
+		{"catalog suffix E + 4k tag (lone)", "IPX-535E-4k.mp4", "IPX-535"},
+		{"catalog suffix Z + 1080p tag (lone)", "ABC-123Z-1080p.mp4", "ABC-123"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2774,6 +2776,32 @@ func TestValidateMultipartInDirectory_LetterPrefixTrailingNumberEndToEnd(t *test
 	if confirmed != 2 {
 		t.Errorf("expected both trailing-number siblings to confirm multipart, got %d", confirmed)
 	}
+}
+
+// TestValidateMultipartInDirectory_LoneEZCatalogSuffixRestored verifies that a lone
+// E/Z-suffixed catalog ID with a quality tag (e.g. IPX-535E-4k) has its ID restored to
+// IPX-535E after validation, since E is a catalog suffix (not a part letter) when there
+// are no confirming siblings.
+func TestValidateMultipartInDirectory_LoneEZCatalogSuffixRestored(t *testing.T) {
+	cfg := &Config{RegexEnabled: false}
+	m, err := NewMatcher(cfg)
+	require.NoError(t, err)
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535E-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535E-4k.mp4"},
+	}
+	results := m.Match(files)
+	require.Len(t, results, 1)
+	// Pre-validation: E is optimistically stripped
+	assert.Equal(t, "IPX-535", results[0].ID, "pre-validation: E stripped optimistically")
+	assert.Equal(t, PatternLetter, results[0].MultipartPattern)
+
+	validated := ValidateMultipartInDirectory(results)
+	require.Len(t, validated, 1)
+	assert.False(t, validated[0].IsMultiPart, "lone file must not be multipart")
+	assert.Equal(t, "IPX-535E", validated[0].ID, "post-validation: lone E catalog suffix must be restored")
+	assert.Equal(t, 0, validated[0].PartNumber, "PartNumber cleared")
+	assert.Equal(t, "", validated[0].PartSuffix, "PartSuffix cleared")
 }
 
 // TestValidateMultipartInDirectory_SGKI071EndToEnd tests the specific regression case

--- a/internal/matcher/multipart.go
+++ b/internal/matcher/multipart.go
@@ -76,7 +76,26 @@ func DetectPartSuffix(nameWithoutExt, id string) (int, string, string, string) {
 		}
 	}
 
-	// 3) Trailing number after separator at end of remainder: -un-javgg.net-1, _site.name-2
+	// 3) Letter parts: single trailing letter (A/B/C/...) optionally separated by dash/underscore/space
+	// Only accept when the remainder is just that letter (plus optional separators) - AMBIGUOUS
+	// These need directory context validation to confirm multipart status.
+	if m := reLetterOnlyRemainder.FindStringSubmatch(trimmed); len(m) == 2 {
+		if n, suf, ok := letterPart(m[1]); ok {
+			return n, suf, PatternLetter, ""
+		}
+	}
+
+	// 4) Letter + digit-first trailing content (e.g. a-4k, b-1080p, a-4k-60). The part
+	// identity is the letter; the trailing content is a resolution/quality tag. Checked
+	// BEFORE the trailing-number pattern so a numeric quality component (e.g. -60 fps
+	// shorthand in "a-4k-60") is not consumed as a trailing part number.
+	if idx := reLetterWithTrailing.FindStringSubmatchIndex(trimmed); idx != nil {
+		if n, suf, ok := letterPart(trimmed[idx[2]:idx[3]]); ok {
+			return n, suf, PatternLetter, trimmed[idx[3]:]
+		}
+	}
+
+	// 5) Trailing number after separator at end of remainder: -un-javgg.net-1, _site.name-2
 	// This handles filenames where site tags or other noise sits between the ID and the part number.
 	// The separator (- or _) + digits at the very end suggests a part number, but it's not
 	// as unambiguous as a clean remainder-only match (step 2), so directory validation is required.
@@ -87,21 +106,6 @@ func DetectPartSuffix(nameWithoutExt, id string) (int, string, string, string) {
 		if n, err := strconv.Atoi(numStr); err == nil && n > 0 {
 			prefix := trimmed[:len(trimmed)-len(m[0])]
 			return n, "-" + numStr, PatternTrailing, prefix
-		}
-	}
-
-	// 4) Letter parts: single trailing letter (A/B/C/...) optionally separated by dash/underscore/space
-	// Only accept when the remainder is just that letter (plus optional separators) - AMBIGUOUS
-	// These need directory context validation to confirm multipart status.
-	if m := reLetterOnlyRemainder.FindStringSubmatch(trimmed); len(m) == 2 {
-		if n, suf, ok := letterPart(m[1]); ok {
-			return n, suf, PatternLetter, ""
-		}
-	}
-
-	if idx := reLetterWithTrailing.FindStringSubmatchIndex(trimmed); idx != nil {
-		if n, suf, ok := letterPart(trimmed[idx[2]:idx[3]]); ok {
-			return n, suf, PatternLetter, trimmed[idx[3]:]
 		}
 	}
 

--- a/internal/matcher/multipart.go
+++ b/internal/matcher/multipart.go
@@ -13,7 +13,7 @@ var (
 	rePlainNumber = regexp.MustCompile(`^[-_.\s]?(\d{1,2})$`)
 	// Strict letter-only remainder: optional sep + [a-z] + optional sep
 	reLetterOnlyRemainder = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])\s*$`)
-	reLetterWithTrailing  = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])[-_.\s]+(?:\d{3,}|\d[a-z0-9]*[a-z][a-z0-9]*)(?:[-_.\s]+[a-z0-9]+)*\s*$`)
+	reLetterWithTrailing  = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])[-_.\s]+\[?(?:\d{3,}|\d[a-z0-9]*[a-z][a-z0-9]*)\]?[a-z0-9]*(?:[-_.\s]+\[?[a-z0-9]+\]?)*\s*$`)
 	// Trailing number at end of remainder after separator: ...-1, ..._2, ...3, etc.
 	// Catches part numbers buried behind noise like "-un-javgg.net-1"
 	reTrailingPartNumber = regexp.MustCompile(`[-_.](\d{1,2})$`)

--- a/internal/matcher/multipart.go
+++ b/internal/matcher/multipart.go
@@ -13,7 +13,7 @@ var (
 	rePlainNumber = regexp.MustCompile(`^[-_.\s]?(\d{1,2})$`)
 	// Strict letter-only remainder: optional sep + [a-z] + optional sep
 	reLetterOnlyRemainder = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])\s*$`)
-	reLetterWithTrailing  = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])[-_.\s]+\d[a-z0-9]*[a-z][a-z0-9]*(?:[-_.\s]+[a-z0-9]+)*\s*$`)
+	reLetterWithTrailing  = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])[-_.\s]+(?:\d{3,}|\d[a-z0-9]*[a-z][a-z0-9]*)(?:[-_.\s]+[a-z0-9]+)*\s*$`)
 	// Trailing number at end of remainder after separator: ...-1, ..._2, ...3, etc.
 	// Catches part numbers buried behind noise like "-un-javgg.net-1"
 	reTrailingPartNumber = regexp.MustCompile(`[-_.](\d{1,2})$`)

--- a/internal/matcher/multipart.go
+++ b/internal/matcher/multipart.go
@@ -13,7 +13,7 @@ var (
 	rePlainNumber = regexp.MustCompile(`^[-_.\s]?(\d{1,2})$`)
 	// Strict letter-only remainder: optional sep + [a-z] + optional sep
 	reLetterOnlyRemainder = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])\s*$`)
-	reLetterWithTrailing  = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])[-_.\s]+\d[a-z0-9]*[a-z][a-z0-9]*(?:[-_.\s]+\d[a-z0-9]*)*\s*$`)
+	reLetterWithTrailing  = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])[-_.\s]+\d[a-z0-9]*[a-z][a-z0-9]*(?:[-_.\s]+[a-z0-9]+)*\s*$`)
 	// Trailing number at end of remainder after separator: ...-1, ..._2, ...3, etc.
 	// Catches part numbers buried behind noise like "-un-javgg.net-1"
 	reTrailingPartNumber = regexp.MustCompile(`[-_.](\d{1,2})$`)

--- a/internal/matcher/multipart.go
+++ b/internal/matcher/multipart.go
@@ -13,6 +13,7 @@ var (
 	rePlainNumber = regexp.MustCompile(`^[-_.\s]?(\d{1,2})$`)
 	// Strict letter-only remainder: optional sep + [a-z] + optional sep
 	reLetterOnlyRemainder = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])\s*$`)
+	reLetterWithTrailing  = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])(?:[-_.\s]+\d[a-z0-9]*)+\s*$`)
 	// Trailing number at end of remainder after separator: ...-1, ..._2, ...3, etc.
 	// Catches part numbers buried behind noise like "-un-javgg.net-1"
 	reTrailingPartNumber = regexp.MustCompile(`[-_.](\d{1,2})$`)
@@ -93,13 +94,26 @@ func DetectPartSuffix(nameWithoutExt, id string) (int, string, string, string) {
 	// Only accept when the remainder is just that letter (plus optional separators) - AMBIGUOUS
 	// These need directory context validation to confirm multipart status.
 	if m := reLetterOnlyRemainder.FindStringSubmatch(trimmed); len(m) == 2 {
-		letter := strings.ToUpper(m[1])
-		n := int(letter[0]-'A') + 1
-		if n >= 1 && n <= 26 {
-			return n, "-" + letter, PatternLetter, ""
+		if n, suf, ok := letterPart(m[1]); ok {
+			return n, suf, PatternLetter, ""
+		}
+	}
+
+	if idx := reLetterWithTrailing.FindStringSubmatchIndex(trimmed); idx != nil {
+		if n, suf, ok := letterPart(trimmed[idx[2]:idx[3]]); ok {
+			return n, suf, PatternLetter, trimmed[idx[3]:]
 		}
 	}
 
 	// No recognizable part
 	return 0, "", PatternNone, ""
+}
+
+func letterPart(letter string) (int, string, bool) {
+	upper := strings.ToUpper(letter)
+	n := int(upper[0]-'A') + 1
+	if n < 1 || n > 26 {
+		return 0, "", false
+	}
+	return n, "-" + upper, true
 }

--- a/internal/matcher/multipart.go
+++ b/internal/matcher/multipart.go
@@ -13,7 +13,7 @@ var (
 	rePlainNumber = regexp.MustCompile(`^[-_.\s]?(\d{1,2})$`)
 	// Strict letter-only remainder: optional sep + [a-z] + optional sep
 	reLetterOnlyRemainder = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])\s*$`)
-	reLetterWithTrailing  = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])(?:[-_.\s]+\d[a-z0-9]*)+\s*$`)
+	reLetterWithTrailing  = regexp.MustCompile(`(?i)^\s*[-_.\s]?([a-z])[-_.\s]+\d[a-z0-9]*[a-z][a-z0-9]*(?:[-_.\s]+\d[a-z0-9]*)*\s*$`)
 	// Trailing number at end of remainder after separator: ...-1, ..._2, ...3, etc.
 	// Catches part numbers buried behind noise like "-un-javgg.net-1"
 	reTrailingPartNumber = regexp.MustCompile(`[-_.](\d{1,2})$`)

--- a/internal/matcher/multipart_test.go
+++ b/internal/matcher/multipart_test.go
@@ -43,6 +43,8 @@ func TestDetectPartSuffix(t *testing.T) {
 		{"SVFLA-001b-4k-h265", "SVFLA-001", 2, "-B", PatternLetter},
 		{"SVFLA-001a-1080", "SVFLA-001", 1, "-A", PatternLetter},
 		{"SVFLA-001b-1080", "SVFLA-001", 2, "-B", PatternLetter},
+		{"SVFLA-001a-[4k]", "SVFLA-001", 1, "-A", PatternLetter},
+		{"SVFLA-001b-[4k]", "SVFLA-001", 2, "-B", PatternLetter},
 
 		// No pattern
 		{"ABC-123", "ABC-123", 0, "", PatternNone},

--- a/internal/matcher/multipart_test.go
+++ b/internal/matcher/multipart_test.go
@@ -41,6 +41,8 @@ func TestDetectPartSuffix(t *testing.T) {
 		{"IPX-535-C-2", "IPX-535", 2, "-2", PatternTrailing},
 		{"SVFLA-001a-4k-HDR", "SVFLA-001", 1, "-A", PatternLetter},
 		{"SVFLA-001b-4k-h265", "SVFLA-001", 2, "-B", PatternLetter},
+		{"SVFLA-001a-1080", "SVFLA-001", 1, "-A", PatternLetter},
+		{"SVFLA-001b-1080", "SVFLA-001", 2, "-B", PatternLetter},
 
 		// No pattern
 		{"ABC-123", "ABC-123", 0, "", PatternNone},

--- a/internal/matcher/multipart_test.go
+++ b/internal/matcher/multipart_test.go
@@ -32,9 +32,16 @@ func TestDetectPartSuffix(t *testing.T) {
 		{"IPX-535-Z", "IPX-535", 26, "-Z", PatternLetter},
 		{"ABW-121-C", "ABW-121", 3, "-C", PatternLetter}, // Chinese subtitle case
 
+		// Letter + trailing content (quality/resolution tag) - ambiguous, need directory validation
+		{"SVFLA-001a-4k", "SVFLA-001", 1, "-A", PatternLetter},
+		{"SVFLA-001b-1080p", "SVFLA-001", 2, "-B", PatternLetter},
+
 		// No pattern
 		{"ABC-123", "ABC-123", 0, "", PatternNone},
 		{"IPX-535 no suffix", "IPX-535", 0, "", PatternNone},
+		{"IPX-535-4k", "IPX-535", 0, "", PatternNone},
+		{"IPX-535-1080p", "IPX-535", 0, "", PatternNone},
+		{"IPX-535-FHD", "IPX-535", 0, "", PatternNone},
 	}
 
 	for _, tt := range tests {
@@ -43,6 +50,30 @@ func TestDetectPartSuffix(t *testing.T) {
 			assert.Equal(t, tt.wantNum, num, "PartNumber mismatch")
 			assert.Equal(t, tt.wantSuf, suf, "PartSuffix mismatch")
 			assert.Equal(t, tt.wantPattern, pattern, "PatternType mismatch")
+		})
+	}
+}
+
+func TestLetterPart_OutOfRange(t *testing.T) {
+	tests := []struct {
+		name   string
+		letter string
+		ok     bool
+	}{
+		{"digit zero", "0", false},
+		{"digit nine", "9", false},
+		{"symbol at", "@", false},
+		{"lowercase a", "a", true},
+		{"lowercase z", "z", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, suf, ok := letterPart(tt.letter)
+			assert.Equal(t, tt.ok, ok)
+			if !ok {
+				assert.Equal(t, 0, n)
+				assert.Equal(t, "", suf)
+			}
 		})
 	}
 }

--- a/internal/matcher/multipart_test.go
+++ b/internal/matcher/multipart_test.go
@@ -37,6 +37,8 @@ func TestDetectPartSuffix(t *testing.T) {
 		{"SVFLA-001b-1080p", "SVFLA-001", 2, "-B", PatternLetter},
 		{"IPX-535a-4k-60", "IPX-535", 1, "-A", PatternLetter},
 		{"IPX-535b-4k-60", "IPX-535", 2, "-B", PatternLetter},
+		{"IPX-535-C-1", "IPX-535", 1, "-1", PatternTrailing},
+		{"IPX-535-C-2", "IPX-535", 2, "-2", PatternTrailing},
 
 		// No pattern
 		{"ABC-123", "ABC-123", 0, "", PatternNone},

--- a/internal/matcher/multipart_test.go
+++ b/internal/matcher/multipart_test.go
@@ -35,6 +35,8 @@ func TestDetectPartSuffix(t *testing.T) {
 		// Letter + trailing content (quality/resolution tag) - ambiguous, need directory validation
 		{"SVFLA-001a-4k", "SVFLA-001", 1, "-A", PatternLetter},
 		{"SVFLA-001b-1080p", "SVFLA-001", 2, "-B", PatternLetter},
+		{"IPX-535a-4k-60", "IPX-535", 1, "-A", PatternLetter},
+		{"IPX-535b-4k-60", "IPX-535", 2, "-B", PatternLetter},
 
 		// No pattern
 		{"ABC-123", "ABC-123", 0, "", PatternNone},

--- a/internal/matcher/multipart_test.go
+++ b/internal/matcher/multipart_test.go
@@ -39,6 +39,8 @@ func TestDetectPartSuffix(t *testing.T) {
 		{"IPX-535b-4k-60", "IPX-535", 2, "-B", PatternLetter},
 		{"IPX-535-C-1", "IPX-535", 1, "-1", PatternTrailing},
 		{"IPX-535-C-2", "IPX-535", 2, "-2", PatternTrailing},
+		{"SVFLA-001a-4k-HDR", "SVFLA-001", 1, "-A", PatternLetter},
+		{"SVFLA-001b-4k-h265", "SVFLA-001", 2, "-B", PatternLetter},
 
 		// No pattern
 		{"ABC-123", "ABC-123", 0, "", PatternNone},

--- a/internal/matcher/url_parser_test.go
+++ b/internal/matcher/url_parser_test.go
@@ -29,6 +29,20 @@ func (m *mockScraper) IsEnabled() bool                                    { retu
 func (m *mockScraper) Config() *models.ScraperSettings                    { return nil }
 func (m *mockScraper) Close() error                                       { return nil }
 
+func TestIsNilInterface(t *testing.T) {
+	assert.True(t, isNilInterface(nil), "untyped nil")
+	var typedNilPtr *int
+	assert.True(t, isNilInterface(typedNilPtr), "typed nil pointer")
+	var typedNilMap map[string]int
+	assert.True(t, isNilInterface(typedNilMap), "typed nil map")
+	var typedNilSlice []int
+	assert.True(t, isNilInterface(typedNilSlice), "typed nil slice")
+	assert.False(t, isNilInterface(42), "non-nil int")
+	assert.False(t, isNilInterface("x"), "non-nil string")
+	s := "ok"
+	assert.False(t, isNilInterface(&s), "non-nil pointer")
+}
+
 // Scraper URL-handling methods
 func (m *mockScraper) CanHandleURL(_ string) bool {
 	return m.canHandle

--- a/internal/organizer/organizer_multipart_test.go
+++ b/internal/organizer/organizer_multipart_test.go
@@ -1,12 +1,16 @@
 package organizer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
 
+	"github.com/javinizer/javinizer-go/internal/matcher"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/operationmode"
 )
@@ -164,4 +168,189 @@ func TestOrganizeBatch_GroupsAndSortsParts(t *testing.T) {
 	if dir0 != dir1 {
 		t.Errorf("Parts should be in the same folder: got %q and %q", dir0, dir1)
 	}
+}
+
+// TestPlan_LetterQualityTagNoCollision_EndToEnd verifies the reported regression:
+// SVFLA-001a-4k.mp4 + SVFLA-001b-4k.mp4 must organize to distinct filenames via the
+// real matcher -> ValidateMultipartInDirectory -> organizer.plan pipeline, using the
+// default conditional template <ID><IF:MULTIPART>-pt<PART></IF>.
+func TestPlan_LetterQualityTagNoCollision_EndToEnd(t *testing.T) {
+	cfg := &Config{
+		FolderFormat:    "<ID>",
+		FileFormat:      "<ID><IF:MULTIPART>-pt<PART></IF>",
+		RenameFile:      true,
+		OperationMode:   operationmode.OperationModeOrganize,
+		SubfolderFormat: []string{},
+		MaxPathLength:   260,
+	}
+	o := NewOrganizer(afero.NewOsFs(), cfg, nil, nil)
+
+	m, err := matcher.NewMatcher(&matcher.Config{RegexEnabled: false})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "SVFLA-001a-4k.mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001a-4k.mp4"},
+		{Name: "SVFLA-001b-4k.mp4", Extension: ".mp4", Path: "/media/JAV/SVFLA-001b-4k.mp4"},
+	}
+
+	results := matcher.ValidateMultipartInDirectory(m.Match(files))
+
+	movie := &models.Movie{ID: "SVFLA-001", Title: "Test"}
+	seen := map[string]bool{}
+	for _, r := range results {
+		fmi := models.FileMatchInfo{
+			MovieID: r.ID, IsMultiPart: r.IsMultiPart, PartNumber: r.PartNumber, PartSuffix: r.PartSuffix,
+			Path: r.File.Path, Name: r.File.Name, Extension: r.File.Extension,
+		}
+		plan, err := o.plan(fmi, movie, "/dest", false, "")
+		if err != nil {
+			t.Fatalf("plan %s: %v", r.File.Name, err)
+		}
+		if seen[plan.TargetFile] {
+			t.Fatalf("filename collision: %q produced more than once", plan.TargetFile)
+		}
+		seen[plan.TargetFile] = true
+	}
+
+	want := map[string]bool{"SVFLA-001-pt1.mp4": true, "SVFLA-001-pt2.mp4": true}
+	for f := range want {
+		if !seen[f] {
+			t.Errorf("missing expected TargetFile %q; got %v", f, seen)
+		}
+	}
+	for f := range seen {
+		if !want[f] {
+			t.Errorf("unexpected TargetFile %q", f)
+		}
+	}
+}
+
+// TestPlan_LetterSamePartDifferentQuality_NoPtCollision verifies that two encodes of the
+// SAME part (same letter, different quality tag) are NOT confirmed multipart, so they do
+// not both render the colliding -pt1 name. They stay single-part; any duplicate-target
+// collision is surfaced by the existing plan.Conflicts mechanism, not invented here.
+func TestPlan_LetterSamePartDifferentQuality_NoPtCollision(t *testing.T) {
+	cfg := &Config{
+		FolderFormat:    "<ID>",
+		FileFormat:      "<ID><IF:MULTIPART>-pt<PART></IF>",
+		RenameFile:      true,
+		OperationMode:   operationmode.OperationModeOrganize,
+		SubfolderFormat: []string{},
+		MaxPathLength:   260,
+	}
+	o := NewOrganizer(afero.NewOsFs(), cfg, nil, nil)
+
+	m, err := matcher.NewMatcher(&matcher.Config{RegexEnabled: false})
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535a-4k.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-4k.mp4"},
+		{Name: "IPX-535a-1080p.mp4", Extension: ".mp4", Path: "/media/JAV/IPX-535a-1080p.mp4"},
+	}
+
+	results := matcher.ValidateMultipartInDirectory(m.Match(files))
+
+	movie := &models.Movie{ID: "IPX-535", Title: "Test"}
+	targets := map[string]int{}
+	for _, r := range results {
+		if r.IsMultiPart {
+			t.Errorf("%s: same-part-different-quality must stay single-part, got IsMultiPart=true", r.File.Name)
+		}
+		fmi := models.FileMatchInfo{
+			MovieID: r.ID, IsMultiPart: r.IsMultiPart, PartNumber: r.PartNumber, PartSuffix: r.PartSuffix,
+			Path: r.File.Path, Name: r.File.Name, Extension: r.File.Extension,
+		}
+		plan, err := o.plan(fmi, movie, "/dest", false, "")
+		if err != nil {
+			t.Fatalf("plan %s: %v", r.File.Name, err)
+		}
+		if strings.Contains(plan.TargetFile, "-pt") {
+			t.Errorf("same-part-different-quality must not render a -pt name, got %q", plan.TargetFile)
+		}
+		targets[plan.TargetFile]++
+	}
+
+	// Both encodes are the same part: they share the single-part name <ID>.<ext>.
+	// The duplicate-target collision is surfaced by execute-time conflict detection
+	// (see TestOrganizerWithAfero_MoveCollision), not invented by the matcher.
+	if len(targets) != 1 {
+		t.Errorf("expected both encodes to share the single-part name, got %v", targets)
+	}
+	if _, ok := targets["IPX-535.mp4"]; !ok {
+		t.Errorf("expected single-part name IPX-535.mp4, got %v", targets)
+	}
+}
+
+// TestPlan_LetterSamePart_EncodeNoDataLoss_Execute verifies at EXECUTE time (not just
+// plan) that two encodes of the same part (a-4k + a-1080p) do not cause data loss:
+// the first moves to the single-part name, the second is skipped via the existing
+// target-exists conflict detection rather than overwriting the first.
+func TestPlan_LetterSamePart_EncodeNoDataLoss_Execute(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	srcDir := "/src"
+	require.NoError(t, fs.MkdirAll(srcDir, 0755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(srcDir, "IPX-535a-4k.mp4"), []byte("encode-4k"), 0644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(srcDir, "IPX-535a-1080p.mp4"), []byte("encode-1080p"), 0644))
+
+	cfg := &Config{
+		FolderFormat:    "<ID>",
+		FileFormat:      "<ID><IF:MULTIPART>-pt<PART></IF>",
+		RenameFile:      true,
+		OperationMode:   operationmode.OperationModeOrganize,
+		SubfolderFormat: []string{},
+		MaxPathLength:   260,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+
+	m, err := matcher.NewMatcher(&matcher.Config{RegexEnabled: false})
+	require.NoError(t, err)
+
+	files := []models.FileMatchInfo{
+		{Name: "IPX-535a-4k.mp4", Extension: ".mp4", Path: filepath.Join(srcDir, "IPX-535a-4k.mp4")},
+		{Name: "IPX-535a-1080p.mp4", Extension: ".mp4", Path: filepath.Join(srcDir, "IPX-535a-1080p.mp4")},
+	}
+	results := matcher.ValidateMultipartInDirectory(m.Match(files))
+	for _, r := range results {
+		require.False(t, r.IsMultiPart, "same-part encodes must stay single-part")
+	}
+
+	movie := &models.Movie{ID: "IPX-535", Title: "Test"}
+	destDir := "/dest"
+	var firstResult, secondResult *OrganizeResult
+	for i, r := range results {
+		fmi := models.FileMatchInfo{
+			MovieID: r.ID, IsMultiPart: r.IsMultiPart, PartNumber: r.PartNumber, PartSuffix: r.PartSuffix,
+			Path: r.File.Path, Name: r.File.Name, Extension: r.File.Extension,
+		}
+		res, err := org.Organize(context.Background(), OrganizeCmd{
+			Match:     fmi,
+			Movie:     movie,
+			DestDir:   destDir,
+			MoveFiles: true,
+		})
+		if i == 0 {
+			firstResult = res
+			require.NoError(t, err, "first encode should move")
+			require.True(t, res.Moved, "first encode should move to IPX-535.mp4")
+		} else {
+			secondResult = res
+			// Second encode targets the same name; existing conflict detection must reject it
+			// (Organize returns nil + error on conflict) rather than overwriting the first.
+			require.Error(t, err, "second encode must error on duplicate target, not overwrite")
+			if res != nil {
+				require.False(t, res.Moved, "second encode must not overwrite the first (no data loss)")
+			}
+		}
+	}
+
+	// Verify the first encode's content survived (no overwrite).
+	content, err := afero.ReadFile(fs, filepath.Join(destDir, "IPX-535", "IPX-535.mp4"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("encode-4k"), content, "first encode content must be preserved")
+	_ = firstResult
+	_ = secondResult
 }

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -170,14 +170,16 @@ func buildScrapeCmd(
 		manualURL = isManualURLInput(trimmed)
 	}
 	if movieID == "" {
-		// Prefer the directory-validated FileMatchInfo.MovieID (set by the scan/match
-		// phase, e.g. a restored E/Z catalog suffix) over the matcher's unvalidated
-		// heuristic — keeps the scrape ID consistent with the validated match result.
-		if fmi.MovieID != "" {
+		// MovieIDOverride (per-file rescrape override) takes precedence over the
+		// validated FileMatchInfo.MovieID, then the matcher fallback.
+		if override, ok := cfg.MovieIDOverride[filePath]; ok {
+			movieID = override
+		} else if fmi.MovieID != "" {
+			// Prefer the directory-validated FileMatchInfo.MovieID (set by the scan/match
+			// phase, e.g. a restored E/Z catalog suffix) over the matcher's unvalidated
+			// heuristic — keeps the scrape ID consistent with the validated match result.
 			movieID = fmi.MovieID
 			movieIDFromMatcher = true
-		} else if override, ok := cfg.MovieIDOverride[filePath]; ok {
-			movieID = override
 		} else {
 			movieID = ""
 			if inputs.Matcher != nil {

--- a/internal/worker/scrape_phase.go
+++ b/internal/worker/scrape_phase.go
@@ -77,8 +77,8 @@ func (p *scrapePhase) Run(ctx context.Context, inputs scrapePhaseInputs, files [
 			// below) — off the errgroup-gated critical path, so SQLite's
 			// single-writer lock never serializes the per-file scrape workers
 			// (root cause of the 5→1 worker degradation).
-			cmd, fromMatcher := buildScrapeCmd(filePath, inputs, cfg)
 			fmi := inputs.FileMatchInfo[filePath]
+			cmd, fromMatcher := buildScrapeCmd(filePath, fmi, inputs, cfg)
 			outcome := scrapeFile(egCtx, filePath, fmi, cmd, fromMatcher, inputs, cfg)
 			// Broadcast per-file scrape progress over WebSocket so the frontend's
 			// messagesByFile populates and ProgressModal shows live per-file status.
@@ -149,6 +149,7 @@ func isManualURLInput(raw string) bool {
 // to use, and builds the command.
 func buildScrapeCmd(
 	filePath string,
+	fmi models.FileMatchInfo,
 	inputs scrapePhaseInputs,
 	cfg ScrapePhaseConfig,
 ) (scrape.ScrapeCmd, bool) {
@@ -169,7 +170,13 @@ func buildScrapeCmd(
 		manualURL = isManualURLInput(trimmed)
 	}
 	if movieID == "" {
-		if override, ok := cfg.MovieIDOverride[filePath]; ok {
+		// Prefer the directory-validated FileMatchInfo.MovieID (set by the scan/match
+		// phase, e.g. a restored E/Z catalog suffix) over the matcher's unvalidated
+		// heuristic — keeps the scrape ID consistent with the validated match result.
+		if fmi.MovieID != "" {
+			movieID = fmi.MovieID
+			movieIDFromMatcher = true
+		} else if override, ok := cfg.MovieIDOverride[filePath]; ok {
 			movieID = override
 		} else {
 			movieID = ""

--- a/internal/worker/scrape_phase_test.go
+++ b/internal/worker/scrape_phase_test.go
@@ -179,7 +179,7 @@ func TestBuildScrapeCmd_ManualInputTrimmedForMovieIDAndRawInput(t *testing.T) {
 	const file = "/videos/ABC-001.mp4"
 	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
 
-	cmd, _ := buildScrapeCmd(file, inputs, ScrapePhaseConfig{RawInputOverride: map[string]string{file: "  IPX-123  "}})
+	cmd, _ := buildScrapeCmd(file, models.FileMatchInfo{}, inputs, ScrapePhaseConfig{RawInputOverride: map[string]string{file: "  IPX-123  "}})
 
 	assert.Equal(t, "IPX-123", cmd.MovieID, "MovieID is trimmed so failure JobEvents + row-identity identify the row, not '  IPX-123  '")
 	assert.Equal(t, "IPX-123", cmd.RawInput, "RawInput is trimmed (mirrors rescrape_phase.go:203 queryOverride = TrimSpace(ManualSearchInput))")
@@ -190,7 +190,7 @@ func TestBuildScrapeCmd_EmptyOrWhitespaceManualInputIsNoOverride(t *testing.T) {
 	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
 
 	for _, raw := range []string{"", "   ", "\t\n"} {
-		cmd, _ := buildScrapeCmd(file, inputs, ScrapePhaseConfig{RawInputOverride: map[string]string{file: raw}})
+		cmd, _ := buildScrapeCmd(file, models.FileMatchInfo{}, inputs, ScrapePhaseConfig{RawInputOverride: map[string]string{file: raw}})
 		assert.Equal(t, "ABC-001", cmd.MovieID, "empty/whitespace input %q should be no override (auto-ID from matcher)", raw)
 		assert.Equal(t, "", cmd.RawInput, "empty/whitespace input %q should not set RawInput", raw)
 	}
@@ -201,14 +201,14 @@ func TestBuildScrapeCmd_URLInputBypassesBatchGlobalScrapers_IDInputKeepsThem(t *
 	batchGlobal := []string{"r18dev", "dmm"}
 	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
 
-	urlCmd, _ := buildScrapeCmd(file, inputs, ScrapePhaseConfig{
+	urlCmd, _ := buildScrapeCmd(file, models.FileMatchInfo{}, inputs, ScrapePhaseConfig{
 		SelectedScrapers: batchGlobal,
 		RawInputOverride: map[string]string{file: "https://www.javbus.com/ABC-001"},
 	})
 	assert.Equal(t, "https://www.javbus.com/ABC-001", urlCmd.RawInput)
 	assert.Empty(t, urlCmd.SelectedScrapers, "URL rows bypass the batch-global scraper picker so resolveScrapeInput sets PriorityOverride")
 
-	idCmd, _ := buildScrapeCmd(file, inputs, ScrapePhaseConfig{
+	idCmd, _ := buildScrapeCmd(file, models.FileMatchInfo{}, inputs, ScrapePhaseConfig{
 		SelectedScrapers: batchGlobal,
 		RawInputOverride: map[string]string{file: "ABC-001"},
 	})
@@ -224,7 +224,7 @@ func TestBuildScrapeCmd_ManualURLInput_RedactsQueryFromMovieID(t *testing.T) {
 	const file = "/videos/ABC-001.mp4"
 	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
 
-	cmd, _ := buildScrapeCmd(file, inputs, ScrapePhaseConfig{
+	cmd, _ := buildScrapeCmd(file, models.FileMatchInfo{}, inputs, ScrapePhaseConfig{
 		RawInputOverride: map[string]string{file: "https://www.javbus.com/ABC-001?token=secret&sig=abc"},
 	})
 
@@ -239,11 +239,24 @@ func TestBuildScrapeCmd_ManualIDInput_RedactionIsNoOp(t *testing.T) {
 	const file = "/videos/ABC-001.mp4"
 	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
 
-	cmd, _ := buildScrapeCmd(file, inputs, ScrapePhaseConfig{
+	cmd, _ := buildScrapeCmd(file, models.FileMatchInfo{}, inputs, ScrapePhaseConfig{
 		RawInputOverride: map[string]string{file: "IPX-123"},
 	})
 	assert.Equal(t, "IPX-123", cmd.MovieID)
 	assert.Equal(t, "IPX-123", cmd.RawInput)
+}
+
+func TestBuildScrapeCmd_PrefersValidatedFileMatchInfoMovieID(t *testing.T) {
+	const file = "/videos/IPX-535E-4k.mp4"
+	m, err := matcher.NewMatcher(&matcher.Config{RegexEnabled: false})
+	require.NoError(t, err)
+	inputs := scrapePhaseInputs{Matcher: m}
+	// Validated FileMatchInfo carries the restored catalog ID (E not stripped, lone file)
+	fmi := models.FileMatchInfo{MovieID: "IPX-535E", Path: file, Name: "IPX-535E-4k.mp4", Extension: ".mp4"}
+
+	cmd, _ := buildScrapeCmd(file, fmi, inputs, ScrapePhaseConfig{})
+
+	assert.Equal(t, "IPX-535E", cmd.MovieID, "validated FileMatchInfo.MovieID must take precedence over MatchString's unvalidated heuristic")
 }
 
 func TestBuildScrapeCmd_NoManualInputAutoIDsFromMatcher(t *testing.T) {
@@ -251,7 +264,7 @@ func TestBuildScrapeCmd_NoManualInputAutoIDsFromMatcher(t *testing.T) {
 	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}
 	cfg := ScrapePhaseConfig{}
 
-	cmd, _ := buildScrapeCmd(file, inputs, cfg)
+	cmd, _ := buildScrapeCmd(file, models.FileMatchInfo{}, inputs, cfg)
 
 	assert.Equal(t, "ABC-001", cmd.MovieID, "no manual input: the matcher result is used as the MovieID")
 	assert.Equal(t, "", cmd.RawInput, "no manual input: RawInput stays empty so resolveScrapeInput is a no-op")
@@ -262,7 +275,7 @@ func TestBuildScrapeCmd_ManualInputUsedAsIDBypassingMatcher(t *testing.T) {
 	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "MATCHED-001"}}
 	cfg := ScrapePhaseConfig{RawInputOverride: map[string]string{file: "MANUAL-123"}}
 
-	cmd, _ := buildScrapeCmd(file, inputs, cfg)
+	cmd, _ := buildScrapeCmd(file, models.FileMatchInfo{}, inputs, cfg)
 
 	assert.Equal(t, "MANUAL-123", cmd.MovieID, "manual input is used as the MovieID, not the matcher result")
 	assert.Equal(t, "MANUAL-123", cmd.RawInput, "RawInput carries the manual input so resolveScrapeInput parses it downstream")

--- a/internal/worker/scrape_phase_test.go
+++ b/internal/worker/scrape_phase_test.go
@@ -259,6 +259,20 @@ func TestBuildScrapeCmd_PrefersValidatedFileMatchInfoMovieID(t *testing.T) {
 	assert.Equal(t, "IPX-535E", cmd.MovieID, "validated FileMatchInfo.MovieID must take precedence over MatchString's unvalidated heuristic")
 }
 
+func TestBuildScrapeCmd_MovieIDOverrideBeatsFileMatchInfoMovieID(t *testing.T) {
+	const file = "/videos/IPX-535E-4k.mp4"
+	m, err := matcher.NewMatcher(&matcher.Config{RegexEnabled: false})
+	require.NoError(t, err)
+	inputs := scrapePhaseInputs{Matcher: m}
+	fmi := models.FileMatchInfo{MovieID: "IPX-535E", Path: file, Name: "IPX-535E-4k.mp4", Extension: ".mp4"}
+
+	cmd, _ := buildScrapeCmd(file, fmi, inputs, ScrapePhaseConfig{
+		MovieIDOverride: map[string]string{file: "OVERRIDE-001"},
+	})
+
+	assert.Equal(t, "OVERRIDE-001", cmd.MovieID, "MovieIDOverride must take precedence over the validated FileMatchInfo.MovieID")
+}
+
 func TestBuildScrapeCmd_NoManualInputAutoIDsFromMatcher(t *testing.T) {
 	const file = "/videos/ABC-001.mp4"
 	inputs := scrapePhaseInputs{Matcher: &stubMatcher{result: "ABC-001"}}


### PR DESCRIPTION
## Problem

Multi-part files whose part marker is a single letter immediately followed by a quality/resolution tag (e.g. `SVFLA-001a-4k.mp4` + `SVFLA-001b-4k.mp4`) were not detected as multi-part. `DetectPartSuffix` only treated a post-ID remainder as a letter part when the *entire* remainder was a single letter (`A`, `-b`); `a-4k` fell through to `PatternNone`, so both files got `IsMultiPart=false`/`PartNumber=0`. The naming template `<ID><IF:MULTIPART>-pt<PART></IF>` then collapsed to `<ID>` for both, producing identical filenames (`SVFLA-001.mp4`) that collided on disk. The review UI still labeled the files "Part 1"/"Part 2" by ordinal count, masking the collision.

Reported by a user; no existing tracked issue.

## Fix

- **Detect letter + resolution-tag suffixes.** `DetectPartSuffix` now classifies a single-letter part marker followed by a digit-first resolution tag (`a-4k`, `b-1080p`, `a-720p`) as an ambiguous `PatternLetter` — the same class as a bare `A`/`B` suffix. Trailing content that is *not* digit-first (e.g. `-extra`, `-bonus`) is left as `PatternNone`, so edition/variant files are not misclassified as parts.
- **Directory-context validation** (`ValidateMultipartInDirectory`):
  - Confirm a letter group as multipart only when every part letter occurs exactly once (no duplicate encodes — e.g. `a-4k.mp4` + `a-4k.mkv`, or `a-4k` + `a-1080p`, stay single-part).
  - Reject a group whose part numbers collide with parts already confirmed by explicit (`-pt1`) or trailing-number (`-HD-1`) patterns.
  - Bare letters (`ABW-121-C`) and tagged letters (`a-4k`) are separate conventions and do not cross-validate for sibling confirmation; a confirmed set's part numbers block the other convention to avoid colliding `-pt1`/ `-pt2` targets.
  - Trailing content (`-4k` vs `-1080p`) is irrelevant to part identity, so `a-4k` + `b-1080p` confirm as parts 1 and 2.
  - Unconfirmed letter files have `PartNumber`/`PartSuffix` cleared so a lone file does not render part metadata as single-part.
- **No template/config/downstream changes.** `FileMatchInfo.IsMultiPart`/`PartNumber`/`PartSuffix` already feed the organizer, downloader, and frontend. Genuine duplicate single-part targets fall back to the organize layer's existing conflict detection (the documented TOCTOU at `strategy_inplace.go:234` is pre-existing and out of scope for this fix).

## Tests

- `internal/matcher` is at **100% coverage**.
- New cases: the reported `SVFLA-001a/b-4k` collision; same-part duplicate encodes (`a-4k.mp4` + `a-4k.mkv`, `a-4k` + `a-1080p`); cross-pattern overlap (letter vs explicit `-pt1` vs trailing `-HD-1`); disjoint quality-tag groups; bare-vs-tagged non-cross-validation; non-resolution trailing words (`-extra`); the lone-file field-clear path; and an execute-path organizer test proving no data loss for duplicate encodes.
- Refactor: builtin matcher regex → `regexp.MustCompile` (compile-time-valid constant, removes a dead error branch).