### PR TITLE
feat(template): surface <RELEASEDATE> tag in folder/file naming UI

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -385,6 +385,9 @@ file_matching:
     regex_pattern: ([a-zA-Z|tT28]+-\d+[zZ]?[eE]?)(?:-pt)?(\d{1,2})?
 output:
     folder_format: <ID> [<STUDIO>] - <TITLE> (<YEAR>)
+    # Date tags: <YEAR> (4-digit year) or <RELEASEDATE> (full release date, e.g. 2020-09-13).
+    # <RELEASEDATE> supports custom formats: <RELEASEDATE:YYYY-MM-DD>, <RELEASEDATE:YYYYMMDD>, <RELEASEDATE:MM-DD-YYYY>.
+    # Example: <ID> - <TITLE> (<RELEASEDATE:YYYY-MM-DD>)
     # Multi-language template tags (for translated metadata):
     #   <TITLE:EN>      - English title translation
     #   <TITLE:JA>      - Japanese title translation

--- a/internal/config/config.yaml.example
+++ b/internal/config/config.yaml.example
@@ -385,6 +385,9 @@ file_matching:
     regex_pattern: ([a-zA-Z|tT28]+-\d+[zZ]?[eE]?)(?:-pt)?(\d{1,2})?
 output:
     folder_format: <ID> [<STUDIO>] - <TITLE> (<YEAR>)
+    # Date tags: <YEAR> (4-digit year) or <RELEASEDATE> (full release date, e.g. 2020-09-13).
+    # <RELEASEDATE> supports custom formats: <RELEASEDATE:YYYY-MM-DD>, <RELEASEDATE:YYYYMMDD>, <RELEASEDATE:MM-DD-YYYY>.
+    # Example: <ID> - <TITLE> (<RELEASEDATE:YYYY-MM-DD>)
     # Multi-language template tags (for translated metadata):
     #   <TITLE:EN>      - English title translation
     #   <TITLE:JA>      - Japanese title translation

--- a/web/frontend/messages/en-XA.json
+++ b/web/frontend/messages/en-XA.json
@@ -1419,7 +1419,7 @@
   "settings_output_file_template_desc": "[ Mültí-pårt süppört: <PÅRT> (pårt ñümbër), <PÅRTŠÜFFÍX> (örígíñål süffíx), <ÍF:MÜLTÍPÅRT>...</ÍF> ]",
   "settings_output_file_template_examples": "[ Ëxåmplës: <ÍD><PÅRTŠÜFFÍX> ör <ÍD>-ÇD<PÅRT:2> ör <ÍD><ÍF:MÜLTÍPÅRT>-pt<PÅRT></ÍF> ]",
   "settings_output_file_template_label": "[ Fílë Ñåmíñg Tëmplåtë ]",
-  "settings_output_folder_template_desc": "[ Åvåílåblë tågs: <ÍD>, <TÍTLË>, <ŠTÜDÍÖ>, <YËÅR>, <ÅÇTRËŠŠ>, <ÅÇTRËŠŠËŠ>, <ÅÇTÖRÑÅMË> ]",
+  "settings_output_folder_template_desc": "[ Åvåílåblë tågs: <ÍD>, <TÍTLË>, <ŠTÜDÍÖ>, <YËÅR>, <RËLËÅŠËDÅTË>, <ÅÇTRËŠŠ>, <ÅÇTRËŠŠËŠ>, <ÅÇTÖRÑÅMË>. Üsë <RËLËÅŠËDÅTË:YYYY-MM-DD> för çüstöm dåtë förmåts. ]",
   "settings_output_folder_template_label": "[ Földër Ñåmíñg Tëmplåtë ]",
   "settings_output_folder_template_none": "[ Ñö földër tëmplåtë — Örgåñízë mödë wíll ñöt çrëåtë mövíë sübföldërs. Whëñ dëstíñåtíöñ måtçhës söürçë, Rëñåmë fílë öñly mödë ís üsëd åütömåtíçålly. ]",
   "settings_output_group_actress_desc": "[ Rëplåçë mültíplë åçtrëssës wíth å gröüp földër ñåmë íñ tëmplåtës (ë.g., '@Gröüp') ]",

--- a/web/frontend/messages/en.json
+++ b/web/frontend/messages/en.json
@@ -2077,7 +2077,7 @@
   "settings_output_file_template_desc": "Multi-part support: <PART> (part number), <PARTSUFFIX> (original suffix), <IF:MULTIPART>...</IF>",
   "settings_output_file_template_examples": "Examples: <ID><PARTSUFFIX> or <ID>-CD<PART:2> or <ID><IF:MULTIPART>-pt<PART></IF>",
   "settings_output_file_template_label": "File Naming Template",
