### PR TITLE
feat(nfo): write <set> in tiered Kodi 19+ collection format

### DIFF
--- a/internal/nfo/coverage_test.go
+++ b/internal/nfo/coverage_test.go
@@ -461,7 +461,7 @@ func TestMovieToNFO_AllFields(t *testing.T) {
 	assert.Equal(t, "Test Maker", nfo.Studio)
 	assert.Equal(t, "Test Maker", nfo.Maker)
 	assert.Equal(t, "Test Label", nfo.Label)
-	assert.Equal(t, "Test Series", nfo.Set)
+	assert.Equal(t, "Test Series", string(nfo.Set))
 	assert.Equal(t, 9.0, nfo.Ratings.Rating[0].Value)
 	assert.Equal(t, 100, nfo.Ratings.Rating[0].Votes)
 	assert.Len(t, nfo.Genres, 2)

--- a/internal/nfo/integration_test.go
+++ b/internal/nfo/integration_test.go
@@ -393,7 +393,7 @@ func verifyNFOContent(t *testing.T, nfo *Movie, movie *models.Movie, cfg *Config
 	if nfo.Label != movie.Label {
 		t.Errorf("Label mismatch: got %s, want %s", nfo.Label, movie.Label)
 	}
-	if nfo.Set != movie.Series {
+	if string(nfo.Set) != movie.Series {
 		t.Errorf("Set mismatch: got %s, want %s", nfo.Set, movie.Series)
 	}
 

--- a/internal/nfo/nfo_test.go
+++ b/internal/nfo/nfo_test.go
@@ -90,7 +90,7 @@ func TestNFOXMLGeneration(t *testing.T) {
 					assert.Equal(t, "Test Studio", nfo.Studio)
 					assert.Equal(t, "Test Studio", nfo.Maker)
 					assert.Equal(t, "Test Label", nfo.Label)
-					assert.Equal(t, "Test Series Name", nfo.Set)
+					assert.Equal(t, "Test Series Name", string(nfo.Set))
 				},
 				func(t *testing.T, nfo *Movie) {
 					require.Len(t, nfo.UniqueID, 1)

--- a/internal/nfo/parser.go
+++ b/internal/nfo/parser.go
@@ -142,7 +142,7 @@ func nfoToMovie(nfo *Movie) (*models.Movie, []string) {
 		Director:      nfo.Director,
 		Maker:         nfo.Maker,
 		Label:         nfo.Label,
-		Series:        nfo.Set,
+		Series:        string(nfo.Set),
 		Runtime:       nfo.Runtime,
 		ReleaseYear:   nfo.Year,
 	}

--- a/internal/nfo/set.go
+++ b/internal/nfo/set.go
@@ -29,7 +29,10 @@ func (s SetString) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if err := e.EncodeElement(string(s), xml.StartElement{Name: xml.Name{Local: "name"}}); err != nil {
 		return err
 	}
-	return e.EncodeToken(start.End())
+	if err := e.EncodeToken(start.End()); err != nil {
+		return err
+	}
+	return e.Flush()
 }
 
 // UnmarshalXML accepts both the tiered <set><name>...</name></set> form and

--- a/internal/nfo/set.go
+++ b/internal/nfo/set.go
@@ -23,16 +23,9 @@ func (s SetString) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if s == "" {
 		return nil
 	}
-	if err := e.EncodeToken(start); err != nil {
-		return err
-	}
-	if err := e.EncodeElement(string(s), xml.StartElement{Name: xml.Name{Local: "name"}}); err != nil {
-		return err
-	}
-	if err := e.EncodeToken(start.End()); err != nil {
-		return err
-	}
-	return e.Flush()
+	return e.EncodeElement(struct {
+		Name string `xml:"name"`
+	}{Name: string(s)}, start)
 }
 
 // UnmarshalXML accepts both the tiered <set><name>...</name></set> form and

--- a/internal/nfo/set.go
+++ b/internal/nfo/set.go
@@ -1,0 +1,62 @@
+package nfo
+
+import (
+	"encoding/xml"
+	"strings"
+)
+
+// SetString is the movie series/collection name. It marshals in the tiered
+// Kodi 19+ format expected by Jellyfin, Plex, and Emby:
+//
+//	<set>
+//	  <name>Collection Name</name>
+//	</set>
+//
+// Unmarshaling accepts both the tiered form above and the legacy flat form
+// <set>Collection Name</set> produced by older javinizer versions, so existing
+// NFOs on disk continue to round-trip correctly.
+type SetString string
+
+// MarshalXML emits the tiered <set><name>...</name></set> structure. Empty
+// values are omitted via the struct tag's omitempty.
+func (s SetString) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if s == "" {
+		return nil
+	}
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	if err := e.EncodeElement(string(s), xml.StartElement{Name: xml.Name{Local: "name"}}); err != nil {
+		return err
+	}
+	return e.EncodeToken(start.End())
+}
+
+// UnmarshalXML accepts both the tiered <set><name>...</name></set> form and
+// the legacy flat <set>Name</set> form.
+func (s *SetString) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch t := tok.(type) {
+		case xml.CharData:
+			if v := strings.TrimSpace(string(t)); v != "" {
+				*s = SetString(v)
+			}
+		case xml.StartElement:
+			if t.Name.Local == "name" {
+				var name string
+				if err := d.DecodeElement(&name, &t); err != nil {
+					return err
+				}
+				*s = SetString(strings.TrimSpace(name))
+			} else if err := d.Skip(); err != nil {
+				return err
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}

--- a/internal/nfo/set.go
+++ b/internal/nfo/set.go
@@ -33,8 +33,14 @@ func (s SetString) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 }
 
 // UnmarshalXML accepts both the tiered <set><name>...</name></set> form and
-// the legacy flat <set>Name</set> form.
+// the legacy flat <set>Name</set> form. When a <set> element contains both a
+// <name> child and bare character data, the <name> child value wins regardless
+// of document order. Other child elements (e.g. <overview>) are skipped.
+// Values are trimmed of surrounding whitespace.
 func (s *SetString) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var flat string
+	var name string
+	hasName := false
 	for {
 		tok, err := d.Token()
 		if err != nil {
@@ -42,20 +48,26 @@ func (s *SetString) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		}
 		switch t := tok.(type) {
 		case xml.CharData:
-			if v := strings.TrimSpace(string(t)); v != "" {
-				*s = SetString(v)
+			if v := strings.TrimSpace(string(t)); v != "" && flat == "" {
+				flat = v
 			}
 		case xml.StartElement:
 			if t.Name.Local == "name" {
-				var name string
-				if err := d.DecodeElement(&name, &t); err != nil {
+				var n string
+				if err := d.DecodeElement(&n, &t); err != nil {
 					return err
 				}
-				*s = SetString(strings.TrimSpace(name))
+				name = strings.TrimSpace(n)
+				hasName = true
 			} else if err := d.Skip(); err != nil {
 				return err
 			}
 		case xml.EndElement:
+			if hasName {
+				*s = SetString(name)
+			} else {
+				*s = SetString(flat)
+			}
 			return nil
 		}
 	}

--- a/internal/nfo/set.go
+++ b/internal/nfo/set.go
@@ -39,9 +39,11 @@ func (s SetString) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 // the legacy flat <set>Name</set> form. When a <set> element contains both a
 // <name> child and bare character data, the <name> child value wins regardless
 // of document order. Other child elements (e.g. <overview>) are skipped.
-// Values are trimmed of surrounding whitespace.
+// All direct character data is accumulated (so a legacy flat value split
+// across multiple CharData tokens, e.g. via CDATA or comments, is preserved)
+// and trimmed of surrounding whitespace only at the closing element.
 func (s *SetString) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	var flat string
+	var flat strings.Builder
 	var name string
 	hasName := false
 	for {
@@ -51,9 +53,7 @@ func (s *SetString) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		}
 		switch t := tok.(type) {
 		case xml.CharData:
-			if v := strings.TrimSpace(string(t)); v != "" && flat == "" {
-				flat = v
-			}
+			flat.Write(t)
 		case xml.StartElement:
 			if t.Name.Local == "name" {
 				var n string
@@ -69,7 +69,7 @@ func (s *SetString) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			if hasName {
 				*s = SetString(name)
 			} else {
-				*s = SetString(flat)
+				*s = SetString(strings.TrimSpace(flat.String()))
 			}
 			return nil
 		}

--- a/internal/nfo/set_test.go
+++ b/internal/nfo/set_test.go
@@ -1,0 +1,95 @@
+package nfo
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetString_MarshalTieredFormat(t *testing.T) {
+	movie := Movie{
+		Title: "Test",
+		Set:   SetString("Beautiful Days Series"),
+	}
+	xmlData, err := xml.MarshalIndent(movie, "", "  ")
+	require.NoError(t, err)
+	xmlStr := string(xmlData)
+
+	assert.Contains(t, xmlStr, "<set>")
+	assert.Contains(t, xmlStr, "<name>Beautiful Days Series</name>")
+	assert.NotContains(t, xmlStr, "<set>Beautiful Days Series</set>")
+}
+
+func TestSetString_MarshalEmpty(t *testing.T) {
+	movie := Movie{Title: "Test", Set: SetString("")}
+	xmlData, err := xml.MarshalIndent(movie, "", "  ")
+	require.NoError(t, err)
+	assert.NotContains(t, string(xmlData), "<set>")
+}
+
+func TestSetString_UnmarshalTieredFormat(t *testing.T) {
+	xmlStr := `<movie><title>Test</title><set><name>Beautiful Days Series</name></set></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Equal(t, "Beautiful Days Series", string(movie.Set))
+}
+
+func TestSetString_UnmarshalLegacyFlatFormat(t *testing.T) {
+	xmlStr := `<movie><title>Test</title><set>Beautiful Days Series</set></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Equal(t, "Beautiful Days Series", string(movie.Set))
+}
+
+func TestSetString_UnmarshalTieredWithWhitespace(t *testing.T) {
+	xmlStr := `<movie><set>
+  <name>  Trimmed Series  </name>
+</set></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Equal(t, "Trimmed Series", string(movie.Set))
+}
+
+func TestSetString_UnmarshalEmptySet(t *testing.T) {
+	xmlStr := `<movie><title>Test</title><set></set></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Empty(t, movie.Set)
+}
+
+func TestSetString_UnmarshalSkipsUnknownChildren(t *testing.T) {
+	xmlStr := `<movie><set><overview>Extra</overview><name>Real Series</name></set></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Equal(t, "Real Series", string(movie.Set))
+}
+
+func TestSetString_RoundTrip(t *testing.T) {
+	original := Movie{Title: "Round Trip", Set: SetString("Collection Name")}
+	xmlData, err := xml.MarshalIndent(original, "", "  ")
+	require.NoError(t, err)
+
+	var parsed Movie
+	require.NoError(t, xml.Unmarshal(xmlData, &parsed))
+	assert.Equal(t, original.Set, parsed.Set)
+}
+
+func TestSetString_LegacyRoundTrip(t *testing.T) {
+	legacy := `<movie><title>Legacy</title><set>Legacy Series</set></movie>`
+	var parsed Movie
+	require.NoError(t, xml.Unmarshal([]byte(legacy), &parsed))
+	assert.Equal(t, "Legacy Series", string(parsed.Set))
+
+	remarshaled, err := xml.MarshalIndent(parsed, "", "  ")
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(remarshaled), "<name>Legacy Series</name>"),
+		"remarshaled NFO should use the tiered format even when parsed from legacy flat form")
+}

--- a/internal/nfo/set_test.go
+++ b/internal/nfo/set_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"bytes"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -170,4 +171,44 @@ func TestSetString_WriteNFOEscaping(t *testing.T) {
 	require.NotNil(t, parsed.Movie)
 	assert.Equal(t, `Bob's "Best" <Series> & Co`, parsed.Movie.Series,
 		"set name with special characters must round-trip exactly through WriteNFO+ParseNFO")
+}
+
+func TestSetString_MarshalXMLEmptyDirectCall(t *testing.T) {
+	err := SetString("").MarshalXML(xml.NewEncoder(failingWriter{}), xml.StartElement{Name: xml.Name{Local: "set"}})
+	require.NoError(t, err, "empty SetString returns nil before touching the encoder")
+}
+
+func TestSetString_MarshalXMLEncoderError(t *testing.T) {
+	var s SetString = "Series"
+	// failAfterNWriter{remaining: 0} fails on the first write, so EncodeToken(start)
+	// (which flushes the start element) surfaces its error immediately.
+	err := s.MarshalXML(xml.NewEncoder(&failAfterNWriter{remaining: 0}), xml.StartElement{Name: xml.Name{Local: "set"}})
+	require.Error(t, err, "MarshalXML should surface the EncodeToken(start) write error")
+}
+
+func TestSetString_UnmarshalXMLTokenError(t *testing.T) {
+	var s SetString
+	// After consuming <set>, the trailing "<" is not a valid token, so the
+	// d.Token() call inside UnmarshalXML returns a syntax error.
+	d := xml.NewDecoder(bytes.NewReader([]byte("<set><")))
+	d.Token()
+	err := s.UnmarshalXML(d, xml.StartElement{Name: xml.Name{Local: "set"}})
+	require.Error(t, err, "invalid token input should surface a Token error")
+}
+
+func TestSetString_UnmarshalXMLUnknownChildSkipError(t *testing.T) {
+	var s SetString
+	d := xml.NewDecoder(bytes.NewReader([]byte("<set><bad><nested></name></set>")))
+	d.Token()
+	err := s.UnmarshalXML(d, xml.StartElement{Name: xml.Name{Local: "set"}})
+	require.Error(t, err, "malformed unknown child should surface a Skip error")
+}
+
+func TestSetString_UnmarshalXMLNameDecodeError(t *testing.T) {
+	var s SetString
+	// <name> with a mismatched nested element fails d.DecodeElement.
+	d := xml.NewDecoder(bytes.NewReader([]byte("<set><name><unclosed></name></set>")))
+	d.Token()
+	err := s.UnmarshalXML(d, xml.StartElement{Name: xml.Name{Local: "set"}})
+	require.Error(t, err, "malformed <name> child should surface a DecodeElement error")
 }

--- a/internal/nfo/set_test.go
+++ b/internal/nfo/set_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -64,8 +65,40 @@ func TestSetString_UnmarshalEmptySet(t *testing.T) {
 	assert.Empty(t, movie.Set)
 }
 
-func TestSetString_UnmarshalSkipsUnknownChildren(t *testing.T) {
+func TestSetString_UnmarshalSelfClosingEmptySet(t *testing.T) {
+	xmlStr := `<movie><title>Test</title><set/></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Empty(t, movie.Set)
+}
+
+func TestSetString_UnmarshalUnknownChildrenBeforeName(t *testing.T) {
 	xmlStr := `<movie><set><overview>Extra</overview><name>Real Series</name></set></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Equal(t, "Real Series", string(movie.Set))
+}
+
+func TestSetString_UnmarshalUnknownChildrenAfterName(t *testing.T) {
+	xmlStr := `<movie><set><name>Real Series</name><overview>Extra</overview></set></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Equal(t, "Real Series", string(movie.Set))
+}
+
+func TestSetString_UnmarshalNameWinsOverTrailingChardata(t *testing.T) {
+	xmlStr := `<movie><set><name>Real Series</name>trailing text</set></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Equal(t, "Real Series", string(movie.Set))
+}
+
+func TestSetString_UnmarshalNameWinsOverLeadingChardata(t *testing.T) {
+	xmlStr := `<movie><set>leading text<name>Real Series</name></set></movie>`
 	var movie Movie
 	err := xml.Unmarshal([]byte(xmlStr), &movie)
 	require.NoError(t, err)
@@ -92,4 +125,49 @@ func TestSetString_LegacyRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, strings.Contains(string(remarshaled), "<name>Legacy Series</name>"),
 		"remarshaled NFO should use the tiered format even when parsed from legacy flat form")
+}
+
+func TestSetString_UnmarshalFirstChardataWinsForMixedFlat(t *testing.T) {
+	xmlStr := `<movie><set>abc<overview/>def</set></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", string(movie.Set),
+		"degenerate mixed flat+unknown content: first non-empty chardata wins (deterministic, spec-silent)")
+}
+
+func TestSetString_UnmarshalEmptyNameWinsOverFlat(t *testing.T) {
+	xmlStr := `<movie><set>Flat Collection<name></name></set></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Empty(t, movie.Set,
+		"empty <name> child value wins per spec (name wins regardless of order); degenerate input")
+}
+
+func TestSetString_WriteNFOEscaping(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	gen := NewGenerator(fs, &Config{})
+	nfo := &Movie{
+		Title: "Test",
+		Set:   SetString(`Bob's "Best" <Series> & Co`),
+	}
+
+	err := gen.WriteNFO(nfo, "/test.nfo")
+	require.NoError(t, err)
+
+	data, err := afero.ReadFile(fs, "/test.nfo")
+	require.NoError(t, err)
+	output := string(data)
+
+	assert.Contains(t, output, `<name>Bob's "Best" &lt;Series&gt; &amp; Co</name>`,
+		"set name in <name> chardata: quotes/apostrophes literal (unescaped by unescapeQuotesInText), angle brackets/ampersands escaped")
+	assert.NotContains(t, output, `&#34;`, "double quotes in <name> must not be numeric-escaped")
+	assert.NotContains(t, output, `&#39;`, "apostrophes in <name> must not be numeric-escaped")
+
+	parsed, perr := ParseNFO(fs, "/test.nfo")
+	require.NoError(t, perr)
+	require.NotNil(t, parsed.Movie)
+	assert.Equal(t, `Bob's "Best" <Series> & Co`, parsed.Movie.Series,
+		"set name with special characters must round-trip exactly through WriteNFO+ParseNFO")
 }

--- a/internal/nfo/set_test.go
+++ b/internal/nfo/set_test.go
@@ -128,13 +128,15 @@ func TestSetString_LegacyRoundTrip(t *testing.T) {
 		"remarshaled NFO should use the tiered format even when parsed from legacy flat form")
 }
 
-func TestSetString_UnmarshalFirstChardataWinsForMixedFlat(t *testing.T) {
+func TestSetString_UnmarshalAccumulatesSplitChardata(t *testing.T) {
+	// A legacy flat value split across multiple CharData tokens (here by an
+	// empty unknown child) is accumulated, not truncated to the first token.
 	xmlStr := `<movie><set>abc<overview/>def</set></movie>`
 	var movie Movie
 	err := xml.Unmarshal([]byte(xmlStr), &movie)
 	require.NoError(t, err)
-	assert.Equal(t, "abc", string(movie.Set),
-		"degenerate mixed flat+unknown content: first non-empty chardata wins (deterministic, spec-silent)")
+	assert.Equal(t, "abcdef", string(movie.Set),
+		"split flat chardata should be concatenated, matching plain string unmarshaling")
 }
 
 func TestSetString_UnmarshalEmptyNameWinsOverFlat(t *testing.T) {
@@ -211,4 +213,15 @@ func TestSetString_UnmarshalXMLNameDecodeError(t *testing.T) {
 	d.Token()
 	err := s.UnmarshalXML(d, xml.StartElement{Name: xml.Name{Local: "set"}})
 	require.Error(t, err, "malformed <name> child should surface a DecodeElement error")
+}
+
+func TestSetString_UnmarshalCDATAChardataPreserved(t *testing.T) {
+	// Regression for Codex P2: a legacy flat value split across CharData by a
+	// CDATA section must not be truncated to the first token.
+	xmlStr := `<movie><set>Part 1 <![CDATA[& Part 2]]></set></movie>`
+	var movie Movie
+	err := xml.Unmarshal([]byte(xmlStr), &movie)
+	require.NoError(t, err)
+	assert.Equal(t, "Part 1 & Part 2", string(movie.Set),
+		"chardata split by a CDATA section must be concatenated")
 }

--- a/internal/nfo/testdata/sample_kodi.nfo
+++ b/internal/nfo/testdata/sample_kodi.nfo
@@ -24,7 +24,9 @@
   <studio>IdeaPocket</studio>
   <maker>IdeaPocket</maker>
   <label>IP Premium</label>
-  <set>Beautiful Days Series</set>
+  <set>
+    <name>Beautiful Days Series</name>
+  </set>
   <genre>Beautiful Girl</genre>
   <genre>Featured Actress</genre>
   <genre>Digital Mosaic</genre>

--- a/internal/nfo/transform.go
+++ b/internal/nfo/transform.go
@@ -302,7 +302,7 @@ func (g *Generator) buildNFO(input nfoInput) *Movie {
 		Studio:        input.maker,
 		Maker:         input.maker,
 		Label:         input.label,
-		Set:           input.series,
+		Set:           SetString(input.series),
 	}
 
 	if input.contentID != "" {

--- a/internal/nfo/types.go
+++ b/internal/nfo/types.go
@@ -37,10 +37,10 @@ type Movie struct {
 	Credits  string  `xml:"credits,omitempty"` // Writer/credits
 
 	// Production info
-	Studio string `xml:"studio,omitempty"` // Production studio
-	Maker  string `xml:"maker,omitempty"`  // Custom field for JAV maker
-	Label  string `xml:"label,omitempty"`  // Custom field for JAV label
-	Set    string `xml:"set,omitempty"`    // Series name
+	Studio string    `xml:"studio,omitempty"` // Production studio
+	Maker  string    `xml:"maker,omitempty"`  // Custom field for JAV maker
+	Label  string    `xml:"label,omitempty"`  // Custom field for JAV label
+	Set    SetString `xml:"set,omitempty"`    // Series name (tiered <set><name>...</name></set>)
 
 	// Categories
 	Genres []string `xml:"genre,omitempty"`


### PR DESCRIPTION
## Summary

Closes #190

Media servers (Jellyfin 10.11+, Plex, Emby) require the tiered Kodi 19+ `<set>` structure for automatic collection handling:

```xml
<set>
  <name>Collection Name</name>
</set>
```

instead of the legacy flat `<set>Collection Name</set>` that javinizer currently writes. The flat form is silently ignored by all three servers reported in the issue, so users lose automatic collection grouping.

The tiered format is the [documented Kodi NFO standard](https://kodi.wiki/view/NFO_files/Movies) (`<set>` with `<name>` and optional `<overview>` children), and the Plex NFO agent explicitly "follows the Kodi NFO specification."

This change was planned and reviewed via an OpenSpec change at `openspec/changes/nfo-set-tiered-format/` (proposal, design, specs, tasks) and reviewed by an external LLM before implementation.

## Changes

- **`internal/nfo/set.go`** (new) — Add `SetString`, a named `string` type with:
  - `MarshalXML`: emits the tiered `<set><name>...</name></set>` structure (empty values omitted via `omitempty`).
  - `UnmarshalXML`: accepts **both** the new tiered form and the legacy flat `<set>Name</set>` form, so existing NFOs on disk continue to round-trip. When a `<set>` has both a `<name>` child and bare character data, `<name>` wins **regardless of document order** (order-independent). Unknown child elements (e.g. `<overview>`) are skipped.
- **`internal/nfo/types.go`** — Change the `Set` field from `string` to `SetString`.
- **`internal/nfo/transform.go`** / **`parser.go`** — Convert at the package boundary (`SetString(input.series)` / `string(nfo.Set)`).
- **`testdata/sample_kodi.nfo`** — Updated to the tiered format.
- **`internal/nfo/set_test.go`** (new) — 16 tests covering: tiered marshal output, empty omission, unmarshal of tiered/legacy/whitespace/empty/self-closing, unknown children before/after `<name>`, `<name>`-wins-over-chardata (both orders), degenerate mixed-content (first-chardata-wins, empty-`<name>`-wins), round-trip, legacy→tiered remarshal, and a full `WriteNFO`→`ParseNFO` escaping regression test.

## Design notes

- **No config toggle.** The issue offered "a custom toggle **or** set the default to the new format." The tiered form is the documented Kodi standard and is expected by all current major media servers; the legacy flat form is deprecated and supported only on the read path. Backward compatibility is achieved on the read path, not via an opt-in.
- **Backward compatible.** `UnmarshalXML` reads both forms, so re-scraping a movie whose NFO was written by an older javinizer version still picks up the series name; the regenerated NFO uses the tiered form.
- **No `<overview>` child is written.** javinizer has no set-overview data model; the Kodi-spec `<overview>` child is tolerated on read (skipped as an unknown child).
- **Escaping unchanged.** The set name moves from `<set>` chardata to `<name>` chardata; the existing `unescapeQuotesInText` post-processing (which unescapes `"`/`'` in element text) applies identically, so quoting/escaping behavior is unchanged (verified by a regression test).
- **Minimal API surface.** `SetString` is a named `string` type, so `nfo.Set` stays string-like at the package boundary.
- **No frontend change.** The Settings NFO section has no series/set format field; the review Source Viewer "series" field is format-agnostic; no raw NFO XML preview exists in the UI.

## Verification

- `go test ./internal/nfo/...` — pass (incl. 16 `SetString` tests)
- `go test -short ./internal/workflow/...` — pass (downstream NFO-writing paths)
- `go vet ./internal/nfo/... ./internal/workflow/...` — clean
- `go build ./...` — succeeds
- `gofmt -l internal/nfo/` — clean
- Pre-commit hook (gofmt, vet, test -short, build, swagger) — all passed

## Example output

```xml
<movie>
  <title>Beautiful Day</title>
  <set>
    <name>Beautiful Days Series</name>
  </set>
</movie>
```