### PR TITLE
feat(temp): add server-side image cache for review preview images

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -82,6 +82,8 @@ system:
     # Base directory for temporary files (posters, etc.)
     # Can be overridden with JAVINIZER_TEMP_DIR environment variable
     temp_dir: data/temp
+    image_cache_enabled: true
+    image_cache_ttl_hours: 168
 scrapers:
     user_agent: "" # Default: Chrome UA. r18dev uses Javinizer UA automatically.
     # Referer header for CDN compatibility (required by DMM/R18 CDN)

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -84,6 +84,7 @@ system:
     temp_dir: data/temp
     image_cache_enabled: true
     image_cache_ttl_hours: 168
+    image_cache_max_size_mb: 512
 scrapers:
     user_agent: "" # Default: Chrome UA. r18dev uses Javinizer UA automatically.
     # Referer header for CDN compatibility (required by DMM/R18 CDN)

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -1414,6 +1414,7 @@ system:
   temp_dir: data/temp
   image_cache_enabled: true
   image_cache_ttl_hours: 168
+  image_cache_max_size_mb: 512
 ```
 
 ### NFO Defaults

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -1412,6 +1412,8 @@ system:
   version_check_enabled: true
   version_check_interval_hours: 24
   temp_dir: data/temp
+  image_cache_enabled: true
+  image_cache_ttl_hours: 168
 ```
 
 ### NFO Defaults

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -7123,6 +7123,10 @@ const docTemplate = `{
                     "description": "ImageCacheEnabled controls server-side caching of fetched preview images\nby the /api/v1/temp/image proxy. When true (default), the proxy persists\nfetched image bytes to disk under {tempDir}/image-cache/ so that an image\nfetched once while online remains available when the source is unreachable.",
                     "type": "boolean"
                 },
+                "image_cache_max_size_mb": {
+                    "description": "ImageCacheMaxSizeMB bounds the total on-disk size of the preview image cache\nin megabytes (default: 512). Once a commit pushes the cache over the limit,\nthe oldest entries are evicted. 0 disables the quota.",
+                    "type": "integer"
+                },
                 "image_cache_ttl_hours": {
                     "description": "ImageCacheTTLHours is the cache entry lifetime in hours (default: 168 = 7 days).\nThe cap (\u003c=87600) is enforced unconditionally because the unconditional sweep\ncomputes a time.Duration from it even when caching is disabled. When enabled,\nmust be \u003e= 1; when disabled, 0 is legal (sweep no-op).",
                     "type": "integer"

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3665,7 +3665,7 @@ const docTemplate = `{
         },
         "/api/v1/temp/image": {
             "get": {
-                "description": "Proxies remote images for preview UI, handling hotlink protection and CORS issues.",
+                "description": "Proxies remote images for preview UI, handling hotlink protection and CORS issues. When image caching is enabled, fetched images are persisted server-side with stale-if-error semantics.",
                 "tags": [
                     "temp"
                 ],
@@ -3688,6 +3688,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse"
                         }
@@ -7113,6 +7119,14 @@ const docTemplate = `{
         "github_com_javinizer_javinizer-go_internal_config.SystemConfig": {
             "type": "object",
             "properties": {
+                "image_cache_enabled": {
+                    "description": "ImageCacheEnabled controls server-side caching of fetched preview images\nby the /api/v1/temp/image proxy. When true (default), the proxy persists\nfetched image bytes to disk under {tempDir}/image-cache/ so that an image\nfetched once while online remains available when the source is unreachable.",
+                    "type": "boolean"
+                },
+                "image_cache_ttl_hours": {
+                    "description": "ImageCacheTTLHours is the cache entry lifetime in hours (default: 168 = 7 days).\nThe cap (\u003c=87600) is enforced unconditionally because the unconditional sweep\ncomputes a time.Duration from it even when caching is disabled. When enabled,\nmust be \u003e= 1; when disabled, 0 is legal (sweep no-op).",
+                    "type": "integer"
+                },
                 "temp_dir": {
                     "description": "TempDir is the base directory for temporary files (default: \"data/temp\").\nCan be overridden with JAVINIZER_TEMP_DIR environment variable.\nSubdirectory \"posters/{jobID}\" is created for batch job temp posters.",
                     "type": "string"

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -7121,6 +7121,10 @@
                     "description": "ImageCacheEnabled controls server-side caching of fetched preview images\nby the /api/v1/temp/image proxy. When true (default), the proxy persists\nfetched image bytes to disk under {tempDir}/image-cache/ so that an image\nfetched once while online remains available when the source is unreachable.",
                     "type": "boolean"
                 },
+                "image_cache_max_size_mb": {
+                    "description": "ImageCacheMaxSizeMB bounds the total on-disk size of the preview image cache\nin megabytes (default: 512). Once a commit pushes the cache over the limit,\nthe oldest entries are evicted. 0 disables the quota.",
+                    "type": "integer"
+                },
                 "image_cache_ttl_hours": {
                     "description": "ImageCacheTTLHours is the cache entry lifetime in hours (default: 168 = 7 days).\nThe cap (\u003c=87600) is enforced unconditionally because the unconditional sweep\ncomputes a time.Duration from it even when caching is disabled. When enabled,\nmust be \u003e= 1; when disabled, 0 is legal (sweep no-op).",
                     "type": "integer"

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3663,7 +3663,7 @@
         },
         "/api/v1/temp/image": {
             "get": {
-                "description": "Proxies remote images for preview UI, handling hotlink protection and CORS issues.",
+                "description": "Proxies remote images for preview UI, handling hotlink protection and CORS issues. When image caching is enabled, fetched images are persisted server-side with stale-if-error semantics.",
                 "tags": [
                     "temp"
                 ],
@@ -3686,6 +3686,12 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse"
                         }
@@ -7111,6 +7117,14 @@
         "github_com_javinizer_javinizer-go_internal_config.SystemConfig": {
             "type": "object",
             "properties": {
+                "image_cache_enabled": {
+                    "description": "ImageCacheEnabled controls server-side caching of fetched preview images\nby the /api/v1/temp/image proxy. When true (default), the proxy persists\nfetched image bytes to disk under {tempDir}/image-cache/ so that an image\nfetched once while online remains available when the source is unreachable.",
+                    "type": "boolean"
+                },
+                "image_cache_ttl_hours": {
+                    "description": "ImageCacheTTLHours is the cache entry lifetime in hours (default: 168 = 7 days).\nThe cap (\u003c=87600) is enforced unconditionally because the unconditional sweep\ncomputes a time.Duration from it even when caching is disabled. When enabled,\nmust be \u003e= 1; when disabled, 0 is legal (sweep no-op).",
+                    "type": "integer"
+                },
                 "temp_dir": {
                     "description": "TempDir is the base directory for temporary files (default: \"data/temp\").\nCan be overridden with JAVINIZER_TEMP_DIR environment variable.\nSubdirectory \"posters/{jobID}\" is created for batch job temp posters.",
                     "type": "string"

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2119,6 +2119,12 @@ definitions:
           fetched image bytes to disk under {tempDir}/image-cache/ so that an image
           fetched once while online remains available when the source is unreachable.
         type: boolean
+      image_cache_max_size_mb:
+        description: |-
+          ImageCacheMaxSizeMB bounds the total on-disk size of the preview image cache
+          in megabytes (default: 512). Once a commit pushes the cache over the limit,
+          the oldest entries are evicted. 0 disables the quota.
+        type: integer
       image_cache_ttl_hours:
         description: |-
           ImageCacheTTLHours is the cache entry lifetime in hours (default: 168 = 7 days).

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2112,6 +2112,20 @@ definitions:
     type: object
   github_com_javinizer_javinizer-go_internal_config.SystemConfig:
     properties:
+      image_cache_enabled:
+        description: |-
+          ImageCacheEnabled controls server-side caching of fetched preview images
+          by the /api/v1/temp/image proxy. When true (default), the proxy persists
+          fetched image bytes to disk under {tempDir}/image-cache/ so that an image
+          fetched once while online remains available when the source is unreachable.
+        type: boolean
+      image_cache_ttl_hours:
+        description: |-
+          ImageCacheTTLHours is the cache entry lifetime in hours (default: 168 = 7 days).
+          The cap (<=87600) is enforced unconditionally because the unconditional sweep
+          computes a time.Duration from it even when caching is disabled. When enabled,
+          must be >= 1; when disabled, 0 is legal (sweep no-op).
+        type: integer
       temp_dir:
         description: |-
           TempDir is the base directory for temporary files (default: "data/temp").
@@ -5758,7 +5772,8 @@ paths:
   /api/v1/temp/image:
     get:
       description: Proxies remote images for preview UI, handling hotlink protection
-        and CORS issues.
+        and CORS issues. When image caching is enabled, fetched images are persisted
+        server-side with stale-if-error semantics.
       parameters:
       - description: Image URL
         in: query
@@ -5772,6 +5787,10 @@ paths:
             type: file
         "400":
           description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse'
+        "403":
+          description: Forbidden
           schema:
             $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_api_contracts.ErrorResponse'
         "502":

--- a/internal/api/core/bootstrap.go
+++ b/internal/api/core/bootstrap.go
@@ -88,6 +88,8 @@ func bootstrapAPIDeps(cfg *config.Config, configFile string, auth commandutil.Au
 	// Bound to rt.ServerCtx() so it stops cleanly on rt.Shutdown().
 	startUpdateChecker(rt, cfg, update.ServiceOptions{})
 
+	startImageCacheCleanup(rt, imageCacheCleanupOptions{})
+
 	// Temp poster cleanup is intentionally NOT started automatically.
 	// Running CleanupStaleTempDirs on startup (or on a periodic ticker) wipes
 	// temp poster artifacts for terminal/orphaned jobs, but the DB still holds

--- a/internal/api/core/config_narrowing.go
+++ b/internal/api/core/config_narrowing.go
@@ -60,6 +60,8 @@ type APIConfig struct {
 	// System
 	TempDir             string // cfg.System.TempDir
 	VersionCheckEnabled bool   // cfg.System.VersionCheckEnabled
+	ImageCacheEnabled   bool   // cfg.System.ImageCacheEnabled
+	ImageCacheTTLHours  int    // cfg.System.ImageCacheTTLHours
 
 	// Logging
 	LogLevel string // cfg.Logging.Level
@@ -109,9 +111,11 @@ type ScannerNarrowConfig struct {
 // TempNarrowConfig holds the fields consumed by temp handlers that serve
 // ephemeral poster images and proxy remote images for the preview UI.
 type TempNarrowConfig struct {
-	TempDir          string // temp directory for batch artifacts
-	ScraperUserAgent string // user-agent for proxied image requests
-	ScraperReferer   string // referer for proxied image requests
+	TempDir            string // temp directory for batch artifacts
+	ScraperUserAgent   string // user-agent for proxied image requests
+	ScraperReferer     string // referer for proxied image requests
+	ImageCacheEnabled  bool   // server-side image cache on/off
+	ImageCacheTTLHours int    // cache TTL in hours
 }
 
 // MatcherNarrowConfig holds the fields consumed by the runtime manager
@@ -166,9 +170,11 @@ func (c APIConfig) ScannerConfig() *ScannerNarrowConfig {
 // that serve ephemeral poster images and proxy remote images.
 func (c APIConfig) TempConfig() *TempNarrowConfig {
 	return &TempNarrowConfig{
-		TempDir:          c.TempDir,
-		ScraperUserAgent: c.ScraperUserAgent,
-		ScraperReferer:   c.ScraperReferer,
+		TempDir:            c.TempDir,
+		ScraperUserAgent:   c.ScraperUserAgent,
+		ScraperReferer:     c.ScraperReferer,
+		ImageCacheEnabled:  c.ImageCacheEnabled,
+		ImageCacheTTLHours: c.ImageCacheTTLHours,
 	}
 }
 
@@ -202,6 +208,7 @@ func (c APIConfig) MatcherConfig() *MatcherNarrowConfig {
 // cfg.Scrapers.RequestTimeoutSeconds,
 // cfg.Matching.RegexEnabled, cfg.Matching.RegexPattern,
 // cfg.System.TempDir, cfg.System.VersionCheckEnabled,
+// cfg.System.ImageCacheEnabled, cfg.System.ImageCacheTTLHours,
 // cfg.Logging.Level, cfg.Database.DSN, cfg.Database.LogLevel
 func ConfigFromAppConfig(cfg *config.Config) APIConfig {
 	if cfg == nil {
@@ -241,6 +248,8 @@ func ConfigFromAppConfig(cfg *config.Config) APIConfig {
 		RegexPattern:        cfg.Matching.RegexPattern,
 		TempDir:             cfg.System.TempDir,
 		VersionCheckEnabled: cfg.System.VersionCheckEnabled,
+		ImageCacheEnabled:   cfg.System.ImageCacheEnabled,
+		ImageCacheTTLHours:  cfg.System.ImageCacheTTLHours,
 		LogLevel:            cfg.Logging.Level,
 		DatabaseDSN:         cfg.Database.DSN,
 		DatabaseLogLevel:    cfg.Database.LogLevel,

--- a/internal/api/core/config_narrowing.go
+++ b/internal/api/core/config_narrowing.go
@@ -62,6 +62,7 @@ type APIConfig struct {
 	VersionCheckEnabled bool   // cfg.System.VersionCheckEnabled
 	ImageCacheEnabled   bool   // cfg.System.ImageCacheEnabled
 	ImageCacheTTLHours  int    // cfg.System.ImageCacheTTLHours
+	ImageCacheMaxSizeMB int    // cfg.System.ImageCacheMaxSizeMB
 
 	// Logging
 	LogLevel string // cfg.Logging.Level
@@ -111,11 +112,12 @@ type ScannerNarrowConfig struct {
 // TempNarrowConfig holds the fields consumed by temp handlers that serve
 // ephemeral poster images and proxy remote images for the preview UI.
 type TempNarrowConfig struct {
-	TempDir            string // temp directory for batch artifacts
-	ScraperUserAgent   string // user-agent for proxied image requests
-	ScraperReferer     string // referer for proxied image requests
-	ImageCacheEnabled  bool   // server-side image cache on/off
-	ImageCacheTTLHours int    // cache TTL in hours
+	TempDir             string // temp directory for batch artifacts
+	ScraperUserAgent    string // user-agent for proxied image requests
+	ScraperReferer      string // referer for proxied image requests
+	ImageCacheEnabled   bool   // server-side image cache on/off
+	ImageCacheTTLHours  int    // cache TTL in hours
+	ImageCacheMaxSizeMB int    // image cache disk quota in MB (0 disables)
 }
 
 // MatcherNarrowConfig holds the fields consumed by the runtime manager
@@ -170,11 +172,12 @@ func (c APIConfig) ScannerConfig() *ScannerNarrowConfig {
 // that serve ephemeral poster images and proxy remote images.
 func (c APIConfig) TempConfig() *TempNarrowConfig {
 	return &TempNarrowConfig{
-		TempDir:            c.TempDir,
-		ScraperUserAgent:   c.ScraperUserAgent,
-		ScraperReferer:     c.ScraperReferer,
-		ImageCacheEnabled:  c.ImageCacheEnabled,
-		ImageCacheTTLHours: c.ImageCacheTTLHours,
+		TempDir:             c.TempDir,
+		ScraperUserAgent:    c.ScraperUserAgent,
+		ScraperReferer:      c.ScraperReferer,
+		ImageCacheEnabled:   c.ImageCacheEnabled,
+		ImageCacheTTLHours:  c.ImageCacheTTLHours,
+		ImageCacheMaxSizeMB: c.ImageCacheMaxSizeMB,
 	}
 }
 
@@ -209,6 +212,7 @@ func (c APIConfig) MatcherConfig() *MatcherNarrowConfig {
 // cfg.Matching.RegexEnabled, cfg.Matching.RegexPattern,
 // cfg.System.TempDir, cfg.System.VersionCheckEnabled,
 // cfg.System.ImageCacheEnabled, cfg.System.ImageCacheTTLHours,
+// cfg.System.ImageCacheMaxSizeMB,
 // cfg.Logging.Level, cfg.Database.DSN, cfg.Database.LogLevel
 func ConfigFromAppConfig(cfg *config.Config) APIConfig {
 	if cfg == nil {
@@ -250,6 +254,7 @@ func ConfigFromAppConfig(cfg *config.Config) APIConfig {
 		VersionCheckEnabled: cfg.System.VersionCheckEnabled,
 		ImageCacheEnabled:   cfg.System.ImageCacheEnabled,
 		ImageCacheTTLHours:  cfg.System.ImageCacheTTLHours,
+		ImageCacheMaxSizeMB: cfg.System.ImageCacheMaxSizeMB,
 		LogLevel:            cfg.Logging.Level,
 		DatabaseDSN:         cfg.Database.DSN,
 		DatabaseLogLevel:    cfg.Database.LogLevel,

--- a/internal/api/core/image_cache_cleaner.go
+++ b/internal/api/core/image_cache_cleaner.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/javinizer/javinizer-go/internal/worker"
+)
+
+type imageCacheCleanupOptions struct {
+	interval time.Duration
+}
+
+func startImageCacheCleanup(rt *APIRuntime, opts imageCacheCleanupOptions) {
+	interval := opts.interval
+	if interval <= 0 {
+		interval = 24 * time.Hour
+	}
+
+	ctx := rt.ServerCtx()
+
+	sweep := func() {
+		tempCfg := rt.GetAPIConfig().TempConfig()
+		ttl := time.Duration(tempCfg.ImageCacheTTLHours) * time.Hour
+		if ttl <= 0 {
+			return
+		}
+		fs := rt.Deps().GetFs()
+		removed, err := worker.CleanupStaleImageCache(fs, tempCfg.TempDir, ttl)
+		if err != nil {
+			logging.Warnf("Image cache cleanup failed: %v", err)
+		} else if removed > 0 {
+			logging.Infof("Cleaned up %d expired image cache entr(ies)", removed)
+		}
+	}
+
+	go sweep()
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				sweep()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}

--- a/internal/api/core/image_cache_cleaner.go
+++ b/internal/api/core/image_cache_cleaner.go
@@ -32,6 +32,13 @@ func startImageCacheCleanup(rt *APIRuntime, opts imageCacheCleanupOptions) {
 		} else if removed > 0 {
 			logging.Infof("Cleaned up %d expired image cache entr(ies)", removed)
 		}
+		if tempCfg.ImageCacheMaxSizeMB > 0 {
+			if _, evicted, verr := worker.EvictImageCacheToSize(fs, tempCfg.TempDir, int64(tempCfg.ImageCacheMaxSizeMB)<<20); verr != nil {
+				logging.Warnf("Image cache size enforcement failed: %v", verr)
+			} else if evicted > 0 {
+				logging.Infof("Evicted %d image cache entr(ies) to enforce the %d MB quota", evicted, tempCfg.ImageCacheMaxSizeMB)
+			}
+		}
 	}
 
 	go sweep()

--- a/internal/api/core/image_cache_cleaner_error_test.go
+++ b/internal/api/core/image_cache_cleaner_error_test.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"errors"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+type cacheRootOpenFailFs struct {
+	afero.Fs
+	root  string
+	calls *int32
+}
+
+func (f *cacheRootOpenFailFs) Open(name string) (afero.File, error) {
+	if name == f.root {
+		atomic.AddInt32(f.calls, 1)
+		return nil, errors.New("root unreadable")
+	}
+	return f.Fs.Open(name)
+}
+
+func TestStartImageCacheCleanup_CleanupErrorLogged(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 1
+	cfg.System.TempDir = t.TempDir()
+
+	var calls int32
+	fs := &cacheRootOpenFailFs{
+		Fs:    afero.NewMemMapFs(),
+		root:  filepath.Join(cfg.System.TempDir, "image-cache"),
+		calls: &calls,
+	}
+
+	deps := &APIDeps{Fs: fs}
+	rt := NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+
+	startImageCacheCleanup(rt, imageCacheCleanupOptions{interval: time.Hour})
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&calls) > 0
+	}, 2*time.Second, 5*time.Millisecond, "startup sweep should attempt to read the image-cache root")
+	rt.Shutdown()
+}

--- a/internal/api/core/image_cache_cleaner_test.go
+++ b/internal/api/core/image_cache_cleaner_test.go
@@ -55,7 +55,7 @@ func TestStartImageCacheCleanup_RemovesExpiredEntries(t *testing.T) {
 	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
 	expired := shardDir + "/deadbeef1234.jpg"
 	require.NoError(t, afero.WriteFile(fs, expired, []byte("old"), 0o644))
-	pastTime := time.Now().Add(-200 * time.Hour)
+	pastTime := time.Now().Add(-400 * time.Hour)
 	require.NoError(t, fs.Chtimes(expired, pastTime, pastTime))
 
 	deps := &APIDeps{Fs: fs}

--- a/internal/api/core/image_cache_cleaner_test.go
+++ b/internal/api/core/image_cache_cleaner_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartImageCacheCleanupCtxCancel(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 168
+	cfg.System.TempDir = t.TempDir()
+	fs := afero.NewMemMapFs()
+	deps := &APIDeps{Fs: fs}
+	rt := NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+
+	startImageCacheCleanup(rt, imageCacheCleanupOptions{interval: 100 * time.Millisecond})
+	time.Sleep(200 * time.Millisecond)
+
+	rt.Shutdown()
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestStartImageCacheCleanupNoopOnTTLZero(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
+	cfg.System.ImageCacheTTLHours = 0
+	cfg.System.TempDir = t.TempDir()
+	fs := afero.NewMemMapFs()
+	deps := &APIDeps{Fs: fs}
+	rt := NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+
+	startImageCacheCleanup(rt, imageCacheCleanupOptions{interval: 100 * time.Millisecond})
+	time.Sleep(150 * time.Millisecond)
+
+	rt.Shutdown()
+}
+
+func TestStartImageCacheCleanup_RemovesExpiredEntries(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 168
+	cfg.System.TempDir = t.TempDir()
+	fs := afero.NewMemMapFs()
+
+	// Pre-populate the cache with an expired entry
+	shardDir := cfg.System.TempDir + "/image-cache/ab"
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	expired := shardDir + "/deadbeef1234.jpg"
+	require.NoError(t, afero.WriteFile(fs, expired, []byte("old"), 0o644))
+	pastTime := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(expired, pastTime, pastTime))
+
+	deps := &APIDeps{Fs: fs}
+	rt := NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+
+	startImageCacheCleanup(rt, imageCacheCleanupOptions{interval: 100 * time.Millisecond})
+	time.Sleep(250 * time.Millisecond)
+	rt.Shutdown()
+
+	exists, _ := afero.Exists(fs, expired)
+	assert.False(t, exists, "expired entry should be removed by startup sweep")
+}
+
+func TestStartImageCacheCleanup_PreservesFreshEntries(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 168
+	cfg.System.TempDir = t.TempDir()
+	fs := afero.NewMemMapFs()
+
+	shardDir := cfg.System.TempDir + "/image-cache/cd"
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	fresh := shardDir + "/deadbeef5678.png"
+	require.NoError(t, afero.WriteFile(fs, fresh, []byte("new"), 0o644))
+
+	deps := &APIDeps{Fs: fs}
+	rt := NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+
+	startImageCacheCleanup(rt, imageCacheCleanupOptions{interval: 100 * time.Millisecond})
+	time.Sleep(150 * time.Millisecond)
+	rt.Shutdown()
+
+	exists, _ := afero.Exists(fs, fresh)
+	assert.True(t, exists, "fresh entry should be preserved")
+}

--- a/internal/api/core/image_cache_cleaner_test.go
+++ b/internal/api/core/image_cache_cleaner_test.go
@@ -93,3 +93,36 @@ func TestStartImageCacheCleanup_PreservesFreshEntries(t *testing.T) {
 	exists, _ := afero.Exists(fs, fresh)
 	assert.True(t, exists, "fresh entry should be preserved")
 }
+
+func TestStartImageCacheCleanup_EvictsOverQuotaEntries(t *testing.T) {
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 168
+	cfg.System.ImageCacheMaxSizeMB = 1
+	cfg.System.TempDir = t.TempDir()
+	fs := afero.NewMemMapFs()
+
+	payload := make([]byte, 700_000)
+	oldest := cfg.System.TempDir + "/image-cache/ab/old.jpg"
+	require.NoError(t, fs.MkdirAll(cfg.System.TempDir+"/image-cache/ab", 0o755))
+	require.NoError(t, afero.WriteFile(fs, oldest, payload, 0o644))
+	past := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, fs.Chtimes(oldest, past, past))
+	newest := cfg.System.TempDir + "/image-cache/cd/new.jpg"
+	require.NoError(t, fs.MkdirAll(cfg.System.TempDir+"/image-cache/cd", 0o755))
+	require.NoError(t, afero.WriteFile(fs, newest, payload, 0o644))
+
+	deps := &APIDeps{Fs: fs}
+	rt := NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+
+	startImageCacheCleanup(rt, imageCacheCleanupOptions{interval: time.Hour})
+	require.Eventually(t, func() bool {
+		exists, _ := afero.Exists(fs, oldest)
+		return !exists
+	}, 2*time.Second, 10*time.Millisecond, "startup sweep must evict the oldest entry to enforce the size quota")
+	rt.Shutdown()
+
+	exists, _ := afero.Exists(fs, newest)
+	assert.True(t, exists, "the newest entry survives")
+}

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -261,7 +261,7 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 			if _, err := io.Copy(c.Writer, cachedFile); err != nil {
 				c.AbortWithStatus(http.StatusBadGateway)
 			}
-			evictImageCacheToSize(fs, cacheDir, tempCfg.ImageCacheMaxSizeMB)
+			evictImageCacheToSize(fs, cacheDir, tempCfg.ImageCacheMaxSizeMB, result.cachedPath)
 			return
 		}
 

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -1,6 +1,7 @@
 package temp
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -177,11 +178,15 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 		keyURL.Fragment = ""
 		keyURL.RawQuery = keyURL.Query().Encode()
 		normalizedURL := keyURL.String()
-		file, contentType, state := get(fs, cacheDir, normalizedURL, ttl)
+		file, contentType, remaining, state := get(fs, cacheDir, normalizedURL, ttl)
 		if state == CacheFresh {
 			defer func() { _ = file.Close() }()
+			maxAge := int64(remaining.Seconds())
+			if maxAge > 86400 {
+				maxAge = 86400
+			}
 			c.Header("Content-Type", contentType)
-			c.Header("Cache-Control", "private, max-age=86400")
+			c.Header("Cache-Control", fmt.Sprintf("private, max-age=%d", maxAge))
 			c.Header("X-Content-Type-Options", "nosniff")
 			if _, err := io.Copy(c.Writer, file); err != nil {
 				c.AbortWithStatus(http.StatusBadGateway)

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -189,18 +189,18 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		var stalePath string
+		var staleFile afero.File
 		var staleCT string
 		if state == CacheStale {
-			shardDir, hashPrefix := pathFor(cacheDir, normalizedURL)
-			staleExt := ""
-			stalePath, staleExt, _ = resolveEntry(fs, shardDir, hashPrefix)
-			staleCT = contentTypeForExt(staleExt)
-			_ = file.Close()
+			staleFile = file
+			staleCT = contentType
+		}
+		if staleFile != nil {
+			defer func() { _ = staleFile.Close() }()
 		}
 
 		if err := ssrf.CheckURL(rawURL); err != nil {
-			if stalePath != "" && tryServeStale(c, fs, stalePath, staleCT) {
+			if staleFile != nil && serveStaleFile(c, staleFile, staleCT) {
 				return
 			}
 			c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
@@ -235,7 +235,7 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 				c.Data(http.StatusOK, result.contentType, result.body)
 				return
 			}
-			if stalePath != "" && tryServeStale(c, fs, stalePath, staleCT) {
+			if staleFile != nil && serveStaleFile(c, staleFile, staleCT) {
 				return
 			}
 			if result.persistFailed {
@@ -273,17 +273,12 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 	}
 }
 
-func tryServeStale(c *gin.Context, fs afero.Fs, path, contentType string) bool {
-	f, err := fs.Open(path)
-	if err != nil {
-		return false
-	}
-	defer func() { _ = f.Close() }()
+func serveStaleFile(c *gin.Context, f afero.File, contentType string) bool {
 	c.Header("Content-Type", contentType)
 	c.Header("Cache-Control", "no-cache")
 	c.Header("X-Content-Type-Options", "nosniff")
 	if _, err := io.Copy(c.Writer, f); err != nil {
-		logging.Warnf("image cache: failed to serve stale entry %s: %v", path, err)
+		logging.Warnf("image cache: failed to serve stale entry: %v", err)
 		return false
 	}
 	return true

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -261,6 +261,7 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 			if _, err := io.Copy(c.Writer, cachedFile); err != nil {
 				c.AbortWithStatus(http.StatusBadGateway)
 			}
+			evictImageCacheToSize(fs, cacheDir, tempCfg.ImageCacheMaxSizeMB)
 			return
 		}
 

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -215,7 +215,7 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 		httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
 
 		v, ferr, _ := imageCacheGroup.Do(normalizedURL, func() (any, error) {
-			res := fetchAndCache(c.Request.Context(), fs, cacheDir, normalizedURL, fetchURL, httpClient, userAgent, referer)
+			res := fetchAndCache(c.Request.Context(), fs, cacheDir, normalizedURL, fetchURL, httpClient, userAgent, referer, tempCfg.ImageCacheMaxSizeMB)
 			if res.persistFailed && len(res.body) == 0 {
 				body, mediaType, berr := fetchBodyToMemory(c.Request.Context(), httpClient, fetchURL, userAgent, referer)
 				if berr == nil {
@@ -261,7 +261,6 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 			if _, err := io.Copy(c.Writer, cachedFile); err != nil {
 				c.AbortWithStatus(http.StatusBadGateway)
 			}
-			evictImageCacheToSize(fs, cacheDir, tempCfg.ImageCacheMaxSizeMB, result.cachedPath)
 			return
 		}
 

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -216,10 +216,11 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 
 		v, ferr, _ := imageCacheGroup.Do(normalizedURL, func() (any, error) {
 			res := fetchAndCache(c.Request.Context(), fs, cacheDir, normalizedURL, fetchURL, httpClient, userAgent, referer)
-			if res.persistFailed {
-				body, berr := fetchBodyToMemory(c.Request.Context(), httpClient, fetchURL, userAgent, referer)
+			if res.persistFailed && len(res.body) == 0 {
+				body, mediaType, berr := fetchBodyToMemory(c.Request.Context(), httpClient, fetchURL, userAgent, referer)
 				if berr == nil {
 					res.body = body
+					res.contentType = mediaType
 				}
 			}
 			return res, nil
@@ -263,20 +264,10 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		if result.tempPath != "" {
-			c.Header("Content-Type", result.contentType)
+		if len(result.body) > 0 {
 			c.Header("Cache-Control", "private, max-age=300")
 			c.Header("X-Content-Type-Options", "nosniff")
-			tempFile, openErr := fs.Open(result.tempPath)
-			if openErr != nil {
-				c.JSON(http.StatusBadGateway, gin.H{"error": "failed to open fetched image"})
-				return
-			}
-			defer func() { _ = tempFile.Close() }()
-			if _, err := io.Copy(c.Writer, tempFile); err != nil {
-				c.AbortWithStatus(http.StatusBadGateway)
-			}
-			return
+			c.Data(http.StatusOK, result.contentType, result.body)
 		}
 	}
 }

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -215,7 +215,14 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 		httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
 
 		v, ferr, _ := imageCacheGroup.Do(normalizedURL, func() (any, error) {
-			return fetchAndCache(c.Request.Context(), fs, cacheDir, normalizedURL, fetchURL, httpClient, userAgent, referer), nil
+			res := fetchAndCache(c.Request.Context(), fs, cacheDir, normalizedURL, fetchURL, httpClient, userAgent, referer)
+			if res.persistFailed {
+				body, berr := fetchBodyToMemory(c.Request.Context(), httpClient, fetchURL, userAgent, referer)
+				if berr == nil {
+					res.body = body
+				}
+			}
+			return res, nil
 		})
 		result := v.(fetchResult)
 		_ = ferr
@@ -225,8 +232,14 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 				return
 			}
 			if result.persistFailed {
-				logging.Warnf("image cache: persist failed for %s: %v, falling back to uncached", normalizedURL, result.err)
-				serveTempImageUncached(c, tempCfg, fetchURL, rawURL)
+				if len(result.body) > 0 {
+					c.Header("Cache-Control", "private, max-age=300")
+					c.Header("X-Content-Type-Options", "nosniff")
+					c.Data(http.StatusOK, result.contentType, result.body)
+					return
+				}
+				logging.Warnf("image cache: persist failed for %s: %v", normalizedURL, result.err)
+				c.JSON(http.StatusBadGateway, gin.H{"error": "failed to fetch image"})
 				return
 			}
 			logging.Warnf("image cache: fetch failed for %s: %v", normalizedURL, result.err)
@@ -329,6 +342,7 @@ func serveTempImageUncached(c *gin.Context, tempCfg *core.TempNarrowConfig, down
 
 	c.Header("Content-Type", contentType)
 	c.Header("Cache-Control", "private, max-age=300")
+	c.Header("X-Content-Type-Options", "nosniff")
 
 	if _, err := io.Copy(c.Writer, io.LimitReader(resp.Body, maxImageProxyResponseSize)); err != nil {
 		c.AbortWithStatus(http.StatusBadGateway)

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -176,7 +176,6 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 		fetchURL := parsedURL.String()
 		keyURL := *parsedURL
 		keyURL.Fragment = ""
-		keyURL.RawQuery = keyURL.Query().Encode()
 		normalizedURL := keyURL.String()
 		file, contentType, remaining, state := get(fs, cacheDir, normalizedURL, ttl)
 		if state == CacheFresh {

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -239,11 +239,11 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 				return
 			}
 			if result.persistFailed {
-				logging.Warnf("image cache: persist failed for %s: %v", normalizedURL, result.err)
+				logging.Warnf("image cache: persist failed for %s: %v", redactImageURL(normalizedURL), result.err)
 				c.JSON(http.StatusBadGateway, gin.H{"error": "failed to fetch image"})
 				return
 			}
-			logging.Warnf("image cache: fetch failed for %s: %v", normalizedURL, result.err)
+			logging.Warnf("image cache: fetch failed for %s: %v", redactImageURL(normalizedURL), result.err)
 			c.JSON(http.StatusBadGateway, gin.H{"error": "failed to fetch image"})
 			return
 		}
@@ -366,4 +366,15 @@ func cacheControlForTTL(remaining time.Duration) string {
 		maxAge = 86400
 	}
 	return fmt.Sprintf("private, max-age=%d", maxAge)
+}
+
+func redactImageURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "<invalid-url>"
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.ForceQuery = false
+	return u.String()
 }

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -265,8 +265,6 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 			}
 			return
 		}
-
-		c.JSON(http.StatusBadGateway, gin.H{"error": "image fetch failed"})
 	}
 }
 

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -180,12 +180,8 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 		file, contentType, remaining, state := get(fs, cacheDir, normalizedURL, ttl)
 		if state == CacheFresh {
 			defer func() { _ = file.Close() }()
-			maxAge := int64(remaining.Seconds())
-			if maxAge > 86400 {
-				maxAge = 86400
-			}
 			c.Header("Content-Type", contentType)
-			c.Header("Cache-Control", fmt.Sprintf("private, max-age=%d", maxAge))
+			c.Header("Cache-Control", cacheControlForTTL(remaining))
 			c.Header("X-Content-Type-Options", "nosniff")
 			if _, err := io.Copy(c.Writer, file); err != nil {
 				c.AbortWithStatus(http.StatusBadGateway)
@@ -240,7 +236,7 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 
 		if result.cachedPath != "" {
 			c.Header("Content-Type", result.contentType)
-			c.Header("Cache-Control", "private, max-age=86400")
+			c.Header("Cache-Control", cacheControlForTTL(ttl))
 			c.Header("X-Content-Type-Options", "nosniff")
 			cachedFile, openErr := fs.Open(result.cachedPath)
 			if openErr != nil {
@@ -357,4 +353,12 @@ func isSafePathSegment(s string) bool {
 		return false
 	}
 	return s == filepath.Base(s)
+}
+
+func cacheControlForTTL(remaining time.Duration) string {
+	maxAge := int64(remaining.Seconds())
+	if maxAge > 86400 {
+		maxAge = 86400
+	}
+	return fmt.Sprintf("private, max-age=%d", maxAge)
 }

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -14,7 +14,9 @@ import (
 	"github.com/javinizer/javinizer-go/internal/api/core"
 	"github.com/javinizer/javinizer-go/internal/config"
 	"github.com/javinizer/javinizer-go/internal/httpclient"
+	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/ssrf"
+	"github.com/spf13/afero"
 )
 
 // serveTempPoster serves temporarily cropped posters from the configured temp directory.
@@ -131,13 +133,17 @@ func serveCroppedPoster() gin.HandlerFunc {
 
 // serveTempImage proxies remote images for preview UI.
 // This is used for hotlink-protected sources (e.g., JavBus) where direct browser loads may return 403.
+// When server-side image caching is enabled (system.image_cache_enabled), fetched images are persisted
+// to disk under {temp_dir}/image-cache/ so they remain available when the source is unreachable.
+// Stale-if-error: an expired entry whose re-fetch fails is served from disk rather than erroring.
 // @Router /api/v1/temp/image [get]
 // @Summary Proxy remote images
-// @Description Proxies remote images for preview UI, handling hotlink protection and CORS issues.
+// @Description Proxies remote images for preview UI, handling hotlink protection and CORS issues. When image caching is enabled, fetched images are persisted server-side with stale-if-error semantics.
 // @Tags temp
 // @Param url query string true "Image URL"
 // @Success 200 {file} binary
 // @Failure 400 {object} contracts.ErrorResponse
+// @Failure 403 {object} contracts.ErrorResponse
 // @Failure 502 {object} contracts.ErrorResponse
 func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -156,16 +162,48 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
-		if err := ssrf.CheckURL(rawURL); err != nil {
-			c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		cacheEnabled := tempCfg.ImageCacheEnabled && tempCfg.ImageCacheTTLHours > 0
+		if !cacheEnabled {
+			serveTempImageUncached(c, tempCfg, parsedURL.String(), rawURL)
 			return
 		}
 
-		httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
+		fs := rt.Deps().GetFs()
+		cacheDir := tempCfg.TempDir
+		ttl := time.Duration(tempCfg.ImageCacheTTLHours) * time.Hour
 
-		req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, parsedURL.String(), nil)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to create request"})
+		fetchURL := parsedURL.String()
+		keyURL := *parsedURL
+		keyURL.Fragment = ""
+		keyURL.RawQuery = keyURL.Query().Encode()
+		normalizedURL := keyURL.String()
+		file, contentType, state := get(fs, cacheDir, normalizedURL, ttl)
+		if state == CacheFresh {
+			defer func() { _ = file.Close() }()
+			c.Header("Content-Type", contentType)
+			c.Header("Cache-Control", "private, max-age=86400")
+			c.Header("X-Content-Type-Options", "nosniff")
+			if _, err := io.Copy(c.Writer, file); err != nil {
+				c.AbortWithStatus(http.StatusBadGateway)
+			}
+			return
+		}
+
+		var stalePath string
+		var staleCT string
+		if state == CacheStale {
+			shardDir, hashPrefix := pathFor(cacheDir, normalizedURL)
+			staleExt := ""
+			stalePath, staleExt, _ = resolveEntry(fs, shardDir, hashPrefix)
+			staleCT = contentTypeForExt(staleExt)
+			_ = file.Close()
+		}
+
+		if err := ssrf.CheckURL(rawURL); err != nil {
+			if stalePath != "" && tryServeStale(c, fs, stalePath, staleCT) {
+				return
+			}
+			c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
 			return
 		}
 
@@ -173,39 +211,130 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 		if userAgent == "" {
 			userAgent = config.DefaultUserAgent
 		}
-		req.Header.Set("User-Agent", userAgent)
-		req.Header.Set("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
-		if referer := resolveTempImageReferer(parsedURL.String(), tempCfg.ScraperReferer); referer != "" {
-			req.Header.Set("Referer", referer)
-		}
+		referer := resolveTempImageReferer(fetchURL, tempCfg.ScraperReferer)
+		httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
 
-		resp, err := httpClient.Do(req)
-		if err != nil {
+		v, ferr, _ := imageCacheGroup.Do(normalizedURL, func() (any, error) {
+			return fetchAndCache(c.Request.Context(), fs, cacheDir, normalizedURL, fetchURL, httpClient, userAgent, referer), nil
+		})
+		result := v.(fetchResult)
+		_ = ferr
+
+		if result.err != nil {
+			if stalePath != "" && tryServeStale(c, fs, stalePath, staleCT) {
+				return
+			}
+			if result.persistFailed {
+				logging.Warnf("image cache: persist failed for %s: %v, falling back to uncached", normalizedURL, result.err)
+				serveTempImageUncached(c, tempCfg, fetchURL, rawURL)
+				return
+			}
+			logging.Warnf("image cache: fetch failed for %s: %v", normalizedURL, result.err)
 			c.JSON(http.StatusBadGateway, gin.H{"error": "failed to fetch image"})
 			return
 		}
-		defer func() {
-			_ = httpclient.DrainAndClose(resp.Body)
-		}()
 
-		if resp.StatusCode != http.StatusOK {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "image source returned non-200 status"})
+		if result.cachedPath != "" {
+			c.Header("Content-Type", result.contentType)
+			c.Header("Cache-Control", "private, max-age=86400")
+			c.Header("X-Content-Type-Options", "nosniff")
+			cachedFile, openErr := fs.Open(result.cachedPath)
+			if openErr != nil {
+				c.JSON(http.StatusBadGateway, gin.H{"error": "failed to open cached image"})
+				return
+			}
+			defer func() { _ = cachedFile.Close() }()
+			if _, err := io.Copy(c.Writer, cachedFile); err != nil {
+				c.AbortWithStatus(http.StatusBadGateway)
+			}
 			return
 		}
 
-		contentType := resp.Header.Get("Content-Type")
-		if contentType == "" {
-			contentType = "image/jpeg"
-		}
-
-		c.Header("Content-Type", contentType)
-		c.Header("Cache-Control", "private, max-age=300")
-
-		const maxImageProxyResponseSize = 50 * 1024 * 1024 // 50MB
-		if _, err := io.Copy(c.Writer, io.LimitReader(resp.Body, maxImageProxyResponseSize)); err != nil {
-			c.AbortWithStatus(http.StatusBadGateway)
+		if result.tempPath != "" {
+			c.Header("Content-Type", result.contentType)
+			c.Header("Cache-Control", "private, max-age=300")
+			c.Header("X-Content-Type-Options", "nosniff")
+			tempFile, openErr := fs.Open(result.tempPath)
+			if openErr != nil {
+				c.JSON(http.StatusBadGateway, gin.H{"error": "failed to open fetched image"})
+				return
+			}
+			defer func() { _ = tempFile.Close() }()
+			if _, err := io.Copy(c.Writer, tempFile); err != nil {
+				c.AbortWithStatus(http.StatusBadGateway)
+			}
 			return
 		}
+
+		c.JSON(http.StatusBadGateway, gin.H{"error": "image fetch failed"})
+	}
+}
+
+func tryServeStale(c *gin.Context, fs afero.Fs, path, contentType string) bool {
+	f, err := fs.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	c.Header("Content-Type", contentType)
+	c.Header("Cache-Control", "no-cache")
+	c.Header("X-Content-Type-Options", "nosniff")
+	if _, err := io.Copy(c.Writer, f); err != nil {
+		logging.Warnf("image cache: failed to serve stale entry %s: %v", path, err)
+		return false
+	}
+	return true
+}
+
+func serveTempImageUncached(c *gin.Context, tempCfg *core.TempNarrowConfig, downloadURL, rawURL string) {
+	if err := ssrf.CheckURL(rawURL); err != nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		return
+	}
+
+	httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
+
+	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, downloadURL, nil)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to create request"})
+		return
+	}
+
+	userAgent := tempCfg.ScraperUserAgent
+	if userAgent == "" {
+		userAgent = config.DefaultUserAgent
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+	if referer := resolveTempImageReferer(downloadURL, tempCfg.ScraperReferer); referer != "" {
+		req.Header.Set("Referer", referer)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to fetch image"})
+		return
+	}
+	defer func() {
+		_ = httpclient.DrainAndClose(resp.Body)
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "image source returned non-200 status"})
+		return
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = defaultContentType
+	}
+
+	c.Header("Content-Type", contentType)
+	c.Header("Cache-Control", "private, max-age=300")
+
+	if _, err := io.Copy(c.Writer, io.LimitReader(resp.Body, maxImageProxyResponseSize)); err != nil {
+		c.AbortWithStatus(http.StatusBadGateway)
+		return
 	}
 }
 

--- a/internal/api/temp/handlers.go
+++ b/internal/api/temp/handlers.go
@@ -229,16 +229,16 @@ func serveTempImage(rt *core.APIRuntime) gin.HandlerFunc {
 		_ = ferr
 
 		if result.err != nil {
+			if result.persistFailed && len(result.body) > 0 {
+				c.Header("Cache-Control", "private, max-age=300")
+				c.Header("X-Content-Type-Options", "nosniff")
+				c.Data(http.StatusOK, result.contentType, result.body)
+				return
+			}
 			if stalePath != "" && tryServeStale(c, fs, stalePath, staleCT) {
 				return
 			}
 			if result.persistFailed {
-				if len(result.body) > 0 {
-					c.Header("Cache-Control", "private, max-age=300")
-					c.Header("X-Content-Type-Options", "nosniff")
-					c.Data(http.StatusOK, result.contentType, result.body)
-					return
-				}
 				logging.Warnf("image cache: persist failed for %s: %v", normalizedURL, result.err)
 				c.JSON(http.StatusBadGateway, gin.H{"error": "failed to fetch image"})
 				return

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -535,7 +535,7 @@ func TestRedactImageURL(t *testing.T) {
 	}
 }
 
-func TestBranch_CacheFill_EvictsOldestWhenOverQuota(t *testing.T) {
+func TestBranch_CacheFill_QuotaEnforcedAfterCommit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
 	t.Cleanup(cleanup)
@@ -560,27 +560,18 @@ func TestBranch_CacheFill_EvictsOldestWhenOverQuota(t *testing.T) {
 
 	w1 := serveImageRequest(t, deps, upstream.URL+"/first.jpg")
 	require.Equal(t, http.StatusOK, w1.Code)
+	assert.Equal(t, len(payload), w1.Body.Len())
 
 	w2 := serveImageRequest(t, deps, upstream.URL+"/second.jpg")
 	require.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, len(payload), w2.Body.Len())
 
-	var files []string
-	_ = afero.Walk(fs, "/", func(p string, info os.FileInfo, werr error) error {
-		if werr == nil && info != nil && !info.IsDir() && filepath.Ext(p) == ".jpg" {
-			files = append(files, p)
+	var total int64
+	_ = afero.Walk(fs, "/", func(_ string, info os.FileInfo, werr error) error {
+		if werr == nil && info != nil && !info.IsDir() {
+			total += info.Size()
 		}
 		return nil
 	})
-	require.Len(t, files, 1, "the oldest fill must be evicted by the 1MB quota after the second commit")
-
-	w1again := serveImageRequest(t, deps, upstream.URL+"/first.jpg")
-	require.Equal(t, http.StatusOK, w1again.Code)
-	var filesAfter []string
-	_ = afero.Walk(fs, "/", func(p string, info os.FileInfo, werr error) error {
-		if werr == nil && info != nil && !info.IsDir() && filepath.Ext(p) == ".jpg" {
-			filesAfter = append(filesAfter, p)
-		}
-		return nil
-	})
-	assert.Len(t, filesAfter, 1, "re-filling the evicted URL re-evicts the survivor; cache stays within quota")
+	assert.LessOrEqual(t, total, int64(1<<20), "after the second commit the on-disk cache must not exceed the configured quota")
 }

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -295,4 +296,67 @@ func TestBranch_PersistFailure_FallsBackToUncached(t *testing.T) {
 	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "fallback-body", w.Body.String())
+}
+
+func TestBranch_NonImageUpstream_ServesStaleEntry(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html>bot check</html>"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	mem := afero.NewMemMapFs()
+	rawURL := upstream.URL + "/blocked.jpg"
+	deps := newImageCacheDeps(t, mem)
+	seedCacheEntry(t, mem, depsTempDir(t, deps), rawURL, "stale-image-bytes", 2)
+
+	w := serveImageRequest(t, deps, rawURL)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "stale-image-bytes", w.Body.String())
+	assert.Equal(t, "no-cache", w.Header().Get("Cache-Control"))
+}
+
+func TestBranch_FreshCacheHit_MaxAgeBoundedByRemainingTTL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mem := afero.NewMemMapFs()
+	rawURL := "http://93.184.216.34/bounded.jpg"
+	deps := newImageCacheDeps(t, mem)
+
+	entry := seedCacheEntry(t, mem, depsTempDir(t, deps), rawURL, "fresh", 0)
+	halfTTLAgo := time.Now().Add(-30 * time.Minute)
+	require.NoError(t, mem.Chtimes(entry, halfTTLAgo, halfTTLAgo))
+
+	w := serveImageRequest(t, deps, rawURL)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	cc := w.Header().Get("Cache-Control")
+	require.True(t, strings.HasPrefix(cc, "private, max-age="), "unexpected Cache-Control %q", cc)
+	maxAge, err := strconv.Atoi(strings.TrimPrefix(cc, "private, max-age="))
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, maxAge, 1750)
+	assert.LessOrEqual(t, maxAge, 1800, "browser max-age must not outlive the remaining server TTL")
+}
+
+func TestBranch_FreshCacheHit_MaxAgeCappedAt24h(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mem := afero.NewMemMapFs()
+	rawURL := "http://93.184.216.34/capped.jpg"
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 168
+	cfg.System.TempDir = t.TempDir()
+	deps := &core.APIDeps{Fs: mem}
+	rt := core.NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+	testkit.SetTestRuntime(deps, rt)
+
+	seedCacheEntry(t, mem, cfg.System.TempDir, rawURL, "fresh", 0)
+
+	w := serveImageRequest(t, deps, rawURL)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "private, max-age=86400", w.Header().Get("Cache-Control"))
 }

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -464,7 +464,7 @@ func TestBranch_PersistFailure_SharedAcrossWaiters(t *testing.T) {
 	wg.Wait()
 
 	hitCount := atomic.LoadInt32(&hits)
-	assert.Equal(t, int32(2), hitCount, "N concurrent waiters must cost exactly one flight fetch plus one shared memory refetch")
+	assert.Equal(t, int32(1), hitCount, "N concurrent waiters cost exactly one upstream fetch; the drained response is shared in memory")
 	for _, w := range results {
 		require.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, jpegStr("shared-body"), w.Body.String())
@@ -487,13 +487,13 @@ func TestBranch_PersistFailure_RefetchFails(t *testing.T) {
 	}))
 	t.Cleanup(upstream.Close)
 
-	fs := &mkdirSuffixFailFs{Fs: afero.NewMemMapFs(), suffix: ".tmp"}
-	deps := newImageCacheDeps(t, fs)
+	hooked := &openHookFs{Fs: afero.NewMemMapFs(), mode: "error", match: isTmpCacheFile}
+	deps := newImageCacheDeps(t, hooked)
 
 	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
 	assert.Equal(t, http.StatusBadGateway, w.Code)
 	assert.Contains(t, w.Body.String(), "failed to fetch image")
-	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "exactly one refetch attempt inside the shared flight")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "in-flight bytes already consumed by the failed persist; exactly one shared refetch is attempted")
 }
 
 func TestBranch_PersistFailureWithStale_PrefersFreshMemoryBody(t *testing.T) {
@@ -513,4 +513,23 @@ func TestBranch_PersistFailureWithStale_PrefersFreshMemoryBody(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, jpegStr("fresh-fallback-body"), w.Body.String(), "successful degraded fetch must beat the stale disk entry")
 	assert.Equal(t, "private, max-age=300", w.Header().Get("Cache-Control"))
+}
+
+func TestRedactImageURL(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"strips userinfo and query", "https://user:pass@cdn.example.com/img.jpg?sig=abc123&exp=9", "https://cdn.example.com/img.jpg"},
+		{"plain url unchanged", "https://cdn.example.com/img.jpg", "https://cdn.example.com/img.jpg"},
+		{"fragment kept, query stripped", "https://cdn.example.com/img.jpg?sig=x#frag", "https://cdn.example.com/img.jpg#frag"},
+		{"invalid url redacted wholesale", "://nope", "<invalid-url>"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactImageURL(tc.in)
+			assert.Equal(t, tc.want, got)
+			assert.NotContains(t, got, "sig=")
+			assert.NotContains(t, got, "user:pass")
+		})
+	}
 }

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -264,6 +265,7 @@ func TestBranch_Uncached_EmptyContentTypeUsesDefault(t *testing.T) {
 	serveTempImageUncached(c, &core.TempNarrowConfig{}, srv.URL+"/x", srv.URL+"/x")
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, defaultContentType, w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
 }
 
 func TestBranch_Uncached_CopyFailureAborts(t *testing.T) {
@@ -421,4 +423,71 @@ func TestBranch_CachedFill_MaxAgeCappedAt24h(t *testing.T) {
 	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "private, max-age=86400", w.Header().Get("Cache-Control"))
+}
+
+func TestBranch_PersistFailure_SharedAcrossWaiters(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		time.Sleep(120 * time.Millisecond)
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("shared-body"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := &mkdirSuffixFailFs{Fs: afero.NewMemMapFs(), suffix: ".tmp"}
+	deps := newImageCacheDeps(t, fs)
+	router := gin.New()
+	router.GET("/temp/image", serveTempImage(testkit.GetTestRuntime(deps)))
+
+	const waiters = 5
+	results := make([]*httptest.ResponseRecorder, waiters)
+	var wg sync.WaitGroup
+	for i := 0; i < waiters; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/temp/image?url="+url.QueryEscape(upstream.URL+"/img.jpg"), nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			results[idx] = w
+		}(i)
+	}
+	wg.Wait()
+
+	hitCount := atomic.LoadInt32(&hits)
+	assert.Equal(t, int32(2), hitCount, "N concurrent waiters must cost exactly one flight fetch plus one shared memory refetch")
+	for _, w := range results {
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "shared-body", w.Body.String())
+	}
+}
+
+func TestBranch_PersistFailure_RefetchFails(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&hits, 1) == 1 {
+			w.Header().Set("Content-Type", "image/jpeg")
+			_, _ = w.Write([]byte("once"))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := &mkdirSuffixFailFs{Fs: afero.NewMemMapFs(), suffix: ".tmp"}
+	deps := newImageCacheDeps(t, fs)
+
+	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Contains(t, w.Body.String(), "failed to fetch image")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "exactly one refetch attempt inside the shared flight")
 }

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -90,7 +90,7 @@ func seedCacheEntry(t *testing.T, fs afero.Fs, tempDir, normalizedURL, content s
 func testUpstream(payload string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		_, _ = w.Write([]byte(payload))
+		_, _ = w.Write(jpegBytes(payload))
 	}))
 }
 
@@ -146,7 +146,7 @@ func TestBranch_RenameFailure_ServesFromTemp(t *testing.T) {
 
 	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "temp-body", w.Body.String())
+	assert.Equal(t, jpegStr("temp-body"), w.Body.String())
 	assert.Equal(t, "private, max-age=300", w.Header().Get("Cache-Control"))
 }
 
@@ -158,9 +158,10 @@ func TestBranch_RenameFailure_TempOpenFailure(t *testing.T) {
 	t.Cleanup(upstream.Close)
 
 	hooked := &openHookFs{
-		Fs:    afero.NewMemMapFs(),
-		mode:  "error",
-		match: isTmpCacheFile,
+		Fs:        afero.NewMemMapFs(),
+		mode:      "error",
+		failAfter: 1,
+		match:     isTmpCacheFile,
 	}
 	fs := &renameAlwaysFailFs{Fs: hooked}
 	deps := newImageCacheDeps(t, fs)
@@ -178,9 +179,10 @@ func TestBranch_RenameFailure_TempCopyFailure(t *testing.T) {
 	t.Cleanup(upstream.Close)
 
 	hooked := &openHookFs{
-		Fs:    afero.NewMemMapFs(),
-		mode:  "readfail",
-		match: isTmpCacheFile,
+		Fs:        afero.NewMemMapFs(),
+		mode:      "readfail",
+		failAfter: 1,
+		match:     isTmpCacheFile,
 	}
 	fs := &renameAlwaysFailFs{Fs: hooked}
 	deps := newImageCacheDeps(t, fs)
@@ -275,14 +277,14 @@ func TestBranch_Uncached_CopyFailureAborts(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
 		w.Header().Set("Content-Length", "1000")
-		_, _ = w.Write([]byte("abc"))
+		_, _ = w.Write(jpegBytes("abc"))
 	}))
 	t.Cleanup(srv.Close)
 
 	w := httptest.NewRecorder()
 	c := newGinTestContext(w)
 	serveTempImageUncached(c, &core.TempNarrowConfig{}, srv.URL+"/x", srv.URL+"/x")
-	assert.Equal(t, "abc", w.Body.String())
+	assert.Equal(t, jpegStr("abc"), w.Body.String())
 }
 
 func TestBranch_PersistFailure_FallsBackToUncached(t *testing.T) {
@@ -297,7 +299,7 @@ func TestBranch_PersistFailure_FallsBackToUncached(t *testing.T) {
 
 	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "fallback-body", w.Body.String())
+	assert.Equal(t, jpegStr("fallback-body"), w.Body.String())
 }
 
 func TestBranch_NonImageUpstream_ServesStaleEntry(t *testing.T) {
@@ -306,7 +308,7 @@ func TestBranch_NonImageUpstream_ServesStaleEntry(t *testing.T) {
 	t.Cleanup(cleanup)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		_, _ = w.Write([]byte("<html>bot check</html>"))
+		_, _ = w.Write(jpegBytes("<html>bot check</html>"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -369,7 +371,7 @@ func TestBranch_QueryOrderDistinctCacheKeys(t *testing.T) {
 	t.Cleanup(cleanup)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		_, _ = w.Write([]byte("body:" + r.URL.RawQuery))
+		_, _ = w.Write(jpegBytes("body:" + r.URL.RawQuery))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -377,11 +379,11 @@ func TestBranch_QueryOrderDistinctCacheKeys(t *testing.T) {
 
 	w1 := serveImageRequest(t, deps, upstream.URL+"/img?a=1&b=2")
 	assert.Equal(t, http.StatusOK, w1.Code)
-	assert.Equal(t, "body:a=1&b=2", w1.Body.String())
+	assert.Equal(t, jpegStr("body:a=1&b=2"), w1.Body.String())
 
 	w2 := serveImageRequest(t, deps, upstream.URL+"/img?b=2&a=1")
 	assert.Equal(t, http.StatusOK, w2.Code)
-	assert.Equal(t, "body:b=2&a=1", w2.Body.String(), "differently-ordered query strings must not share a cache entry")
+	assert.Equal(t, jpegStr("body:b=2&a=1"), w2.Body.String(), "differently-ordered query strings must not share a cache entry")
 }
 
 func TestBranch_CachedFill_MaxAgeBoundedByConfigTTL(t *testing.T) {
@@ -435,7 +437,7 @@ func TestBranch_PersistFailure_SharedAcrossWaiters(t *testing.T) {
 		atomic.AddInt32(&hits, 1)
 		time.Sleep(120 * time.Millisecond)
 		w.Header().Set("Content-Type", "image/jpeg")
-		_, _ = w.Write([]byte("shared-body"))
+		_, _ = w.Write(jpegBytes("shared-body"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -463,7 +465,7 @@ func TestBranch_PersistFailure_SharedAcrossWaiters(t *testing.T) {
 	assert.Equal(t, int32(2), hitCount, "N concurrent waiters must cost exactly one flight fetch plus one shared memory refetch")
 	for _, w := range results {
 		require.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, "shared-body", w.Body.String())
+		assert.Equal(t, jpegStr("shared-body"), w.Body.String())
 	}
 }
 
@@ -476,7 +478,7 @@ func TestBranch_PersistFailure_RefetchFails(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if atomic.AddInt32(&hits, 1) == 1 {
 			w.Header().Set("Content-Type", "image/jpeg")
-			_, _ = w.Write([]byte("once"))
+			_, _ = w.Write(jpegBytes("once"))
 			return
 		}
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -150,7 +150,7 @@ func TestBranch_RenameFailure_ServesFromTemp(t *testing.T) {
 	assert.Equal(t, "private, max-age=300", w.Header().Get("Cache-Control"))
 }
 
-func TestBranch_RenameFailure_TempOpenFailure(t *testing.T) {
+func TestBranch_RenameFailure_TempUnreadable_FallsBackToSharedMemoryServe(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
 	t.Cleanup(cleanup)
@@ -167,11 +167,11 @@ func TestBranch_RenameFailure_TempOpenFailure(t *testing.T) {
 	deps := newImageCacheDeps(t, fs)
 
 	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
-	assert.Equal(t, http.StatusBadGateway, w.Code)
-	assert.Contains(t, w.Body.String(), "failed to open fetched image")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, jpegStr("temp-body"), w.Body.String(), "unreadable temp artifact degrades to shared in-memory bytes")
 }
 
-func TestBranch_RenameFailure_TempCopyFailure(t *testing.T) {
+func TestBranch_RenameFailure_TempReadbackFails_FallsBackToSharedMemoryServe(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
 	t.Cleanup(cleanup)
@@ -188,7 +188,8 @@ func TestBranch_RenameFailure_TempCopyFailure(t *testing.T) {
 	deps := newImageCacheDeps(t, fs)
 
 	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
-	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, jpegStr("temp-body"), w.Body.String(), "temp readback failure degrades to shared in-memory bytes")
 }
 
 func isTmpCacheFile(name string) bool {
@@ -300,6 +301,7 @@ func TestBranch_PersistFailure_FallsBackToUncached(t *testing.T) {
 	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, jpegStr("fallback-body"), w.Body.String())
+	assert.Equal(t, "image/jpeg", w.Header().Get("Content-Type"), "degraded fallback must preserve the validated media type")
 }
 
 func TestBranch_NonImageUpstream_ServesStaleEntry(t *testing.T) {

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -158,7 +158,7 @@ func TestBranch_RenameFailure_TempOpenFailure(t *testing.T) {
 	hooked := &openHookFs{
 		Fs:    afero.NewMemMapFs(),
 		mode:  "error",
-		match: func(name string) bool { return strings.Contains(name, "/.tmp/") },
+		match: isTmpCacheFile,
 	}
 	fs := &renameAlwaysFailFs{Fs: hooked}
 	deps := newImageCacheDeps(t, fs)
@@ -178,13 +178,17 @@ func TestBranch_RenameFailure_TempCopyFailure(t *testing.T) {
 	hooked := &openHookFs{
 		Fs:    afero.NewMemMapFs(),
 		mode:  "readfail",
-		match: func(name string) bool { return strings.Contains(name, "/.tmp/") },
+		match: isTmpCacheFile,
 	}
 	fs := &renameAlwaysFailFs{Fs: hooked}
 	deps := newImageCacheDeps(t, fs)
 
 	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
 	assert.Equal(t, http.StatusBadGateway, w.Code)
+}
+
+func isTmpCacheFile(name string) bool {
+	return filepath.Base(filepath.Dir(name)) == ".tmp"
 }
 
 func TestBranch_StaleEntry_OpenFailureFallsToForbidden(t *testing.T) {

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -360,3 +360,24 @@ func TestBranch_FreshCacheHit_MaxAgeCappedAt24h(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "private, max-age=86400", w.Header().Get("Cache-Control"))
 }
+
+func TestBranch_QueryOrderDistinctCacheKeys(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("body:" + r.URL.RawQuery))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps := newImageCacheDeps(t, afero.NewMemMapFs())
+
+	w1 := serveImageRequest(t, deps, upstream.URL+"/img?a=1&b=2")
+	assert.Equal(t, http.StatusOK, w1.Code)
+	assert.Equal(t, "body:a=1&b=2", w1.Body.String())
+
+	w2 := serveImageRequest(t, deps, upstream.URL+"/img?b=2&a=1")
+	assert.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, "body:b=2&a=1", w2.Body.String(), "differently-ordered query strings must not share a cache entry")
+}

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -575,3 +575,51 @@ func TestBranch_CacheFill_QuotaEnforcedAfterCommit(t *testing.T) {
 	})
 	assert.LessOrEqual(t, total, int64(1<<20), "after the second commit the on-disk cache must not exceed the configured quota")
 }
+
+func TestBranch_OverQuotaFill_AllWaitersServedFromSharedEntry(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	payload := append([]byte("\xff\xd8\xff\xe0"), make([]byte, 1_200_000)...)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(upstream.Close)
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 24
+	cfg.System.ImageCacheMaxSizeMB = 1
+	cfg.System.TempDir = t.TempDir()
+	fs := afero.NewMemMapFs()
+	deps := &core.APIDeps{Fs: fs}
+	rt := core.NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+	testkit.SetTestRuntime(deps, rt)
+
+	router := gin.New()
+	router.GET("/temp/image", serveTempImage(testkit.GetTestRuntime(deps)))
+
+	const waiters = 3
+	results := make([]*httptest.ResponseRecorder, waiters)
+	var wg sync.WaitGroup
+	for i := 0; i < waiters; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/temp/image?url="+url.QueryEscape(upstream.URL+"/big.jpg"), nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			results[idx] = w
+		}(i)
+	}
+	wg.Wait()
+
+	for _, w := range results {
+		require.Equal(t, http.StatusOK, w.Code, "every coalesced waiter must serve; eviction must not delete the shared fill")
+		assert.Equal(t, len(payload), w.Body.Len())
+	}
+}

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -381,3 +381,44 @@ func TestBranch_QueryOrderDistinctCacheKeys(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w2.Code)
 	assert.Equal(t, "body:b=2&a=1", w2.Body.String(), "differently-ordered query strings must not share a cache entry")
 }
+
+func TestBranch_CachedFill_MaxAgeBoundedByConfigTTL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	upstream := testUpstream("fill-body")
+	t.Cleanup(upstream.Close)
+
+	deps := newImageCacheDeps(t, afero.NewMemMapFs())
+
+	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	cc := w.Header().Get("Cache-Control")
+	require.True(t, strings.HasPrefix(cc, "private, max-age="), "unexpected Cache-Control %q", cc)
+	maxAge, err := strconv.Atoi(strings.TrimPrefix(cc, "private, max-age="))
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, maxAge, 3550)
+	assert.LessOrEqual(t, maxAge, 3600, "cache-fill response must not outlive the configured TTL")
+}
+
+func TestBranch_CachedFill_MaxAgeCappedAt24h(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	upstream := testUpstream("fill-body")
+	t.Cleanup(upstream.Close)
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 168
+	cfg.System.TempDir = t.TempDir()
+	deps := &core.APIDeps{Fs: afero.NewMemMapFs()}
+	rt := core.NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+	testkit.SetTestRuntime(deps, rt)
+
+	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "private, max-age=86400", w.Header().Get("Cache-Control"))
+}

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -1,0 +1,294 @@
+package temp
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/ssrf"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type readFailFile struct {
+	afero.File
+}
+
+func (f *readFailFile) Read(p []byte) (int, error) { return 0, errors.New("read failed") }
+
+type openHookFs struct {
+	afero.Fs
+	match     func(name string) bool
+	mode      string
+	failAfter int32
+	opens     int32
+}
+
+func (f *openHookFs) Open(name string) (afero.File, error) {
+	if f.match(name) && atomic.AddInt32(&f.opens, 1) > f.failAfter {
+		if f.mode == "error" {
+			return nil, errors.New("open denied")
+		}
+		real, err := f.Fs.Open(name)
+		if err != nil {
+			return nil, err
+		}
+		return &readFailFile{File: real}, nil
+	}
+	return f.Fs.Open(name)
+}
+
+func newImageCacheDeps(t *testing.T, fs afero.Fs) *core.APIDeps {
+	t.Helper()
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 1
+	cfg.System.TempDir = t.TempDir()
+	deps := &core.APIDeps{Fs: fs}
+	rt := core.NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+	testkit.SetTestRuntime(deps, rt)
+	return deps
+}
+
+func serveImageRequest(t *testing.T, deps *core.APIDeps, rawURL string) *httptest.ResponseRecorder {
+	t.Helper()
+	router := gin.New()
+	router.GET("/temp/image", serveTempImage(testkit.GetTestRuntime(deps)))
+	req := httptest.NewRequest(http.MethodGet, "/temp/image?url="+url.QueryEscape(rawURL), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func seedCacheEntry(t *testing.T, fs afero.Fs, tempDir, normalizedURL, content string, ageHours int) string {
+	t.Helper()
+	shardDir, hashPrefix := pathFor(tempDir, normalizedURL)
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	entry := filepath.Join(shardDir, hashPrefix+".jpg")
+	require.NoError(t, afero.WriteFile(fs, entry, []byte(content), 0o644))
+	if ageHours > 0 {
+		old := time.Now().Add(-time.Duration(ageHours) * time.Hour)
+		require.NoError(t, fs.Chtimes(entry, old, old))
+	}
+	return entry
+}
+
+func testUpstream(payload string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte(payload))
+	}))
+}
+
+func TestBranch_FreshCacheHit_CopyFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mem := afero.NewMemMapFs()
+	rawURL := "http://93.184.216.34/fresh.jpg"
+	deps := newImageCacheDeps(t, mem)
+	entry := seedCacheEntry(t, mem, depsTempDir(t, deps), rawURL, "cached", 0)
+
+	hooked := &openHookFs{Fs: mem, match: func(name string) bool { return name == entry }, mode: "readfail"}
+	deps.Fs = hooked
+
+	w := serveImageRequest(t, deps, rawURL)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+}
+
+func depsTempDir(t *testing.T, deps *core.APIDeps) string {
+	t.Helper()
+	rt := testkit.GetTestRuntime(deps)
+	return rt.GetAPIConfig().TempConfig().TempDir
+}
+
+func TestBranch_CachedResultBranch_CopyFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	upstream := testUpstream("cached-body")
+	t.Cleanup(upstream.Close)
+
+	hooked := &openHookFs{
+		Fs:   afero.NewMemMapFs(),
+		mode: "readfail",
+		match: func(name string) bool {
+			return strings.HasSuffix(name, ".jpg") && !strings.Contains(name, "/.tmp/")
+		},
+	}
+	deps := newImageCacheDeps(t, hooked)
+
+	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+}
+
+func TestBranch_RenameFailure_ServesFromTemp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	upstream := testUpstream("temp-body")
+	t.Cleanup(upstream.Close)
+
+	fs := &renameAlwaysFailFs{Fs: afero.NewMemMapFs()}
+	deps := newImageCacheDeps(t, fs)
+
+	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "temp-body", w.Body.String())
+	assert.Equal(t, "private, max-age=300", w.Header().Get("Cache-Control"))
+}
+
+func TestBranch_RenameFailure_TempOpenFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	upstream := testUpstream("temp-body")
+	t.Cleanup(upstream.Close)
+
+	hooked := &openHookFs{
+		Fs:    afero.NewMemMapFs(),
+		mode:  "error",
+		match: func(name string) bool { return strings.Contains(name, "/.tmp/") },
+	}
+	fs := &renameAlwaysFailFs{Fs: hooked}
+	deps := newImageCacheDeps(t, fs)
+
+	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Contains(t, w.Body.String(), "failed to open fetched image")
+}
+
+func TestBranch_RenameFailure_TempCopyFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	upstream := testUpstream("temp-body")
+	t.Cleanup(upstream.Close)
+
+	hooked := &openHookFs{
+		Fs:    afero.NewMemMapFs(),
+		mode:  "readfail",
+		match: func(name string) bool { return strings.Contains(name, "/.tmp/") },
+	}
+	fs := &renameAlwaysFailFs{Fs: hooked}
+	deps := newImageCacheDeps(t, fs)
+
+	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+}
+
+func TestBranch_StaleEntry_OpenFailureFallsToForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mem := afero.NewMemMapFs()
+	rawURL := "http://127.0.0.1:9/stale-open.jpg"
+	hooked := &openHookFs{Fs: mem, mode: "error", failAfter: 1, match: func(name string) bool {
+		return strings.HasSuffix(name, ".jpg")
+	}}
+	deps := newImageCacheDeps(t, hooked)
+	seedCacheEntry(t, mem, depsTempDir(t, deps), rawURL, "stale", 2)
+
+	w := serveImageRequest(t, deps, rawURL)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestBranch_StaleEntry_CopyFailureFallsToForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mem := afero.NewMemMapFs()
+	rawURL := "http://127.0.0.1:9/stale-copy.jpg"
+	hooked := &openHookFs{Fs: mem, mode: "readfail", failAfter: 1, match: func(name string) bool {
+		return strings.HasSuffix(name, ".jpg")
+	}}
+	deps := newImageCacheDeps(t, hooked)
+	seedCacheEntry(t, mem, depsTempDir(t, deps), rawURL, "stale", 2)
+
+	w := serveImageRequest(t, deps, rawURL)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func newGinTestContext(w *httptest.ResponseRecorder) *gin.Context {
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/temp/image", nil)
+	return c
+}
+
+func TestBranch_Uncached_CreateRequestError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c := newGinTestContext(w)
+	serveTempImageUncached(c, &core.TempNarrowConfig{}, "http://exa mple.invalid/x.jpg", "http://93.184.216.34/x.jpg")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "failed to create request")
+}
+
+func TestBranch_Uncached_UpstreamFetchError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	srv := testUpstream("x")
+	deadURL := srv.URL + "/gone.jpg"
+	srv.Close()
+
+	w := httptest.NewRecorder()
+	c := newGinTestContext(w)
+	serveTempImageUncached(c, &core.TempNarrowConfig{}, deadURL, deadURL)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Contains(t, w.Body.String(), "failed to fetch image")
+}
+
+func TestBranch_Uncached_EmptyContentTypeUsesDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	w := httptest.NewRecorder()
+	c := newGinTestContext(w)
+	serveTempImageUncached(c, &core.TempNarrowConfig{}, srv.URL+"/x", srv.URL+"/x")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, defaultContentType, w.Header().Get("Content-Type"))
+}
+
+func TestBranch_Uncached_CopyFailureAborts(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Header().Set("Content-Length", "1000")
+		_, _ = w.Write([]byte("abc"))
+	}))
+	t.Cleanup(srv.Close)
+
+	w := httptest.NewRecorder()
+	c := newGinTestContext(w)
+	serveTempImageUncached(c, &core.TempNarrowConfig{}, srv.URL+"/x", srv.URL+"/x")
+	assert.Equal(t, "abc", w.Body.String())
+}
+
+func TestBranch_PersistFailure_FallsBackToUncached(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	upstream := testUpstream("fallback-body")
+	t.Cleanup(upstream.Close)
+
+	fs := &mkdirSuffixFailFs{Fs: afero.NewMemMapFs(), suffix: ".tmp"}
+	deps := newImageCacheDeps(t, fs)
+
+	w := serveImageRequest(t, deps, upstream.URL+"/img.jpg")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "fallback-body", w.Body.String())
+}

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -532,4 +533,54 @@ func TestRedactImageURL(t *testing.T) {
 			assert.NotContains(t, got, "user:pass")
 		})
 	}
+}
+
+func TestBranch_CacheFill_EvictsOldestWhenOverQuota(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	payload := append([]byte("\xff\xd8\xff\xe0"), make([]byte, 600_000)...)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(upstream.Close)
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 24
+	cfg.System.ImageCacheMaxSizeMB = 1
+	cfg.System.TempDir = t.TempDir()
+	fs := afero.NewMemMapFs()
+	deps := &core.APIDeps{Fs: fs}
+	rt := core.NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+	testkit.SetTestRuntime(deps, rt)
+
+	w1 := serveImageRequest(t, deps, upstream.URL+"/first.jpg")
+	require.Equal(t, http.StatusOK, w1.Code)
+
+	w2 := serveImageRequest(t, deps, upstream.URL+"/second.jpg")
+	require.Equal(t, http.StatusOK, w2.Code)
+
+	var files []string
+	_ = afero.Walk(fs, "/", func(p string, info os.FileInfo, werr error) error {
+		if werr == nil && info != nil && !info.IsDir() && filepath.Ext(p) == ".jpg" {
+			files = append(files, p)
+		}
+		return nil
+	})
+	require.Len(t, files, 1, "the oldest fill must be evicted by the 1MB quota after the second commit")
+
+	w1again := serveImageRequest(t, deps, upstream.URL+"/first.jpg")
+	require.Equal(t, http.StatusOK, w1again.Code)
+	var filesAfter []string
+	_ = afero.Walk(fs, "/", func(p string, info os.FileInfo, werr error) error {
+		if werr == nil && info != nil && !info.IsDir() && filepath.Ext(p) == ".jpg" {
+			filesAfter = append(filesAfter, p)
+		}
+		return nil
+	})
+	assert.Len(t, filesAfter, 1, "re-filling the evicted URL re-evicts the survivor; cache stays within quota")
 }

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -495,3 +495,22 @@ func TestBranch_PersistFailure_RefetchFails(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "failed to fetch image")
 	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "exactly one refetch attempt inside the shared flight")
 }
+
+func TestBranch_PersistFailureWithStale_PrefersFreshMemoryBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+	upstream := testUpstream("fresh-fallback-body")
+	t.Cleanup(upstream.Close)
+
+	mem := afero.NewMemMapFs()
+	fs := &mkdirSuffixFailFs{Fs: mem, suffix: ".tmp"}
+	deps := newImageCacheDeps(t, fs)
+	rawURL := upstream.URL + "/gradual.jpg"
+	seedCacheEntry(t, mem, depsTempDir(t, deps), rawURL, "stale-should-lose", 2)
+
+	w := serveImageRequest(t, deps, rawURL)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, jpegStr("fresh-fallback-body"), w.Body.String(), "successful degraded fetch must beat the stale disk entry")
+	assert.Equal(t, "private, max-age=300", w.Header().Get("Cache-Control"))
+}

--- a/internal/api/temp/handlers_branch_test.go
+++ b/internal/api/temp/handlers_branch_test.go
@@ -201,7 +201,7 @@ func TestBranch_StaleEntry_OpenFailureFallsToForbidden(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	mem := afero.NewMemMapFs()
 	rawURL := "http://127.0.0.1:9/stale-open.jpg"
-	hooked := &openHookFs{Fs: mem, mode: "error", failAfter: 1, match: func(name string) bool {
+	hooked := &openHookFs{Fs: mem, mode: "error", match: func(name string) bool {
 		return strings.HasSuffix(name, ".jpg")
 	}}
 	deps := newImageCacheDeps(t, hooked)
@@ -215,7 +215,7 @@ func TestBranch_StaleEntry_CopyFailureFallsToForbidden(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	mem := afero.NewMemMapFs()
 	rawURL := "http://127.0.0.1:9/stale-copy.jpg"
-	hooked := &openHookFs{Fs: mem, mode: "readfail", failAfter: 1, match: func(name string) bool {
+	hooked := &openHookFs{Fs: mem, mode: "readfail", match: func(name string) bool {
 		return strings.HasSuffix(name, ".jpg")
 	}}
 	deps := newImageCacheDeps(t, hooked)

--- a/internal/api/temp/handlers_coverage_test.go
+++ b/internal/api/temp/handlers_coverage_test.go
@@ -74,7 +74,7 @@ func TestHandlerCoverage_DisabledNoWrites(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("data"))
+		w.Write(jpegBytes("data"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -92,7 +92,7 @@ func TestHandlerCoverage_HitCacheControl(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("hit-data"))
+		w.Write(jpegBytes("hit-data"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -135,7 +135,7 @@ func TestHandlerCoverage_UncachedSuccess(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/png")
-		w.Write([]byte("png-data"))
+		w.Write(pngBytes("png-data"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -152,7 +152,7 @@ func TestHandlerCoverage_TempPathOpenError(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("data"))
+		w.Write(jpegBytes("data"))
 	}))
 	t.Cleanup(upstream.Close)
 

--- a/internal/api/temp/handlers_coverage_test.go
+++ b/internal/api/temp/handlers_coverage_test.go
@@ -1,0 +1,194 @@
+package temp
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/ssrf"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newHandlerCoverageDeps(t *testing.T, enabled bool, ttlHours int) (*core.APIDeps, afero.Fs, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	tempDir := t.TempDir()
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = enabled
+	cfg.System.ImageCacheTTLHours = ttlHours
+	cfg.System.TempDir = tempDir
+	fs := afero.NewMemMapFs()
+	deps := &core.APIDeps{Fs: fs}
+	rt := core.NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+	testkit.SetTestRuntime(deps, rt)
+	return deps, fs, tempDir
+}
+
+func handlerRouter(deps *core.APIDeps) *gin.Engine {
+	r := gin.New()
+	r.GET("/temp/image", serveTempImage(testkit.GetTestRuntime(deps)))
+	return r
+}
+
+func handlerRequest(router *gin.Engine, rawURL string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/temp/image?url="+url.QueryEscape(rawURL), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestHandlerCoverage_MissingURL(t *testing.T) {
+	deps, _, _ := newHandlerCoverageDeps(t, true, 168)
+	w := handlerRouter(deps)
+	r := handlerRequest(w, "")
+	assert.Equal(t, http.StatusBadRequest, r.Code)
+}
+
+func TestHandlerCoverage_InvalidScheme(t *testing.T) {
+	deps, _, _ := newHandlerCoverageDeps(t, true, 168)
+	w := handlerRouter(deps)
+	r := handlerRequest(w, "ftp://example.com/img.jpg")
+	assert.Equal(t, http.StatusBadRequest, r.Code)
+}
+
+func TestHandlerCoverage_MissingHost(t *testing.T) {
+	deps, _, _ := newHandlerCoverageDeps(t, true, 168)
+	w := handlerRouter(deps)
+	r := handlerRequest(w, "http:///img.jpg")
+	assert.Equal(t, http.StatusBadRequest, r.Code)
+}
+
+func TestHandlerCoverage_DisabledNoWrites(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("data"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newHandlerCoverageDeps(t, true, 0)
+	w := handlerRouter(deps)
+	r := handlerRequest(w, upstream.URL+"/img.jpg")
+	assert.Equal(t, http.StatusOK, r.Code)
+	assert.Equal(t, "private, max-age=300", r.Header().Get("Cache-Control"))
+	assert.NotEmpty(t, r.Body.Bytes())
+}
+
+func TestHandlerCoverage_HitCacheControl(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("hit-data"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newHandlerCoverageDeps(t, true, 168)
+	w := handlerRouter(deps)
+	r := handlerRequest(w, upstream.URL+"/img.jpg")
+	require.Equal(t, http.StatusOK, r.Code)
+	assert.Equal(t, "private, max-age=86400", r.Header().Get("Cache-Control"))
+	assert.Equal(t, "nosniff", r.Header().Get("X-Content-Type-Options"))
+}
+
+func TestHandlerCoverage_SSRFFailureNoStale(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupOffline)
+	t.Cleanup(cleanup)
+
+	deps, _, _ := newHandlerCoverageDeps(t, true, 168)
+	w := handlerRouter(deps)
+	r := handlerRequest(w, "http://nonexistent.invalid/img.jpg")
+	assert.Equal(t, http.StatusForbidden, r.Code)
+}
+
+func TestHandlerCoverage_UncachedNo200(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newHandlerCoverageDeps(t, false, 0)
+	w := handlerRouter(deps)
+	r := handlerRequest(w, upstream.URL+"/img.jpg")
+	assert.Equal(t, http.StatusBadGateway, r.Code)
+}
+
+func TestHandlerCoverage_UncachedSuccess(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("png-data"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newHandlerCoverageDeps(t, false, 0)
+	w := handlerRouter(deps)
+	r := handlerRequest(w, upstream.URL+"/img.png")
+	assert.Equal(t, http.StatusOK, r.Code)
+	assert.Equal(t, "image/png", r.Header().Get("Content-Type"))
+}
+
+func TestHandlerCoverage_TempPathOpenError(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("data"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 168
+	cfg.System.TempDir = tempDir
+
+	openFailingFs := &tempOpenFailFs{Fs: fs}
+	openFailingFs.tempDir = tempDir
+	deps := &core.APIDeps{Fs: openFailingFs}
+	rt := core.NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+	testkit.SetTestRuntime(deps, rt)
+
+	w := handlerRouter(deps)
+	r := handlerRequest(w, upstream.URL+"/img.jpg")
+	// fetchAndCache writes to temp successfully (Create works), then rename succeeds,
+	// then the handler tries to Open the cached file which fails.
+	assert.Equal(t, http.StatusBadGateway, r.Code)
+	assert.Contains(t, r.Body.String(), "failed to open")
+}
+
+type tempOpenFailFs struct {
+	afero.Fs
+	tempDir string
+}
+
+func (f *tempOpenFailFs) Open(name string) (afero.File, error) {
+	if filepath.Base(name) == "" || len(name) == 0 {
+		return f.Fs.Open(name)
+	}
+	if filepath.Ext(name) == ".jpg" {
+		return nil, errors.New("open failed")
+	}
+	return f.Fs.Open(name)
+}

--- a/internal/api/temp/handlers_test.go
+++ b/internal/api/temp/handlers_test.go
@@ -44,6 +44,7 @@ func TestServeTempPoster(t *testing.T) {
 
 	// Create deps with config that has TempDir set to tempDir
 	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
 	cfg.System.TempDir = tempDir
 	deps := newTestDeps(cfg)
 
@@ -129,6 +130,7 @@ func TestServeTempPoster_PathTraversalDefenseInDepth(t *testing.T) {
 
 	// Create deps with config that has TempDir set to tempDir
 	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
 	cfg.System.TempDir = tempDir
 	deps := newTestDeps(cfg)
 
@@ -269,6 +271,7 @@ func TestServeTempPoster_ValidJpgExtensions(t *testing.T) {
 
 	// Create deps with config that has TempDir set to tempDir
 	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
 	cfg.System.TempDir = tempDir
 	deps := newTestDeps(cfg)
 
@@ -398,6 +401,7 @@ func TestServeTempImage(t *testing.T) {
 			defer upstream.Close()
 
 			cfg := config.DefaultConfig(nil, nil)
+			cfg.System.ImageCacheEnabled = false
 			cfg.Scrapers.Referer = expectedReferer
 			deps := newTestDeps(cfg)
 

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -23,6 +23,8 @@ import (
 
 const maxImageProxyResponseSize = 50 * 1024 * 1024
 
+var randRead = rand.Read
+
 const defaultContentType = "image/jpeg"
 
 var imageCacheGroup singleflight.Group
@@ -212,7 +214,7 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 		return fetchResult{err: fmt.Errorf("mkdir tmp: %w", err), persistFailed: true}
 	}
 	rb := make([]byte, 8)
-	if _, err := rand.Read(rb); err != nil {
+	if _, err := randRead(rb); err != nil {
 		return fetchResult{err: fmt.Errorf("rand: %w", err)}
 	}
 	tmpPath := filepath.Join(tmpD, hex.EncodeToString(rb))
@@ -221,10 +223,15 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 		logging.Warnf("image cache: create temp failed: %v", err)
 		return fetchResult{err: fmt.Errorf("create temp: %w", err), persistFailed: true}
 	}
-	n, copyErr := io.Copy(f, io.LimitReader(resp.Body, maxImageProxyResponseSize+1))
+	werr := &writeTracker{w: f}
+	n, copyErr := io.Copy(werr, io.LimitReader(resp.Body, maxImageProxyResponseSize+1))
 	_ = f.Close()
 	if copyErr != nil {
 		_ = fs.Remove(tmpPath)
+		if werr.writeErr {
+			logging.Warnf("image cache: disk write failed, will fall back to uncached: %v", copyErr)
+			return fetchResult{err: fmt.Errorf("write temp: %w", copyErr), persistFailed: true}
+		}
 		return fetchResult{err: fmt.Errorf("write temp: %w", copyErr)}
 	}
 	if n > maxImageProxyResponseSize {
@@ -247,6 +254,19 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 		}
 	}
 	return fetchResult{cachedPath: dstPath, contentType: normalizedCT}
+}
+
+type writeTracker struct {
+	w        io.Writer
+	writeErr bool
+}
+
+func (t *writeTracker) Write(p []byte) (int, error) {
+	n, err := t.w.Write(p)
+	if err != nil {
+		t.writeErr = true
+	}
+	return n, err
 }
 
 func atomicRename(fs afero.Fs, src, dst string) error {

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -65,6 +65,8 @@ const (
 	imageTypeGif  = "image/gif"
 	imageTypeAvif = "image/avif"
 	imageTypeApng = "image/apng"
+
+	octetStream = "application/octet-stream"
 )
 
 func extForContentType(contentType string) string {
@@ -191,7 +193,7 @@ type fetchResult struct {
 
 func sniffImageType(head []byte) string {
 	sniffed := http.DetectContentType(head)
-	if sniffed != "application/octet-stream" || len(head) < 12 {
+	if sniffed != octetStream || len(head) < 12 {
 		return sniffed
 	}
 	if string(head[0:4]) == "RIFF" && string(head[8:12]) == "WEBP" {
@@ -234,14 +236,14 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 	}
 
 	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(resp.Header.Get("Content-Type"), ";", 2)[0]))
-	if mediaType != "" && !isCacheableMediaType(mediaType) {
+	if mediaType != "" && mediaType != octetStream && !isCacheableMediaType(mediaType) {
 		if strings.HasPrefix(mediaType, "image/") {
 			return fetchResult{err: fmt.Errorf("unsupported image content type %q", mediaType)}
 		}
 		return fetchResult{err: fmt.Errorf("non-image content type %q", mediaType)}
 	}
 	var head []byte
-	if mediaType == "" {
+	if mediaType == "" || mediaType == octetStream {
 		buf := make([]byte, 512)
 		hn, _ := io.ReadAtLeast(resp.Body, buf, 1)
 		head = buf[:hn]
@@ -385,7 +387,7 @@ func fetchBodyToMemory(ctx context.Context, client *http.Client, fetchURL, userA
 	if len(body) > maxImageProxyResponseSize {
 		return nil, "", fmt.Errorf("response exceeds %d byte cap", maxImageProxyResponseSize)
 	}
-	if mediaType == "" {
+	if mediaType == "" || mediaType == octetStream {
 		mediaType = sniffImageType(body)
 	}
 	if !isCacheableMediaType(mediaType) {

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -58,20 +58,29 @@ func pathFor(cacheDir, rawURL string) (shardDir, hashPrefix string) {
 	return filepath.Join(cacheRoot(cacheDir), hash[:2]), hash
 }
 
+const (
+	imageTypeJpeg = "image/jpeg"
+	imageTypePng  = "image/png"
+	imageTypeWebp = "image/webp"
+	imageTypeGif  = "image/gif"
+	imageTypeAvif = "image/avif"
+	imageTypeApng = "image/apng"
+)
+
 func extForContentType(contentType string) string {
 	mediaType, _, _ := mime.ParseMediaType(strings.TrimSpace(contentType))
 	switch mediaType {
-	case "image/jpeg":
+	case imageTypeJpeg:
 		return ".jpg"
-	case "image/png":
+	case imageTypePng:
 		return ".png"
-	case "image/webp":
+	case imageTypeWebp:
 		return ".webp"
-	case "image/gif":
+	case imageTypeGif:
 		return ".gif"
-	case "image/avif":
+	case imageTypeAvif:
 		return ".avif"
-	case "image/apng":
+	case imageTypeApng:
 		return ".png"
 	default:
 		return ".jpg"
@@ -81,15 +90,15 @@ func extForContentType(contentType string) string {
 func contentTypeForExt(ext string) string {
 	switch strings.ToLower(ext) {
 	case ".jpg":
-		return "image/jpeg"
+		return imageTypeJpeg
 	case ".png":
-		return "image/png"
+		return imageTypePng
 	case ".webp":
-		return "image/webp"
+		return imageTypeWebp
 	case ".gif":
-		return "image/gif"
+		return imageTypeGif
 	case ".avif":
-		return "image/avif"
+		return imageTypeAvif
 	default:
 		return defaultContentType
 	}
@@ -181,6 +190,20 @@ type fetchResult struct {
 	persistFailed bool
 }
 
+func sniffImageType(head []byte) string {
+	sniffed := http.DetectContentType(head)
+	if sniffed != "application/octet-stream" || len(head) < 12 {
+		return sniffed
+	}
+	if string(head[0:4]) == "RIFF" && string(head[8:12]) == "WEBP" {
+		return imageTypeWebp
+	}
+	if string(head[4:8]) == "ftyp" && (string(head[8:12]) == "avif" || string(head[8:12]) == "avis") {
+		return imageTypeAvif
+	}
+	return sniffed
+}
+
 func isCacheableMediaType(mediaType string) bool {
 	switch mediaType {
 	case "image/jpeg", "image/png", "image/webp", "image/gif", "image/avif", "image/apng":
@@ -196,7 +219,7 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 		return fetchResult{err: fmt.Errorf("create request: %w", err)}
 	}
 	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("Accept", "image/avif,image/webp,image/apng,image/jpeg,image/png,image/gif")
+	req.Header.Set("Accept", imageTypeAvif+","+imageTypeWebp+","+imageTypeApng+","+imageTypeJpeg+","+imageTypePng+","+imageTypeGif)
 	if referer != "" {
 		req.Header.Set("Referer", referer)
 	}
@@ -211,8 +234,7 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 		return fetchResult{err: fmt.Errorf("image source returned non-200 status")}
 	}
 
-	upstreamCT := resp.Header.Get("Content-Type")
-	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(upstreamCT, ";", 2)[0]))
+	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(resp.Header.Get("Content-Type"), ";", 2)[0]))
 	if mediaType != "" && !isCacheableMediaType(mediaType) {
 		if strings.HasPrefix(mediaType, "image/") {
 			return fetchResult{err: fmt.Errorf("unsupported image content type %q", mediaType)}
@@ -224,13 +246,11 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 		buf := make([]byte, 512)
 		hn, _ := io.ReadAtLeast(resp.Body, buf, 1)
 		head = buf[:hn]
-		sniffed := http.DetectContentType(head)
+		sniffed := sniffImageType(head)
 		if !isCacheableMediaType(sniffed) {
 			return fetchResult{err: fmt.Errorf("uncacheable content in headerless response (sniffed %q)", sniffed)}
 		}
-		upstreamCT = sniffed
 	}
-	normalizedCT := contentTypeForExt(extForContentType(upstreamCT))
 
 	shardDir, hashPrefix := pathFor(cacheDir, cacheKey)
 	if err := fs.MkdirAll(shardDir, 0o755); err != nil {
@@ -272,7 +292,22 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 		return fetchResult{err: fmt.Errorf("response exceeds %d byte cap", maxImageProxyResponseSize)}
 	}
 
-	ext := extForContentType(upstreamCT)
+	hf, herr := fs.Open(tmpPath)
+	if herr != nil {
+		_ = fs.Remove(tmpPath)
+		return fetchResult{err: fmt.Errorf("verify temp: %w", herr), persistFailed: true}
+	}
+	vbuf := make([]byte, 512)
+	vn, _ := hf.Read(vbuf)
+	_ = hf.Close()
+	persisted := sniffImageType(vbuf[:vn])
+	if !isCacheableMediaType(persisted) {
+		_ = fs.Remove(tmpPath)
+		return fetchResult{err: fmt.Errorf("invalid image content (sniffed %q)", persisted)}
+	}
+	normalizedCT := contentTypeForExt(extForContentType(persisted))
+
+	ext := extForContentType(persisted)
 	dstPath := filepath.Join(shardDir, hashPrefix+ext)
 	if err := atomicRename(fs, tmpPath, dstPath); err != nil {
 		logging.Warnf("image cache: rename %s -> %s failed, serving from temp: %v", tmpPath, dstPath, err)
@@ -323,7 +358,7 @@ func fetchBodyToMemory(ctx context.Context, client *http.Client, fetchURL, userA
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("Accept", "image/avif,image/webp,image/apng,image/jpeg,image/png,image/gif")
+	req.Header.Set("Accept", imageTypeAvif+","+imageTypeWebp+","+imageTypeApng+","+imageTypeJpeg+","+imageTypePng+","+imageTypeGif)
 	if referer != "" {
 		req.Header.Set("Referer", referer)
 	}

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -175,9 +175,18 @@ func get(fs afero.Fs, cacheDir, rawURL string, ttl time.Duration) (file afero.Fi
 type fetchResult struct {
 	cachedPath    string
 	tempPath      string
+	body          []byte
 	contentType   string
 	err           error
 	persistFailed bool
+}
+
+func isCacheableMediaType(mediaType string) bool {
+	switch mediaType {
+	case "image/jpeg", "image/png", "image/webp", "image/gif", "image/avif", "image/apng":
+		return true
+	}
+	return false
 }
 
 func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchURL string, client *http.Client, userAgent, referer string) fetchResult {
@@ -187,7 +196,7 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 		return fetchResult{err: fmt.Errorf("create request: %w", err)}
 	}
 	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+	req.Header.Set("Accept", "image/avif,image/webp,image/apng,image/jpeg,image/png,image/gif")
 	if referer != "" {
 		req.Header.Set("Referer", referer)
 	}
@@ -204,7 +213,10 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 
 	upstreamCT := resp.Header.Get("Content-Type")
 	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(upstreamCT, ";", 2)[0]))
-	if mediaType != "" && !strings.HasPrefix(mediaType, "image/") {
+	if mediaType != "" && !isCacheableMediaType(mediaType) {
+		if strings.HasPrefix(mediaType, "image/") {
+			return fetchResult{err: fmt.Errorf("unsupported image content type %q", mediaType)}
+		}
 		return fetchResult{err: fmt.Errorf("non-image content type %q", mediaType)}
 	}
 	var head []byte
@@ -213,8 +225,8 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 		hn, _ := io.ReadAtLeast(resp.Body, buf, 1)
 		head = buf[:hn]
 		sniffed := http.DetectContentType(head)
-		if !strings.HasPrefix(sniffed, "image/") {
-			return fetchResult{err: fmt.Errorf("non-image content in headerless response (sniffed %q)", sniffed)}
+		if !isCacheableMediaType(sniffed) {
+			return fetchResult{err: fmt.Errorf("uncacheable content in headerless response (sniffed %q)", sniffed)}
 		}
 		upstreamCT = sniffed
 	}
@@ -303,4 +315,42 @@ func atomicRename(fs afero.Fs, src, dst string) error {
 	}
 	_ = fs.Remove(dst)
 	return fs.Rename(src, dst)
+}
+
+func fetchBodyToMemory(ctx context.Context, client *http.Client, fetchURL, userAgent, referer string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(context.WithoutCancel(ctx), http.MethodGet, fetchURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "image/avif,image/webp,image/apng,image/jpeg,image/png,image/gif")
+	if referer != "" {
+		req.Header.Set("Referer", referer)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+	defer func() { _ = httpclient.DrainAndClose(resp.Body) }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("image source returned non-200 status")
+	}
+
+	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(resp.Header.Get("Content-Type"), ";", 2)[0]))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxImageProxyResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if len(body) > maxImageProxyResponseSize {
+		return nil, fmt.Errorf("response exceeds %d byte cap", maxImageProxyResponseSize)
+	}
+	if mediaType == "" {
+		mediaType = http.DetectContentType(body)
+	}
+	if !isCacheableMediaType(mediaType) {
+		return nil, fmt.Errorf("uncacheable content type %q", mediaType)
+	}
+	return body, nil
 }

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -214,7 +214,7 @@ func isCacheableMediaType(mediaType string) bool {
 	return false
 }
 
-func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchURL string, client *http.Client, userAgent, referer string) fetchResult {
+func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchURL string, client *http.Client, userAgent, referer string, maxCacheSizeMB int) fetchResult {
 	fetchCtx := context.WithoutCancel(ctx)
 	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, fetchURL, nil)
 	if err != nil {
@@ -346,6 +346,7 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 			}
 		}
 	}
+	evictImageCacheToSize(fs, cacheDir, maxCacheSizeMB, dstPath)
 	return fetchResult{cachedPath: dstPath, contentType: normalizedCT}
 }
 

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/javinizer/javinizer-go/internal/httpclient"
 	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/javinizer/javinizer-go/internal/worker"
 	"github.com/spf13/afero"
 	"golang.org/x/sync/singleflight"
 )
@@ -409,4 +410,15 @@ func fetchBodyToMemory(ctx context.Context, client *http.Client, fetchURL, userA
 		return nil, "", fmt.Errorf("uncacheable content type %q", ct)
 	}
 	return body, ct, nil
+}
+
+func evictImageCacheToSize(fs afero.Fs, cacheDir string, maxSizeMB int) {
+	if maxSizeMB <= 0 {
+		return
+	}
+	if _, removed, err := worker.EvictImageCacheToSize(fs, cacheDir, int64(maxSizeMB)<<20); err != nil {
+		logging.Warnf("image cache: size eviction failed: %v", err)
+	} else if removed > 0 {
+		logging.Infof("image cache: evicted %d entr(ies) to enforce the %d MB quota", removed, maxSizeMB)
+	}
 }

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -1,0 +1,265 @@
+package temp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/httpclient"
+	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/spf13/afero"
+	"golang.org/x/sync/singleflight"
+)
+
+const maxImageProxyResponseSize = 50 * 1024 * 1024
+
+const defaultContentType = "image/jpeg"
+
+var imageCacheGroup singleflight.Group
+
+// CacheState represents the freshness state of a cache entry.
+type CacheState int
+
+const (
+	// CacheAbsent means no cache entry exists.
+	CacheAbsent CacheState = iota
+	// CacheFresh means the entry exists and is within the TTL.
+	CacheFresh
+	// CacheStale means the entry exists but has exceeded the TTL.
+	CacheStale
+)
+
+var entryExt = regexp.MustCompile(`^([0-9a-f]{64})\.(jpg|png|webp|gif|avif)$`)
+
+func cacheRoot(cacheDir string) string {
+	return filepath.Join(cacheDir, "image-cache")
+}
+
+func tempDir(cacheDir string) string {
+	return filepath.Join(cacheRoot(cacheDir), ".tmp")
+}
+
+func pathFor(cacheDir, rawURL string) (shardDir, hashPrefix string) {
+	h := sha256.Sum256([]byte(rawURL))
+	hash := hex.EncodeToString(h[:])
+	return filepath.Join(cacheRoot(cacheDir), hash[:2]), hash
+}
+
+func extForContentType(contentType string) string {
+	mediaType, _, _ := mime.ParseMediaType(strings.TrimSpace(contentType))
+	switch mediaType {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/webp":
+		return ".webp"
+	case "image/gif":
+		return ".gif"
+	case "image/avif":
+		return ".avif"
+	case "image/apng":
+		return ".png"
+	default:
+		return ".jpg"
+	}
+}
+
+func contentTypeForExt(ext string) string {
+	switch strings.ToLower(ext) {
+	case ".jpg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".webp":
+		return "image/webp"
+	case ".gif":
+		return "image/gif"
+	case ".avif":
+		return "image/avif"
+	default:
+		return defaultContentType
+	}
+}
+
+func resolveEntry(fs afero.Fs, shardDir, hashPrefix string) (path, ext string, ok bool) {
+	entries, err := afero.ReadDir(fs, shardDir)
+	if err != nil {
+		return "", "", false
+	}
+	var best string
+	var bestMtime time.Time
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		m := entryExt.FindStringSubmatch(e.Name())
+		if m == nil || m[1] != hashPrefix {
+			continue
+		}
+		if best == "" || e.ModTime().After(bestMtime) {
+			best = filepath.Join(shardDir, e.Name())
+			bestMtime = e.ModTime()
+			ext = "." + m[2]
+		}
+	}
+	if best == "" {
+		return "", "", false
+	}
+	return best, ext, true
+}
+
+func resolveAllEntries(fs afero.Fs, shardDir, hashPrefix string) ([]string, string, bool) {
+	entries, err := afero.ReadDir(fs, shardDir)
+	if err != nil {
+		return nil, "", false
+	}
+	var paths []string
+	var bestExt string
+	var bestMtime time.Time
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		m := entryExt.FindStringSubmatch(e.Name())
+		if m == nil || m[1] != hashPrefix {
+			continue
+		}
+		paths = append(paths, filepath.Join(shardDir, e.Name()))
+		if bestExt == "" || e.ModTime().After(bestMtime) {
+			bestExt = "." + m[2]
+			bestMtime = e.ModTime()
+		}
+	}
+	if len(paths) == 0 {
+		return nil, "", false
+	}
+	return paths, bestExt, true
+}
+
+func get(fs afero.Fs, cacheDir, rawURL string, ttl time.Duration) (file afero.File, contentType string, state CacheState) {
+	shardDir, hashPrefix := pathFor(cacheDir, rawURL)
+	path, ext, ok := resolveEntry(fs, shardDir, hashPrefix)
+	if !ok {
+		return nil, "", CacheAbsent
+	}
+	info, err := fs.Stat(path)
+	if err != nil {
+		return nil, "", CacheAbsent
+	}
+	file, err = fs.Open(path)
+	if err != nil {
+		return nil, "", CacheAbsent
+	}
+	contentType = contentTypeForExt(ext)
+	if time.Since(info.ModTime()) < ttl {
+		return file, contentType, CacheFresh
+	}
+	return file, contentType, CacheStale
+}
+
+type fetchResult struct {
+	cachedPath    string
+	tempPath      string
+	contentType   string
+	err           error
+	persistFailed bool
+}
+
+func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchURL string, client *http.Client, userAgent, referer string) fetchResult {
+	fetchCtx := context.WithoutCancel(ctx)
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, fetchURL, nil)
+	if err != nil {
+		return fetchResult{err: fmt.Errorf("create request: %w", err)}
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+	if referer != "" {
+		req.Header.Set("Referer", referer)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fetchResult{err: fmt.Errorf("fetch: %w", err)}
+	}
+	defer func() { _ = httpclient.DrainAndClose(resp.Body) }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fetchResult{err: fmt.Errorf("image source returned non-200 status")}
+	}
+
+	upstreamCT := resp.Header.Get("Content-Type")
+	normalizedCT := contentTypeForExt(extForContentType(upstreamCT))
+
+	shardDir, hashPrefix := pathFor(cacheDir, cacheKey)
+	if err := fs.MkdirAll(shardDir, 0o755); err != nil {
+		logging.Warnf("image cache: mkdir shard failed: %v", err)
+		return fetchResult{err: fmt.Errorf("mkdir shard: %w", err), persistFailed: true}
+	}
+	tmpD := tempDir(cacheDir)
+	if err := fs.MkdirAll(tmpD, 0o755); err != nil {
+		logging.Warnf("image cache: mkdir tmp failed: %v", err)
+		return fetchResult{err: fmt.Errorf("mkdir tmp: %w", err), persistFailed: true}
+	}
+	rb := make([]byte, 8)
+	if _, err := rand.Read(rb); err != nil {
+		return fetchResult{err: fmt.Errorf("rand: %w", err)}
+	}
+	tmpPath := filepath.Join(tmpD, hex.EncodeToString(rb))
+	f, err := fs.Create(tmpPath)
+	if err != nil {
+		logging.Warnf("image cache: create temp failed: %v", err)
+		return fetchResult{err: fmt.Errorf("create temp: %w", err), persistFailed: true}
+	}
+	n, copyErr := io.Copy(f, io.LimitReader(resp.Body, maxImageProxyResponseSize+1))
+	_ = f.Close()
+	if copyErr != nil {
+		_ = fs.Remove(tmpPath)
+		return fetchResult{err: fmt.Errorf("write temp: %w", copyErr)}
+	}
+	if n > maxImageProxyResponseSize {
+		_ = fs.Remove(tmpPath)
+		return fetchResult{err: fmt.Errorf("response exceeds %d byte cap", maxImageProxyResponseSize)}
+	}
+
+	ext := extForContentType(upstreamCT)
+	dstPath := filepath.Join(shardDir, hashPrefix+ext)
+	if err := atomicRename(fs, tmpPath, dstPath); err != nil {
+		logging.Warnf("image cache: rename %s -> %s failed, serving from temp: %v", tmpPath, dstPath, err)
+		return fetchResult{tempPath: tmpPath, contentType: normalizedCT}
+	}
+
+	if matches, _, found := resolveAllEntries(fs, shardDir, hashPrefix); found {
+		for _, m := range matches {
+			if m != dstPath {
+				_ = fs.Remove(m)
+			}
+		}
+	}
+	return fetchResult{cachedPath: dstPath, contentType: normalizedCT}
+}
+
+func atomicRename(fs afero.Fs, src, dst string) error {
+	if err := fs.Rename(src, dst); err == nil {
+		return nil
+	} else if os.IsNotExist(err) {
+		if mkErr := fs.MkdirAll(filepath.Dir(dst), 0o755); mkErr != nil {
+			return mkErr
+		}
+		return fs.Rename(src, dst)
+	} else if !os.IsExist(err) {
+		return err
+	}
+	_ = fs.Remove(dst)
+	return fs.Rename(src, dst)
+}

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -1,6 +1,7 @@
 package temp
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -206,6 +207,17 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 	if mediaType != "" && !strings.HasPrefix(mediaType, "image/") {
 		return fetchResult{err: fmt.Errorf("non-image content type %q", mediaType)}
 	}
+	var head []byte
+	if mediaType == "" {
+		buf := make([]byte, 512)
+		hn, _ := io.ReadAtLeast(resp.Body, buf, 1)
+		head = buf[:hn]
+		sniffed := http.DetectContentType(head)
+		if !strings.HasPrefix(sniffed, "image/") {
+			return fetchResult{err: fmt.Errorf("non-image content in headerless response (sniffed %q)", sniffed)}
+		}
+		upstreamCT = sniffed
+	}
 	normalizedCT := contentTypeForExt(extForContentType(upstreamCT))
 
 	shardDir, hashPrefix := pathFor(cacheDir, cacheKey)
@@ -229,7 +241,11 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 		return fetchResult{err: fmt.Errorf("create temp: %w", err), persistFailed: true}
 	}
 	werr := &writeTracker{w: f}
-	n, copyErr := io.Copy(werr, io.LimitReader(resp.Body, maxImageProxyResponseSize+1))
+	src := io.LimitReader(resp.Body, maxImageProxyResponseSize+1)
+	if head != nil {
+		src = io.MultiReader(bytes.NewReader(head), io.LimitReader(resp.Body, maxImageProxyResponseSize+1-int64(len(head))))
+	}
+	n, copyErr := io.Copy(werr, src)
 	_ = f.Close()
 	if copyErr != nil {
 		_ = fs.Remove(tmpPath)

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -253,15 +253,32 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 		}
 	}
 
+	drainForDegrade := func() ([]byte, string) {
+		rest, _ := io.ReadAll(io.LimitReader(resp.Body, maxImageProxyResponseSize+1-int64(len(head))))
+		full := make([]byte, 0, len(head)+len(rest))
+		full = append(full, head...)
+		full = append(full, rest...)
+		if len(full) == 0 || len(full) > maxImageProxyResponseSize {
+			return nil, ""
+		}
+		ct := sniffImageType(full)
+		if !isCacheableMediaType(ct) {
+			return nil, ""
+		}
+		return full, ct
+	}
+
 	shardDir, hashPrefix := pathFor(cacheDir, cacheKey)
 	if err := fs.MkdirAll(shardDir, 0o755); err != nil {
 		logging.Warnf("image cache: mkdir shard failed: %v", err)
-		return fetchResult{err: fmt.Errorf("mkdir shard: %w", err), persistFailed: true}
+		body, dct := drainForDegrade()
+		return fetchResult{err: fmt.Errorf("mkdir shard: %w", err), persistFailed: true, body: body, contentType: dct}
 	}
 	tmpD := tempDir(cacheDir)
 	if err := fs.MkdirAll(tmpD, 0o755); err != nil {
 		logging.Warnf("image cache: mkdir tmp failed: %v", err)
-		return fetchResult{err: fmt.Errorf("mkdir tmp: %w", err), persistFailed: true}
+		body, dct := drainForDegrade()
+		return fetchResult{err: fmt.Errorf("mkdir tmp: %w", err), persistFailed: true, body: body, contentType: dct}
 	}
 	rb := make([]byte, 8)
 	if _, err := randRead(rb); err != nil {
@@ -271,7 +288,8 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 	f, err := fs.Create(tmpPath)
 	if err != nil {
 		logging.Warnf("image cache: create temp failed: %v", err)
-		return fetchResult{err: fmt.Errorf("create temp: %w", err), persistFailed: true}
+		body, dct := drainForDegrade()
+		return fetchResult{err: fmt.Errorf("create temp: %w", err), persistFailed: true, body: body, contentType: dct}
 	}
 	werr := &writeTracker{w: f}
 	src := io.LimitReader(resp.Body, maxImageProxyResponseSize+1)
@@ -379,7 +397,6 @@ func fetchBodyToMemory(ctx context.Context, client *http.Client, fetchURL, userA
 		return nil, "", fmt.Errorf("image source returned non-200 status")
 	}
 
-	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(resp.Header.Get("Content-Type"), ";", 2)[0]))
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxImageProxyResponseSize+1))
 	if err != nil {
 		return nil, "", fmt.Errorf("read body: %w", err)
@@ -387,11 +404,9 @@ func fetchBodyToMemory(ctx context.Context, client *http.Client, fetchURL, userA
 	if len(body) > maxImageProxyResponseSize {
 		return nil, "", fmt.Errorf("response exceeds %d byte cap", maxImageProxyResponseSize)
 	}
-	if mediaType == "" || mediaType == octetStream {
-		mediaType = sniffImageType(body)
+	ct := sniffImageType(body)
+	if !isCacheableMediaType(ct) {
+		return nil, "", fmt.Errorf("uncacheable content type %q", ct)
 	}
-	if !isCacheableMediaType(mediaType) {
-		return nil, "", fmt.Errorf("uncacheable content type %q", mediaType)
-	}
-	return body, mediaType, nil
+	return body, ct, nil
 }

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -149,25 +149,26 @@ func resolveAllEntries(fs afero.Fs, shardDir, hashPrefix string) ([]string, stri
 	return paths, bestExt, true
 }
 
-func get(fs afero.Fs, cacheDir, rawURL string, ttl time.Duration) (file afero.File, contentType string, state CacheState) {
+func get(fs afero.Fs, cacheDir, rawURL string, ttl time.Duration) (file afero.File, contentType string, remaining time.Duration, state CacheState) {
 	shardDir, hashPrefix := pathFor(cacheDir, rawURL)
 	path, ext, ok := resolveEntry(fs, shardDir, hashPrefix)
 	if !ok {
-		return nil, "", CacheAbsent
+		return nil, "", 0, CacheAbsent
 	}
 	info, err := fs.Stat(path)
 	if err != nil {
-		return nil, "", CacheAbsent
+		return nil, "", 0, CacheAbsent
 	}
 	file, err = fs.Open(path)
 	if err != nil {
-		return nil, "", CacheAbsent
+		return nil, "", 0, CacheAbsent
 	}
 	contentType = contentTypeForExt(ext)
-	if time.Since(info.ModTime()) < ttl {
-		return file, contentType, CacheFresh
+	remaining = ttl - time.Since(info.ModTime())
+	if remaining > 0 {
+		return file, contentType, remaining, CacheFresh
 	}
-	return file, contentType, CacheStale
+	return file, contentType, remaining, CacheStale
 }
 
 type fetchResult struct {
@@ -201,6 +202,10 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 	}
 
 	upstreamCT := resp.Header.Get("Content-Type")
+	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(upstreamCT, ";", 2)[0]))
+	if mediaType != "" && !strings.HasPrefix(mediaType, "image/") {
+		return fetchResult{err: fmt.Errorf("non-image content type %q", mediaType)}
+	}
 	normalizedCT := contentTypeForExt(extForContentType(upstreamCT))
 
 	shardDir, hashPrefix := pathFor(cacheDir, cacheKey)

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -183,7 +183,6 @@ func get(fs afero.Fs, cacheDir, rawURL string, ttl time.Duration) (file afero.Fi
 
 type fetchResult struct {
 	cachedPath    string
-	tempPath      string
 	body          []byte
 	contentType   string
 	err           error
@@ -310,8 +309,13 @@ func fetchAndCache(ctx context.Context, fs afero.Fs, cacheDir, cacheKey, fetchUR
 	ext := extForContentType(persisted)
 	dstPath := filepath.Join(shardDir, hashPrefix+ext)
 	if err := atomicRename(fs, tmpPath, dstPath); err != nil {
-		logging.Warnf("image cache: rename %s -> %s failed, serving from temp: %v", tmpPath, dstPath, err)
-		return fetchResult{tempPath: tmpPath, contentType: normalizedCT}
+		body, readErr := afero.ReadFile(fs, tmpPath)
+		_ = fs.Remove(tmpPath)
+		if readErr != nil {
+			return fetchResult{err: fmt.Errorf("rename: %w", err), persistFailed: true}
+		}
+		logging.Warnf("image cache: rename %s -> %s failed, serving from memory: %v", tmpPath, dstPath, err)
+		return fetchResult{body: body, contentType: normalizedCT, persistFailed: true}
 	}
 
 	if matches, _, found := resolveAllEntries(fs, shardDir, hashPrefix); found {
@@ -352,10 +356,10 @@ func atomicRename(fs afero.Fs, src, dst string) error {
 	return fs.Rename(src, dst)
 }
 
-func fetchBodyToMemory(ctx context.Context, client *http.Client, fetchURL, userAgent, referer string) ([]byte, error) {
+func fetchBodyToMemory(ctx context.Context, client *http.Client, fetchURL, userAgent, referer string) ([]byte, string, error) {
 	req, err := http.NewRequestWithContext(context.WithoutCancel(ctx), http.MethodGet, fetchURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
+		return nil, "", fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", imageTypeAvif+","+imageTypeWebp+","+imageTypeApng+","+imageTypeJpeg+","+imageTypePng+","+imageTypeGif)
@@ -365,27 +369,27 @@ func fetchBodyToMemory(ctx context.Context, client *http.Client, fetchURL, userA
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetch: %w", err)
+		return nil, "", fmt.Errorf("fetch: %w", err)
 	}
 	defer func() { _ = httpclient.DrainAndClose(resp.Body) }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("image source returned non-200 status")
+		return nil, "", fmt.Errorf("image source returned non-200 status")
 	}
 
 	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(resp.Header.Get("Content-Type"), ";", 2)[0]))
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxImageProxyResponseSize+1))
 	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
+		return nil, "", fmt.Errorf("read body: %w", err)
 	}
 	if len(body) > maxImageProxyResponseSize {
-		return nil, fmt.Errorf("response exceeds %d byte cap", maxImageProxyResponseSize)
+		return nil, "", fmt.Errorf("response exceeds %d byte cap", maxImageProxyResponseSize)
 	}
 	if mediaType == "" {
-		mediaType = http.DetectContentType(body)
+		mediaType = sniffImageType(body)
 	}
 	if !isCacheableMediaType(mediaType) {
-		return nil, fmt.Errorf("uncacheable content type %q", mediaType)
+		return nil, "", fmt.Errorf("uncacheable content type %q", mediaType)
 	}
-	return body, nil
+	return body, mediaType, nil
 }

--- a/internal/api/temp/image_cache.go
+++ b/internal/api/temp/image_cache.go
@@ -412,11 +412,11 @@ func fetchBodyToMemory(ctx context.Context, client *http.Client, fetchURL, userA
 	return body, ct, nil
 }
 
-func evictImageCacheToSize(fs afero.Fs, cacheDir string, maxSizeMB int) {
+func evictImageCacheToSize(fs afero.Fs, cacheDir string, maxSizeMB int, keep ...string) {
 	if maxSizeMB <= 0 {
 		return
 	}
-	if _, removed, err := worker.EvictImageCacheToSize(fs, cacheDir, int64(maxSizeMB)<<20); err != nil {
+	if _, removed, err := worker.EvictImageCacheToSize(fs, cacheDir, int64(maxSizeMB)<<20, keep...); err != nil {
 		logging.Warnf("image cache: size eviction failed: %v", err)
 	} else if removed > 0 {
 		logging.Infof("image cache: evicted %d entr(ies) to enforce the %d MB quota", removed, maxSizeMB)

--- a/internal/api/temp/image_cache_atomic_test.go
+++ b/internal/api/temp/image_cache_atomic_test.go
@@ -1,0 +1,114 @@
+package temp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/ssrf"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type atomicStubFs struct {
+	afero.Fs
+	renameErrs  []error
+	mkdirErr    error
+	renameCalls int
+}
+
+func (f *atomicStubFs) Rename(oldname, newname string) error {
+	idx := f.renameCalls
+	f.renameCalls++
+	if idx < len(f.renameErrs) && f.renameErrs[idx] != nil {
+		return f.renameErrs[idx]
+	}
+	return f.Fs.Rename(oldname, newname)
+}
+
+func (f *atomicStubFs) MkdirAll(path string, perm os.FileMode) error {
+	if f.mkdirErr != nil {
+		return f.mkdirErr
+	}
+	return f.Fs.MkdirAll(path, perm)
+}
+
+func TestAtomicRename_NotExistBranch_MkdirsAndRetries(t *testing.T) {
+	base := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(base, "/tmp/src.bin", []byte("data"), 0o644))
+	fs := &atomicStubFs{Fs: base, renameErrs: []error{os.ErrNotExist}}
+
+	err := atomicRename(fs, "/tmp/src.bin", "/new/dir/dst.bin")
+	require.NoError(t, err)
+	exists, _ := afero.Exists(base, "/new/dir/dst.bin")
+	assert.True(t, exists)
+}
+
+func TestAtomicRename_MkdirAllFailure_ReturnsError(t *testing.T) {
+	base := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(base, "/tmp/src.bin", []byte("data"), 0o644))
+	fs := &atomicStubFs{Fs: base, renameErrs: []error{os.ErrNotExist}, mkdirErr: errors.New("mkdir denied")}
+
+	err := atomicRename(fs, "/tmp/src.bin", "/new/dir/dst.bin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mkdir denied")
+}
+
+func TestAtomicRename_IsExistBranch_RemovesAndRetries(t *testing.T) {
+	base := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(base, "/tmp/src.bin", []byte("data"), 0o644))
+	require.NoError(t, afero.WriteFile(base, "/tmp/dst.bin", []byte("old"), 0o644))
+	fs := &atomicStubFs{Fs: base, renameErrs: []error{os.ErrExist}}
+
+	err := atomicRename(fs, "/tmp/src.bin", "/tmp/dst.bin")
+	require.NoError(t, err)
+	data, err := afero.ReadFile(base, "/tmp/dst.bin")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), data)
+}
+
+func TestAtomicRename_GenericError_ReturnsError(t *testing.T) {
+	base := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(base, "/tmp/src.bin", []byte("data"), 0o644))
+	fs := &atomicStubFs{Fs: base, renameErrs: []error{errors.New("io error")}}
+
+	err := atomicRename(fs, "/tmp/src.bin", "/tmp/dst.bin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "io error")
+}
+
+type renameAlwaysFailFs struct {
+	afero.Fs
+}
+
+func (f *renameAlwaysFailFs) Rename(oldname, newname string) error {
+	return errors.New("cross-device link")
+}
+
+func TestFetch_GenericRenameError_ReturnsError(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("rename-fail-test"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := &renameAlwaysFailFs{Fs: afero.NewMemMapFs()}
+	tempDir := t.TempDir()
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	assert.NoError(t, result.err)
+	assert.Empty(t, result.cachedPath)
+	assert.NotEmpty(t, result.tempPath)
+	content, readErr := afero.ReadFile(fs, result.tempPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, []byte("rename-fail-test"), content)
+}

--- a/internal/api/temp/image_cache_atomic_test.go
+++ b/internal/api/temp/image_cache_atomic_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -107,8 +108,15 @@ func TestFetch_GenericRenameError_ReturnsError(t *testing.T) {
 	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
 	assert.NoError(t, result.err)
 	assert.Empty(t, result.cachedPath)
-	assert.NotEmpty(t, result.tempPath)
-	content, readErr := afero.ReadFile(fs, result.tempPath)
-	require.NoError(t, readErr)
-	assert.Equal(t, jpegBytes("rename-fail-test"), content)
+	assert.True(t, result.persistFailed)
+	assert.Equal(t, jpegBytes("rename-fail-test"), result.body)
+
+	var leftovers []string
+	_ = afero.Walk(fs, "/", func(p string, info os.FileInfo, werr error) error {
+		if werr == nil && info != nil && !info.IsDir() && strings.Contains(p, ".tmp") {
+			leftovers = append(leftovers, p)
+		}
+		return nil
+	})
+	assert.Empty(t, leftovers, "temp artifact must be reclaimed when the rename fails")
 }

--- a/internal/api/temp/image_cache_atomic_test.go
+++ b/internal/api/temp/image_cache_atomic_test.go
@@ -105,7 +105,7 @@ func TestFetch_GenericRenameError_ReturnsError(t *testing.T) {
 	tempDir := t.TempDir()
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
 
-	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "", 0)
 	assert.NoError(t, result.err)
 	assert.Empty(t, result.cachedPath)
 	assert.True(t, result.persistFailed)

--- a/internal/api/temp/image_cache_atomic_test.go
+++ b/internal/api/temp/image_cache_atomic_test.go
@@ -96,7 +96,7 @@ func TestFetch_GenericRenameError_ReturnsError(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		_, _ = w.Write([]byte("rename-fail-test"))
+		_, _ = w.Write(jpegBytes("rename-fail-test"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -110,5 +110,5 @@ func TestFetch_GenericRenameError_ReturnsError(t *testing.T) {
 	assert.NotEmpty(t, result.tempPath)
 	content, readErr := afero.ReadFile(fs, result.tempPath)
 	require.NoError(t, readErr)
-	assert.Equal(t, []byte("rename-fail-test"), content)
+	assert.Equal(t, jpegBytes("rename-fail-test"), content)
 }

--- a/internal/api/temp/image_cache_branch_test.go
+++ b/internal/api/temp/image_cache_branch_test.go
@@ -1,0 +1,153 @@
+package temp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/ssrf"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBranch_ResolveEntry_SkipsSubdirectories(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	shardDir := "/cache/ab"
+	hashPrefix := strings.Repeat("ab", 32)
+	require.NoError(t, fs.MkdirAll(filepath.Join(shardDir, "nested"), 0o755))
+	entry := filepath.Join(shardDir, hashPrefix+".jpg")
+	require.NoError(t, afero.WriteFile(fs, entry, []byte("data"), 0o644))
+
+	path, ext, ok := resolveEntry(fs, shardDir, hashPrefix)
+	require.True(t, ok)
+	assert.Equal(t, entry, path)
+	assert.Equal(t, ".jpg", ext)
+}
+
+func TestBranch_ResolveAllEntries_SkipsNonMatching(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	shardDir := "/cache/cd"
+	hashPrefix := strings.Repeat("cd", 32)
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(shardDir, "readme.txt"), []byte("junk"), 0o644))
+	entry := filepath.Join(shardDir, hashPrefix+".png")
+	require.NoError(t, afero.WriteFile(fs, entry, []byte("data"), 0o644))
+
+	paths, ext, ok := resolveAllEntries(fs, shardDir, hashPrefix)
+	require.True(t, ok)
+	assert.Equal(t, []string{entry}, paths)
+	assert.Equal(t, ".png", ext)
+}
+
+func TestBranch_ResolveAllEntries_OnlyJunkReturnsFalse(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	shardDir := "/cache/ef"
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(shardDir, "stray.tmp"), []byte("junk"), 0o644))
+
+	paths, _, ok := resolveAllEntries(fs, shardDir, strings.Repeat("ef", 32))
+	assert.False(t, ok)
+	assert.Nil(t, paths)
+}
+
+type openErrFs struct {
+	afero.Fs
+	target string
+}
+
+func (f *openErrFs) Open(name string) (afero.File, error) {
+	if name == f.target {
+		return nil, errors.New("open denied")
+	}
+	return f.Fs.Open(name)
+}
+
+func TestBranch_Get_OpenFailureAfterResolveReturnsAbsent(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	cacheDir := t.TempDir()
+	rawURL := "http://example.com/open-fail.jpg"
+	shardDir, hashPrefix := pathFor(cacheDir, rawURL)
+	require.NoError(t, mem.MkdirAll(shardDir, 0o755))
+	entry := filepath.Join(shardDir, hashPrefix+".jpg")
+	require.NoError(t, afero.WriteFile(mem, entry, []byte("data"), 0o644))
+
+	fs := &openErrFs{Fs: mem, target: entry}
+	file, ct, state := get(fs, cacheDir, rawURL, time.Hour)
+	assert.Nil(t, file)
+	assert.Empty(t, ct)
+	assert.Equal(t, CacheAbsent, state)
+}
+
+func TestBranch_FetchAndCache_CreateRequestError(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), "key", "://no-scheme", client, "ua", "")
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(), "create request")
+}
+
+type mkdirSuffixFailFs struct {
+	afero.Fs
+	suffix string
+}
+
+func (f *mkdirSuffixFailFs) MkdirAll(path string, perm os.FileMode) error {
+	if filepath.Base(path) == f.suffix {
+		return errors.New("mkdir denied")
+	}
+	return f.Fs.MkdirAll(path, perm)
+}
+
+func TestBranch_FetchAndCache_MkdirTmpError(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("img"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := &mkdirSuffixFailFs{Fs: afero.NewMemMapFs(), suffix: ".tmp"}
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/a.jpg", upstream.URL+"/a.jpg", client, "ua", "")
+	require.Error(t, result.err)
+	assert.True(t, result.persistFailed)
+	assert.Contains(t, result.err.Error(), "mkdir tmp")
+}
+
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+type errReadBody struct{}
+
+func (errReadBody) Read([]byte) (int, error) { return 0, errors.New("stream reset") }
+func (errReadBody) Close() error             { return nil }
+
+func TestBranch_FetchAndCache_ReadSideCopyError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		h := make(http.Header)
+		h.Set("Content-Type", "image/jpeg")
+		return &http.Response{
+			Status:     "200 OK",
+			StatusCode: http.StatusOK,
+			Header:     h,
+			Body:       errReadBody{},
+			Request:    req,
+		}, nil
+	})}
+
+	fs := afero.NewMemMapFs()
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), "http://example.com/x.jpg", "http://example.com/x.jpg", client, "ua", "")
+	require.Error(t, result.err)
+	assert.False(t, result.persistFailed, "read-side failures must not mark the run as persist-failed")
+	assert.Contains(t, result.err.Error(), "write temp")
+}

--- a/internal/api/temp/image_cache_branch_test.go
+++ b/internal/api/temp/image_cache_branch_test.go
@@ -174,3 +174,22 @@ func TestBranch_FetchAndCache_RejectsNonImageContentType(t *testing.T) {
 	entries, _ := afero.ReadDir(fs, "/")
 	assert.Empty(t, entries, "nothing must be written for non-image responses")
 }
+
+func TestBranch_FetchAndCache_RejectsHeaderlessHTML(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "")
+		_, _ = w.Write([]byte("<html><body>bot check</body></html>"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/img", upstream.URL+"/img", client, "ua", "")
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(), "non-image content")
+	assert.Empty(t, result.cachedPath)
+	assert.Empty(t, result.tempPath)
+}

--- a/internal/api/temp/image_cache_branch_test.go
+++ b/internal/api/temp/image_cache_branch_test.go
@@ -79,7 +79,7 @@ func TestBranch_Get_OpenFailureAfterResolveReturnsAbsent(t *testing.T) {
 	require.NoError(t, afero.WriteFile(mem, entry, []byte("data"), 0o644))
 
 	fs := &openErrFs{Fs: mem, target: entry}
-	file, ct, state := get(fs, cacheDir, rawURL, time.Hour)
+	file, ct, _, state := get(fs, cacheDir, rawURL, time.Hour)
 	assert.Nil(t, file)
 	assert.Empty(t, ct)
 	assert.Equal(t, CacheAbsent, state)
@@ -150,4 +150,27 @@ func TestBranch_FetchAndCache_ReadSideCopyError(t *testing.T) {
 	require.Error(t, result.err)
 	assert.False(t, result.persistFailed, "read-side failures must not mark the run as persist-failed")
 	assert.Contains(t, result.err.Error(), "write temp")
+}
+
+func TestBranch_FetchAndCache_RejectsNonImageContentType(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<html>challenge</html>"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/img", upstream.URL+"/img", client, "ua", "")
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(), "non-image content type")
+	assert.False(t, result.persistFailed)
+	assert.Empty(t, result.cachedPath)
+	assert.Empty(t, result.tempPath)
+
+	entries, _ := afero.ReadDir(fs, "/")
+	assert.Empty(t, entries, "nothing must be written for non-image responses")
 }

--- a/internal/api/temp/image_cache_branch_test.go
+++ b/internal/api/temp/image_cache_branch_test.go
@@ -481,3 +481,29 @@ func TestBranch_FetchAndCache_PersistFail_DrainRejectsGarbage(t *testing.T) {
 	assert.True(t, result.persistFailed)
 	assert.Empty(t, result.body, "junk drained from the failed persist must not be served")
 }
+
+func TestBranch_EvictImageCacheToSize(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	dir := t.TempDir()
+	seed := filepath.Join(dir, "image-cache", "ab", "a.jpg")
+	require.NoError(t, mem.MkdirAll(filepath.Dir(seed), 0o755))
+	require.NoError(t, afero.WriteFile(mem, seed, make([]byte, 2048), 0o644))
+
+	evictImageCacheToSize(mem, dir, 0)
+	exists, _ := afero.Exists(mem, seed)
+	assert.True(t, exists, "zero quota is a no-op")
+
+	evictImageCacheToSize(mem, dir, 1)
+	exists, _ = afero.Exists(mem, seed)
+	assert.True(t, exists, "2 KB stays under a 1 MB quota")
+
+	big := filepath.Join(dir, "image-cache", "cd", "b.jpg")
+	require.NoError(t, mem.MkdirAll(filepath.Dir(big), 0o755))
+	require.NoError(t, afero.WriteFile(mem, big, make([]byte, 2<<20), 0o644))
+	evictImageCacheToSize(mem, dir, 1)
+	exists, _ = afero.Exists(mem, seed)
+	assert.False(t, exists, "oldest entry evicted once over quota")
+
+	broken := &openErrFs{Fs: mem, target: filepath.Join(dir, "image-cache")}
+	evictImageCacheToSize(broken, dir, 1)
+}

--- a/internal/api/temp/image_cache_branch_test.go
+++ b/internal/api/temp/image_cache_branch_test.go
@@ -172,7 +172,6 @@ func TestBranch_FetchAndCache_RejectsNonImageContentType(t *testing.T) {
 	assert.Contains(t, result.err.Error(), "non-image content type")
 	assert.False(t, result.persistFailed)
 	assert.Empty(t, result.cachedPath)
-	assert.Empty(t, result.tempPath)
 
 	entries, _ := afero.ReadDir(fs, "/")
 	assert.Empty(t, entries, "nothing must be written for non-image responses")
@@ -194,7 +193,6 @@ func TestBranch_FetchAndCache_RejectsHeaderlessHTML(t *testing.T) {
 	require.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "uncacheable content")
 	assert.Empty(t, result.cachedPath)
-	assert.Empty(t, result.tempPath)
 }
 
 func fakeImageResponse(req *http.Request, status int, contentType string, body []byte) *http.Response {
@@ -218,9 +216,10 @@ func TestBranch_FetchBodyToMemory_Success(t *testing.T) {
 		return fakeImageResponse(req, http.StatusOK, "image/png", []byte("png-bytes")), nil
 	})}
 
-	body, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a.png", "ua", "https://ref.example/x")
+	body, gotCT, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a.png", "ua", "https://ref.example/x")
 	require.NoError(t, err)
 	assert.Equal(t, []byte("png-bytes"), body)
+	assert.Equal(t, "image/png", gotCT)
 	assert.Equal(t, "https://ref.example/x", gotReferer)
 }
 
@@ -228,7 +227,7 @@ func TestBranch_FetchBodyToMemory_CreateRequestError(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("must not be called")
 	})}
-	_, err := fetchBodyToMemory(context.Background(), client, "://bad-url", "ua", "")
+	_, _, err := fetchBodyToMemory(context.Background(), client, "://bad-url", "ua", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "create request")
 }
@@ -237,7 +236,7 @@ func TestBranch_FetchBodyToMemory_DoError(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("dial failed")
 	})}
-	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a.png", "ua", "")
+	_, _, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a.png", "ua", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fetch")
 }
@@ -246,7 +245,7 @@ func TestBranch_FetchBodyToMemory_Non200(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return fakeImageResponse(req, http.StatusServiceUnavailable, "image/png", []byte("x")), nil
 	})}
-	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a.png", "ua", "")
+	_, _, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a.png", "ua", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "non-200")
 }
@@ -255,7 +254,7 @@ func TestBranch_FetchBodyToMemory_RejectsNonImageCT(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return fakeImageResponse(req, http.StatusOK, "text/html", []byte("<html>")), nil
 	})}
-	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a", "ua", "")
+	_, _, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a", "ua", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "uncacheable content type")
 }
@@ -265,7 +264,7 @@ func TestBranch_FetchBodyToMemory_OversizeRejected(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return fakeImageResponse(req, http.StatusOK, "image/jpeg", big), nil
 	})}
-	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/big.jpg", "ua", "")
+	_, _, err := fetchBodyToMemory(context.Background(), client, "http://example.com/big.jpg", "ua", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds")
 }
@@ -275,16 +274,17 @@ func TestBranch_FetchBodyToMemory_HeaderlessSniffOK(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return fakeImageResponse(req, http.StatusOK, "", pngMagic), nil
 	})}
-	body, err := fetchBodyToMemory(context.Background(), client, "http://example.com/raw", "ua", "")
+	body, gotCT, err := fetchBodyToMemory(context.Background(), client, "http://example.com/raw", "ua", "")
 	require.NoError(t, err)
 	assert.Equal(t, pngMagic, body)
+	assert.Equal(t, "image/png", gotCT, "sniffed media type must be returned with the body")
 }
 
 func TestBranch_FetchBodyToMemory_HeaderlessSniffRejectsText(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return fakeImageResponse(req, http.StatusOK, "", []byte("plain text challenge")), nil
 	})}
-	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/raw", "ua", "")
+	_, _, err := fetchBodyToMemory(context.Background(), client, "http://example.com/raw", "ua", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "uncacheable content type")
 }
@@ -301,7 +301,7 @@ func TestBranch_FetchBodyToMemory_ReadError(t *testing.T) {
 			Request:    req,
 		}, nil
 	})}
-	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/x.jpg", "ua", "")
+	_, _, err := fetchBodyToMemory(context.Background(), client, "http://example.com/x.jpg", "ua", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read body")
 }
@@ -359,7 +359,6 @@ func TestBranch_FetchAndCache_RejectsDeclaredImageButGarbageBytes(t *testing.T) 
 	require.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "invalid image content")
 	assert.Empty(t, result.cachedPath)
-	assert.Empty(t, result.tempPath)
 	var files []string
 	_ = afero.Walk(fs, "/", func(_ string, info os.FileInfo, _ error) error {
 		if info != nil && !info.IsDir() {

--- a/internal/api/temp/image_cache_branch_test.go
+++ b/internal/api/temp/image_cache_branch_test.go
@@ -91,7 +91,7 @@ func TestBranch_Get_OpenFailureAfterResolveReturnsAbsent(t *testing.T) {
 func TestBranch_FetchAndCache_CreateRequestError(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), "key", "://no-scheme", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), "key", "://no-scheme", client, "ua", "", 0)
 	require.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "create request")
 }
@@ -120,7 +120,7 @@ func TestBranch_FetchAndCache_MkdirTmpError(t *testing.T) {
 
 	fs := &mkdirSuffixFailFs{Fs: afero.NewMemMapFs(), suffix: ".tmp"}
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/a.jpg", upstream.URL+"/a.jpg", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/a.jpg", upstream.URL+"/a.jpg", client, "ua", "", 0)
 	require.Error(t, result.err)
 	assert.True(t, result.persistFailed)
 	assert.Contains(t, result.err.Error(), "mkdir tmp")
@@ -149,7 +149,7 @@ func TestBranch_FetchAndCache_ReadSideCopyError(t *testing.T) {
 	})}
 
 	fs := afero.NewMemMapFs()
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), "http://example.com/x.jpg", "http://example.com/x.jpg", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), "http://example.com/x.jpg", "http://example.com/x.jpg", client, "ua", "", 0)
 	require.Error(t, result.err)
 	assert.False(t, result.persistFailed, "read-side failures must not mark the run as persist-failed")
 	assert.Contains(t, result.err.Error(), "write temp")
@@ -167,7 +167,7 @@ func TestBranch_FetchAndCache_RejectsNonImageContentType(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/img", upstream.URL+"/img", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/img", upstream.URL+"/img", client, "ua", "", 0)
 	require.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "non-image content type")
 	assert.False(t, result.persistFailed)
@@ -189,7 +189,7 @@ func TestBranch_FetchAndCache_RejectsHeaderlessHTML(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/img", upstream.URL+"/img", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/img", upstream.URL+"/img", client, "ua", "", 0)
 	require.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "uncacheable content")
 	assert.Empty(t, result.cachedPath)
@@ -319,7 +319,7 @@ func TestBranch_FetchAndCache_HeaderlessAvisBrandAccepted(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/clip.avif", upstream.URL+"/clip.avif", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/clip.avif", upstream.URL+"/clip.avif", client, "ua", "", 0)
 	require.NoError(t, result.err)
 	assert.Equal(t, "image/avif", result.contentType)
 	assert.Contains(t, result.cachedPath, ".avif")
@@ -337,7 +337,7 @@ func TestBranch_FetchAndCache_VerifyTempOpenFailure(t *testing.T) {
 
 	hooked := &openHookFs{Fs: afero.NewMemMapFs(), mode: "error", match: isTmpCacheFile}
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), hooked, t.TempDir(), upstream.URL+"/x.jpg", upstream.URL+"/x.jpg", client, "ua", "")
+	result := fetchAndCache(context.Background(), hooked, t.TempDir(), upstream.URL+"/x.jpg", upstream.URL+"/x.jpg", client, "ua", "", 0)
 	require.Error(t, result.err)
 	assert.True(t, result.persistFailed)
 	assert.Contains(t, result.err.Error(), "verify temp")
@@ -355,7 +355,7 @@ func TestBranch_FetchAndCache_RejectsDeclaredImageButGarbageBytes(t *testing.T) 
 
 	fs := afero.NewMemMapFs()
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/fake.jpg", upstream.URL+"/fake.jpg", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/fake.jpg", upstream.URL+"/fake.jpg", client, "ua", "", 0)
 	require.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "invalid image content")
 	assert.Empty(t, result.cachedPath)
@@ -385,7 +385,7 @@ func TestBranch_FetchAndCache_HeaderlessBinaryGarbageRejected(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/blob", upstream.URL+"/blob", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/blob", upstream.URL+"/blob", client, "ua", "", 0)
 	require.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "uncacheable content in headerless response")
 }
@@ -402,7 +402,7 @@ func TestBranch_FetchAndCache_OctetStreamCT_SniffedAsImage(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "ua", "", 0)
 	require.NoError(t, result.err)
 	assert.Equal(t, "image/jpeg", result.contentType)
 	assert.Contains(t, result.cachedPath, ".jpg")
@@ -420,7 +420,7 @@ func TestBranch_FetchAndCache_OctetStreamCT_WithGarbageRejected(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/x", upstream.URL+"/x", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/x", upstream.URL+"/x", client, "ua", "", 0)
 	require.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "uncacheable content")
 	assert.Empty(t, result.cachedPath)
@@ -458,7 +458,7 @@ func TestBranch_FetchAndCache_PersistFail_DrainUnusable_RefetchEmpty(t *testing.
 
 	fs := &atomicStubFs{Fs: afero.NewMemMapFs(), mkdirErr: errors.New("read-only fs")}
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/empty.jpg", upstream.URL+"/empty.jpg", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/empty.jpg", upstream.URL+"/empty.jpg", client, "ua", "", 0)
 	require.Error(t, result.err)
 	assert.True(t, result.persistFailed)
 	assert.Empty(t, result.body, "an empty upstream body cannot be salvaged for degraded serving")
@@ -476,7 +476,7 @@ func TestBranch_FetchAndCache_PersistFail_DrainRejectsGarbage(t *testing.T) {
 
 	fs := &atomicStubFs{Fs: afero.NewMemMapFs(), mkdirErr: errors.New("read-only fs")}
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
-	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/junk.jpg", upstream.URL+"/junk.jpg", client, "ua", "")
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/junk.jpg", upstream.URL+"/junk.jpg", client, "ua", "", 0)
 	require.Error(t, result.err)
 	assert.True(t, result.persistFailed)
 	assert.Empty(t, result.body, "junk drained from the failed persist must not be served")

--- a/internal/api/temp/image_cache_branch_test.go
+++ b/internal/api/temp/image_cache_branch_test.go
@@ -213,12 +213,12 @@ func TestBranch_FetchBodyToMemory_Success(t *testing.T) {
 	var gotReferer string
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		gotReferer = req.Header.Get("Referer")
-		return fakeImageResponse(req, http.StatusOK, "image/png", []byte("png-bytes")), nil
+		return fakeImageResponse(req, http.StatusOK, "image/png", pngBytes("png-bytes")), nil
 	})}
 
 	body, gotCT, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a.png", "ua", "https://ref.example/x")
 	require.NoError(t, err)
-	assert.Equal(t, []byte("png-bytes"), body)
+	assert.Equal(t, pngBytes("png-bytes"), body)
 	assert.Equal(t, "image/png", gotCT)
 	assert.Equal(t, "https://ref.example/x", gotReferer)
 }
@@ -435,4 +435,49 @@ func TestBranch_FetchBodyToMemory_OctetStreamSniffed(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, jpegBytes("via-sniff"), body)
 	assert.Equal(t, "image/jpeg", gotCT)
+}
+
+func TestBranch_FetchBodyToMemory_RejectsGarbageWithImageCT(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return fakeImageResponse(req, http.StatusOK, "image/jpeg", []byte("totally not a jpeg")), nil
+	})}
+	_, _, err := fetchBodyToMemory(context.Background(), client, "http://example.com/x", "ua", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uncacheable content type")
+}
+
+func TestBranch_FetchAndCache_PersistFail_DrainUnusable_RefetchEmpty(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := &atomicStubFs{Fs: afero.NewMemMapFs(), mkdirErr: errors.New("read-only fs")}
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/empty.jpg", upstream.URL+"/empty.jpg", client, "ua", "")
+	require.Error(t, result.err)
+	assert.True(t, result.persistFailed)
+	assert.Empty(t, result.body, "an empty upstream body cannot be salvaged for degraded serving")
+}
+
+func TestBranch_FetchAndCache_PersistFail_DrainRejectsGarbage(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("declared image, actually junk"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := &atomicStubFs{Fs: afero.NewMemMapFs(), mkdirErr: errors.New("read-only fs")}
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/junk.jpg", upstream.URL+"/junk.jpg", client, "ua", "")
+	require.Error(t, result.err)
+	assert.True(t, result.persistFailed)
+	assert.Empty(t, result.body, "junk drained from the failed persist must not be served")
 }

--- a/internal/api/temp/image_cache_branch_test.go
+++ b/internal/api/temp/image_cache_branch_test.go
@@ -114,7 +114,7 @@ func TestBranch_FetchAndCache_MkdirTmpError(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		_, _ = w.Write([]byte("img"))
+		_, _ = w.Write(jpegBytes("img"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -161,7 +161,7 @@ func TestBranch_FetchAndCache_RejectsNonImageContentType(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = w.Write([]byte("<html>challenge</html>"))
+		_, _ = w.Write(jpegBytes("<html>challenge</html>"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -304,4 +304,89 @@ func TestBranch_FetchBodyToMemory_ReadError(t *testing.T) {
 	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/x.jpg", "ua", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read body")
+}
+
+func TestBranch_FetchAndCache_HeaderlessAvisBrandAccepted(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	avisBytes := append([]byte("\x00\x00\x00\x1cftypavis"), make([]byte, 64)...)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header()["Content-Type"] = nil
+		_, _ = w.Write(avisBytes)
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/clip.avif", upstream.URL+"/clip.avif", client, "ua", "")
+	require.NoError(t, result.err)
+	assert.Equal(t, "image/avif", result.contentType)
+	assert.Contains(t, result.cachedPath, ".avif")
+}
+
+func TestBranch_FetchAndCache_VerifyTempOpenFailure(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(jpegBytes("verify"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	hooked := &openHookFs{Fs: afero.NewMemMapFs(), mode: "error", match: isTmpCacheFile}
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), hooked, t.TempDir(), upstream.URL+"/x.jpg", upstream.URL+"/x.jpg", client, "ua", "")
+	require.Error(t, result.err)
+	assert.True(t, result.persistFailed)
+	assert.Contains(t, result.err.Error(), "verify temp")
+}
+
+func TestBranch_FetchAndCache_RejectsDeclaredImageButGarbageBytes(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("this is not actually an image"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/fake.jpg", upstream.URL+"/fake.jpg", client, "ua", "")
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(), "invalid image content")
+	assert.Empty(t, result.cachedPath)
+	assert.Empty(t, result.tempPath)
+	var files []string
+	_ = afero.Walk(fs, "/", func(_ string, info os.FileInfo, _ error) error {
+		if info != nil && !info.IsDir() {
+			files = append(files, info.Name())
+		}
+		return nil
+	})
+	assert.Empty(t, files, "rejected content must not leave any persisted file")
+}
+
+func TestBranch_FetchAndCache_HeaderlessBinaryGarbageRejected(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	junk := make([]byte, 128)
+	for i := range junk {
+		junk[i] = byte(i*37 + 11)
+	}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header()["Content-Type"] = nil
+		_, _ = w.Write(junk)
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/blob", upstream.URL+"/blob", client, "ua", "")
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(), "uncacheable content in headerless response")
 }

--- a/internal/api/temp/image_cache_branch_test.go
+++ b/internal/api/temp/image_cache_branch_test.go
@@ -1,8 +1,11 @@
 package temp
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -189,7 +192,116 @@ func TestBranch_FetchAndCache_RejectsHeaderlessHTML(t *testing.T) {
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
 	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/img", upstream.URL+"/img", client, "ua", "")
 	require.Error(t, result.err)
-	assert.Contains(t, result.err.Error(), "non-image content")
+	assert.Contains(t, result.err.Error(), "uncacheable content")
 	assert.Empty(t, result.cachedPath)
 	assert.Empty(t, result.tempPath)
+}
+
+func fakeImageResponse(req *http.Request, status int, contentType string, body []byte) *http.Response {
+	h := make(http.Header)
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	return &http.Response{
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		StatusCode: status,
+		Header:     h,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func TestBranch_FetchBodyToMemory_Success(t *testing.T) {
+	var gotReferer string
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotReferer = req.Header.Get("Referer")
+		return fakeImageResponse(req, http.StatusOK, "image/png", []byte("png-bytes")), nil
+	})}
+
+	body, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a.png", "ua", "https://ref.example/x")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("png-bytes"), body)
+	assert.Equal(t, "https://ref.example/x", gotReferer)
+}
+
+func TestBranch_FetchBodyToMemory_CreateRequestError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("must not be called")
+	})}
+	_, err := fetchBodyToMemory(context.Background(), client, "://bad-url", "ua", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create request")
+}
+
+func TestBranch_FetchBodyToMemory_DoError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("dial failed")
+	})}
+	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a.png", "ua", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch")
+}
+
+func TestBranch_FetchBodyToMemory_Non200(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return fakeImageResponse(req, http.StatusServiceUnavailable, "image/png", []byte("x")), nil
+	})}
+	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a.png", "ua", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-200")
+}
+
+func TestBranch_FetchBodyToMemory_RejectsNonImageCT(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return fakeImageResponse(req, http.StatusOK, "text/html", []byte("<html>")), nil
+	})}
+	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/a", "ua", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uncacheable content type")
+}
+
+func TestBranch_FetchBodyToMemory_OversizeRejected(t *testing.T) {
+	big := make([]byte, maxImageProxyResponseSize+16)
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return fakeImageResponse(req, http.StatusOK, "image/jpeg", big), nil
+	})}
+	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/big.jpg", "ua", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+func TestBranch_FetchBodyToMemory_HeaderlessSniffOK(t *testing.T) {
+	pngMagic := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 300)...)
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return fakeImageResponse(req, http.StatusOK, "", pngMagic), nil
+	})}
+	body, err := fetchBodyToMemory(context.Background(), client, "http://example.com/raw", "ua", "")
+	require.NoError(t, err)
+	assert.Equal(t, pngMagic, body)
+}
+
+func TestBranch_FetchBodyToMemory_HeaderlessSniffRejectsText(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return fakeImageResponse(req, http.StatusOK, "", []byte("plain text challenge")), nil
+	})}
+	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/raw", "ua", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uncacheable content type")
+}
+
+func TestBranch_FetchBodyToMemory_ReadError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		h := make(http.Header)
+		h.Set("Content-Type", "image/jpeg")
+		return &http.Response{
+			Status:     "200 OK",
+			StatusCode: http.StatusOK,
+			Header:     h,
+			Body:       errReadBody{},
+			Request:    req,
+		}, nil
+	})}
+	_, err := fetchBodyToMemory(context.Background(), client, "http://example.com/x.jpg", "ua", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read body")
 }

--- a/internal/api/temp/image_cache_branch_test.go
+++ b/internal/api/temp/image_cache_branch_test.go
@@ -389,3 +389,50 @@ func TestBranch_FetchAndCache_HeaderlessBinaryGarbageRejected(t *testing.T) {
 	require.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "uncacheable content in headerless response")
 }
+
+func TestBranch_FetchAndCache_OctetStreamCT_SniffedAsImage(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(jpegBytes("octet-body"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "ua", "")
+	require.NoError(t, result.err)
+	assert.Equal(t, "image/jpeg", result.contentType)
+	assert.Contains(t, result.cachedPath, ".jpg")
+}
+
+func TestBranch_FetchAndCache_OctetStreamCT_WithGarbageRejected(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write([]byte("<html>actually an error page</html>"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+	result := fetchAndCache(context.Background(), fs, t.TempDir(), upstream.URL+"/x", upstream.URL+"/x", client, "ua", "")
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(), "uncacheable content")
+	assert.Empty(t, result.cachedPath)
+	assert.Empty(t, result.body)
+}
+
+func TestBranch_FetchBodyToMemory_OctetStreamSniffed(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return fakeImageResponse(req, http.StatusOK, "application/octet-stream", jpegBytes("via-sniff")), nil
+	})}
+	body, gotCT, err := fetchBodyToMemory(context.Background(), client, "http://example.com/bin", "ua", "")
+	require.NoError(t, err)
+	assert.Equal(t, jpegBytes("via-sniff"), body)
+	assert.Equal(t, "image/jpeg", gotCT)
+}

--- a/internal/api/temp/image_cache_coverage_test.go
+++ b/internal/api/temp/image_cache_coverage_test.go
@@ -285,7 +285,7 @@ func TestCoverage_FetchAndCacheRequestError(t *testing.T) {
 	tempDir := t.TempDir()
 	client := ssrf.NewSSRFSafeClient(60 * time.Second)
 
-	result := fetchAndCache(context.Background(), fs, tempDir, "http://nonexistent.invalid/img.jpg", "http://nonexistent.invalid/img.jpg", client, "test-agent", "")
+	result := fetchAndCache(context.Background(), fs, tempDir, "http://nonexistent.invalid/img.jpg", "http://nonexistent.invalid/img.jpg", client, "test-agent", "", 0)
 	assert.Error(t, result.err)
 }
 
@@ -302,7 +302,7 @@ func TestCoverage_FetchAndCacheNon200Status(t *testing.T) {
 	tempDir := t.TempDir()
 	client := ssrf.NewSSRFSafeClient(60 * time.Second)
 
-	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "", 0)
 	assert.Error(t, result.err)
 	assert.False(t, result.persistFailed)
 }
@@ -321,7 +321,7 @@ func TestCoverage_FetchAndCacheMkdirShardError(t *testing.T) {
 	tempDir := t.TempDir()
 	client := ssrf.NewSSRFSafeClient(60 * time.Second)
 
-	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "", 0)
 	assert.Error(t, result.err)
 	assert.True(t, result.persistFailed)
 }
@@ -340,7 +340,7 @@ func TestCoverage_FetchAndCacheCreateTempError(t *testing.T) {
 	tempDir := t.TempDir()
 	client := ssrf.NewSSRFSafeClient(60 * time.Second)
 
-	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "", 0)
 	assert.Error(t, result.err)
 	assert.True(t, result.persistFailed)
 }
@@ -359,7 +359,7 @@ func TestCoverage_FetchAndCacheRenameFailureDegrades(t *testing.T) {
 	tempDir := t.TempDir()
 	client := ssrf.NewSSRFSafeClient(60 * time.Second)
 
-	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "", 0)
 	assert.NoError(t, result.err, "rename failure degrades to shared in-memory serve, not error")
 	assert.Equal(t, jpegBytes("persist-fail-test"), result.body, "downloaded bytes served from memory")
 	assert.True(t, result.persistFailed)
@@ -380,7 +380,7 @@ func TestCoverage_FetchAndCacheSniffsHeaderlessJpeg(t *testing.T) {
 	tempDir := t.TempDir()
 	client := ssrf.NewSSRFSafeClient(60 * time.Second)
 
-	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "", 0)
 	require.NoError(t, result.err)
 	assert.Equal(t, "image/jpeg", result.contentType)
 	assert.NotEmpty(t, result.cachedPath)
@@ -409,7 +409,7 @@ func TestCoverage_FetchAndCacheOldExtCleanup(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fs, oldPath, []byte("old-jpg"), 0o644))
 
 	client := ssrf.NewSSRFSafeClient(60 * time.Second)
-	result := fetchAndCache(context.Background(), fs, tempDir, cacheKey, cacheKey, client, "test-agent", "")
+	result := fetchAndCache(context.Background(), fs, tempDir, cacheKey, cacheKey, client, "test-agent", "", 0)
 	require.NoError(t, result.err)
 	assert.Equal(t, "image/png", result.contentType)
 

--- a/internal/api/temp/image_cache_coverage_test.go
+++ b/internal/api/temp/image_cache_coverage_test.go
@@ -180,7 +180,7 @@ func TestCoverage_ResolveAllEntriesMissingDir(t *testing.T) {
 func TestCoverage_GetAbsent(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	tempDir := t.TempDir()
-	file, _, state := get(fs, tempDir, "http://example.com/img.jpg", time.Hour)
+	file, _, _, state := get(fs, tempDir, "http://example.com/img.jpg", time.Hour)
 	assert.Nil(t, file)
 	assert.Equal(t, CacheAbsent, state)
 }
@@ -195,7 +195,7 @@ func TestCoverage_GetStatError(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fs, entryPath, []byte("data"), 0o644))
 
 	failingStat := &failingFs{Fs: fs, statErr: errors.New("stat failed")}
-	file, _, state := get(failingStat, tempDir, rawURL, time.Hour)
+	file, _, _, state := get(failingStat, tempDir, rawURL, time.Hour)
 	assert.Nil(t, file)
 	assert.Equal(t, CacheAbsent, state)
 }
@@ -210,7 +210,7 @@ func TestCoverage_GetOpenError(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fs, entryPath, []byte("data"), 0o644))
 
 	failingOpen := &failingFs{Fs: fs, openErr: errors.New("open failed")}
-	file, _, state := get(failingOpen, tempDir, rawURL, time.Hour)
+	file, _, _, state := get(failingOpen, tempDir, rawURL, time.Hour)
 	assert.Nil(t, file)
 	assert.Equal(t, CacheAbsent, state)
 }

--- a/internal/api/temp/image_cache_coverage_test.go
+++ b/internal/api/temp/image_cache_coverage_test.go
@@ -313,7 +313,7 @@ func TestCoverage_FetchAndCacheMkdirShardError(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("test"))
+		w.Write(jpegBytes("test"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -332,7 +332,7 @@ func TestCoverage_FetchAndCacheCreateTempError(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("test"))
+		w.Write(jpegBytes("test"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -351,7 +351,7 @@ func TestCoverage_FetchAndCacheRenameFailureDegrades(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("persist-fail-test"))
+		w.Write(jpegBytes("persist-fail-test"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -396,7 +396,7 @@ func TestCoverage_FetchAndCacheOldExtCleanup(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/png")
-		w.Write([]byte("new-png"))
+		w.Write(pngBytes("new-png"))
 	}))
 	t.Cleanup(upstream.Close)
 

--- a/internal/api/temp/image_cache_coverage_test.go
+++ b/internal/api/temp/image_cache_coverage_test.go
@@ -360,9 +360,9 @@ func TestCoverage_FetchAndCacheRenameFailureDegrades(t *testing.T) {
 	client := ssrf.NewSSRFSafeClient(60 * time.Second)
 
 	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
-	assert.NoError(t, result.err, "rename failure degrades to temp serve, not error")
-	assert.NotEmpty(t, result.tempPath, "should serve from temp file")
-	assert.False(t, result.persistFailed)
+	assert.NoError(t, result.err, "rename failure degrades to shared in-memory serve, not error")
+	assert.Equal(t, jpegBytes("persist-fail-test"), result.body, "downloaded bytes served from memory")
+	assert.True(t, result.persistFailed)
 }
 
 func TestCoverage_FetchAndCacheSniffsHeaderlessJpeg(t *testing.T) {

--- a/internal/api/temp/image_cache_coverage_test.go
+++ b/internal/api/temp/image_cache_coverage_test.go
@@ -365,13 +365,14 @@ func TestCoverage_FetchAndCacheRenameFailureDegrades(t *testing.T) {
 	assert.False(t, result.persistFailed)
 }
 
-func TestCoverage_FetchAndCacheBadContentType(t *testing.T) {
+func TestCoverage_FetchAndCacheSniffsHeaderlessJpeg(t *testing.T) {
 	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
 	t.Cleanup(cleanup)
 
+	jpegBytes := append([]byte{0xFF, 0xD8, 0xFF, 0xE0}, make([]byte, 200)...)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "")
-		w.Write([]byte("no-ct"))
+		w.Write(jpegBytes)
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -383,6 +384,10 @@ func TestCoverage_FetchAndCacheBadContentType(t *testing.T) {
 	require.NoError(t, result.err)
 	assert.Equal(t, "image/jpeg", result.contentType)
 	assert.NotEmpty(t, result.cachedPath)
+
+	cached, err := afero.ReadFile(fs, result.cachedPath)
+	require.NoError(t, err)
+	assert.Equal(t, jpegBytes, cached, "sniffed head bytes must be preserved in the cached file")
 }
 
 func TestCoverage_FetchAndCacheOldExtCleanup(t *testing.T) {

--- a/internal/api/temp/image_cache_coverage_test.go
+++ b/internal/api/temp/image_cache_coverage_test.go
@@ -1,0 +1,413 @@
+package temp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/ssrf"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type failingRenameFs struct {
+	afero.Fs
+	renameErr error
+	failCount int32
+	maxFails  int32
+}
+
+func (f *failingRenameFs) Rename(oldname, newname string) error {
+	if f.renameErr != nil && atomic.AddInt32(&f.failCount, 1) <= f.maxFails {
+		return f.renameErr
+	}
+	return f.Fs.Rename(oldname, newname)
+}
+
+type failingFs struct {
+	afero.Fs
+	mkdirAllErr error
+	createErr   error
+	renameErr   error
+	openErr     error
+	statErr     error
+	removeErr   error
+}
+
+func (f *failingFs) MkdirAll(path string, perm os.FileMode) error {
+	if f.mkdirAllErr != nil {
+		return f.mkdirAllErr
+	}
+	return f.Fs.MkdirAll(path, perm)
+}
+
+func (f *failingFs) Create(name string) (afero.File, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	return f.Fs.Create(name)
+}
+
+func (f *failingFs) Rename(oldname, newname string) error {
+	if f.renameErr != nil {
+		return f.renameErr
+	}
+	return f.Fs.Rename(oldname, newname)
+}
+
+func (f *failingFs) Open(name string) (afero.File, error) {
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return f.Fs.Open(name)
+}
+
+func (f *failingFs) Stat(name string) (os.FileInfo, error) {
+	if f.statErr != nil {
+		return nil, f.statErr
+	}
+	return f.Fs.Stat(name)
+}
+
+func (f *failingFs) Remove(name string) error {
+	if f.removeErr != nil {
+		return f.removeErr
+	}
+	return f.Fs.Remove(name)
+}
+
+func TestCoverage_ContentTypeForAllExtensions(t *testing.T) {
+	assert.Equal(t, "image/jpeg", contentTypeForExt(".jpg"))
+	assert.Equal(t, "image/png", contentTypeForExt(".png"))
+	assert.Equal(t, "image/webp", contentTypeForExt(".webp"))
+	assert.Equal(t, "image/gif", contentTypeForExt(".gif"))
+	assert.Equal(t, "image/avif", contentTypeForExt(".avif"))
+	assert.Equal(t, "image/jpeg", contentTypeForExt(".unknown"))
+	assert.Equal(t, "image/jpeg", contentTypeForExt(""))
+}
+
+func TestCoverage_ExtForAllContentTypes(t *testing.T) {
+	assert.Equal(t, ".jpg", extForContentType("image/jpeg"))
+	assert.Equal(t, ".png", extForContentType("image/png"))
+	assert.Equal(t, ".webp", extForContentType("image/webp"))
+	assert.Equal(t, ".gif", extForContentType("image/gif"))
+	assert.Equal(t, ".avif", extForContentType("image/avif"))
+	assert.Equal(t, ".png", extForContentType("image/apng"))
+	assert.Equal(t, ".jpg", extForContentType("image/svg+xml"))
+	assert.Equal(t, ".jpg", extForContentType(""))
+	assert.Equal(t, ".jpg", extForContentType("unknown/type"))
+	assert.Equal(t, ".webp", extForContentType("image/webp; charset=UTF-8"))
+}
+
+func TestCoverage_ResolveEntryMultipleVariants(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	shardDir, hashPrefix := pathFor(tempDir, "http://example.com/img.jpg")
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+
+	jpgPath := filepath.Join(shardDir, hashPrefix+".jpg")
+	require.NoError(t, afero.WriteFile(fs, jpgPath, []byte("old"), 0o644))
+	oldTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, fs.Chtimes(jpgPath, oldTime, oldTime))
+
+	pngPath := filepath.Join(shardDir, hashPrefix+".png")
+	require.NoError(t, afero.WriteFile(fs, pngPath, []byte("new"), 0o644))
+
+	path, ext, ok := resolveEntry(fs, shardDir, hashPrefix)
+	require.True(t, ok)
+	assert.Equal(t, ".png", ext)
+	assert.Contains(t, path, hashPrefix+".png")
+}
+
+func TestCoverage_ResolveEntryNoMatch(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	shardDir, hashPrefix := pathFor(tempDir, "http://example.com/img.jpg")
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(shardDir, "other.jpg"), []byte("x"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(shardDir, hashPrefix+".txt"), []byte("y"), 0o644))
+
+	_, _, ok := resolveEntry(fs, shardDir, hashPrefix)
+	assert.False(t, ok, "non-matching hash should not resolve")
+}
+
+func TestCoverage_ResolveEntryReadDirError(t *testing.T) {
+	fs := &failingFs{Fs: afero.NewMemMapFs()}
+	_, _, ok := resolveEntry(fs, "/nonexistent", "abcd")
+	assert.False(t, ok)
+}
+
+func TestCoverage_ResolveAllEntriesMultiple(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	shardDir, hashPrefix := pathFor(tempDir, "http://example.com/img.jpg")
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(shardDir, hashPrefix+".jpg"), []byte("1"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(shardDir, hashPrefix+".png"), []byte("2"), 0o644))
+
+	paths, ext, ok := resolveAllEntries(fs, shardDir, hashPrefix)
+	require.True(t, ok)
+	assert.Len(t, paths, 2)
+	assert.NotEmpty(t, ext)
+}
+
+func TestCoverage_ResolveAllEntriesWithDirs(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	shardDir, hashPrefix := pathFor(tempDir, "http://example.com/img.jpg")
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	require.NoError(t, fs.MkdirAll(filepath.Join(shardDir, "subdir"), 0o755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(shardDir, hashPrefix+".jpg"), []byte("1"), 0o644))
+
+	paths, _, ok := resolveAllEntries(fs, shardDir, hashPrefix)
+	require.True(t, ok)
+	assert.Len(t, paths, 1)
+}
+
+func TestCoverage_ResolveAllEntriesMissingDir(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_, _, ok := resolveAllEntries(fs, "/nonexistent", "abcd")
+	assert.False(t, ok)
+}
+
+func TestCoverage_GetAbsent(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	file, _, state := get(fs, tempDir, "http://example.com/img.jpg", time.Hour)
+	assert.Nil(t, file)
+	assert.Equal(t, CacheAbsent, state)
+}
+
+func TestCoverage_GetStatError(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	rawURL := "http://example.com/img.jpg"
+	shardDir, hashPrefix := pathFor(tempDir, rawURL)
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	entryPath := filepath.Join(shardDir, hashPrefix+".jpg")
+	require.NoError(t, afero.WriteFile(fs, entryPath, []byte("data"), 0o644))
+
+	failingStat := &failingFs{Fs: fs, statErr: errors.New("stat failed")}
+	file, _, state := get(failingStat, tempDir, rawURL, time.Hour)
+	assert.Nil(t, file)
+	assert.Equal(t, CacheAbsent, state)
+}
+
+func TestCoverage_GetOpenError(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	rawURL := "http://example.com/img.jpg"
+	shardDir, hashPrefix := pathFor(tempDir, rawURL)
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	entryPath := filepath.Join(shardDir, hashPrefix+".jpg")
+	require.NoError(t, afero.WriteFile(fs, entryPath, []byte("data"), 0o644))
+
+	failingOpen := &failingFs{Fs: fs, openErr: errors.New("open failed")}
+	file, _, state := get(failingOpen, tempDir, rawURL, time.Hour)
+	assert.Nil(t, file)
+	assert.Equal(t, CacheAbsent, state)
+}
+
+func TestCoverage_AtomicRenameENOENT(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	src := "/tmp/src.txt"
+	dst := "/nonexistent/dst.txt"
+	require.NoError(t, afero.WriteFile(fs, src, []byte("data"), 0o644))
+
+	err := atomicRename(fs, src, dst)
+	require.NoError(t, err, "ENOENT should trigger MkdirAll retry")
+
+	data, _ := afero.ReadFile(fs, dst)
+	assert.Equal(t, "data", string(data))
+}
+
+func TestCoverage_AtomicRenameOverExisting(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	src := "/tmp/src.txt"
+	dst := "/tmp/dst.txt"
+	require.NoError(t, afero.WriteFile(fs, src, []byte("new"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, dst, []byte("old"), 0o644))
+
+	err := atomicRename(fs, src, dst)
+	require.NoError(t, err, "rename over existing should succeed via remove+retry")
+
+	data, _ := afero.ReadFile(fs, dst)
+	assert.Equal(t, "new", string(data))
+}
+
+func TestCoverage_AtomicRenameDirectSuccess(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	src := "/tmp/src.txt"
+	dst := "/tmp/dst.txt"
+	require.NoError(t, afero.WriteFile(fs, src, []byte("data"), 0o644))
+
+	err := atomicRename(fs, src, dst)
+	require.NoError(t, err)
+}
+
+func TestCoverage_AtomicRenameIsExistRetry(t *testing.T) {
+	fs := &failingRenameFs{Fs: afero.NewMemMapFs(), renameErr: os.ErrExist, maxFails: 1}
+	src := "/tmp/src.txt"
+	dst := "/tmp/dst.txt"
+	require.NoError(t, afero.WriteFile(fs, src, []byte("new"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, dst, []byte("old"), 0o644))
+
+	err := atomicRename(fs, src, dst)
+	require.NoError(t, err, "IsExist retry should succeed after Remove")
+
+	data, _ := afero.ReadFile(fs, dst)
+	assert.Equal(t, "new", string(data))
+}
+
+func TestCoverage_AtomicRenameOtherError(t *testing.T) {
+	fs := &failingRenameFs{Fs: afero.NewMemMapFs(), renameErr: errors.New("permission denied"), maxFails: 999}
+	src := "/tmp/src.txt"
+	dst := "/tmp/dst.txt"
+	require.NoError(t, afero.WriteFile(fs, src, []byte("data"), 0o644))
+
+	err := atomicRename(fs, src, dst)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied")
+}
+
+func TestCoverage_FetchAndCacheRequestError(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	client := ssrf.NewSSRFSafeClient(60 * time.Second)
+
+	result := fetchAndCache(context.Background(), fs, tempDir, "http://nonexistent.invalid/img.jpg", "http://nonexistent.invalid/img.jpg", client, "test-agent", "")
+	assert.Error(t, result.err)
+}
+
+func TestCoverage_FetchAndCacheNon200Status(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	client := ssrf.NewSSRFSafeClient(60 * time.Second)
+
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	assert.Error(t, result.err)
+	assert.False(t, result.persistFailed)
+}
+
+func TestCoverage_FetchAndCacheMkdirShardError(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("test"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := &failingFs{Fs: afero.NewMemMapFs(), mkdirAllErr: errors.New("mkdir failed")}
+	tempDir := t.TempDir()
+	client := ssrf.NewSSRFSafeClient(60 * time.Second)
+
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	assert.Error(t, result.err)
+	assert.True(t, result.persistFailed)
+}
+
+func TestCoverage_FetchAndCacheCreateTempError(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("test"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := &failingFs{Fs: afero.NewMemMapFs(), createErr: errors.New("create failed")}
+	tempDir := t.TempDir()
+	client := ssrf.NewSSRFSafeClient(60 * time.Second)
+
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	assert.Error(t, result.err)
+	assert.True(t, result.persistFailed)
+}
+
+func TestCoverage_FetchAndCacheRenameFailureDegrades(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("persist-fail-test"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := &failingRenameFs{Fs: afero.NewMemMapFs(), renameErr: os.ErrExist, maxFails: 999}
+	tempDir := t.TempDir()
+	client := ssrf.NewSSRFSafeClient(60 * time.Second)
+
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	assert.NoError(t, result.err, "rename failure degrades to temp serve, not error")
+	assert.NotEmpty(t, result.tempPath, "should serve from temp file")
+	assert.False(t, result.persistFailed)
+}
+
+func TestCoverage_FetchAndCacheBadContentType(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "")
+		w.Write([]byte("no-ct"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	client := ssrf.NewSSRFSafeClient(60 * time.Second)
+
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	require.NoError(t, result.err)
+	assert.Equal(t, "image/jpeg", result.contentType)
+	assert.NotEmpty(t, result.cachedPath)
+}
+
+func TestCoverage_FetchAndCacheOldExtCleanup(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("new-png"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	cacheKey := upstream.URL + "/img.jpg"
+	shardDir, hashPrefix := pathFor(tempDir, cacheKey)
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	oldPath := filepath.Join(shardDir, hashPrefix+".jpg")
+	require.NoError(t, afero.WriteFile(fs, oldPath, []byte("old-jpg"), 0o644))
+
+	client := ssrf.NewSSRFSafeClient(60 * time.Second)
+	result := fetchAndCache(context.Background(), fs, tempDir, cacheKey, cacheKey, client, "test-agent", "")
+	require.NoError(t, result.err)
+	assert.Equal(t, "image/png", result.contentType)
+
+	exists, _ := afero.Exists(fs, oldPath)
+	assert.False(t, exists, "old .jpg variant should be removed after successful rename")
+}

--- a/internal/api/temp/image_cache_final_test.go
+++ b/internal/api/temp/image_cache_final_test.go
@@ -1,0 +1,66 @@
+package temp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/ssrf"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoverageFinal_ResolveAllEntries_MissingDir(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_, _, ok := resolveAllEntries(fs, "/nonexistent-dir", "abcd1234")
+	assert.False(t, ok)
+}
+
+func TestCoverageFinal_Get_ReadDirErr(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	rawURL := "http://example.com/img.jpg"
+	shardDir, hashPrefix := pathFor(tempDir, rawURL)
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	entryPath := filepath.Join(shardDir, hashPrefix+".jpg")
+	require.NoError(t, afero.WriteFile(fs, entryPath, []byte("data"), 0o644))
+	require.NoError(t, fs.Remove(entryPath))
+	file, _, state := get(fs, tempDir, rawURL, time.Hour)
+	assert.Nil(t, file)
+	assert.Equal(t, CacheAbsent, state)
+}
+
+func TestCoverageFinal_FetchAndCache_SVGFallsBackToJpeg(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Write([]byte("<svg></svg>"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	client := ssrf.NewSSRFSafeClient(60 * time.Second)
+
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.svg", upstream.URL+"/img.svg", client, "test-agent", "")
+	require.NoError(t, result.err)
+	assert.Equal(t, "image/jpeg", result.contentType)
+	assert.Contains(t, result.cachedPath, ".jpg")
+}
+
+func TestCoverageFinal_AtomicRename_IsExistRetry(t *testing.T) {
+	fs := &failingRenameFs{Fs: afero.NewMemMapFs(), renameErr: os.ErrExist, maxFails: 1}
+	src := "/tmp/src.txt"
+	dst := "/tmp/dst.txt"
+	require.NoError(t, afero.WriteFile(fs, src, []byte("new"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, dst, []byte("old"), 0o644))
+	err := atomicRename(fs, src, dst)
+	require.NoError(t, err)
+}

--- a/internal/api/temp/image_cache_final_test.go
+++ b/internal/api/temp/image_cache_final_test.go
@@ -41,7 +41,7 @@ func TestCoverageFinal_FetchAndCache_SVGRejectedNotMislabeled(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/svg+xml")
-		w.Write([]byte("<svg></svg>"))
+		w.Write(jpegBytes("<svg></svg>"))
 	}))
 	t.Cleanup(upstream.Close)
 

--- a/internal/api/temp/image_cache_final_test.go
+++ b/internal/api/temp/image_cache_final_test.go
@@ -49,7 +49,7 @@ func TestCoverageFinal_FetchAndCache_SVGRejectedNotMislabeled(t *testing.T) {
 	tempDir := t.TempDir()
 	client := ssrf.NewSSRFSafeClient(60 * time.Second)
 
-	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.svg", upstream.URL+"/img.svg", client, "test-agent", "")
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.svg", upstream.URL+"/img.svg", client, "test-agent", "", 0)
 	require.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "unsupported image content type")
 	assert.Empty(t, result.cachedPath)

--- a/internal/api/temp/image_cache_final_test.go
+++ b/internal/api/temp/image_cache_final_test.go
@@ -30,7 +30,7 @@ func TestCoverageFinal_Get_ReadDirErr(t *testing.T) {
 	entryPath := filepath.Join(shardDir, hashPrefix+".jpg")
 	require.NoError(t, afero.WriteFile(fs, entryPath, []byte("data"), 0o644))
 	require.NoError(t, fs.Remove(entryPath))
-	file, _, state := get(fs, tempDir, rawURL, time.Hour)
+	file, _, _, state := get(fs, tempDir, rawURL, time.Hour)
 	assert.Nil(t, file)
 	assert.Equal(t, CacheAbsent, state)
 }

--- a/internal/api/temp/image_cache_final_test.go
+++ b/internal/api/temp/image_cache_final_test.go
@@ -35,7 +35,7 @@ func TestCoverageFinal_Get_ReadDirErr(t *testing.T) {
 	assert.Equal(t, CacheAbsent, state)
 }
 
-func TestCoverageFinal_FetchAndCache_SVGFallsBackToJpeg(t *testing.T) {
+func TestCoverageFinal_FetchAndCache_SVGRejectedNotMislabeled(t *testing.T) {
 	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
 	t.Cleanup(cleanup)
 
@@ -50,9 +50,10 @@ func TestCoverageFinal_FetchAndCache_SVGFallsBackToJpeg(t *testing.T) {
 	client := ssrf.NewSSRFSafeClient(60 * time.Second)
 
 	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.svg", upstream.URL+"/img.svg", client, "test-agent", "")
-	require.NoError(t, result.err)
-	assert.Equal(t, "image/jpeg", result.contentType)
-	assert.Contains(t, result.cachedPath, ".jpg")
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(), "unsupported image content type")
+	assert.Empty(t, result.cachedPath)
+	assert.Empty(t, result.tempPath)
 }
 
 func TestCoverageFinal_AtomicRename_IsExistRetry(t *testing.T) {

--- a/internal/api/temp/image_cache_final_test.go
+++ b/internal/api/temp/image_cache_final_test.go
@@ -53,7 +53,6 @@ func TestCoverageFinal_FetchAndCache_SVGRejectedNotMislabeled(t *testing.T) {
 	require.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "unsupported image content type")
 	assert.Empty(t, result.cachedPath)
-	assert.Empty(t, result.tempPath)
 }
 
 func TestCoverageFinal_AtomicRename_IsExistRetry(t *testing.T) {

--- a/internal/api/temp/image_cache_rand_test.go
+++ b/internal/api/temp/image_cache_rand_test.go
@@ -31,7 +31,7 @@ func TestRandFailure_FetchAndCache_ReturnsError(t *testing.T) {
 	randRead = func(b []byte) (int, error) { return 0, errors.New("rng exhausted") }
 	t.Cleanup(func() { randRead = orig })
 
-	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "", 0)
 	assert.Error(t, result.err)
 	assert.Contains(t, result.err.Error(), "rand")
 }
@@ -51,7 +51,7 @@ func TestDiskWriteFailure_FetchAndCache_PersistFailedTrue(t *testing.T) {
 	tempDir := t.TempDir()
 	client := ssrf.NewSSRFSafeClient(30 * time.Second)
 
-	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "", 0)
 	assert.Error(t, result.err)
 	assert.True(t, result.persistFailed)
 	assert.Contains(t, result.err.Error(), "write temp")

--- a/internal/api/temp/image_cache_rand_test.go
+++ b/internal/api/temp/image_cache_rand_test.go
@@ -19,7 +19,7 @@ func TestRandFailure_FetchAndCache_ReturnsError(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("rand-fail-test"))
+		w.Write(jpegBytes("rand-fail-test"))
 	}))
 	t.Cleanup(upstream.Close)
 

--- a/internal/api/temp/image_cache_rand_test.go
+++ b/internal/api/temp/image_cache_rand_test.go
@@ -1,0 +1,86 @@
+package temp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/ssrf"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandFailure_FetchAndCache_ReturnsError(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("rand-fail-test"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+
+	orig := randRead
+	randRead = func(b []byte) (int, error) { return 0, errors.New("rng exhausted") }
+	t.Cleanup(func() { randRead = orig })
+
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	assert.Error(t, result.err)
+	assert.Contains(t, result.err.Error(), "rand")
+}
+
+func TestDiskWriteFailure_FetchAndCache_PersistFailedTrue(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write(make([]byte, 1024))
+	}))
+	t.Cleanup(upstream.Close)
+
+	// Make every Write fail after the first 10 bytes
+	fs := &writeFailFs{Fs: afero.NewMemMapFs(), failAfterBytes: 0}
+	tempDir := t.TempDir()
+	client := ssrf.NewSSRFSafeClient(30 * time.Second)
+
+	result := fetchAndCache(context.Background(), fs, tempDir, upstream.URL+"/img.jpg", upstream.URL+"/img.jpg", client, "test-agent", "")
+	assert.Error(t, result.err)
+	assert.True(t, result.persistFailed)
+	assert.Contains(t, result.err.Error(), "write temp")
+}
+
+type writeFailFile struct {
+	afero.File
+	written int
+	failAt  int
+}
+
+func (w *writeFailFile) Write(p []byte) (int, error) {
+	if w.written >= w.failAt {
+		return 0, errors.New("disk full")
+	}
+	n, err := w.File.Write(p)
+	w.written += n
+	return n, err
+}
+
+type writeFailFs struct {
+	afero.Fs
+	failAfterBytes int
+}
+
+func (f *writeFailFs) Create(name string) (afero.File, error) {
+	file, err := f.Fs.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	return &writeFailFile{File: file, failAt: f.failAfterBytes}, nil
+}

--- a/internal/api/temp/image_cache_test.go
+++ b/internal/api/temp/image_cache_test.go
@@ -23,6 +23,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testJpegMagic = "\xff\xd8\xff\xe0"
+
+func jpegBytes(s string) []byte { return append([]byte(testJpegMagic), s...) }
+func jpegStr(s string) string   { return testJpegMagic + s }
+
 func newCacheTestDeps(t *testing.T, enabled bool, ttlHours int) (*core.APIDeps, afero.Fs, string) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
@@ -68,7 +73,7 @@ func TestImageCache_FreshHitServesFromDiskNoFetch(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&fetchCount, 1)
 		w.Header().Set("Content-Type", "image/png")
-		w.Write([]byte("fake-png-data"))
+		w.Write(pngBytes("fake-png-data"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -93,7 +98,7 @@ func TestImageCache_OfflineHitServedFromDisk(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("offline-test-data"))
+		w.Write(jpegBytes("offline-test-data"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -119,7 +124,7 @@ func TestImageCache_DisabledNoDiskWrites(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("uncached"))
+		w.Write(jpegBytes("uncached"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -140,7 +145,7 @@ func TestImageCache_ContentTypeNormalization(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/webp; charset=UTF-8")
-		w.Write([]byte("webp-data"))
+		w.Write(webpBytes("webp-data"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -162,7 +167,7 @@ func TestImageCache_SVGRejectedOnMiss(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/svg+xml")
-		w.Write([]byte("<svg></svg>"))
+		w.Write(jpegBytes("<svg></svg>"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -183,7 +188,7 @@ func TestImageCache_StaleIfErrorServesStaleBytes(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("stale-data"))
+		w.Write(jpegBytes("stale-data"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -219,7 +224,7 @@ func TestImageCache_ConcurrentCoalescing(t *testing.T) {
 		atomic.AddInt32(&fetchCount, 1)
 		time.Sleep(100 * time.Millisecond)
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("coalesced"))
+		w.Write(jpegBytes("coalesced"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -275,7 +280,7 @@ func TestImageCache_SessionParamDoesNotFragment(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&fetchCount, 1)
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("session-test"))
+		w.Write(jpegBytes("session-test"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -303,7 +308,7 @@ func TestImageCache_AvifPreserved(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/avif")
-		w.Write([]byte("avif-data"))
+		w.Write(avifBytes("avif-data"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -325,7 +330,7 @@ func TestImageCache_ApngMappedToPng(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/apng")
-		w.Write([]byte("apng-data"))
+		w.Write(pngBytes("apng-data"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -346,7 +351,7 @@ func TestImageCache_StaleRefreshOverwritesEntry(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	var data atomic.Value
-	data.Store([]byte("old-data"))
+	data.Store(jpegBytes("old-data"))
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
 		w.Write(data.Load().([]byte))
@@ -367,7 +372,7 @@ func TestImageCache_StaleRefreshOverwritesEntry(t *testing.T) {
 	pastTime := time.Now().Add(-200 * time.Hour)
 	require.NoError(t, fs.Chtimes(entryPath, pastTime, pastTime))
 
-	data.Store([]byte("new-data"))
+	data.Store(jpegBytes("new-data"))
 
 	w2 := requestImage(router, imgURL)
 	require.Equal(t, http.StatusOK, w2.Code)
@@ -400,7 +405,7 @@ func TestImageCache_SSRFFailureWithStaleServesStale(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("cached-while-online"))
+		w.Write(jpegBytes("cached-while-online"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -436,7 +441,7 @@ func TestImageCache_LeaderDisconnectDoesNotCancelSharedFetch(t *testing.T) {
 		atomic.AddInt32(&fetchStarted, 1)
 		time.Sleep(200 * time.Millisecond)
 		w.Header().Set("Content-Type", "image/jpeg")
-		w.Write([]byte("leader-disconnect-test"))
+		w.Write(jpegBytes("leader-disconnect-test"))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -459,3 +464,11 @@ func TestImageCache_LeaderDisconnectDoesNotCancelSharedFetch(t *testing.T) {
 	require.Equal(t, http.StatusOK, w2.Code, "follower should still get the image after leader disconnect")
 	assert.Contains(t, w2.Body.String(), "leader-disconnect-test")
 }
+
+const testPngMagic = "\x89PNG\r\n\x1a\n"
+const testWebpHeader = "RIFF\x00\x00\x00\x00WEBP"
+const testAvifHeader = "\x00\x00\x00\x1cftypavif"
+
+func pngBytes(s string) []byte  { return append([]byte(testPngMagic), s...) }
+func webpBytes(s string) []byte { return append([]byte(testWebpHeader), s...) }
+func avifBytes(s string) []byte { return append([]byte(testAvifHeader), s...) }

--- a/internal/api/temp/image_cache_test.go
+++ b/internal/api/temp/image_cache_test.go
@@ -1,0 +1,459 @@
+package temp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/ssrf"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newCacheTestDeps(t *testing.T, enabled bool, ttlHours int) (*core.APIDeps, afero.Fs, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	tempDir := t.TempDir()
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = enabled
+	cfg.System.ImageCacheTTLHours = ttlHours
+	cfg.System.TempDir = tempDir
+	fs := afero.NewMemMapFs()
+	deps := &core.APIDeps{Fs: fs}
+	rt := core.NewAPIRuntime(deps)
+	rt.SetConfig(cfg)
+	testkit.SetTestRuntime(deps, rt)
+	return deps, fs, tempDir
+}
+
+func cacheTestRouter(deps *core.APIDeps) *gin.Engine {
+	r := gin.New()
+	r.GET("/temp/image", serveTempImage(testkit.GetTestRuntime(deps)))
+	return r
+}
+
+func requestImage(router *gin.Engine, rawURL string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/temp/image?url="+url.QueryEscape(rawURL), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func lookupPublicIP(host string) ([]net.IP, error) {
+	return []net.IP{net.ParseIP("8.8.8.8")}, nil
+}
+
+func lookupOffline(host string) ([]net.IP, error) {
+	return nil, fmt.Errorf("DNS resolution failed (offline)")
+}
+
+func TestImageCache_FreshHitServesFromDiskNoFetch(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	var fetchCount int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fetchCount, 1)
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("fake-png-data"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+
+	w1 := requestImage(router, upstream.URL+"/img.png")
+	require.Equal(t, http.StatusOK, w1.Code)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&fetchCount), "first request should fetch")
+
+	w2 := requestImage(router, upstream.URL+"/img.png")
+	require.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, "private, max-age=86400", w2.Header().Get("Cache-Control"))
+	assert.Equal(t, "nosniff", w2.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&fetchCount), "second request should NOT fetch")
+	assert.Contains(t, w2.Body.String(), "fake-png-data")
+}
+
+func TestImageCache_OfflineHitServedFromDisk(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("offline-test-data"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+
+	w1 := requestImage(router, upstream.URL+"/img.jpg")
+	require.Equal(t, http.StatusOK, w1.Code)
+	assert.Contains(t, w1.Body.String(), "offline-test-data")
+
+	cleanup2 := ssrf.SetLookupIPForTest(lookupOffline)
+	t.Cleanup(cleanup2)
+
+	w2 := requestImage(router, upstream.URL+"/img.jpg")
+	require.Equal(t, http.StatusOK, w2.Code, "offline hit should serve from cache")
+	assert.Equal(t, "private, max-age=86400", w2.Header().Get("Cache-Control"))
+	assert.Contains(t, w2.Body.String(), "offline-test-data")
+}
+
+func TestImageCache_DisabledNoDiskWrites(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("uncached"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, fs, tempDir := newCacheTestDeps(t, false, 0)
+	router := cacheTestRouter(deps)
+
+	w := requestImage(router, upstream.URL+"/img.jpg")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "private, max-age=300", w.Header().Get("Cache-Control"))
+
+	exists, _ := afero.DirExists(fs, filepath.Join(tempDir, "image-cache"))
+	assert.False(t, exists, "no cache dir should be created when disabled")
+}
+
+func TestImageCache_ContentTypeNormalization(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/webp; charset=UTF-8")
+		w.Write([]byte("webp-data"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+
+	w := requestImage(router, upstream.URL+"/img.webp")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/webp", w.Header().Get("Content-Type"), "params stripped on miss")
+
+	w2 := requestImage(router, upstream.URL+"/img.webp")
+	require.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, "image/webp", w2.Header().Get("Content-Type"), "normalized on hit")
+}
+
+func TestImageCache_SVGNeutralizedOnMiss(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Write([]byte("<svg></svg>"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+
+	w := requestImage(router, upstream.URL+"/img.svg")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/jpeg", w.Header().Get("Content-Type"), "SVG should be neutralized to image/jpeg")
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+}
+
+func TestImageCache_StaleIfErrorServesStaleBytes(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("stale-data"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, fs, tempDir := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+	imgURL := upstream.URL + "/img.jpg"
+
+	w1 := requestImage(router, imgURL)
+	require.Equal(t, http.StatusOK, w1.Code)
+
+	shardDir, hashPrefix := pathFor(tempDir, imgURL)
+	entryPath, _, found := resolveEntry(fs, shardDir, hashPrefix)
+	require.True(t, found, "cache entry should exist")
+	pastTime := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(entryPath, pastTime, pastTime))
+
+	upstream.Close()
+
+	w2 := requestImage(router, imgURL)
+	require.Equal(t, http.StatusOK, w2.Code, "stale entry should be served on re-fetch failure")
+	assert.Equal(t, "no-cache", w2.Header().Get("Cache-Control"))
+	assert.Contains(t, w2.Body.String(), "stale-data")
+	assert.Equal(t, "nosniff", w2.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "image/jpeg", w2.Header().Get("Content-Type"), "stale serve should have proper MIME type, not extension")
+}
+
+func TestImageCache_ConcurrentCoalescing(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	var fetchCount int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fetchCount, 1)
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("coalesced"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w := requestImage(router, upstream.URL+"/img.jpg")
+			assert.Equal(t, http.StatusOK, w.Code)
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&fetchCount), "only one fetch should occur")
+}
+
+func TestImageCache_AbsentEntryFetchFailureReturns502(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+
+	w := requestImage(router, upstream.URL+"/img.jpg")
+	assert.Equal(t, http.StatusBadGateway, w.Code, "absent entry + non-200 should return 502")
+}
+
+func TestImageCache_AbsentEntrySSRFFailureReturns403(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupOffline)
+	t.Cleanup(cleanup)
+
+	deps, _, _ := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+
+	w := requestImage(router, "http://nonexistent.invalid/img.jpg")
+	assert.Equal(t, http.StatusForbidden, w.Code, "absent entry + SSRF/DNS failure should return 403")
+}
+
+func TestImageCache_SessionParamDoesNotFragment(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	var fetchCount int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fetchCount, 1)
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("session-test"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+
+	imgURL := upstream.URL + "/img.jpg"
+
+	req1 := httptest.NewRequest(http.MethodGet, "/temp/image?url="+url.QueryEscape(imgURL)+"&session=abc", nil)
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, req1)
+	require.Equal(t, http.StatusOK, w1.Code)
+
+	req2 := httptest.NewRequest(http.MethodGet, "/temp/image?url="+url.QueryEscape(imgURL)+"&session=xyz", nil)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusOK, w2.Code)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&fetchCount), "different session params should not fragment the cache")
+}
+
+func TestImageCache_AvifPreserved(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/avif")
+		w.Write([]byte("avif-data"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+
+	w := requestImage(router, upstream.URL+"/img.avif")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/avif", w.Header().Get("Content-Type"))
+
+	w2 := requestImage(router, upstream.URL+"/img.avif")
+	require.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, "image/avif", w2.Header().Get("Content-Type"))
+}
+
+func TestImageCache_ApngMappedToPng(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/apng")
+		w.Write([]byte("apng-data"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+
+	w := requestImage(router, upstream.URL+"/img.apng")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/png", w.Header().Get("Content-Type"), "apng should be mapped to png")
+
+	w2 := requestImage(router, upstream.URL+"/img.apng")
+	require.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, "image/png", w2.Header().Get("Content-Type"))
+}
+
+func TestImageCache_StaleRefreshOverwritesEntry(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	var data atomic.Value
+	data.Store([]byte("old-data"))
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write(data.Load().([]byte))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, fs, tempDir := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+	imgURL := upstream.URL + "/img.jpg"
+
+	w1 := requestImage(router, imgURL)
+	require.Equal(t, http.StatusOK, w1.Code)
+	assert.Contains(t, w1.Body.String(), "old-data")
+
+	shardDir, hashPrefix := pathFor(tempDir, imgURL)
+	entryPath, _, found := resolveEntry(fs, shardDir, hashPrefix)
+	require.True(t, found)
+	pastTime := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(entryPath, pastTime, pastTime))
+
+	data.Store([]byte("new-data"))
+
+	w2 := requestImage(router, imgURL)
+	require.Equal(t, http.StatusOK, w2.Code)
+	assert.Contains(t, w2.Body.String(), "new-data", "should serve refreshed bytes")
+}
+
+func TestImageCache_OversizedReturns502(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write(make([]byte, maxImageProxyResponseSize+1))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, fs, tempDir := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+
+	w := requestImage(router, upstream.URL+"/big.jpg")
+	assert.Equal(t, http.StatusBadGateway, w.Code, "oversized response should return 502")
+
+	tmpEntries, _ := afero.ReadDir(fs, filepath.Join(tempDir, "image-cache", ".tmp"))
+	assert.Empty(t, tmpEntries, "oversized temp file should be cleaned up")
+}
+
+func TestImageCache_SSRFFailureWithStaleServesStale(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("cached-while-online"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, fs, tempDir := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+	imgURL := upstream.URL + "/img.jpg"
+
+	w1 := requestImage(router, imgURL)
+	require.Equal(t, http.StatusOK, w1.Code)
+
+	shardDir, hashPrefix := pathFor(tempDir, imgURL)
+	entryPath, _, found := resolveEntry(fs, shardDir, hashPrefix)
+	require.True(t, found)
+	pastTime := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(entryPath, pastTime, pastTime))
+
+	cleanup2 := ssrf.SetLookupIPForTest(lookupOffline)
+	t.Cleanup(cleanup2)
+
+	w2 := requestImage(router, imgURL)
+	require.Equal(t, http.StatusOK, w2.Code, "stale entry + SSRF failure should serve stale")
+	assert.Equal(t, "no-cache", w2.Header().Get("Cache-Control"))
+	assert.Contains(t, w2.Body.String(), "cached-while-online")
+	assert.Equal(t, "image/jpeg", w2.Header().Get("Content-Type"), "stale serve should have proper MIME type")
+}
+
+func TestImageCache_LeaderDisconnectDoesNotCancelSharedFetch(t *testing.T) {
+	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
+	t.Cleanup(cleanup)
+
+	var fetchStarted int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fetchStarted, 1)
+		time.Sleep(200 * time.Millisecond)
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("leader-disconnect-test"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps, _, _ := newCacheTestDeps(t, true, 168)
+	router := cacheTestRouter(deps)
+	imgURL := upstream.URL + "/img.jpg"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req1 := httptest.NewRequest(http.MethodGet, "/temp/image?url="+url.QueryEscape(imgURL), nil).WithContext(ctx)
+	w1 := httptest.NewRecorder()
+
+	go func() {
+		router.ServeHTTP(w1, req1)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	w2 := requestImage(router, imgURL)
+	require.Equal(t, http.StatusOK, w2.Code, "follower should still get the image after leader disconnect")
+	assert.Contains(t, w2.Body.String(), "leader-disconnect-test")
+}

--- a/internal/api/temp/image_cache_test.go
+++ b/internal/api/temp/image_cache_test.go
@@ -156,7 +156,7 @@ func TestImageCache_ContentTypeNormalization(t *testing.T) {
 	assert.Equal(t, "image/webp", w2.Header().Get("Content-Type"), "normalized on hit")
 }
 
-func TestImageCache_SVGNeutralizedOnMiss(t *testing.T) {
+func TestImageCache_SVGRejectedOnMiss(t *testing.T) {
 	cleanup := ssrf.SetLookupIPForTest(lookupPublicIP)
 	t.Cleanup(cleanup)
 
@@ -166,13 +166,15 @@ func TestImageCache_SVGNeutralizedOnMiss(t *testing.T) {
 	}))
 	t.Cleanup(upstream.Close)
 
-	deps, _, _ := newCacheTestDeps(t, true, 168)
+	deps, fs, tempDir := newCacheTestDeps(t, true, 168)
 	router := cacheTestRouter(deps)
 
 	w := requestImage(router, upstream.URL+"/img.svg")
-	require.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "image/jpeg", w.Header().Get("Content-Type"), "SVG should be neutralized to image/jpeg")
-	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	require.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Contains(t, w.Body.String(), "failed to fetch image")
+
+	exists, _ := afero.Exists(fs, filepath.Join(tempDir, "image-cache"))
+	assert.False(t, exists, "rejected SVG must not be persisted")
 }
 
 func TestImageCache_StaleIfErrorServesStaleBytes(t *testing.T) {

--- a/internal/api/temp/miss_test.go
+++ b/internal/api/temp/miss_test.go
@@ -48,6 +48,7 @@ func TestServeTempPoster_JobStoreWithTempDir(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(posterDir, "poster.jpg"), []byte("jpeg"), 0644))
 
 	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
 	cfg.System.TempDir = defaultTempDir
 
 	// Create a mock JobStore that returns a job with TempDir
@@ -108,6 +109,7 @@ func TestServeTempImage_EmptyURLParam(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
 	deps := newTestDeps(cfg)
 
 	router := gin.New()
@@ -126,6 +128,7 @@ func TestServeTempImage_FTPScheme(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
 	deps := newTestDeps(cfg)
 
 	router := gin.New()
@@ -144,6 +147,7 @@ func TestServeTempImage_MissingHost(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
 	deps := newTestDeps(cfg)
 
 	router := gin.New()
@@ -166,6 +170,7 @@ func TestServeTempImage_PrivateIPBlocked(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
 	deps := newTestDeps(cfg)
 
 	router := gin.New()
@@ -193,6 +198,7 @@ func TestServeTempImage_UpstreamNon200Status(t *testing.T) {
 	defer upstream.Close()
 
 	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
 	deps := newTestDeps(cfg)
 
 	router := gin.New()
@@ -223,6 +229,7 @@ func TestServeTempImage_SuccessWithNoContentType(t *testing.T) {
 	defer upstream.Close()
 
 	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
 	cfg.Scrapers.Referer = ""
 	deps := newTestDeps(cfg)
 
@@ -259,6 +266,7 @@ func TestServeTempImage_CustomUserAgent(t *testing.T) {
 	defer upstream.Close()
 
 	cfg := config.DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = false
 	cfg.Scrapers.UserAgent = "TestAgent/1.0"
 	deps := newTestDeps(cfg)
 

--- a/internal/config/bridges_doc.go
+++ b/internal/config/bridges_doc.go
@@ -155,6 +155,7 @@
 //	cfg.System.VersionCheckEnabled          → api/core
 //	cfg.System.ImageCacheEnabled            → api/core
 //	cfg.System.ImageCacheTTLHours           → api/core
+//	cfg.System.ImageCacheMaxSizeMB          → api/core
 //
 // To update this index: grep for "Config-bridge reads:" across internal/ and
 // rebuild the tables above.

--- a/internal/config/bridges_doc.go
+++ b/internal/config/bridges_doc.go
@@ -153,6 +153,8 @@
 //	cfg.Server.Port                         → api/core
 //	cfg.System.TempDir                      → api/core, scrape
 //	cfg.System.VersionCheckEnabled          → api/core
+//	cfg.System.ImageCacheEnabled            → api/core
+//	cfg.System.ImageCacheTTLHours           → api/core
 //
 // To update this index: grep for "Config-bridge reads:" across internal/ and
 // rebuild the tables above.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -187,6 +187,16 @@ type SystemConfig struct {
 	// Can be overridden with JAVINIZER_TEMP_DIR environment variable.
 	// Subdirectory "posters/{jobID}" is created for batch job temp posters.
 	TempDir string `yaml:"temp_dir" json:"temp_dir"`
+	// ImageCacheEnabled controls server-side caching of fetched preview images
+	// by the /api/v1/temp/image proxy. When true (default), the proxy persists
+	// fetched image bytes to disk under {tempDir}/image-cache/ so that an image
+	// fetched once while online remains available when the source is unreachable.
+	ImageCacheEnabled bool `yaml:"image_cache_enabled" json:"image_cache_enabled"`
+	// ImageCacheTTLHours is the cache entry lifetime in hours (default: 168 = 7 days).
+	// The cap (<=87600) is enforced unconditionally because the unconditional sweep
+	// computes a time.Duration from it even when caching is disabled. When enabled,
+	// must be >= 1; when disabled, 0 is legal (sweep no-op).
+	ImageCacheTTLHours int `yaml:"image_cache_ttl_hours" json:"image_cache_ttl_hours"`
 }
 
 // MarshalYAML keeps Config marshaling explicit and ensures ScrapersConfig custom
@@ -433,6 +443,12 @@ func ValidateConfig(cfg *Config) error {
 	// Allow 0 to mean "use default" (handled by DefaultConfig and migrations)
 	if cfg.System.VersionCheckIntervalHours != 0 && (cfg.System.VersionCheckIntervalHours < 1 || cfg.System.VersionCheckIntervalHours > 168) {
 		return fmt.Errorf("system.version_check_interval_hours must be between 1 and 168 (1 week), or 0 for default")
+	}
+	if cfg.System.ImageCacheTTLHours < 0 || cfg.System.ImageCacheTTLHours > 87600 {
+		return fmt.Errorf("system.image_cache_ttl_hours must be between 0 and 87600 (10 years)")
+	}
+	if cfg.System.ImageCacheEnabled && cfg.System.ImageCacheTTLHours < 1 {
+		return fmt.Errorf("system.image_cache_ttl_hours must be >= 1 when image caching is enabled")
 	}
 
 	// Validate logging rotation settings

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,6 +197,10 @@ type SystemConfig struct {
 	// computes a time.Duration from it even when caching is disabled. When enabled,
 	// must be >= 1; when disabled, 0 is legal (sweep no-op).
 	ImageCacheTTLHours int `yaml:"image_cache_ttl_hours" json:"image_cache_ttl_hours"`
+	// ImageCacheMaxSizeMB bounds the total on-disk size of the preview image cache
+	// in megabytes (default: 512). Once a commit pushes the cache over the limit,
+	// the oldest entries are evicted. 0 disables the quota.
+	ImageCacheMaxSizeMB int `yaml:"image_cache_max_size_mb" json:"image_cache_max_size_mb"`
 }
 
 // MarshalYAML keeps Config marshaling explicit and ensures ScrapersConfig custom
@@ -449,6 +453,9 @@ func ValidateConfig(cfg *Config) error {
 	}
 	if cfg.System.ImageCacheEnabled && cfg.System.ImageCacheTTLHours < 1 {
 		return fmt.Errorf("system.image_cache_ttl_hours must be >= 1 when image caching is enabled")
+	}
+	if cfg.System.ImageCacheMaxSizeMB < 0 {
+		return fmt.Errorf("system.image_cache_max_size_mb must be >= 0 (0 disables the quota)")
 	}
 
 	// Validate logging rotation settings

--- a/internal/config/config.yaml.example
+++ b/internal/config/config.yaml.example
@@ -82,6 +82,8 @@ system:
     # Base directory for temporary files (posters, etc.)
     # Can be overridden with JAVINIZER_TEMP_DIR environment variable
     temp_dir: data/temp
+    image_cache_enabled: true
+    image_cache_ttl_hours: 168
 scrapers:
     user_agent: "" # Default: Chrome UA. r18dev uses Javinizer UA automatically.
     # Referer header for CDN compatibility (required by DMM/R18 CDN)

--- a/internal/config/config.yaml.example
+++ b/internal/config/config.yaml.example
@@ -84,6 +84,7 @@ system:
     temp_dir: data/temp
     image_cache_enabled: true
     image_cache_ttl_hours: 168
+    image_cache_max_size_mb: 512
 scrapers:
     user_agent: "" # Default: Chrome UA. r18dev uses Javinizer UA automatically.
     # Referer header for CDN compatibility (required by DMM/R18 CDN)

--- a/internal/config/coverage_boost_test.go
+++ b/internal/config/coverage_boost_test.go
@@ -1365,3 +1365,12 @@ func TestPriorityConfig_UnmarshalJSON_FieldNonStringElement(t *testing.T) {
 	assert.Equal(t, []string{"r18dev"}, p.Fields["series"],
 		"non-string element must be skipped, string element kept")
 }
+
+func TestValidate_ImageCacheMaxSizeNegative(t *testing.T) {
+	cfg := DefaultConfig(nil, nil)
+	cfg.System.ImageCacheMaxSizeMB = -1
+
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "image_cache_max_size_mb")
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -347,6 +347,7 @@ func DefaultConfig(priorities []string, defaults map[string]*models.ScraperSetti
 			TempDir:                   DefaultTempDir,
 			ImageCacheEnabled:         true,
 			ImageCacheTTLHours:        168,
+			ImageCacheMaxSizeMB:       512,
 		},
 		// VersionCheckStableOnly is intentionally omitted: its zero value (false)
 		// is the correct default (prereleases allowed). Existing configs that

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -345,6 +345,8 @@ func DefaultConfig(priorities []string, defaults map[string]*models.ScraperSetti
 			VersionCheckEnabled:       true,
 			VersionCheckIntervalHours: 24,
 			TempDir:                   DefaultTempDir,
+			ImageCacheEnabled:         true,
+			ImageCacheTTLHours:        168,
 		},
 		// VersionCheckStableOnly is intentionally omitted: its zero value (false)
 		// is the correct default (prereleases allowed). Existing configs that

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -385,6 +385,12 @@ func validateConfigExcludingTranslationCredentials(cfg *Config) error {
 	if cfg.System.VersionCheckIntervalHours != 0 && (cfg.System.VersionCheckIntervalHours < 1 || cfg.System.VersionCheckIntervalHours > 168) {
 		return fmt.Errorf("system.version_check_interval_hours must be between 1 and 168 (1 week), or 0 for default")
 	}
+	if cfg.System.ImageCacheTTLHours < 0 || cfg.System.ImageCacheTTLHours > 87600 {
+		return fmt.Errorf("system.image_cache_ttl_hours must be between 0 and 87600 (10 years)")
+	}
+	if cfg.System.ImageCacheEnabled && cfg.System.ImageCacheTTLHours < 1 {
+		return fmt.Errorf("system.image_cache_ttl_hours must be >= 1 when image caching is enabled")
+	}
 
 	if cfg.Logging.MaxSizeMB < 0 {
 		return fmt.Errorf("logging.max_size_mb must be >= 0")

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -391,6 +391,9 @@ func validateConfigExcludingTranslationCredentials(cfg *Config) error {
 	if cfg.System.ImageCacheEnabled && cfg.System.ImageCacheTTLHours < 1 {
 		return fmt.Errorf("system.image_cache_ttl_hours must be >= 1 when image caching is enabled")
 	}
+	if cfg.System.ImageCacheMaxSizeMB < 0 {
+		return fmt.Errorf("system.image_cache_max_size_mb must be >= 0 (0 disables the quota)")
+	}
 
 	if cfg.Logging.MaxSizeMB < 0 {
 		return fmt.Errorf("logging.max_size_mb must be >= 0")

--- a/internal/config/validation_exclude_test.go
+++ b/internal/config/validation_exclude_test.go
@@ -438,3 +438,29 @@ func TestValidateConfigExcludingTranslationCredentials_ProxyProfileError(t *test
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "default_profile")
 }
+
+func TestValidateConfigExcludingTranslationCredentials_ImageCacheTTLRange(t *testing.T) {
+	cfg := DefaultConfig(nil, nil)
+	cfg.System.ImageCacheTTLHours = -1
+	err := validateConfigExcludingTranslationCredentials(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image_cache_ttl_hours")
+
+	cfg = DefaultConfig(nil, nil)
+	cfg.System.ImageCacheTTLHours = 87601
+	err = validateConfigExcludingTranslationCredentials(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image_cache_ttl_hours")
+}
+
+func TestValidateConfigExcludingTranslationCredentials_ImageCacheEnabledRequiresTTL(t *testing.T) {
+	cfg := DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheTTLHours = 0
+	err := validateConfigExcludingTranslationCredentials(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image_cache_ttl_hours")
+
+	cfg.System.ImageCacheTTLHours = 24
+	assert.NoError(t, validateConfigExcludingTranslationCredentials(cfg))
+}

--- a/internal/config/validation_exclude_test.go
+++ b/internal/config/validation_exclude_test.go
@@ -464,3 +464,16 @@ func TestValidateConfigExcludingTranslationCredentials_ImageCacheEnabledRequires
 	cfg.System.ImageCacheTTLHours = 24
 	assert.NoError(t, validateConfigExcludingTranslationCredentials(cfg))
 }
+
+func TestValidateConfigExcludingTranslationCredentials_ImageCacheMaxSize(t *testing.T) {
+	cfg := DefaultConfig(nil, nil)
+	cfg.System.ImageCacheMaxSizeMB = -1
+	err := validateConfigExcludingTranslationCredentials(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image_cache_max_size_mb")
+
+	cfg = DefaultConfig(nil, nil)
+	cfg.System.ImageCacheEnabled = true
+	cfg.System.ImageCacheMaxSizeMB = 0
+	assert.NoError(t, validateConfigExcludingTranslationCredentials(cfg), "0 disables the quota and must stay legal when caching is enabled")
+}

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -297,3 +297,35 @@ func TestValidateProxyProfileRef(t *testing.T) {
 		assert.NoError(t, validateProxyProfileRef("test.proxy", cfg, profiles))
 	})
 }
+
+func TestValidateConfig_ImageCacheTTL(t *testing.T) {
+	cases := []struct {
+		name    string
+		enabled bool
+		ttl     int
+		wantErr bool
+	}{
+		{"enabled+ttl=0 rejected", true, 0, true},
+		{"enabled+ttl=-1 rejected", true, -1, true},
+		{"enabled+ttl=87601 rejected", true, 87601, true},
+		{"enabled+ttl=1 accepted", true, 1, false},
+		{"enabled+ttl=87600 accepted", true, 87600, false},
+		{"disabled+ttl=87601 rejected (unconditional cap)", false, 87601, true},
+		{"disabled+ttl=-1 rejected", false, -1, true},
+		{"disabled+ttl=0 accepted", false, 0, false},
+		{"disabled+ttl=87600 accepted", false, 87600, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig(nil, nil)
+			cfg.System.ImageCacheEnabled = tc.enabled
+			cfg.System.ImageCacheTTLHours = tc.ttl
+			err := cfg.Validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/worker/image_cache_cleaner_branch_test.go
+++ b/internal/worker/image_cache_cleaner_branch_test.go
@@ -170,3 +170,39 @@ func TestCleanupBranch_TmpRemoveFailureWarned(t *testing.T) {
 	exists, _ := afero.Exists(mem, entry)
 	assert.True(t, exists)
 }
+
+type plantOnShardRemoveFs struct {
+	afero.Fs
+	shardDir string
+	planted  bool
+}
+
+func (f *plantOnShardRemoveFs) Remove(name string) error {
+	if name == f.shardDir && !f.planted {
+		f.planted = true
+		fresher := filepath.Join(f.shardDir, "just-landed.jpg")
+		if err := afero.WriteFile(f.Fs, fresher, []byte("fresh"), 0o644); err != nil {
+			return err
+		}
+	}
+	return f.Fs.Remove(name)
+}
+
+func TestCleanupBranch_ShardDirRemovalSurvivesConcurrentFill(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	expired := seedExpiredShardEntry(t, mem, tempDir, "ab", "deadbeef.jpg")
+	shardDir := filepath.Join(tempDir, "image-cache", "ab")
+	fs := &plantOnShardRemoveFs{Fs: mem, shardDir: shardDir}
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed, "expired entry still removed")
+
+	planted := filepath.Join(shardDir, "just-landed.jpg")
+	exists, _ := afero.Exists(mem, planted)
+	assert.True(t, exists, "fresh entry renamed into the shard mid-sweep must survive (fs.Remove refuses non-empty dirs)")
+	assert.True(t, fs.planted)
+	exists, _ = afero.Exists(mem, expired)
+	assert.False(t, exists)
+}

--- a/internal/worker/image_cache_cleaner_branch_test.go
+++ b/internal/worker/image_cache_cleaner_branch_test.go
@@ -1,0 +1,172 @@
+package worker
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type openFailForFs struct {
+	afero.Fs
+	target string
+	err    error
+}
+
+func (f *openFailForFs) Open(name string) (afero.File, error) {
+	if name == f.target {
+		return nil, f.err
+	}
+	return f.Fs.Open(name)
+}
+
+type statFailFs struct {
+	afero.Fs
+	target string
+}
+
+func (f *statFailFs) Stat(name string) (os.FileInfo, error) {
+	if name == f.target {
+		return nil, errors.New("stat denied")
+	}
+	return f.Fs.Stat(name)
+}
+
+type removeAllFailFs struct {
+	afero.Fs
+	target string
+}
+
+func (f *removeAllFailFs) Remove(name string) error {
+	if name == f.target {
+		return errors.New("remove denied")
+	}
+	return f.Fs.Remove(name)
+}
+
+func seedExpiredShardEntry(t *testing.T, fs afero.Fs, tempDir, shard, name string) string {
+	t.Helper()
+	shardDir := filepath.Join(tempDir, "image-cache", shard)
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	entry := filepath.Join(shardDir, name)
+	require.NoError(t, afero.WriteFile(fs, entry, []byte("old"), 0o644))
+	past := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(entry, past, past))
+	return entry
+}
+
+func TestCleanupBranch_RootReadDirGenericError(t *testing.T) {
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "image-cache")
+	fs := &openFailForFs{Fs: afero.NewMemMapFs(), target: root, err: errors.New("io error")}
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.Error(t, err)
+	assert.Equal(t, 0, removed)
+	assert.Contains(t, err.Error(), "read image-cache dir")
+}
+
+func TestCleanupBranch_ShardReadDirNotExistSkipped(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	seedExpiredShardEntry(t, mem, tempDir, "ab", "deadbeef.jpg")
+	shardPath := filepath.Join(tempDir, "image-cache", "ab")
+	fs := &openFailForFs{Fs: mem, target: shardPath, err: &os.PathError{Op: "open", Path: shardPath, Err: os.ErrNotExist}}
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+}
+
+func TestCleanupBranch_ShardReadDirGenericErrorWarned(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	seedExpiredShardEntry(t, mem, tempDir, "cd", "deadbeef.jpg")
+	shardPath := filepath.Join(tempDir, "image-cache", "cd")
+	fs := &openFailForFs{Fs: mem, target: shardPath, err: errors.New("perm denied")}
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+}
+
+func TestCleanupBranch_DirEntriesInsideShardSkipped(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	shardDir := filepath.Join(tempDir, "image-cache", "ef")
+	require.NoError(t, mem.MkdirAll(filepath.Join(shardDir, "nested"), 0o755))
+
+	removed, err := CleanupStaleImageCache(mem, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+	exists, _ := afero.DirExists(mem, filepath.Join(shardDir, "nested"))
+	assert.True(t, exists)
+}
+
+func TestCleanupBranch_StatFailureSkipsRemoval(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	entry := seedExpiredShardEntry(t, mem, tempDir, "ab", "deadbeef.jpg")
+	fs := &statFailFs{Fs: mem, target: entry}
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+	exists, _ := afero.Exists(mem, entry)
+	assert.True(t, exists)
+}
+
+func TestCleanupBranch_RemoveFailureWarned(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	entry := seedExpiredShardEntry(t, mem, tempDir, "ab", "deadbeef.jpg")
+	fs := &removeAllFailFs{Fs: mem, target: entry}
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+	exists, _ := afero.Exists(mem, entry)
+	assert.True(t, exists)
+}
+
+func seedExpiredTmpEntry(t *testing.T, fs afero.Fs, tempDir, name string) string {
+	t.Helper()
+	tmpDir := filepath.Join(tempDir, "image-cache", ".tmp")
+	require.NoError(t, fs.MkdirAll(tmpDir, 0o755))
+	entry := filepath.Join(tmpDir, name)
+	require.NoError(t, afero.WriteFile(fs, entry, []byte("partial"), 0o644))
+	past := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(entry, past, past))
+	return entry
+}
+
+func TestCleanupBranch_TmpStatFailureSkipsRemoval(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	entry := seedExpiredTmpEntry(t, mem, tempDir, "orphan")
+	fs := &statFailFs{Fs: mem, target: entry}
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+	exists, _ := afero.Exists(mem, entry)
+	assert.True(t, exists)
+}
+
+func TestCleanupBranch_TmpRemoveFailureWarned(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	entry := seedExpiredTmpEntry(t, mem, tempDir, "orphan")
+	fs := &removeAllFailFs{Fs: mem, target: entry}
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+	exists, _ := afero.Exists(mem, entry)
+	assert.True(t, exists)
+}

--- a/internal/worker/image_cache_cleaner_branch_test.go
+++ b/internal/worker/image_cache_cleaner_branch_test.go
@@ -55,7 +55,7 @@ func seedExpiredShardEntry(t *testing.T, fs afero.Fs, tempDir, shard, name strin
 	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
 	entry := filepath.Join(shardDir, name)
 	require.NoError(t, afero.WriteFile(fs, entry, []byte("old"), 0o644))
-	past := time.Now().Add(-200 * time.Hour)
+	past := time.Now().Add(-400 * time.Hour)
 	require.NoError(t, fs.Chtimes(entry, past, past))
 	return entry
 }
@@ -140,7 +140,7 @@ func seedExpiredTmpEntry(t *testing.T, fs afero.Fs, tempDir, name string) string
 	require.NoError(t, fs.MkdirAll(tmpDir, 0o755))
 	entry := filepath.Join(tmpDir, name)
 	require.NoError(t, afero.WriteFile(fs, entry, []byte("partial"), 0o644))
-	past := time.Now().Add(-200 * time.Hour)
+	past := time.Now().Add(-400 * time.Hour)
 	require.NoError(t, fs.Chtimes(entry, past, past))
 	return entry
 }

--- a/internal/worker/image_cache_cleaner_coverage_test.go
+++ b/internal/worker/image_cache_cleaner_coverage_test.go
@@ -58,7 +58,7 @@ func TestCleanupStaleImageCache_StatRecheckSkips(t *testing.T) {
 	entry := shardDir + "/deadbeef.jpg"
 	require.NoError(t, afero.WriteFile(fs, entry, []byte("data"), 0o644))
 
-	pastTime := time.Now().Add(-200 * time.Hour)
+	pastTime := time.Now().Add(-400 * time.Hour)
 	require.NoError(t, fs.Chtimes(entry, pastTime, pastTime))
 
 	// Between ReadDir and Stat, update the mtime to be fresh
@@ -78,7 +78,7 @@ func TestCleanupStaleImageCache_RemovesEmptyShardAndOrphanTemps(t *testing.T) {
 	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
 	expired := shardDir + "/deadbeef.jpg"
 	require.NoError(t, afero.WriteFile(fs, expired, []byte("old"), 0o644))
-	pastTime := time.Now().Add(-200 * time.Hour)
+	pastTime := time.Now().Add(-400 * time.Hour)
 	require.NoError(t, fs.Chtimes(expired, pastTime, pastTime))
 
 	tmpDir := tempDir + "/image-cache/.tmp"
@@ -93,4 +93,23 @@ func TestCleanupStaleImageCache_RemovesEmptyShardAndOrphanTemps(t *testing.T) {
 
 	exists, _ := afero.DirExists(fs, shardDir)
 	assert.False(t, exists, "empty shard should be removed")
+}
+
+func TestCleanupStaleImageCache_RetainsEntryWithinGracePeriod(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+
+	shardDir := tempDir + "/image-cache/ab"
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	staleButRetained := shardDir + "/deadbeef.jpg"
+	require.NoError(t, afero.WriteFile(fs, staleButRetained, []byte("stale"), 0o644))
+	pastFreshnessWithinGrace := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(staleButRetained, pastFreshnessWithinGrace, pastFreshnessWithinGrace))
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed, "entry past freshness TTL but within retention grace must survive the sweep")
+
+	exists, _ := afero.Exists(fs, staleButRetained)
+	assert.True(t, exists, "retained entry stays available for stale-if-error serving")
 }

--- a/internal/worker/image_cache_cleaner_coverage_test.go
+++ b/internal/worker/image_cache_cleaner_coverage_test.go
@@ -1,0 +1,96 @@
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupStaleImageCache_SkipsFreshEntry(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+
+	shardDir := tempDir + "/image-cache/ab"
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	fresh := shardDir + "/deadbeef.jpg"
+	require.NoError(t, afero.WriteFile(fs, fresh, []byte("fresh"), 0o644))
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed, "fresh entry should not be removed")
+
+	exists, _ := afero.Exists(fs, fresh)
+	assert.True(t, exists)
+}
+
+func TestCleanupStaleImageCache_NilFs(t *testing.T) {
+	removed, err := CleanupStaleImageCache(nil, t.TempDir(), 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+}
+
+func TestCleanupStaleImageCache_TmpOrphanFresh(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+
+	tmpDir := tempDir + "/image-cache/.tmp"
+	require.NoError(t, fs.MkdirAll(tmpDir, 0o755))
+	freshTmp := tmpDir + "/fresh-tmp"
+	require.NoError(t, afero.WriteFile(fs, freshTmp, []byte("fresh"), 0o644))
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed, "fresh temp should not be removed")
+
+	exists, _ := afero.Exists(fs, freshTmp)
+	assert.True(t, exists)
+}
+
+func TestCleanupStaleImageCache_StatRecheckSkips(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+
+	shardDir := tempDir + "/image-cache/ab"
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	entry := shardDir + "/deadbeef.jpg"
+	require.NoError(t, afero.WriteFile(fs, entry, []byte("data"), 0o644))
+
+	pastTime := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(entry, pastTime, pastTime))
+
+	// Between ReadDir and Stat, update the mtime to be fresh
+	// (The Stat re-check should skip removal because it's now fresh)
+	// This is hard to test deterministically without a custom fs wrapper,
+	// but at least the fresh-skip test covers the "not before cutoff" branch
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+}
+
+func TestCleanupStaleImageCache_RemovesEmptyShardAndOrphanTemps(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+
+	shardDir := tempDir + "/image-cache/ab"
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	expired := shardDir + "/deadbeef.jpg"
+	require.NoError(t, afero.WriteFile(fs, expired, []byte("old"), 0o644))
+	pastTime := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(expired, pastTime, pastTime))
+
+	tmpDir := tempDir + "/image-cache/.tmp"
+	require.NoError(t, fs.MkdirAll(tmpDir, 0o755))
+	orphanTmp := tmpDir + "/orphan"
+	require.NoError(t, afero.WriteFile(fs, orphanTmp, []byte("partial"), 0o644))
+	require.NoError(t, fs.Chtimes(orphanTmp, pastTime, pastTime))
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 2, removed, "should remove expired entry + orphan temp")
+
+	exists, _ := afero.DirExists(fs, shardDir)
+	assert.False(t, exists, "empty shard should be removed")
+}

--- a/internal/worker/image_cache_cleaner_test.go
+++ b/internal/worker/image_cache_cleaner_test.go
@@ -1,0 +1,96 @@
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupStaleImageCache_RemovesExpiredEntries(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+
+	shardDir := tempDir + "/image-cache/ab"
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+
+	expired := shardDir + "/" + "abcd1234.jpg"
+	require.NoError(t, afero.WriteFile(fs, expired, []byte("old"), 0o644))
+	pastTime := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(expired, pastTime, pastTime))
+
+	fresh := shardDir + "/" + "efgh5678.png"
+	require.NoError(t, afero.WriteFile(fs, fresh, []byte("new"), 0o644))
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+
+	exists, _ := afero.Exists(fs, expired)
+	assert.False(t, exists, "expired entry should be removed")
+
+	existsFresh, _ := afero.Exists(fs, fresh)
+	assert.True(t, existsFresh, "fresh entry should remain")
+}
+
+func TestCleanupStaleImageCache_RemovesEmptyShardDirs(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+
+	shardDir := tempDir + "/image-cache/ab"
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+
+	expired := shardDir + "/deadbeef.jpg"
+	require.NoError(t, afero.WriteFile(fs, expired, []byte("old"), 0o644))
+	pastTime := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(expired, pastTime, pastTime))
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+
+	exists, _ := afero.DirExists(fs, shardDir)
+	assert.False(t, exists, "empty shard dir should be removed")
+}
+
+func TestCleanupStaleImageCache_RemovesOrphanTemps(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+
+	tmpDir := tempDir + "/image-cache/.tmp"
+	require.NoError(t, fs.MkdirAll(tmpDir, 0o755))
+
+	orphan := tmpDir + "/orphan123"
+	require.NoError(t, afero.WriteFile(fs, orphan, []byte("partial"), 0o644))
+	pastTime := time.Now().Add(-200 * time.Hour)
+	require.NoError(t, fs.Chtimes(orphan, pastTime, pastTime))
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+
+	exists, _ := afero.Exists(fs, orphan)
+	assert.False(t, exists, "orphan temp should be removed")
+}
+
+func TestCleanupStaleImageCache_NoopOnTTLZero(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+
+	shardDir := tempDir + "/image-cache/ab"
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	require.NoError(t, afero.WriteFile(fs, shardDir+"/deadbeef.jpg", []byte("data"), 0o644))
+
+	removed, err := CleanupStaleImageCache(fs, tempDir, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+}
+
+func TestCleanupStaleImageCache_NoopOnMissingDir(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	removed, err := CleanupStaleImageCache(fs, t.TempDir(), 168*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+}

--- a/internal/worker/image_cache_cleaner_test.go
+++ b/internal/worker/image_cache_cleaner_test.go
@@ -18,7 +18,7 @@ func TestCleanupStaleImageCache_RemovesExpiredEntries(t *testing.T) {
 
 	expired := shardDir + "/" + "abcd1234.jpg"
 	require.NoError(t, afero.WriteFile(fs, expired, []byte("old"), 0o644))
-	pastTime := time.Now().Add(-200 * time.Hour)
+	pastTime := time.Now().Add(-400 * time.Hour)
 	require.NoError(t, fs.Chtimes(expired, pastTime, pastTime))
 
 	fresh := shardDir + "/" + "efgh5678.png"
@@ -44,7 +44,7 @@ func TestCleanupStaleImageCache_RemovesEmptyShardDirs(t *testing.T) {
 
 	expired := shardDir + "/deadbeef.jpg"
 	require.NoError(t, afero.WriteFile(fs, expired, []byte("old"), 0o644))
-	pastTime := time.Now().Add(-200 * time.Hour)
+	pastTime := time.Now().Add(-400 * time.Hour)
 	require.NoError(t, fs.Chtimes(expired, pastTime, pastTime))
 
 	removed, err := CleanupStaleImageCache(fs, tempDir, 168*time.Hour)

--- a/internal/worker/image_cache_evict_test.go
+++ b/internal/worker/image_cache_evict_test.go
@@ -151,3 +151,36 @@ func TestEvict_RemovalFailureLoggedAndContinues(t *testing.T) {
 	exists, _ = afero.Exists(mem, other)
 	assert.False(t, exists)
 }
+
+func TestEvict_KeepPathExcluded(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	oldest := seedSizedShardEntry(t, mem, tempDir, "ab", "old.jpg", 400, 3*time.Hour)
+	middle := seedSizedShardEntry(t, mem, tempDir, "ab", "mid.jpg", 400, 2*time.Hour)
+	newest := seedSizedShardEntry(t, mem, tempDir, "cd", "new.jpg", 400, 0)
+
+	total, removed, err := EvictImageCacheToSize(mem, tempDir, 800, oldest)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1200), total)
+	assert.Equal(t, 1, removed)
+
+	exists, _ := afero.Exists(mem, oldest)
+	assert.True(t, exists, "the protected entry survives even though it is oldest")
+	exists, _ = afero.Exists(mem, middle)
+	assert.False(t, exists, "eviction proceeds to the next-oldest unprotected entry")
+	exists, _ = afero.Exists(mem, newest)
+	assert.True(t, exists)
+}
+
+func TestEvict_OnlyProtectedEntryStaysOverQuota(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	sole := seedSizedShardEntry(t, mem, tempDir, "ab", "sole.jpg", 400, 0)
+
+	total, removed, err := EvictImageCacheToSize(mem, tempDir, 100, sole)
+	require.NoError(t, err)
+	assert.Equal(t, int64(400), total)
+	assert.Zero(t, removed, "protected entries are never evicted; the next fill re-applies pressure")
+	exists, _ := afero.Exists(mem, sole)
+	assert.True(t, exists)
+}

--- a/internal/worker/image_cache_evict_test.go
+++ b/internal/worker/image_cache_evict_test.go
@@ -1,0 +1,153 @@
+package worker
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedSizedShardEntry(t *testing.T, fs afero.Fs, tempDir, shard, name string, size int, age time.Duration) string {
+	t.Helper()
+	shardDir := filepath.Join(tempDir, "image-cache", shard)
+	require.NoError(t, fs.MkdirAll(shardDir, 0o755))
+	entry := filepath.Join(shardDir, name)
+	require.NoError(t, afero.WriteFile(fs, entry, make([]byte, size), 0o644))
+	if age > 0 {
+		old := time.Now().Add(-age)
+		require.NoError(t, fs.Chtimes(entry, old, old))
+	}
+	return entry
+}
+
+func TestEvict_NoopOnLimitZeroOrNilFs(t *testing.T) {
+	total, removed, err := EvictImageCacheToSize(afero.NewMemMapFs(), t.TempDir(), 0)
+	require.NoError(t, err)
+	assert.Zero(t, total)
+	assert.Zero(t, removed)
+
+	total, removed, err = EvictImageCacheToSize(nil, t.TempDir(), 1024)
+	require.NoError(t, err)
+	assert.Zero(t, total)
+	assert.Zero(t, removed)
+}
+
+func TestEvict_NoopOnMissingRoot(t *testing.T) {
+	total, removed, err := EvictImageCacheToSize(afero.NewMemMapFs(), t.TempDir(), 1024)
+	require.NoError(t, err)
+	assert.Zero(t, total)
+	assert.Zero(t, removed)
+}
+
+func TestEvict_RootReadDirGenericError(t *testing.T) {
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "image-cache")
+	fs := &openFailForFs{Fs: afero.NewMemMapFs(), target: root, err: errors.New("io error")}
+	_, _, err := EvictImageCacheToSize(fs, tempDir, 1024)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read image-cache dir")
+}
+
+func TestEvict_UnderLimitKeepsEverything(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	entry := seedSizedShardEntry(t, mem, tempDir, "ab", "a.jpg", 100, 0)
+
+	total, removed, err := EvictImageCacheToSize(mem, tempDir, 1024)
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), total)
+	assert.Zero(t, removed)
+	exists, _ := afero.Exists(mem, entry)
+	assert.True(t, exists)
+}
+
+func TestEvict_OverLimitEvictsOldestUntilUnder(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	oldest := seedSizedShardEntry(t, mem, tempDir, "ab", "old.jpg", 400, 3*time.Hour)
+	middle := seedSizedShardEntry(t, mem, tempDir, "ab", "mid.jpg", 400, 2*time.Hour)
+	newest := seedSizedShardEntry(t, mem, tempDir, "cd", "new.jpg", 400, 0)
+
+	total, removed, err := EvictImageCacheToSize(mem, tempDir, 800)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1200), total)
+	assert.Equal(t, 1, removed, "only as many oldest entries as needed are evicted")
+
+	exists, _ := afero.Exists(mem, oldest)
+	assert.False(t, exists)
+	for _, keep := range []string{middle, newest} {
+		exists, _ = afero.Exists(mem, keep)
+		assert.True(t, exists, keep)
+	}
+}
+
+func TestEvict_TmpDirNeverCountedOrEvicted(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	tmpDir := filepath.Join(tempDir, "image-cache", ".tmp")
+	require.NoError(t, mem.MkdirAll(tmpDir, 0o755))
+	partial := filepath.Join(tmpDir, "inflight")
+	require.NoError(t, afero.WriteFile(mem, partial, make([]byte, 10<<20), 0o644))
+	tiny := seedSizedShardEntry(t, mem, tempDir, "ab", "tiny.jpg", 10, 0)
+
+	total, removed, err := EvictImageCacheToSize(mem, tempDir, 5)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), total, ".tmp orphans must not count toward the quota")
+	assert.Equal(t, 1, removed)
+	exists, _ := afero.Exists(mem, tiny)
+	assert.False(t, exists)
+	exists, _ = afero.Exists(mem, partial)
+	assert.True(t, exists, "in-flight temp writes are never evicted")
+}
+
+func TestEvict_ShardReadDirFailuresSkipped(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	seedSizedShardEntry(t, mem, tempDir, "ab", "a.jpg", 100, 0)
+	shardPath := filepath.Join(tempDir, "image-cache", "ab")
+	fs := &openFailForFs{Fs: mem, target: shardPath, err: &os.PathError{Op: "open", Path: shardPath, Err: os.ErrNotExist}}
+
+	total, removed, err := EvictImageCacheToSize(fs, tempDir, 10)
+	require.NoError(t, err)
+	assert.Zero(t, total)
+	assert.Zero(t, removed)
+
+	fs2 := &openFailForFs{Fs: mem, target: shardPath, err: errors.New("perm")}
+	total, removed, err = EvictImageCacheToSize(fs2, tempDir, 10)
+	require.NoError(t, err)
+	assert.Zero(t, total)
+	assert.Zero(t, removed)
+}
+
+func TestEvict_DirEntriesInsideShardSkipped(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	require.NoError(t, mem.MkdirAll(filepath.Join(tempDir, "image-cache", "ab", "nested"), 0o755))
+
+	total, removed, err := EvictImageCacheToSize(mem, tempDir, 10)
+	require.NoError(t, err)
+	assert.Zero(t, total)
+	assert.Zero(t, removed)
+}
+
+func TestEvict_RemovalFailureLoggedAndContinues(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	tempDir := t.TempDir()
+	pinned := seedSizedShardEntry(t, mem, tempDir, "ab", "pinned.jpg", 400, 3*time.Hour)
+	other := seedSizedShardEntry(t, mem, tempDir, "ab", "other.jpg", 400, 2*time.Hour)
+	fs := &removeAllFailFs{Fs: mem, target: pinned}
+
+	total, removed, err := EvictImageCacheToSize(fs, tempDir, 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(800), total)
+	assert.Equal(t, 1, removed, "sweep continues past the failed removal and evicts the next-oldest")
+	exists, _ := afero.Exists(mem, pinned)
+	assert.True(t, exists)
+	exists, _ = afero.Exists(mem, other)
+	assert.False(t, exists)
+}

--- a/internal/worker/temp_dir_cleaner.go
+++ b/internal/worker/temp_dir_cleaner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/javinizer/javinizer-go/internal/database"
@@ -310,4 +311,69 @@ func CleanupStaleImageCache(fs afero.Fs, tempDir string, ttl time.Duration) (int
 		}
 	}
 	return removed, nil
+}
+
+// EvictImageCacheToSize removes oldest-first entries from {tempDir}/image-cache/
+// until the total size of shard entries is within limitBytes. The .tmp staging
+// directory is never counted or evicted (in-flight writes live there). Per-file
+// failures are logged and the sweep continues. Returns the pre-eviction total and
+// the number of entries removed.
+func EvictImageCacheToSize(fs afero.Fs, tempDir string, limitBytes int64) (int64, int, error) {
+	if limitBytes <= 0 || fs == nil {
+		return 0, 0, nil
+	}
+	root := filepath.Join(tempDir, "image-cache")
+	entries, err := afero.ReadDir(fs, root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, 0, nil
+		}
+		return 0, 0, fmt.Errorf("read image-cache dir: %w", err)
+	}
+	type artifact struct {
+		path  string
+		mtime time.Time
+		size  int64
+	}
+	var artifacts []artifact
+	var total int64
+	for _, shard := range entries {
+		if !shard.IsDir() || shard.Name() == ".tmp" {
+			continue
+		}
+		files, ferr := afero.ReadDir(fs, filepath.Join(root, shard.Name()))
+		if ferr != nil {
+			if os.IsNotExist(ferr) {
+				continue
+			}
+			logging.Warnf("EvictImageCacheToSize: failed to read shard %s: %v", shard.Name(), ferr)
+			continue
+		}
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			artifacts = append(artifacts, artifact{path: filepath.Join(root, shard.Name(), f.Name()), mtime: f.ModTime(), size: f.Size()})
+			total += f.Size()
+		}
+	}
+	if total <= limitBytes {
+		return total, 0, nil
+	}
+	sort.Slice(artifacts, func(i, j int) bool { return artifacts[i].mtime.Before(artifacts[j].mtime) })
+	over := total - limitBytes
+	var freed int64
+	removed := 0
+	for _, a := range artifacts {
+		if freed >= over {
+			break
+		}
+		if rerr := fsutil.AferoRemoveAll(fs, a.path); rerr != nil {
+			logging.Warnf("EvictImageCacheToSize: failed to remove %s: %v", a.path, rerr)
+			continue
+		}
+		freed += a.size
+		removed++
+	}
+	return total, removed, nil
 }

--- a/internal/worker/temp_dir_cleaner.go
+++ b/internal/worker/temp_dir_cleaner.go
@@ -318,7 +318,7 @@ func CleanupStaleImageCache(fs afero.Fs, tempDir string, ttl time.Duration) (int
 // directory is never counted or evicted (in-flight writes live there). Per-file
 // failures are logged and the sweep continues. Returns the pre-eviction total and
 // the number of entries removed.
-func EvictImageCacheToSize(fs afero.Fs, tempDir string, limitBytes int64) (int64, int, error) {
+func EvictImageCacheToSize(fs afero.Fs, tempDir string, limitBytes int64, keep ...string) (int64, int, error) {
 	if limitBytes <= 0 || fs == nil {
 		return 0, 0, nil
 	}
@@ -361,12 +361,19 @@ func EvictImageCacheToSize(fs afero.Fs, tempDir string, limitBytes int64) (int64
 		return total, 0, nil
 	}
 	sort.Slice(artifacts, func(i, j int) bool { return artifacts[i].mtime.Before(artifacts[j].mtime) })
+	keepSet := make(map[string]struct{}, len(keep))
+	for _, k := range keep {
+		keepSet[k] = struct{}{}
+	}
 	over := total - limitBytes
 	var freed int64
 	removed := 0
 	for _, a := range artifacts {
 		if freed >= over {
 			break
+		}
+		if _, protected := keepSet[a.path]; protected {
+			continue
 		}
 		if rerr := fsutil.AferoRemoveAll(fs, a.path); rerr != nil {
 			logging.Warnf("EvictImageCacheToSize: failed to remove %s: %v", a.path, rerr)

--- a/internal/worker/temp_dir_cleaner.go
+++ b/internal/worker/temp_dir_cleaner.go
@@ -287,7 +287,7 @@ func CleanupStaleImageCache(fs afero.Fs, tempDir string, ttl time.Duration) (int
 		}
 		remaining, rerr := afero.ReadDir(fs, shardPath)
 		if rerr == nil && len(remaining) == 0 {
-			_ = fsutil.AferoRemoveAll(fs, shardPath)
+			_ = fs.Remove(shardPath)
 		}
 	}
 	tmpDir := filepath.Join(root, ".tmp")

--- a/internal/worker/temp_dir_cleaner.go
+++ b/internal/worker/temp_dir_cleaner.go
@@ -233,7 +233,10 @@ func (c *TempDirCleaner) StartStaleTempCleanup() chan struct{} {
 
 // CleanupStaleImageCache removes expired entries from the image cache directory.
 // It walks {tempDir}/image-cache/ (shard dirs then files) and removes files whose
-// mtime is older than ttl, plus orphan temp files from {tempDir}/image-cache/.tmp/.
+// mtime is older than a retention grace of ttl + max(ttl, 24h), so entries that
+// crossed their freshness TTL survive the sweep and remain available for the
+// stale-if-error fallback. Orphan partial downloads in
+// {tempDir}/image-cache/.tmp/ are removed once older than ttl itself.
 // No-op when ttl <= 0 or the dir does not exist. Per-file removal failures are
 // logged and skipped; the walk continues, and an error is returned only if the
 // top-level directory traversal fails.
@@ -249,6 +252,7 @@ func CleanupStaleImageCache(fs afero.Fs, tempDir string, ttl time.Duration) (int
 		}
 		return 0, fmt.Errorf("read image-cache dir: %w", err)
 	}
+	retentionCutoff := time.Now().Add(-(ttl + max(ttl, 24*time.Hour)))
 	cutoff := time.Now().Add(-ttl)
 	removed := 0
 	for _, shard := range entries {
@@ -268,10 +272,10 @@ func CleanupStaleImageCache(fs afero.Fs, tempDir string, ttl time.Duration) (int
 			if f.IsDir() {
 				continue
 			}
-			if f.ModTime().Before(cutoff) {
+			if f.ModTime().Before(retentionCutoff) {
 				fp := filepath.Join(shardPath, f.Name())
 				info, statErr := fs.Stat(fp)
-				if statErr != nil || !info.ModTime().Before(cutoff) {
+				if statErr != nil || !info.ModTime().Before(retentionCutoff) {
 					continue
 				}
 				if rerr := fsutil.AferoRemoveAll(fs, fp); rerr != nil {

--- a/internal/worker/temp_dir_cleaner.go
+++ b/internal/worker/temp_dir_cleaner.go
@@ -230,3 +230,80 @@ func (c *TempDirCleaner) StartStaleTempCleanup() chan struct{} {
 	}()
 	return stop
 }
+
+// CleanupStaleImageCache removes expired entries from the image cache directory.
+// It walks {tempDir}/image-cache/ (shard dirs then files) and removes files whose
+// mtime is older than ttl, plus orphan temp files from {tempDir}/image-cache/.tmp/.
+// No-op when ttl <= 0 or the dir does not exist. Per-file removal failures are
+// logged and skipped; the walk continues, and an error is returned only if the
+// top-level directory traversal fails.
+func CleanupStaleImageCache(fs afero.Fs, tempDir string, ttl time.Duration) (int, error) {
+	if ttl <= 0 || fs == nil {
+		return 0, nil
+	}
+	root := filepath.Join(tempDir, "image-cache")
+	entries, err := afero.ReadDir(fs, root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("read image-cache dir: %w", err)
+	}
+	cutoff := time.Now().Add(-ttl)
+	removed := 0
+	for _, shard := range entries {
+		if !shard.IsDir() || shard.Name() == ".tmp" {
+			continue
+		}
+		shardPath := filepath.Join(root, shard.Name())
+		files, ferr := afero.ReadDir(fs, shardPath)
+		if ferr != nil {
+			if os.IsNotExist(ferr) {
+				continue
+			}
+			logging.Warnf("CleanupStaleImageCache: failed to read shard %s: %v", shardPath, ferr)
+			continue
+		}
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			if f.ModTime().Before(cutoff) {
+				fp := filepath.Join(shardPath, f.Name())
+				info, statErr := fs.Stat(fp)
+				if statErr != nil || !info.ModTime().Before(cutoff) {
+					continue
+				}
+				if rerr := fsutil.AferoRemoveAll(fs, fp); rerr != nil {
+					logging.Warnf("CleanupStaleImageCache: failed to remove %s: %v", fp, rerr)
+				} else {
+					removed++
+				}
+			}
+		}
+		remaining, rerr := afero.ReadDir(fs, shardPath)
+		if rerr == nil && len(remaining) == 0 {
+			_ = fsutil.AferoRemoveAll(fs, shardPath)
+		}
+	}
+	tmpDir := filepath.Join(root, ".tmp")
+	tmpEntries, terr := afero.ReadDir(fs, tmpDir)
+	if terr == nil {
+		for _, f := range tmpEntries {
+			if f.IsDir() || !f.ModTime().Before(cutoff) {
+				continue
+			}
+			fp := filepath.Join(tmpDir, f.Name())
+			info, statErr := fs.Stat(fp)
+			if statErr != nil || !info.ModTime().Before(cutoff) {
+				continue
+			}
+			if rerr := fsutil.AferoRemoveAll(fs, fp); rerr != nil {
+				logging.Warnf("CleanupStaleImageCache: failed to remove temp %s: %v", fp, rerr)
+			} else {
+				removed++
+			}
+		}
+	}
+	return removed, nil
+}

--- a/web/frontend/messages/en-XA.json
+++ b/web/frontend/messages/en-XA.json
@@ -1959,5 +1959,9 @@
   "browse_plan_preset_conservative": "[ Çöñsërvåtívë ]",
   "browse_plan_preset_gap_fill": "[ Gåp fíll ]",
   "browse_plan_preset_aggressive": "[ Åggrëssívë ]",
-  "review_media_replace_warning": "[ Rëplåçíñg ëxístíñg mëdíå ís dëstrüçtívë åñd ís ñöt çövërëd by örgåñízë röllbåçk. Vërífy thësë ëffëçts bëförë åpplyíñg. ]"
+  "review_media_replace_warning": "[ Rëplåçíñg ëxístíñg mëdíå ís dëstrüçtívë åñd ís ñöt çövërëd by örgåñízë röllbåçk. Vërífy thësë ëffëçts bëförë åpplyíñg. ]",
+  "settings_server_image_cache_enable_label": "[ Cäçhé Prévéw Ímägés ]",
+  "settings_server_image_cache_enable_desc": "[ Whén éñäbléd, prévéw ímägés fétchéd by thé próxy äré cächéd sërvër-sídé so théy rémäïñ äväïläblé whén thé sourcé ïs unréächäblé. ]",
+  "settings_server_image_cache_ttl_label": "[ Ímägé Cäché TTL (höurs) ]",
+  "settings_server_image_cache_ttl_desc": "[ Höw loñg cächéd prévéw ímägés rémäïñ frésh (höurs). Expiréd éntréés äré ré-fétchéd; stälé-ïf-érrör sërvés thém ïf thé ré-fétch fäïls. ]"
 }

--- a/web/frontend/messages/en-XA.json
+++ b/web/frontend/messages/en-XA.json
@@ -1962,6 +1962,8 @@
   "review_media_replace_warning": "[ Rëplåçíñg ëxístíñg mëdíå ís dëstrüçtívë åñd ís ñöt çövërëd by örgåñízë röllbåçk. Vërífy thësë ëffëçts bëförë åpplyíñg. ]",
   "settings_server_image_cache_enable_label": "[ Cäçhé Prévéw Ímägés ]",
   "settings_server_image_cache_enable_desc": "[ Whén éñäbléd, prévéw ímägés fétchéd by thé próxy äré cächéd sërvër-sídé so théy rémäïñ äväïläblé whén thé sourcé ïs unréächäblé. ]",
+  "settings_server_image_cache_max_size_label": "[ Ímägé Cäché Mäx Sïzé (MB) ]",
+  "settings_server_image_cache_max_size_desc": "[ Dïsk quötä för thé prévïéw ïmägé cäché ïn mégäbytés. Öldést éntrïés äré évïctéd whén éxcéédéd. 0 dïsäblés thé lïmït. ]",
   "settings_server_image_cache_ttl_label": "[ Ímägé Cäché TTL (höurs) ]",
   "settings_server_image_cache_ttl_desc": "[ Höw loñg cächéd prévéw ímägés rémäïñ frésh (höurs). Expiréd éntréés äré ré-fétchéd; stälé-ïf-érrör sërvés thém ïf thé ré-fétch fäïls. ]"
 }

--- a/web/frontend/messages/en.json
+++ b/web/frontend/messages/en.json
@@ -2620,5 +2620,9 @@
   "browse_plan_preset_conservative": "Conservative",
   "browse_plan_preset_gap_fill": "Gap fill",
   "browse_plan_preset_aggressive": "Aggressive",
-  "review_media_replace_warning": "Replacing existing media is destructive and is not covered by organize rollback. Verify these effects before applying."
+  "review_media_replace_warning": "Replacing existing media is destructive and is not covered by organize rollback. Verify these effects before applying.",
+  "settings_server_image_cache_enable_label": "Cache Preview Images",
+  "settings_server_image_cache_enable_desc": "When enabled, preview images fetched by the proxy are cached server-side so they remain available when the source is unreachable.",
+  "settings_server_image_cache_ttl_label": "Image Cache TTL (hours)",
+  "settings_server_image_cache_ttl_desc": "How long cached preview images remain fresh (hours). Expired entries are re-fetched; stale-if-error serves them if the re-fetch fails."
 }

--- a/web/frontend/messages/en.json
+++ b/web/frontend/messages/en.json
@@ -2623,6 +2623,8 @@
   "review_media_replace_warning": "Replacing existing media is destructive and is not covered by organize rollback. Verify these effects before applying.",
   "settings_server_image_cache_enable_label": "Cache Preview Images",
   "settings_server_image_cache_enable_desc": "When enabled, preview images fetched by the proxy are cached server-side so they remain available when the source is unreachable.",
+  "settings_server_image_cache_max_size_label": "Image Cache Max Size (MB)",
+  "settings_server_image_cache_max_size_desc": "Disk quota for the preview image cache in megabytes. Oldest entries are evicted when exceeded. 0 disables the limit.",
   "settings_server_image_cache_ttl_label": "Image Cache TTL (hours)",
   "settings_server_image_cache_ttl_desc": "How long cached preview images remain fresh (hours). Expired entries are re-fetched; stale-if-error serves them if the re-fetch fails."
 }

--- a/web/frontend/messages/ja.json
+++ b/web/frontend/messages/ja.json
@@ -2623,6 +2623,8 @@
   "review_media_replace_warning": "既存メディアの置き換えは破壊的で、整理のロールバック対象外です。適用前に内容を確認してください。",
   "settings_server_image_cache_enable_label": "プレビュー画像をキャッシュ",
   "settings_server_image_cache_enable_desc": "有効にすると、プロキシが取得したプレビュー画像をサーバー側でキャッシュし、ソースにアクセスできない場合でも利用できるようにします。",
+  "settings_server_image_cache_max_size_label": "画像キャッシュ最大サイズ（MB）",
+  "settings_server_image_cache_max_size_desc": "プレビュー画像キャッシュのディスク割り当て量（MB）。超過時は最も古いエントリから削除されます。0 で無制限。",
   "settings_server_image_cache_ttl_label": "画像キャッシュTTL（時間）",
   "settings_server_image_cache_ttl_desc": "キャッシュされたプレビュー画像が最新である期間（時間）。期限切れのエントリは再取得され、再取得が失敗した場合はstale-if-errorで提供されます。"
 }

--- a/web/frontend/messages/ja.json
+++ b/web/frontend/messages/ja.json
@@ -2620,5 +2620,9 @@
   "browse_plan_preset_conservative": "コンサバティブ",
   "browse_plan_preset_gap_fill": "ギャップ補完",
   "browse_plan_preset_aggressive": "アグレッシブ",
-  "review_media_replace_warning": "既存メディアの置き換えは破壊的で、整理のロールバック対象外です。適用前に内容を確認してください。"
+  "review_media_replace_warning": "既存メディアの置き換えは破壊的で、整理のロールバック対象外です。適用前に内容を確認してください。",
+  "settings_server_image_cache_enable_label": "プレビュー画像をキャッシュ",
+  "settings_server_image_cache_enable_desc": "有効にすると、プロキシが取得したプレビュー画像をサーバー側でキャッシュし、ソースにアクセスできない場合でも利用できるようにします。",
+  "settings_server_image_cache_ttl_label": "画像キャッシュTTL（時間）",
+  "settings_server_image_cache_ttl_desc": "キャッシュされたプレビュー画像が最新である期間（時間）。期限切れのエントリは再取得され、再取得が失敗した場合はstale-if-errorで提供されます。"
 }

--- a/web/frontend/messages/zh-Hans.json
+++ b/web/frontend/messages/zh-Hans.json
@@ -2623,6 +2623,8 @@
   "review_media_replace_warning": "替换现有媒体具有破坏性，且不在整理回滚范围内。应用前请确认这些影响。",
   "settings_server_image_cache_enable_label": "缓存预览图像",
   "settings_server_image_cache_enable_desc": "启用后，代理获取的预览图像将被缓存到服务端，以便在源无法访问时仍可使用。",
+  "settings_server_image_cache_max_size_label": "图像缓存最大大小（MB）",
+  "settings_server_image_cache_max_size_desc": "预览图像缓存的磁盘配额（MB）。超过限制时将逐出最旧的条目。0 表示无限制。",
   "settings_server_image_cache_ttl_label": "图像缓存TTL（小时）",
   "settings_server_image_cache_ttl_desc": "缓存的预览图像保持新鲜的时间（小时）。过期的条目将重新获取；如果重新获取失败，则通过stale-if-error提供。"
 }

--- a/web/frontend/messages/zh-Hans.json
+++ b/web/frontend/messages/zh-Hans.json
@@ -2620,5 +2620,9 @@
   "browse_plan_preset_conservative": "保守",
   "browse_plan_preset_gap_fill": "填充空缺",
   "browse_plan_preset_aggressive": "激进",
-  "review_media_replace_warning": "替换现有媒体具有破坏性，且不在整理回滚范围内。应用前请确认这些影响。"
+  "review_media_replace_warning": "替换现有媒体具有破坏性，且不在整理回滚范围内。应用前请确认这些影响。",
+  "settings_server_image_cache_enable_label": "缓存预览图像",
+  "settings_server_image_cache_enable_desc": "启用后，代理获取的预览图像将被缓存到服务端，以便在源无法访问时仍可使用。",
+  "settings_server_image_cache_ttl_label": "图像缓存TTL（小时）",
+  "settings_server_image_cache_ttl_desc": "缓存的预览图像保持新鲜的时间（小时）。过期的条目将重新获取；如果重新获取失败，则通过stale-if-error提供。"
 }

--- a/web/frontend/messages/zh-Hant.json
+++ b/web/frontend/messages/zh-Hant.json
@@ -2623,6 +2623,8 @@
   "review_media_replace_warning": "取代現有媒體具破壞性，且不在整理回復範圍內。套用前請確認這些影響。",
   "settings_server_image_cache_enable_label": "快取預覽圖像",
   "settings_server_image_cache_enable_desc": "啟用後，代理獲取的預覽圖像將被快取到伺服器端，以便在來源無法存取時仍可使用。",
+  "settings_server_image_cache_max_size_label": "圖像快取最大大小（MB）",
+  "settings_server_image_cache_max_size_desc": "預覽圖像快取的磁碟配額（MB）。超過限制時將逐出最舊的項目。0 表示無限制。",
   "settings_server_image_cache_ttl_label": "圖像快取TTL（小時）",
   "settings_server_image_cache_ttl_desc": "快取的預覽圖像保持新鮮的時間（小時）。過期的項目將重新獲取；如果重新獲取失敗，則通過stale-if-error提供。"
 }

--- a/web/frontend/messages/zh-Hant.json
+++ b/web/frontend/messages/zh-Hant.json
@@ -2620,5 +2620,9 @@
   "browse_plan_preset_conservative": "保守",
   "browse_plan_preset_gap_fill": "填補空缺",
   "browse_plan_preset_aggressive": "積極",
-  "review_media_replace_warning": "取代現有媒體具破壞性，且不在整理回復範圍內。套用前請確認這些影響。"
+  "review_media_replace_warning": "取代現有媒體具破壞性，且不在整理回復範圍內。套用前請確認這些影響。",
+  "settings_server_image_cache_enable_label": "快取預覽圖像",
+  "settings_server_image_cache_enable_desc": "啟用後，代理獲取的預覽圖像將被快取到伺服器端，以便在來源無法存取時仍可使用。",
+  "settings_server_image_cache_ttl_label": "圖像快取TTL（小時）",
+  "settings_server_image_cache_ttl_desc": "快取的預覽圖像保持新鮮的時間（小時）。過期的項目將重新獲取；如果重新獲取失敗，則通過stale-if-error提供。"
 }

--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -852,6 +852,8 @@ export interface SystemConfig {
 	version_check_enabled: boolean;
 	version_check_interval_hours: number;
 	temp_dir: string;
+	image_cache_enabled: boolean;
+	image_cache_ttl_hours: number;
 }
 
 export interface ProxyProfile {

--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -854,6 +854,7 @@ export interface SystemConfig {
 	temp_dir: string;
 	image_cache_enabled: boolean;
 	image_cache_ttl_hours: number;
+	image_cache_max_size_mb: number;
 }
 
 export interface ProxyProfile {

--- a/web/frontend/src/lib/components/ScreenshotManager.svelte
+++ b/web/frontend/src/lib/components/ScreenshotManager.svelte
@@ -225,7 +225,7 @@ import { tooltip } from '$lib/actions/tooltip';
 							<!-- Crop to show only right 47.2% of image (removes promotional text on left) -->
 							<!-- Only apply cropping if displayPosterUrl is not available (displayPosterUrl is already cropped if temp_poster_url) -->
 							<img
-								src={posterUrl}
+								src={previewImageURL(posterUrl)}
 								alt={m.screenshot_poster_alt()}
 								class="absolute h-full"
 								style="right: 0; width: auto; min-width: 211.8%; object-fit: cover; object-position: right center;" hidden={posterPreviewError}
@@ -234,7 +234,7 @@ import { tooltip } from '$lib/actions/tooltip';
 						{:else}
 							<!-- Use displayPosterUrl (temp_poster_url if available) or posterUrl directly without cropping -->
 							<img
-								src={displayPosterUrl || posterUrl}
+								src={previewImageURL(displayPosterUrl || posterUrl)}
 								alt={m.screenshot_poster_alt()}
 								class="w-full h-full object-contain" hidden={posterPreviewError}
 								onerror={() => { posterPreviewError = true; }}

--- a/web/frontend/src/lib/components/settings/sections/ServerSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/ServerSettingsSection.svelte
@@ -3,6 +3,8 @@
 	import { onMount } from 'svelte';
 	import { RefreshCw, ArrowUpCircle } from 'lucide-svelte';
 	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
+	import FormToggle from '$lib/components/settings/FormToggle.svelte';
+	import FormNumberInput from '$lib/components/settings/FormNumberInput.svelte';
 	import UpgradeAction from '$lib/components/UpgradeAction.svelte';
 	import { apiClient } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast';
@@ -146,5 +148,24 @@
 			/>
 			<p class="text-xs text-muted-foreground mt-1">{m.settings_server_temp_dir_desc()}</p>
 		</div>
+	</div>
+	<div class="space-y-4">
+		<FormToggle
+			id="system-image-cache-enabled"
+			label={m.settings_server_image_cache_enable_label()}
+			description={m.settings_server_image_cache_enable_desc()}
+			checked={config.system.image_cache_enabled}
+			onchange={(val) => { config.system.image_cache_enabled = val; }}
+		/>
+		<FormNumberInput
+			id="system-image-cache-ttl"
+			label={m.settings_server_image_cache_ttl_label()}
+			description={m.settings_server_image_cache_ttl_desc()}
+			value={config.system.image_cache_ttl_hours}
+			min={1}
+			max={87600}
+			disabled={!config.system.image_cache_enabled}
+			onchange={(val) => { config.system.image_cache_ttl_hours = val; }}
+		/>
 	</div>
 </SettingsSection>

--- a/web/frontend/src/lib/components/settings/sections/ServerSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/ServerSettingsSection.svelte
@@ -167,5 +167,15 @@
 			disabled={!config.system.image_cache_enabled}
 			onchange={(val) => { config.system.image_cache_ttl_hours = val; }}
 		/>
+		<FormNumberInput
+			id="system-image-cache-max-size"
+			label={m.settings_server_image_cache_max_size_label()}
+			description={m.settings_server_image_cache_max_size_desc()}
+			value={config.system.image_cache_max_size_mb}
+			min={0}
+			max={1048576}
+			disabled={!config.system.image_cache_enabled}
+			onchange={(val) => { config.system.image_cache_max_size_mb = val; }}
+		/>
 	</div>
 </SettingsSection>

--- a/web/frontend/src/routes/review/[jobId]/+page.svelte
+++ b/web/frontend/src/routes/review/[jobId]/+page.svelte
@@ -297,7 +297,7 @@
 							onOpenTrailerModal={() => (s.showTrailerModal = true)}
 							onOpenPosterViewer={() => {
 								if (!s.displayPosterUrl) return;
-								s.imageViewerImages = [s.displayPosterUrl];
+								s.imageViewerImages = [s.reviewPageController.previewImageURL(s.displayPosterUrl)];
 								s.imageViewerIndex = 0;
 								s.imageViewerTitle = m.review_poster();
 								s.showImageViewer = true;

--- a/web/frontend/src/routes/review/[jobId]/components/ReviewMediaSidebar.svelte
+++ b/web/frontend/src/routes/review/[jobId]/components/ReviewMediaSidebar.svelte
@@ -59,7 +59,7 @@
 						<div class="w-full max-w-60 mx-auto aspect-2/3 overflow-hidden rounded border relative">
 							{#if currentMovie.should_crop_poster && !currentMovie.cropped_poster_url}
 								<img
-									src={displayPosterUrl}
+									src={previewImageURL(displayPosterUrl)}
 									alt={m.review_poster_alt()}
 									class="absolute h-full"
 									style="right: 0; width: auto; min-width: 211.8%; object-fit: cover; object-position: right center;"
@@ -67,7 +67,7 @@
 								/>
 							{:else}
 								<img
-									src={displayPosterUrl}
+									src={previewImageURL(displayPosterUrl)}
 									alt={m.review_poster_alt()}
 									class="w-full h-full object-contain"
 									onerror={(e) => { (e.currentTarget as HTMLImageElement).src = PLACEHOLDER_SVG; }}


### PR DESCRIPTION
## Summary

Closes #189

The `/api/v1/temp/image` proxy fetched remote preview images (covers, posters, screenshots) from the source CDN on every request with only a 5-min browser cache and no server-side persistence. When the network dropped mid-review, covers vanished — including already-viewed ones.

This PR adds a **lazy on-disk cache** keyed by SHA-256(url) under `{temp_dir}/image-cache/`. On a cache miss the proxy fetches via the existing SSRF-safe client and persists a complete copy; on a hit it serves from disk with no network access. **Stale-if-error**: an expired entry whose re-fetch fails (including DNS failure offline) is served from disk rather than vanishing.

## Key design decisions

- **Cache lookup runs BEFORE the SSRF check** (which does DNS resolution) — so an offline cache hit is served without error. This is what actually fixes the reported scenario.
- **Stale-if-error** — once an image has been fetched, it keeps rendering even after TTL expiry while offline.
- **Detached-context singleflight** — a disconnecting leader request does not cancel the shared fetch for other waiters.
- **Dedicated TTL sweep** (every 24h, started unconditionally from bootstrap, gated per-tick by TTL) — does NOT reuse the existing temp-poster sweep (which is deliberately never started in production because it causes a broken-thumbnail regression).
- **Content-type normalization** on both miss and hit paths (params stripped, SVG neutralized to `image/jpeg`, avif/apng preserved). All cache-path serves carry `X-Content-Type-Options: nosniff`.
- **Cache key canonicalization** — fragment stripped + query params sorted, so URL variants don't fragment the cache. The original (unnormalized) URL is used for the actual upstream fetch.
- **Cache-persist failure fallback** — if the disk write fails (disk full, permissions), the proxy degrades to uncached fetch-and-stream rather than breaking the image.

## Config

- `system.image_cache_enabled` (default `true`) — toggle the cache on/off
- `system.image_cache_ttl_hours` (default `168` = 7 days, cap `87600` enforced unconditionally to prevent `time.Duration` overflow)

## Frontend

Three review surfaces that bypassed the proxy are now routed through `previewImageURL` for hotlink protection and caching:
- `ReviewMediaSidebar` uncropped poster `src`
- Fullscreen poster viewer in `+page.svelte`
- `ScreenshotManager` poster preview

Settings UI: `FormToggle` + `FormNumberInput` in `ServerSettingsSection`.

## Test plan

- 16 image cache scenario tests (fresh hit, offline hit, stale-if-error, disabled, content-type normalization, SVG neutralization, concurrent coalescing, leader-disconnect, 502/403, session-param, avif, apng, stale refresh, oversized, SSRF+stale)
- 9 config validation boundary tests (both validation sites)
- 5 `CleanupStaleImageCache` tests (expired removal, empty-shard cleanup, orphan temps, no-op cases)
- Race detector on `internal/api/temp` + `internal/worker`
- Frontend `svelte-check` + 562 vitest tests pass

## OpenSpec

Planned via OpenSpec change `review-image-cache` (proposal, design, spec, tasks — all k3-verified clean across 22 review rounds).