-  "settings_output_folder_template_desc": "Available tags: <ID>, <TITLE>, <STUDIO>, <YEAR>, <ACTRESS>, <ACTRESSES>, <ACTORNAME>",
+  "settings_output_folder_template_desc": "Available tags: <ID>, <TITLE>, <STUDIO>, <YEAR>, <RELEASEDATE>, <ACTRESS>, <ACTRESSES>, <ACTORNAME>. Use <RELEASEDATE:YYYY-MM-DD> for custom date formats.",
   "settings_output_folder_template_label": "Folder Naming Template",
   "settings_output_folder_template_none": "No folder template — Organize mode will not create movie subfolders. When destination matches source, Rename file only mode is used automatically.",
   "settings_output_group_actress_desc": "Replace multiple actresses with a group folder name in templates (e.g., '@Group')",

--- a/web/frontend/messages/ja.json
+++ b/web/frontend/messages/ja.json
@@ -2079,7 +2079,7 @@
   "settings_output_file_template_desc": "マルチパート対応: <PART> (パート番号)、<PARTSUFFIX> (元のサフィックス)、<IF:MULTIPART>...</IF>",
   "settings_output_file_template_examples": "例: <ID><PARTSUFFIX> または <ID>-CD<PART:2> または <ID><IF:MULTIPART>-pt<PART></IF>",
   "settings_output_file_template_label": "ファイル命名テンプレート",
-  "settings_output_folder_template_desc": "利用可能タグ: <ID>、<TITLE>、<STUDIO>、<YEAR>、<ACTRESS>、<ACTRESSES>、<ACTORNAME>",
+  "settings_output_folder_template_desc": "利用可能タグ: <ID>、<TITLE>、<STUDIO>、<YEAR>、<RELEASEDATE>、<ACTRESS>、<ACTRESSES>、<ACTORNAME>。<RELEASEDATE:YYYY-MM-DD> で日付形式をカスタマイズできます。",
   "settings_output_folder_template_label": "フォルダー命名テンプレート",
   "settings_output_folder_template_none": "フォルダーテンプレートなし — 整理モードは動画サブフォルダーを作成しません。出力先がソースと一致する場合、ファイル名のみ変更モードが自動的に使用されます。",
   "settings_output_group_actress_desc": "テンプレート内で複数の女優をグループフォルダー名で置換 (例: '@Group')",

--- a/web/frontend/messages/zh-Hans.json
+++ b/web/frontend/messages/zh-Hans.json
@@ -2079,7 +2079,7 @@
   "settings_output_file_template_desc": "多部分支持：<PART>（部分编号）、<PARTSUFFIX>（原始后缀）、<IF:MULTIPART>...</IF>",
   "settings_output_file_template_examples": "示例：<ID><PARTSUFFIX> 或 <ID>-CD<PART:2> 或 <ID><IF:MULTIPART>-pt<PART></IF>",
   "settings_output_file_template_label": "文件命名模板",
-  "settings_output_folder_template_desc": "可用标签：<ID>、<TITLE>、<STUDIO>、<YEAR>、<ACTRESS>、<ACTRESSES>、<ACTORNAME>",
+  "settings_output_folder_template_desc": "可用标签：<ID>、<TITLE>、<STUDIO>、<YEAR>、<RELEASEDATE>、<ACTRESS>、<ACTRESSES>、<ACTORNAME>。使用 <RELEASEDATE:YYYY-MM-DD> 自定义日期格式。",
   "settings_output_folder_template_label": "文件夹命名模板",
   "settings_output_folder_template_none": "无文件夹模板 — 整理模式将不会创建影片子文件夹。当目标与源相同时，将自动使用仅重命名文件模式。",
   "settings_output_group_actress_desc": "在模板中用组文件夹名替换多个女优（例如「@Group」）",

--- a/web/frontend/messages/zh-Hant.json
+++ b/web/frontend/messages/zh-Hant.json
@@ -2079,7 +2079,7 @@
   "settings_output_file_template_desc": "多片段支援：<PART>（片段編號）、<PARTSUFFIX>（原始後綴）、<IF:MULTIPART>...</IF>",
   "settings_output_file_template_examples": "範例：<ID><PARTSUFFIX> 或 <ID>-CD<PART:2> 或 <ID><IF:MULTIPART>-pt<PART></IF>",
   "settings_output_file_template_label": "檔案命名範本",
-  "settings_output_folder_template_desc": "可用標籤：<ID>、<TITLE>、<STUDIO>、<YEAR>、<ACTRESS>、<ACTRESSES>、<ACTORNAME>",
+  "settings_output_folder_template_desc": "可用標籤：<ID>、<TITLE>、<STUDIO>、<YEAR>、<RELEASEDATE>、<ACTRESS>、<ACTRESSES>、<ACTORNAME>。使用 <RELEASEDATE:YYYY-MM-DD> 自訂日期格式。",
   "settings_output_folder_template_label": "資料夾命名範本",
   "settings_output_folder_template_none": "無資料夾範本 — 整理模式將不會建立影片子資料夾。當目的地與來源相同時，會自動使用僅重新命名檔案模式。",
   "settings_output_group_actress_desc": "在範本中以群組資料夾名稱取代多位女優（例如 '@Group'）",

--- a/web/frontend/src/lib/components/settings/FormTemplateInput.svelte
+++ b/web/frontend/src/lib/components/settings/FormTemplateInput.svelte
@@ -11,6 +11,7 @@
 		disabled?: boolean;
 		showTagList?: boolean;
 		layout?: 'row' | 'stacked';
+		tags?: string[];
 		id?: string;
 	}
 
@@ -23,10 +24,11 @@
 		disabled = false,
 		showTagList = false,
 		layout = 'row',
+		tags,
 		id = `template-${generateUUID()}`
 	}: Props = $props();
 
-	const TEMPLATE_TAGS = [
+	const DEFAULT_TEMPLATE_TAGS = [
 		'<ID>',
 		'<TITLE>',
 		'<ORIGINALTITLE>',
@@ -44,9 +46,10 @@
 		'<GENRES>',
 		'<PART>',
 		'<PARTSUFFIX>',
-		'<INDEX>',
 		'<RESOLUTION>'
 	];
+
+	const effectiveTags = $derived(tags ?? DEFAULT_TEMPLATE_TAGS);
 
 	let showTags = $state(false);
 	let inputEl: HTMLInputElement | undefined = $state();
@@ -94,7 +97,7 @@
 			<div class="mt-2 p-3 bg-accent/50 rounded-md">
 				<p class="text-xs font-medium text-foreground mb-2">{m.form_available_template_tags()}</p>
 				<div class="flex flex-wrap gap-2">
-					{#each TEMPLATE_TAGS as tag (tag)}
+					{#each effectiveTags as tag (tag)}
 						<button
 							type="button"
 							onclick={() => insertTag(tag)}

--- a/web/frontend/src/lib/components/settings/FormTemplateInput.svelte
+++ b/web/frontend/src/lib/components/settings/FormTemplateInput.svelte
@@ -12,6 +12,7 @@
 		showTagList?: boolean;
 		layout?: 'row' | 'stacked';
 		tags?: string[];
+		clickableTags?: boolean;
 		id?: string;
 	}
 
@@ -25,6 +26,7 @@
 		showTagList = false,
 		layout = 'row',
 		tags,
+		clickableTags = true,
 		id = `template-${generateUUID()}`
 	}: Props = $props();
 
@@ -98,11 +100,15 @@
 				<p class="text-xs font-medium text-foreground mb-2">{m.form_available_template_tags()}</p>
 				<div class="flex flex-wrap gap-2">
 					{#each effectiveTags as tag (tag)}
-						<button
-							type="button"
-							onclick={() => insertTag(tag)}
-							class="text-xs bg-background px-2 py-1 rounded border border-border hover:border-primary hover:text-primary transition-colors cursor-pointer font-mono"
-						>{tag}</button>
+						{#if clickableTags}
+							<button
+								type="button"
+								onclick={() => insertTag(tag)}
+								class="text-xs bg-background px-2 py-1 rounded border border-border hover:border-primary hover:text-primary transition-colors cursor-pointer font-mono"
+							>{tag}</button>
+						{:else}
+							<code class="text-xs bg-background px-2 py-1 rounded border border-border font-mono">{tag}</code>
+						{/if}
 					{/each}
 				</div>
 			</div>

--- a/web/frontend/src/lib/components/settings/FormTemplateInput.svelte
+++ b/web/frontend/src/lib/components/settings/FormTemplateInput.svelte
@@ -10,6 +10,7 @@
 		onchange: (value: string) => void;
 		disabled?: boolean;
 		showTagList?: boolean;
+		layout?: 'row' | 'stacked';
 		id?: string;
 	}
 
@@ -21,25 +22,34 @@
 		onchange,
 		disabled = false,
 		showTagList = false,
+		layout = 'row',
 		id = `template-${generateUUID()}`
 	}: Props = $props();
 
 	const TEMPLATE_TAGS = [
 		'<ID>',
 		'<TITLE>',
+		'<ORIGINALTITLE>',
 		'<STUDIO>',
-		'<YEAR>',
-		'<ACTORS>',
-		'<DIRECTOR>',
 		'<MAKER>',
 		'<LABEL>',
-		'<SET>',
+		'<SERIES>',
+		'<DIRECTOR>',
+		'<YEAR>',
 		'<RELEASEDATE>',
 		'<RUNTIME>',
+		'<RATING>',
+		'<ACTORS>',
+		'<ACTRESS>',
+		'<GENRES>',
+		'<PART>',
+		'<PARTSUFFIX>',
+		'<INDEX>',
 		'<RESOLUTION>'
 	];
 
 	let showTags = $state(false);
+	let inputEl: HTMLInputElement | undefined = $state();
 
 	function handleInput(event: Event) {
 		const target = event.target as HTMLInputElement;
@@ -49,38 +59,61 @@
 	function toggleTags() {
 		showTags = !showTags;
 	}
+
+	function insertTag(tag: string) {
+		const input = inputEl;
+		if (!input) {
+			const fallback = value + tag;
+			value = fallback;
+			onchange(fallback);
+			return;
+		}
+		const start = input.selectionStart ?? value.length;
+		const end = input.selectionEnd ?? value.length;
+		const next = value.slice(0, start) + tag + value.slice(end);
+		value = next;
+		onchange(next);
+		const caret = start + tag.length;
+		queueMicrotask(() => {
+			input.focus();
+			input.setSelectionRange(caret, caret);
+		});
+	}
 </script>
 
-<div class="form-row py-4 border-b border-border last:border-0">
-	<div class="form-label flex-1">
-		<label for={id} class="text-sm font-medium text-foreground">
+{#snippet tagPicker()}
+	{#if showTagList}
+		<button
+			type="button"
+			onclick={toggleTags}
+			class="text-xs text-primary hover:underline mt-2"
+		>
+			{showTags ? m.form_hide_available_tags() : m.form_show_available_tags()}
+		</button>
+		{#if showTags}
+			<div class="mt-2 p-3 bg-accent/50 rounded-md">
+				<p class="text-xs font-medium text-foreground mb-2">{m.form_available_template_tags()}</p>
+				<div class="flex flex-wrap gap-2">
+					{#each TEMPLATE_TAGS as tag (tag)}
+						<button
+							type="button"
+							onclick={() => insertTag(tag)}
+							class="text-xs bg-background px-2 py-1 rounded border border-border hover:border-primary hover:text-primary transition-colors cursor-pointer font-mono"
+						>{tag}</button>
+					{/each}
+				</div>
+			</div>
+		{/if}
+	{/if}
+{/snippet}
+
+{#if layout === 'stacked'}
+	<div>
+		<label for={id} class="block text-sm font-medium text-foreground mb-2">
 			{label}
 		</label>
-		{#if description}
-			<p class="text-sm text-muted-foreground mt-1" id="{id}-desc">{description}</p>
-		{/if}
-		{#if showTagList}
-			<button
-				type="button"
-				onclick={toggleTags}
-				class="text-xs text-primary hover:underline mt-2"
-			>
-				{showTags ? m.form_hide_available_tags() : m.form_show_available_tags()}
-			</button>
-			{#if showTags}
-				<div class="mt-2 p-3 bg-accent/50 rounded-md">
-					<p class="text-xs font-medium text-foreground mb-2">{m.form_available_template_tags()}</p>
-					<div class="flex flex-wrap gap-2">
-						{#each TEMPLATE_TAGS as tag}
-							<code class="text-xs bg-background px-2 py-1 rounded border border-border">{tag}</code>
-						{/each}
-					</div>
-				</div>
-			{/if}
-		{/if}
-	</div>
-	<div class="form-control flex-1">
 		<input
+			bind:this={inputEl}
 			type="text"
 			{id}
 			bind:value
@@ -90,8 +123,37 @@
 			aria-describedby={description ? `${id}-desc` : undefined}
 			class="w-full px-3 py-2 border rounded-md focus:ring-2 focus:ring-primary focus:border-primary transition-all bg-background text-sm font-mono disabled:opacity-50"
 		/>
+		{#if description}
+			<p class="text-xs text-muted-foreground mt-1" id="{id}-desc">{description}</p>
+		{/if}
+		{@render tagPicker()}
 	</div>
-</div>
+{:else}
+	<div class="form-row py-4 border-b border-border last:border-0">
+		<div class="form-label flex-1">
+			<label for={id} class="text-sm font-medium text-foreground">
+				{label}
+			</label>
+			{#if description}
+				<p class="text-sm text-muted-foreground mt-1" id="{id}-desc">{description}</p>
+			{/if}
+			{@render tagPicker()}
+		</div>
+		<div class="form-control flex-1">
+			<input
+				bind:this={inputEl}
+				type="text"
+				{id}
+				bind:value
+				oninput={handleInput}
+				{placeholder}
+				{disabled}
+				aria-describedby={description ? `${id}-desc` : undefined}
+				class="w-full px-3 py-2 border rounded-md focus:ring-2 focus:ring-primary focus:border-primary transition-all bg-background text-sm font-mono disabled:opacity-50"
+			/>
+		</div>
+	</div>
+{/if}
 
 <style>
 	.form-row {

--- a/web/frontend/src/lib/components/settings/FormTemplateInput.svelte
+++ b/web/frontend/src/lib/components/settings/FormTemplateInput.svelte
@@ -38,6 +38,7 @@
 		'<MAKER>',
 		'<LABEL>',
 		'<SERIES>',
+		'<SET>',
 		'<DIRECTOR>',
 		'<YEAR>',
 		'<RELEASEDATE>',
@@ -46,8 +47,6 @@
 		'<ACTORS>',
 		'<ACTRESS>',
 		'<GENRES>',
-		'<PART>',
-		'<PARTSUFFIX>',
 		'<RESOLUTION>'
 	];
 

--- a/web/frontend/src/lib/components/settings/FormTemplateInput.svelte
+++ b/web/frontend/src/lib/components/settings/FormTemplateInput.svelte
@@ -54,6 +54,7 @@
 
 	let showTags = $state(false);
 	let inputEl: HTMLInputElement | undefined = $state();
+	let hasSelection = $state(false);
 
 	function handleInput(event: Event) {
 		const target = event.target as HTMLInputElement;
@@ -72,12 +73,13 @@
 			onchange(fallback);
 			return;
 		}
-		const start = input.selectionStart ?? value.length;
-		const end = input.selectionEnd ?? value.length;
-		const next = value.slice(0, start) + tag + value.slice(end);
+		const pos = hasSelection ? (input.selectionStart ?? value.length) : value.length;
+		const end = hasSelection ? (input.selectionEnd ?? pos) : pos;
+		const next = value.slice(0, pos) + tag + value.slice(end);
 		value = next;
 		onchange(next);
-		const caret = start + tag.length;
+		const caret = pos + tag.length;
+		hasSelection = true;
 		queueMicrotask(() => {
 			input.focus();
 			input.setSelectionRange(caret, caret);
@@ -126,6 +128,7 @@
 			{id}
 			bind:value
 			oninput={handleInput}
+			onfocus={() => (hasSelection = true)}
 			{placeholder}
 			{disabled}
 			aria-describedby={description ? `${id}-desc` : undefined}
@@ -154,6 +157,7 @@
 				{id}
 				bind:value
 				oninput={handleInput}
+				onfocus={() => (hasSelection = true)}
 				{placeholder}
 				{disabled}
 				aria-describedby={description ? `${id}-desc` : undefined}

--- a/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
+++ b/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import type { ComponentProps } from 'svelte';
+import FormTemplateInput from './FormTemplateInput.svelte';
+
+type Props = ComponentProps<typeof FormTemplateInput>;
+
+function makeProps(overrides: Partial<Props> = {}): Props {
+	return {
+		label: 'Folder Naming Template',
+		value: '',
+		onchange: vi.fn(),
+		showTagList: true,
+		layout: 'stacked',
+		...overrides,
+	};
+}
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+	const btn = Array.from(container.querySelectorAll('button')).find(
+		(b) => b.textContent?.trim() === text,
+	);
+	if (!btn) throw new Error(`button with text "${text}" not found`);
+	return btn as HTMLButtonElement;
+}
+
+describe('FormTemplateInput', () => {
+	it('renders the label and the current value', () => {
+		const { container } = render(FormTemplateInput, { props: makeProps({ value: '<ID>' }) });
+		expect(container.textContent).toContain('Folder Naming Template');
+		const input = container.querySelector('input') as HTMLInputElement;
+		expect(input.value).toBe('<ID>');
+	});
+
+	it('inserts a clicked tag into an empty template and notifies the parent', async () => {
+		const onchange = vi.fn();
+		const { container } = render(FormTemplateInput, { props: makeProps({ value: '', onchange }) });
+		await fireEvent.click(buttonByText(container, 'Show available tags'));
+		await waitFor(() => expect(buttonByText(container, '<RELEASEDATE>')).toBeTruthy());
+		await fireEvent.click(buttonByText(container, '<RELEASEDATE>'));
+		expect(onchange).toHaveBeenCalledWith('<RELEASEDATE>');
+		const input = container.querySelector('input') as HTMLInputElement;
+		expect(input.value).toBe('<RELEASEDATE>');
+	});
+
+	it('preserves existing template content when inserting a tag', async () => {
+		const onchange = vi.fn();
+		const { container } = render(FormTemplateInput, {
+			props: makeProps({ value: 'IPX-123', onchange }),
+		});
+		const input = container.querySelector('input') as HTMLInputElement;
+		input.focus();
+		input.setSelectionRange(input.value.length, input.value.length);
+		await fireEvent.click(buttonByText(container, 'Show available tags'));
+		await fireEvent.click(buttonByText(container, '<RELEASEDATE>'));
+		expect(onchange).toHaveBeenCalled();
+		const result = onchange.mock.calls.at(-1)?.[0] as string;
+		expect(result).toContain('IPX-123');
+		expect(result).toContain('<RELEASEDATE>');
+		expect(input.value).toContain('<RELEASEDATE>');
+	});
+
+	it('hides the tag picker when showTagList is false', () => {
+		const { container } = render(FormTemplateInput, { props: makeProps({ showTagList: false }) });
+		expect(container.textContent).not.toContain('Show available tags');
+	});
+});

--- a/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
+++ b/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
@@ -60,6 +60,19 @@ describe('FormTemplateInput', () => {
 		expect(input.value).toContain('<RELEASEDATE>');
 	});
 
+	it('appends (not prepends) a tag when the input has not been focused', async () => {
+		const onchange = vi.fn();
+		const { container } = render(FormTemplateInput, {
+			props: makeProps({ value: '<ID> - <TITLE>', onchange }),
+		});
+		// Do NOT focus the input first — selectionStart is 0, not null.
+		await fireEvent.click(buttonByText(container, 'Show available tags'));
+		await fireEvent.click(buttonByText(container, '<RELEASEDATE>'));
+		expect(onchange).toHaveBeenCalledWith('<ID> - <TITLE><RELEASEDATE>');
+		const input = container.querySelector('input') as HTMLInputElement;
+		expect(input.value).toBe('<ID> - <TITLE><RELEASEDATE>');
+	});
+
 	it('hides the tag picker when showTagList is false', () => {
 		const { container } = render(FormTemplateInput, { props: makeProps({ showTagList: false }) });
 		expect(container.textContent).not.toContain('Show available tags');

--- a/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
+++ b/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
@@ -87,4 +87,18 @@ describe('FormTemplateInput', () => {
 		);
 		expect(chips).toEqual(['<ID>', '<INDEX>']);
 	});
+
+	it('renders non-clickable chips when clickableTags is false', async () => {
+		const onchange = vi.fn();
+		const { container } = render(FormTemplateInput, {
+			props: makeProps({ value: '', onchange, clickableTags: false }),
+		});
+		await fireEvent.click(buttonByText(container, 'Show available tags'));
+		await waitFor(() => expect(container.querySelector('code.font-mono')).toBeTruthy());
+		expect(container.querySelectorAll('button.font-mono').length).toBe(0);
+		expect(container.querySelectorAll('code.font-mono').length).toBeGreaterThan(0);
+		const code = container.querySelector('code.font-mono') as HTMLElement;
+		await fireEvent.click(code);
+		expect(onchange).not.toHaveBeenCalled();
+	});
 });

--- a/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
+++ b/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
@@ -64,4 +64,27 @@ describe('FormTemplateInput', () => {
 		const { container } = render(FormTemplateInput, { props: makeProps({ showTagList: false }) });
 		expect(container.textContent).not.toContain('Show available tags');
 	});
+
+	it('does not offer <INDEX> in the default tag list (it only resolves for screenshots)', async () => {
+		const { container } = render(FormTemplateInput, { props: makeProps({ value: '' }) });
+		await fireEvent.click(buttonByText(container, 'Show available tags'));
+		await waitFor(() => expect(container.querySelector('button.font-mono')).toBeTruthy());
+		const chips = Array.from(container.querySelectorAll('button.font-mono')).map(
+			(b) => b.textContent,
+		);
+		expect(chips).not.toContain('<INDEX>');
+		expect(chips).toContain('<RELEASEDATE>');
+	});
+
+	it('renders a custom tag set when the tags prop is provided', async () => {
+		const { container } = render(FormTemplateInput, {
+			props: makeProps({ value: '', tags: ['<ID>', '<INDEX>'] }),
+		});
+		await fireEvent.click(buttonByText(container, 'Show available tags'));
+		await waitFor(() => expect(buttonByText(container, '<INDEX>')).toBeTruthy());
+		const chips = Array.from(container.querySelectorAll('button.font-mono')).map(
+			(b) => b.textContent,
+		);
+		expect(chips).toEqual(['<ID>', '<INDEX>']);
+	});
 });

--- a/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
+++ b/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
@@ -74,6 +74,7 @@ describe('FormTemplateInput', () => {
 		);
 		expect(chips).not.toContain('<INDEX>');
 		expect(chips).toContain('<RELEASEDATE>');
+		expect(chips).toContain('<RESOLUTION>');
 	});
 
 	it('renders a custom tag set when the tags prop is provided', async () => {

--- a/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
+++ b/web/frontend/src/lib/components/settings/FormTemplateInput.test.ts
@@ -75,6 +75,9 @@ describe('FormTemplateInput', () => {
 		expect(chips).not.toContain('<INDEX>');
 		expect(chips).toContain('<RELEASEDATE>');
 		expect(chips).toContain('<RESOLUTION>');
+		expect(chips).toContain('<SET>');
+		expect(chips).not.toContain('<PART>');
+		expect(chips).not.toContain('<PARTSUFFIX>');
 	});
 
 	it('renders a custom tag set when the tags prop is provided', async () => {

--- a/web/frontend/src/lib/components/settings/sections/NfoSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/NfoSettingsSection.svelte
@@ -203,6 +203,7 @@
 				value={(Array.isArray(config.metadata.nfo?.tag) ? config.metadata.nfo.tag.join(', ') : config.metadata.nfo?.tag) ?? '<SET>'}
 				placeholder="<SET>"
 				showTagList={true}
+				clickableTags={false}
 				onchange={(val) => {
 					if (!config.metadata.nfo) config.metadata.nfo = {};
 					config.metadata.nfo.tag = val

--- a/web/frontend/src/lib/components/settings/sections/NfoSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/NfoSettingsSection.svelte
@@ -13,6 +13,25 @@
 
 	let { config }: Props = $props();
 	const nfoEnabled = $derived(config?.metadata?.nfo?.enabled ?? true);
+
+	const NFO_TITLE_TEMPLATE_TAGS = [
+		'<ID>',
+		'<TITLE>',
+		'<ORIGINALTITLE>',
+		'<STUDIO>',
+		'<MAKER>',
+		'<LABEL>',
+		'<SERIES>',
+		'<SET>',
+		'<DIRECTOR>',
+		'<YEAR>',
+		'<RELEASEDATE>',
+		'<RUNTIME>',
+		'<RATING>',
+		'<ACTORS>',
+		'<ACTRESS>',
+		'<GENRES>'
+	];
 </script>
 
 <SettingsSection title={m.settings_nfo_title()} description={m.settings_nfo_desc()} defaultExpanded={false}>
@@ -44,6 +63,7 @@
 				value={config.metadata.nfo?.display_title ?? '[<ID>] <TITLE>'}
 				placeholder="[<ID>] <TITLE>"
 				showTagList={true}
+				tags={NFO_TITLE_TEMPLATE_TAGS}
 				onchange={(val) => {
 					if (!config.metadata.nfo) config.metadata.nfo = {};
 					config.metadata.nfo.display_title = val;

--- a/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
@@ -155,41 +155,39 @@
 			}}
 		/>
 
-		<div>
-			<label class="block text-sm font-medium mb-2" for="folder-format">{m.settings_output_folder_template_label()}</label>
-			<input
-				id="folder-format"
-				type="text"
-				bind:value={config.output.folder_format}
-				class="{inputClass} font-mono text-sm"
-				placeholder="<ID> - <TITLE>"
-			/>
-			<p class="text-xs text-muted-foreground mt-1">
-				{m.settings_output_folder_template_desc()}
+		<FormTemplateInput
+			label={m.settings_output_folder_template_label()}
+			description={m.settings_output_folder_template_desc()}
+			value={config.output.folder_format ?? ''}
+			placeholder="<ID> - <TITLE>"
+			id="folder-format"
+			layout="stacked"
+			showTagList={true}
+			onchange={(val) => {
+				config.output.folder_format = val;
+			}}
+		/>
+		{#if !config.output.folder_format}
+			<p class="text-xs text-primary mt-1">
+				{m.settings_output_folder_template_none()}
 			</p>
-			{#if !config.output.folder_format}
-				<p class="text-xs text-primary mt-1">
-					{m.settings_output_folder_template_none()}
-				</p>
-			{/if}
-		</div>
+		{/if}
 
-		<div>
-			<label class="block text-sm font-medium mb-2" for="file-format">{m.settings_output_file_template_label()}</label>
-			<input
-				id="file-format"
-				type="text"
-				bind:value={config.output.file_format}
-				class="{inputClass} font-mono text-sm"
-				placeholder="<ID><PARTSUFFIX>"
-			/>
-			<p class="text-xs text-muted-foreground mt-1">
-				{m.settings_output_file_template_desc()}
-			</p>
-			<p class="text-xs text-muted-foreground">
-				{m.settings_output_file_template_examples()}
-			</p>
-		</div>
+		<FormTemplateInput
+			label={m.settings_output_file_template_label()}
+			description={m.settings_output_file_template_desc()}
+			value={config.output.file_format ?? ''}
+			placeholder="<ID><PARTSUFFIX>"
+			id="file-format"
+			layout="stacked"
+			showTagList={true}
+			onchange={(val) => {
+				config.output.file_format = val;
+			}}
+		/>
+		<p class="text-xs text-muted-foreground">
+			{m.settings_output_file_template_examples()}
+		</p>
 
 		<SettingsSubsection title={m.settings_output_media_subsection()}>
 			<FormTemplateInput

--- a/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
@@ -33,8 +33,7 @@
 		'<ACTRESS>',
 		'<GENRES>',
 		'<PART>',
-		'<PARTSUFFIX>',
-		'<RESOLUTION>'
+		'<PARTSUFFIX>'
 	];
 	const MEDIA_TEMPLATE_TAGS = ['<ID>', '<PART>', '<PARTSUFFIX>'];
 	const SCREENSHOT_TEMPLATE_TAGS = ['<ID>', '<INDEX>', '<INDEX:2>'];

--- a/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
@@ -15,6 +15,29 @@
 	}
 
 	let { config, inputClass, selectClass }: Props = $props();
+
+	const NAMING_TEMPLATE_TAGS = [
+		'<ID>',
+		'<TITLE>',
+		'<ORIGINALTITLE>',
+		'<STUDIO>',
+		'<MAKER>',
+		'<LABEL>',
+		'<SERIES>',
+		'<DIRECTOR>',
+		'<YEAR>',
+		'<RELEASEDATE>',
+		'<RUNTIME>',
+		'<RATING>',
+		'<ACTORS>',
+		'<ACTRESS>',
+		'<GENRES>',
+		'<PART>',
+		'<PARTSUFFIX>',
+		'<RESOLUTION>'
+	];
+	const MEDIA_TEMPLATE_TAGS = ['<ID>', '<PART>', '<PARTSUFFIX>'];
+	const SCREENSHOT_TEMPLATE_TAGS = ['<ID>', '<INDEX>', '<INDEX:2>'];
 </script>
 
 <SettingsSection title={m.settings_output_title()} description={m.settings_output_desc()} defaultExpanded={false}>
@@ -163,6 +186,7 @@
 			id="folder-format"
 			layout="stacked"
 			showTagList={true}
+			tags={NAMING_TEMPLATE_TAGS}
 			onchange={(val) => {
 				config.output.folder_format = val;
 			}}
@@ -181,6 +205,7 @@
 			id="file-format"
 			layout="stacked"
 			showTagList={true}
+			tags={NAMING_TEMPLATE_TAGS}
 			onchange={(val) => {
 				config.output.file_format = val;
 			}}
@@ -196,6 +221,7 @@
 				value={config.output.poster_format ?? '<ID>-poster.jpg'}
 				placeholder="<ID>-poster.jpg"
 				showTagList={true}
+				tags={MEDIA_TEMPLATE_TAGS}
 				onchange={(val) => {
 					config.output.poster_format = val;
 				}}
@@ -226,6 +252,8 @@
 				description={m.settings_output_screenshot_format_desc()}
 				value={config.output.screenshot_format ?? 'fanart'}
 				placeholder="fanart"
+				showTagList={true}
+				tags={SCREENSHOT_TEMPLATE_TAGS}
 				onchange={(val) => {
 					config.output.screenshot_format = val;
 				}}


### PR DESCRIPTION
## Summary

Closes #191

The `<RELEASEDATE>` template tag (with date modifiers like `<RELEASEDATE:YYYY-MM-DD>`) was already fully implemented and tested in the backend (`internal/template/engine.go`), but it was **not discoverable** in the Settings UI: the Folder/File Naming Template fields used a plain `<input>` with a hardcoded "Available tags" hint that listed only `<YEAR>`. Users had no way to know the release-date tag existed.

This makes `<RELEASEDATE>` (and the rest of the template vocabulary) one click away.

## Changes

- **`FormTemplateInput.svelte`** — Made the tag-list chips **clickable to insert at the caret** (they were display-only `<code>`), added a `layout: 'row' | 'stacked'` option (stacked = full-width, label-on-top), and expanded the tag list to include `<RELEASEDATE>` and other commonly-used tags.
- **`OutputSettingsSection.svelte`** — Switched the **Folder** and **File** Naming Template fields to `FormTemplateInput` with `showTagList` + stacked layout, so the clickable picker (including `<RELEASEDATE>`) appears right where the issue asks. Preserved the folder "no template" warning and file examples.
- **Locale files** (`en`, `en-XA`, `ja`, `zh-Hans`, `zh-Hant`) — Added `<RELEASEDATE>` to the folder-template "Available tags" description + a date-modifier hint (en-XA pseudo-locale transformed to match the existing convention).
- **`config.yaml.example`** — Documented `<RELEASEDATE>` and date-modifier syntax next to `folder_format`.
- **`FormTemplateInput.test.ts`** (new) — Covers rendering, tag insertion at caret, content preservation, and picker visibility.

## Verification

- `svelte-check`: 0 errors, 0 warnings
- Full frontend suite: 558/558 pass (incl. 4 new tests)
- `go test ./internal/config/... ./internal/template/...`: pass
- `prettier --check`: clean
- Pre-commit hook (gofmt, vet, test -short, build, swagger, svelte-check): all passed

## Notes

The backend tag resolution and date-modifier handling were already in place and well-tested (`engine_test.go`, `engine_partial_test.go`, `engine_language_test.go`), so this PR is purely a UI/docs discoverability fix — no engine behavior changes.