### PR TITLE
fix(nfo): expand template tags in tagline and custom NFO tags

### DIFF
--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -510,7 +510,7 @@ metadata:
       - "Japanese"
 ```
 
-**tagline**: Custom tagline template. Supports template tags (see [Template System](./04-template-system.md)); static text without tags is written as-is. A tagline whose template fails to render is dropped (with a warning) instead of failing NFO generation.
+**tagline**: Custom tagline template. Supports template tags (see [Template System](./04-template-system.md)); static text without tags is written as-is. Render or validation errors drop the tagline (with a warning) instead of failing NFO generation; context cancellation still aborts NFO generation.
 
 **credits**: Additional credits to include.
 

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -500,7 +500,7 @@ metadata:
 
 **rating_source**: Source identifier for the rating. Defaults to the first scraper in `scrapers.priority` (`r18dev` with the default priority list). Common values: `r18dev`, `dmm`, `libredmm`, or any scraper name.
 
-**tag**: Array of custom tags to add to every NFO:
+**tag**: Array of custom tags to add to every NFO. Entries support template tags (e.g. `"<ID>"`); entries that fail to render are dropped. Example:
 
 ```yaml
 metadata:
@@ -510,7 +510,7 @@ metadata:
       - "Japanese"
 ```
 
-**tagline**: Custom tagline template (supports template tags).
+**tagline**: Custom tagline template. Supports template tags (see [Template System](./04-template-system.md)); static text without tags is written as-is. A tagline whose template fails to render is dropped (with a warning) instead of failing NFO generation.
 
 **credits**: Additional credits to include.
 

--- a/internal/nfo/actress_role_test.go
+++ b/internal/nfo/actress_role_test.go
@@ -48,7 +48,7 @@ func TestAddGenericRole(t *testing.T) {
 				},
 			}
 
-			nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 			require.Len(t, nfo.Actors, 2)
 			assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -106,7 +106,7 @@ func TestAltNameRole(t *testing.T) {
 				},
 			}
 
-			nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 			require.Len(t, nfo.Actors, 1)
 			assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -136,7 +136,7 @@ func TestBothRoleOptions(t *testing.T) {
 			},
 		}
 
-		nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 		require.Len(t, nfo.Actors, 1)
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -163,7 +163,7 @@ func TestBothRoleOptions(t *testing.T) {
 			},
 		}
 
-		nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 		require.Len(t, nfo.Actors, 1)
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -186,7 +186,7 @@ func TestRoleInXML(t *testing.T) {
 		},
 	}
 
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	// Marshal to XML
 	xmlData, err := xml.MarshalIndent(nfo, "", "  ")
@@ -218,7 +218,7 @@ func TestAltNameRoleInXML(t *testing.T) {
 		},
 	}
 
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	// Marshal to XML
 	xmlData, err := xml.MarshalIndent(nfo, "", "  ")

--- a/internal/nfo/actress_role_test.go
+++ b/internal/nfo/actress_role_test.go
@@ -48,7 +48,7 @@ func TestAddGenericRole(t *testing.T) {
 				},
 			}
 
-			nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 			require.Len(t, nfo.Actors, 2)
 			assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -106,7 +106,7 @@ func TestAltNameRole(t *testing.T) {
 				},
 			}
 
-			nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 			require.Len(t, nfo.Actors, 1)
 			assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -136,7 +136,7 @@ func TestBothRoleOptions(t *testing.T) {
 			},
 		}
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 		require.Len(t, nfo.Actors, 1)
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -163,7 +163,7 @@ func TestBothRoleOptions(t *testing.T) {
 			},
 		}
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 		require.Len(t, nfo.Actors, 1)
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -186,7 +186,7 @@ func TestRoleInXML(t *testing.T) {
 		},
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	// Marshal to XML
 	xmlData, err := xml.MarshalIndent(nfo, "", "  ")
@@ -218,7 +218,7 @@ func TestAltNameRoleInXML(t *testing.T) {
 		},
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	// Marshal to XML
 	xmlData, err := xml.MarshalIndent(nfo, "", "  ")

--- a/internal/nfo/actress_role_test.go
+++ b/internal/nfo/actress_role_test.go
@@ -48,7 +48,7 @@ func TestAddGenericRole(t *testing.T) {
 				},
 			}
 
-			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 			require.Len(t, nfo.Actors, 2)
 			assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -106,7 +106,7 @@ func TestAltNameRole(t *testing.T) {
 				},
 			}
 
-			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 			require.Len(t, nfo.Actors, 1)
 			assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -136,7 +136,7 @@ func TestBothRoleOptions(t *testing.T) {
 			},
 		}
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 		require.Len(t, nfo.Actors, 1)
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -163,7 +163,7 @@ func TestBothRoleOptions(t *testing.T) {
 			},
 		}
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 		require.Len(t, nfo.Actors, 1)
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -186,7 +186,7 @@ func TestRoleInXML(t *testing.T) {
 		},
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	// Marshal to XML
 	xmlData, err := xml.MarshalIndent(nfo, "", "  ")
@@ -218,7 +218,7 @@ func TestAltNameRoleInXML(t *testing.T) {
 		},
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	// Marshal to XML
 	xmlData, err := xml.MarshalIndent(nfo, "", "  ")

--- a/internal/nfo/config.go
+++ b/internal/nfo/config.go
@@ -16,6 +16,7 @@ type NFONameConfig struct {
 	PerFile          bool
 	IsMultiPart      bool
 	PartSuffix       string
+	PartNumber       int
 	FirstNameOrder   bool
 
 	// Actress rendering options mirrored from the app config so that
@@ -113,7 +114,7 @@ func ConfigFromAppConfig(cfg *config.Config, nameCfg NFONameConfig) *Config {
 // ToNFONameConfig converts Config to NFONameConfig, filling in the caller-provided
 // multipart fields. This eliminates manual field-by-field mapping at every call site
 // that needs NFONameConfig from a Config.
-func (c *Config) ToNFONameConfig(isMultiPart bool, partSuffix string) NFONameConfig {
+func (c *Config) ToNFONameConfig(isMultiPart bool, partSuffix string, partNumber int) NFONameConfig {
 	return NFONameConfig{
 		FilenameTemplate:        c.FilenameTemplate,
 		GroupActress:            c.GroupActress,
@@ -122,6 +123,7 @@ func (c *Config) ToNFONameConfig(isMultiPart bool, partSuffix string) NFONameCon
 		PerFile:                 c.PerFile,
 		IsMultiPart:             isMultiPart,
 		PartSuffix:              partSuffix,
+		PartNumber:              partNumber,
 		FirstNameOrder:          c.FirstNameOrder,
 		GroupUnknownActressName: c.GroupUnknownActressName,
 		UnknownActressMode:      c.UnknownActressMode,

--- a/internal/nfo/config_test.go
+++ b/internal/nfo/config_test.go
@@ -39,7 +39,7 @@ func TestConfig_ToNFONameConfig(t *testing.T) {
 		PerFile:          true,
 		FirstNameOrder:   true,
 	}
-	result := c.ToNFONameConfig(true, "-A")
+	result := c.ToNFONameConfig(true, "-A", 0)
 	assert.Equal(t, "{id}", result.FilenameTemplate)
 	assert.True(t, result.GroupActress)
 	assert.True(t, result.IsMultiPart)

--- a/internal/nfo/config_test.go
+++ b/internal/nfo/config_test.go
@@ -39,10 +39,11 @@ func TestConfig_ToNFONameConfig(t *testing.T) {
 		PerFile:          true,
 		FirstNameOrder:   true,
 	}
-	result := c.ToNFONameConfig(true, "-A", 0)
+	result := c.ToNFONameConfig(true, "-A", 2)
 	assert.Equal(t, "{id}", result.FilenameTemplate)
 	assert.True(t, result.GroupActress)
 	assert.True(t, result.IsMultiPart)
 	assert.Equal(t, "-A", result.PartSuffix)
+	assert.Equal(t, 2, result.PartNumber)
 	assert.True(t, result.FirstNameOrder)
 }

--- a/internal/nfo/coverage_test.go
+++ b/internal/nfo/coverage_test.go
@@ -171,7 +171,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		}
 
 		// Pass non-existent video file path
-		nfo := gen.movieToNFO(context.Background(), movie, "/nonexistent/video.mp4", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "/nonexistent/video.mp4", nil)
 
 		// Should handle error gracefully (no stream details)
 		assert.Nil(t, nfo.FileInfo)
@@ -184,7 +184,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		}
 
 		// Pass empty path
-		nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 		// Should not attempt to extract stream details
 		assert.Nil(t, nfo.FileInfo)
@@ -204,7 +204,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		tmpFile := filepath.Join(t.TempDir(), "video.mp4")
 		_ = os.WriteFile(tmpFile, []byte("fake video"), 0644)
 
-		nfo := genNoStream.movieToNFO(context.Background(), movie, tmpFile, nil)
+		nfo, _ := genNoStream.movieToNFO(context.Background(), movie, tmpFile, nil)
 
 		// Should not include stream details when disabled
 		assert.Nil(t, nfo.FileInfo)
@@ -221,7 +221,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		err := os.WriteFile(tmpFile, []byte("This is not a video file"), 0644)
 		require.NoError(t, err)
 
-		nfo := gen.movieToNFO(context.Background(), movie, tmpFile, nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, tmpFile, nil)
 
 		// Should handle invalid video file gracefully (mediainfo will fail)
 		assert.Nil(t, nfo.FileInfo)
@@ -340,7 +340,7 @@ func TestNewGenerator_ConfigDefaults(t *testing.T) {
 			},
 		}
 
-		nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 		assert.Equal(t, "Unknown", nfo.Actors[0].Name)
 	})
 
@@ -383,7 +383,7 @@ func TestMovieToNFO_PreResolvedTags(t *testing.T) {
 
 	gen := NewGenerator(afero.NewOsFs(), nfoCfg)
 
-	nfo := gen.movieToNFO(context.Background(), movie, "", []string{"Tag1", "Tag2"})
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", []string{"Tag1", "Tag2"})
 
 	assert.Contains(t, nfo.Tags, "Tag1")
 	assert.Contains(t, nfo.Tags, "Tag2")
@@ -409,7 +409,7 @@ func TestMovieToNFO_TagDeduplication(t *testing.T) {
 	gen := NewGenerator(afero.NewOsFs(), nfoCfg)
 
 	// Pass "Yui Hatano" as pre-resolved tag — should deduplicate with actress-as-tag and config tag
-	nfo := gen.movieToNFO(context.Background(), movie, "", []string{"Yui Hatano"})
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", []string{"Yui Hatano"})
 
 	// Count occurrences of "Yui Hatano"
 	count := 0
@@ -448,7 +448,7 @@ func TestMovieToNFO_AllFields(t *testing.T) {
 		RatingVotes:   100,
 	}
 
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	// Verify all fields
 	assert.Equal(t, "IPX-001", nfo.ID)

--- a/internal/nfo/coverage_test.go
+++ b/internal/nfo/coverage_test.go
@@ -171,7 +171,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		}
 
 		// Pass non-existent video file path
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "/nonexistent/video.mp4", "", false, nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "/nonexistent/video.mp4", "", 0, false, nil)
 
 		// Should handle error gracefully (no stream details)
 		assert.Nil(t, nfo.FileInfo)
@@ -184,7 +184,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		}
 
 		// Pass empty path
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 		// Should not attempt to extract stream details
 		assert.Nil(t, nfo.FileInfo)
@@ -204,7 +204,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		tmpFile := filepath.Join(t.TempDir(), "video.mp4")
 		_ = os.WriteFile(tmpFile, []byte("fake video"), 0644)
 
-		nfo, _ := genNoStream.movieToNFO(context.Background(), movie, tmpFile, "", false, nil)
+		nfo, _ := genNoStream.movieToNFO(context.Background(), movie, tmpFile, "", 0, false, nil)
 
 		// Should not include stream details when disabled
 		assert.Nil(t, nfo.FileInfo)
@@ -221,7 +221,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		err := os.WriteFile(tmpFile, []byte("This is not a video file"), 0644)
 		require.NoError(t, err)
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, tmpFile, "", false, nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, tmpFile, "", 0, false, nil)
 
 		// Should handle invalid video file gracefully (mediainfo will fail)
 		assert.Nil(t, nfo.FileInfo)
@@ -340,7 +340,7 @@ func TestNewGenerator_ConfigDefaults(t *testing.T) {
 			},
 		}
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 		assert.Equal(t, "Unknown", nfo.Actors[0].Name)
 	})
 
@@ -383,7 +383,7 @@ func TestMovieToNFO_PreResolvedTags(t *testing.T) {
 
 	gen := NewGenerator(afero.NewOsFs(), nfoCfg)
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, []string{"Tag1", "Tag2"})
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, []string{"Tag1", "Tag2"})
 
 	assert.Contains(t, nfo.Tags, "Tag1")
 	assert.Contains(t, nfo.Tags, "Tag2")
@@ -409,7 +409,7 @@ func TestMovieToNFO_TagDeduplication(t *testing.T) {
 	gen := NewGenerator(afero.NewOsFs(), nfoCfg)
 
 	// Pass "Yui Hatano" as pre-resolved tag — should deduplicate with actress-as-tag and config tag
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, []string{"Yui Hatano"})
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, []string{"Yui Hatano"})
 
 	// Count occurrences of "Yui Hatano"
 	count := 0
@@ -448,7 +448,7 @@ func TestMovieToNFO_AllFields(t *testing.T) {
 		RatingVotes:   100,
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	// Verify all fields
 	assert.Equal(t, "IPX-001", nfo.ID)

--- a/internal/nfo/coverage_test.go
+++ b/internal/nfo/coverage_test.go
@@ -171,7 +171,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		}
 
 		// Pass non-existent video file path
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "/nonexistent/video.mp4", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "/nonexistent/video.mp4", "", false, nil)
 
 		// Should handle error gracefully (no stream details)
 		assert.Nil(t, nfo.FileInfo)
@@ -184,7 +184,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		}
 
 		// Pass empty path
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 		// Should not attempt to extract stream details
 		assert.Nil(t, nfo.FileInfo)
@@ -204,7 +204,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		tmpFile := filepath.Join(t.TempDir(), "video.mp4")
 		_ = os.WriteFile(tmpFile, []byte("fake video"), 0644)
 
-		nfo, _ := genNoStream.movieToNFO(context.Background(), movie, tmpFile, nil)
+		nfo, _ := genNoStream.movieToNFO(context.Background(), movie, tmpFile, "", false, nil)
 
 		// Should not include stream details when disabled
 		assert.Nil(t, nfo.FileInfo)
@@ -221,7 +221,7 @@ func TestExtractStreamDetails(t *testing.T) {
 		err := os.WriteFile(tmpFile, []byte("This is not a video file"), 0644)
 		require.NoError(t, err)
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, tmpFile, nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, tmpFile, "", false, nil)
 
 		// Should handle invalid video file gracefully (mediainfo will fail)
 		assert.Nil(t, nfo.FileInfo)
@@ -340,7 +340,7 @@ func TestNewGenerator_ConfigDefaults(t *testing.T) {
 			},
 		}
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 		assert.Equal(t, "Unknown", nfo.Actors[0].Name)
 	})
 
@@ -383,7 +383,7 @@ func TestMovieToNFO_PreResolvedTags(t *testing.T) {
 
 	gen := NewGenerator(afero.NewOsFs(), nfoCfg)
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", []string{"Tag1", "Tag2"})
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, []string{"Tag1", "Tag2"})
 
 	assert.Contains(t, nfo.Tags, "Tag1")
 	assert.Contains(t, nfo.Tags, "Tag2")
@@ -409,7 +409,7 @@ func TestMovieToNFO_TagDeduplication(t *testing.T) {
 	gen := NewGenerator(afero.NewOsFs(), nfoCfg)
 
 	// Pass "Yui Hatano" as pre-resolved tag — should deduplicate with actress-as-tag and config tag
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", []string{"Yui Hatano"})
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, []string{"Yui Hatano"})
 
 	// Count occurrences of "Yui Hatano"
 	count := 0
@@ -448,7 +448,7 @@ func TestMovieToNFO_AllFields(t *testing.T) {
 		RatingVotes:   100,
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	// Verify all fields
 	assert.Equal(t, "IPX-001", nfo.ID)

--- a/internal/nfo/error_handling_test.go
+++ b/internal/nfo/error_handling_test.go
@@ -56,7 +56,7 @@ func TestGenerator_NilFieldSafety(t *testing.T) {
 			gen := NewGenerator(fs, defaultConfig())
 
 			// Should not panic
-			nfo := gen.movieToNFO(context.Background(), tt.movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", nil)
 			assert.NotNil(t, nfo)
 
 			// Generate NFO to verify XML generation doesn't panic
@@ -434,7 +434,7 @@ func TestGenerator_DuplicateActresses(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		gen := NewGenerator(fs, defaultConfig())
 
-		nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 		assert.Len(t, nfo.Actors, 2, "duplicate actress names should be deduplicated")
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -466,7 +466,7 @@ func TestGenerator_DuplicateActresses(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		gen := NewGenerator(fs, defaultConfig())
 
-		nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 		assert.Len(t, nfo.Actors, 1, "duplicate DMMID entries should be deduplicated")
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -487,7 +487,7 @@ func TestGenerator_DuplicateActresses(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		gen := NewGenerator(fs, defaultConfig())
 
-		nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 		assert.Len(t, nfo.Actors, 2, "name normalization should deduplicate mixed case/whitespace variants")
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)

--- a/internal/nfo/error_handling_test.go
+++ b/internal/nfo/error_handling_test.go
@@ -56,7 +56,7 @@ func TestGenerator_NilFieldSafety(t *testing.T) {
 			gen := NewGenerator(fs, defaultConfig())
 
 			// Should not panic
-			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", false, nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", 0, false, nil)
 			assert.NotNil(t, nfo)
 
 			// Generate NFO to verify XML generation doesn't panic
@@ -434,7 +434,7 @@ func TestGenerator_DuplicateActresses(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		gen := NewGenerator(fs, defaultConfig())
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 		assert.Len(t, nfo.Actors, 2, "duplicate actress names should be deduplicated")
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -466,7 +466,7 @@ func TestGenerator_DuplicateActresses(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		gen := NewGenerator(fs, defaultConfig())
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 		assert.Len(t, nfo.Actors, 1, "duplicate DMMID entries should be deduplicated")
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -487,7 +487,7 @@ func TestGenerator_DuplicateActresses(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		gen := NewGenerator(fs, defaultConfig())
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 		assert.Len(t, nfo.Actors, 2, "name normalization should deduplicate mixed case/whitespace variants")
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)

--- a/internal/nfo/error_handling_test.go
+++ b/internal/nfo/error_handling_test.go
@@ -56,7 +56,7 @@ func TestGenerator_NilFieldSafety(t *testing.T) {
 			gen := NewGenerator(fs, defaultConfig())
 
 			// Should not panic
-			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", false, nil)
 			assert.NotNil(t, nfo)
 
 			// Generate NFO to verify XML generation doesn't panic
@@ -434,7 +434,7 @@ func TestGenerator_DuplicateActresses(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		gen := NewGenerator(fs, defaultConfig())
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 		assert.Len(t, nfo.Actors, 2, "duplicate actress names should be deduplicated")
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -466,7 +466,7 @@ func TestGenerator_DuplicateActresses(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		gen := NewGenerator(fs, defaultConfig())
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 		assert.Len(t, nfo.Actors, 1, "duplicate DMMID entries should be deduplicated")
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)
@@ -487,7 +487,7 @@ func TestGenerator_DuplicateActresses(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		gen := NewGenerator(fs, defaultConfig())
 
-		nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+		nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 		assert.Len(t, nfo.Actors, 2, "name normalization should deduplicate mixed case/whitespace variants")
 		assert.Equal(t, "Yui Hatano", nfo.Actors[0].Name)

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -226,7 +226,7 @@ func (g *Generator) Generate(ctx context.Context, movie *models.Movie, outputPat
 	filename += ".nfo"
 
 	fullPath := filepath.Join(outputPath, filename)
-	return g.GenerateAtPath(ctx, movie, fullPath, videoFilePath, tags)
+	return g.generateAtPath(ctx, movie, fullPath, videoFilePath, partSuffix, partSuffix != "" && g.config.PerFile, tags)
 }
 
 // GenerateAtPath creates an NFO file at the specified path without computing
@@ -234,7 +234,14 @@ func (g *Generator) Generate(ctx context.Context, movie *models.Movie, outputPat
 // ResolveNFOFilename) should use this method to avoid dual path computation
 // and ensure the revert log and generator agree on the target path.
 func (g *Generator) GenerateAtPath(ctx context.Context, movie *models.Movie, nfoPath string, videoFilePath string, tags []string) error {
-	nfo, err := g.movieToNFO(ctx, movie, videoFilePath, tags)
+	return g.generateAtPath(ctx, movie, nfoPath, videoFilePath, "", false, tags)
+}
+
+// generateAtPath is the shared write path that threads multipart metadata into
+// the NFO content template context so configured taglines/tags using <PARTSUFFIX>
+// or <IF:MULTIPART> resolve correctly in per-file mode.
+func (g *Generator) generateAtPath(ctx context.Context, movie *models.Movie, nfoPath string, videoFilePath, partSuffix string, isMultiPart bool, tags []string) error {
+	nfo, err := g.movieToNFO(ctx, movie, videoFilePath, partSuffix, isMultiPart, tags)
 	if err != nil {
 		return err
 	}
@@ -262,7 +269,7 @@ func (g *Generator) ResolveAndGenerate(ctx context.Context, movie *models.Movie,
 	nfoFilename := ResolveNFOFilename(g.templateEngine, movie, nameCfg)
 	nfoPath := filepath.ToSlash(filepath.Join(destDir, nfoFilename))
 
-	if genErr := g.GenerateAtPath(ctx, movie, nfoPath, videoFilePath, tags); genErr != nil {
+	if genErr := g.generateAtPath(ctx, movie, nfoPath, videoFilePath, nameCfg.PartSuffix, nameCfg.IsMultiPart, tags); genErr != nil {
 		return "", genErr
 	}
 	return nfoPath, nil
@@ -271,8 +278,8 @@ func (g *Generator) ResolveAndGenerate(ctx context.Context, movie *models.Movie,
 // movieToNFO converts a Movie model to NFO format.
 // videoFilePath: optional path to video file for extracting stream details (empty string to skip)
 // tags: pre-resolved tags from caller (e.g., tag database) — replaces internal DB call
-func (g *Generator) movieToNFO(ctx context.Context, movie *models.Movie, videoFilePath string, tags []string) (*Movie, error) {
-	input, err := g.transformMovieForNFO(ctx, movie, videoFilePath, tags)
+func (g *Generator) movieToNFO(ctx context.Context, movie *models.Movie, videoFilePath, partSuffix string, isMultiPart bool, tags []string) (*Movie, error) {
+	input, err := g.transformMovieForNFO(ctx, movie, videoFilePath, partSuffix, isMultiPart, tags)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/javinizer/javinizer-go/internal/config"
 	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/javinizer/javinizer-go/internal/mediainfo"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/template"
 	"github.com/spf13/afero"
@@ -21,11 +22,12 @@ const defaultNFOFileName = "metadata"
 
 // Generator creates NFO files from movie metadata
 type Generator struct {
-	fs             afero.Fs
-	templateEngine template.EngineInterface
-	config         *Config
-	mediaAnalyzer  mediaAnalyzer
-	encodeFunc     func(io.Writer, *Movie) error
+	fs               afero.Fs
+	templateEngine   template.EngineInterface
+	config           *Config
+	mediaAnalyzer    mediaAnalyzer
+	encodeFunc       func(io.Writer, *Movie) error
+	mediaInfoAnalyze func(ctx context.Context, path string) (*mediainfo.VideoInfo, error)
 }
 
 // NewGenerator returns an NFO generator that writes to fs using the given config.
@@ -64,11 +66,12 @@ func newGeneratorWithAnalyzer(fs afero.Fs, cfg *Config, ma mediaAnalyzer) *Gener
 	}
 
 	return &Generator{
-		fs:             fs,
-		templateEngine: engine,
-		config:         &cfgCopy,
-		mediaAnalyzer:  ma,
-		encodeFunc:     writeNFOXML,
+		fs:               fs,
+		templateEngine:   engine,
+		config:           &cfgCopy,
+		mediaAnalyzer:    ma,
+		encodeFunc:       writeNFOXML,
+		mediaInfoAnalyze: mediainfo.Analyze,
 	}
 }
 

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -231,7 +231,11 @@ func (g *Generator) Generate(ctx context.Context, movie *models.Movie, outputPat
 	// Use ResolveAndGenerate for multipart-aware taglines/tags (<PARTSUFFIX>,
 	// <PART>, <IF:MULTIPART>); Generate's content path mirrors pre-multipart
 	// behavior to avoid half-populated multipart state.
-	return g.generateAtPath(ctx, movie, fullPath, videoFilePath, "", 0, false, tags)
+	nfo, err := g.movieToNFO(ctx, movie, videoFilePath, "", 0, false, tags)
+	if err != nil {
+		return err
+	}
+	return g.WriteNFO(nfo, fullPath)
 }
 
 // GenerateAtPath creates an NFO file at the specified path without computing

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -226,7 +226,7 @@ func (g *Generator) Generate(ctx context.Context, movie *models.Movie, outputPat
 	filename += ".nfo"
 
 	fullPath := filepath.Join(outputPath, filename)
-	return g.generateAtPath(ctx, movie, fullPath, videoFilePath, partSuffix, partSuffix != "" && g.config.PerFile, tags)
+	return g.generateAtPath(ctx, movie, fullPath, videoFilePath, partSuffix, 0, partSuffix != "" && g.config.PerFile, tags)
 }
 
 // GenerateAtPath creates an NFO file at the specified path without computing
@@ -234,14 +234,14 @@ func (g *Generator) Generate(ctx context.Context, movie *models.Movie, outputPat
 // ResolveNFOFilename) should use this method to avoid dual path computation
 // and ensure the revert log and generator agree on the target path.
 func (g *Generator) GenerateAtPath(ctx context.Context, movie *models.Movie, nfoPath string, videoFilePath string, tags []string) error {
-	return g.generateAtPath(ctx, movie, nfoPath, videoFilePath, "", false, tags)
+	return g.generateAtPath(ctx, movie, nfoPath, videoFilePath, "", 0, false, tags)
 }
 
 // generateAtPath is the shared write path that threads multipart metadata into
 // the NFO content template context so configured taglines/tags using <PARTSUFFIX>
 // or <IF:MULTIPART> resolve correctly in per-file mode.
-func (g *Generator) generateAtPath(ctx context.Context, movie *models.Movie, nfoPath string, videoFilePath, partSuffix string, isMultiPart bool, tags []string) error {
-	nfo, err := g.movieToNFO(ctx, movie, videoFilePath, partSuffix, isMultiPart, tags)
+func (g *Generator) generateAtPath(ctx context.Context, movie *models.Movie, nfoPath string, videoFilePath, partSuffix string, partNumber int, isMultiPart bool, tags []string) error {
+	nfo, err := g.movieToNFO(ctx, movie, videoFilePath, partSuffix, partNumber, isMultiPart, tags)
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func (g *Generator) ResolveAndGenerate(ctx context.Context, movie *models.Movie,
 	nfoFilename := ResolveNFOFilename(g.templateEngine, movie, nameCfg)
 	nfoPath := filepath.ToSlash(filepath.Join(destDir, nfoFilename))
 
-	if genErr := g.generateAtPath(ctx, movie, nfoPath, videoFilePath, nameCfg.PartSuffix, nameCfg.IsMultiPart, tags); genErr != nil {
+	if genErr := g.generateAtPath(ctx, movie, nfoPath, videoFilePath, nameCfg.PartSuffix, nameCfg.PartNumber, nameCfg.IsMultiPart, tags); genErr != nil {
 		return "", genErr
 	}
 	return nfoPath, nil
@@ -278,8 +278,8 @@ func (g *Generator) ResolveAndGenerate(ctx context.Context, movie *models.Movie,
 // movieToNFO converts a Movie model to NFO format.
 // videoFilePath: optional path to video file for extracting stream details (empty string to skip)
 // tags: pre-resolved tags from caller (e.g., tag database) — replaces internal DB call
-func (g *Generator) movieToNFO(ctx context.Context, movie *models.Movie, videoFilePath, partSuffix string, isMultiPart bool, tags []string) (*Movie, error) {
-	input, err := g.transformMovieForNFO(ctx, movie, videoFilePath, partSuffix, isMultiPart, tags)
+func (g *Generator) movieToNFO(ctx context.Context, movie *models.Movie, videoFilePath, partSuffix string, partNumber int, isMultiPart bool, tags []string) (*Movie, error) {
+	input, err := g.transformMovieForNFO(ctx, movie, videoFilePath, partSuffix, partNumber, isMultiPart, tags)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -276,7 +276,7 @@ func (g *Generator) ResolveAndGenerate(ctx context.Context, movie *models.Movie,
 
 	contentPartSuffix := nameCfg.PartSuffix
 	contentPartNumber := nameCfg.PartNumber
-	if !nameCfg.PerFile {
+	if !nameCfg.PerFile || !nameCfg.IsMultiPart {
 		contentPartSuffix = ""
 		contentPartNumber = 0
 	}

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -234,7 +234,10 @@ func (g *Generator) Generate(ctx context.Context, movie *models.Movie, outputPat
 // ResolveNFOFilename) should use this method to avoid dual path computation
 // and ensure the revert log and generator agree on the target path.
 func (g *Generator) GenerateAtPath(ctx context.Context, movie *models.Movie, nfoPath string, videoFilePath string, tags []string) error {
-	nfo := g.movieToNFO(ctx, movie, videoFilePath, tags)
+	nfo, err := g.movieToNFO(ctx, movie, videoFilePath, tags)
+	if err != nil {
+		return err
+	}
 	return g.WriteNFO(nfo, nfoPath)
 }
 
@@ -268,9 +271,12 @@ func (g *Generator) ResolveAndGenerate(ctx context.Context, movie *models.Movie,
 // movieToNFO converts a Movie model to NFO format.
 // videoFilePath: optional path to video file for extracting stream details (empty string to skip)
 // tags: pre-resolved tags from caller (e.g., tag database) — replaces internal DB call
-func (g *Generator) movieToNFO(ctx context.Context, movie *models.Movie, videoFilePath string, tags []string) *Movie {
-	input := g.transformMovieForNFO(ctx, movie, videoFilePath, tags)
-	return g.buildNFO(input)
+func (g *Generator) movieToNFO(ctx context.Context, movie *models.Movie, videoFilePath string, tags []string) (*Movie, error) {
+	input, err := g.transformMovieForNFO(ctx, movie, videoFilePath, tags)
+	if err != nil {
+		return nil, err
+	}
+	return g.buildNFO(input), nil
 }
 
 // WriteNFO encodes the NFO struct to the given path, creating parent directories as needed.

--- a/internal/nfo/generator.go
+++ b/internal/nfo/generator.go
@@ -226,7 +226,12 @@ func (g *Generator) Generate(ctx context.Context, movie *models.Movie, outputPat
 	filename += ".nfo"
 
 	fullPath := filepath.Join(outputPath, filename)
-	return g.generateAtPath(ctx, movie, fullPath, videoFilePath, partSuffix, 0, partSuffix != "" && g.config.PerFile, tags)
+	// Generate is the legacy write path and does not thread multipart metadata
+	// into the NFO content context (partSuffix is applied to the filename above).
+	// Use ResolveAndGenerate for multipart-aware taglines/tags (<PARTSUFFIX>,
+	// <PART>, <IF:MULTIPART>); Generate's content path mirrors pre-multipart
+	// behavior to avoid half-populated multipart state.
+	return g.generateAtPath(ctx, movie, fullPath, videoFilePath, "", 0, false, tags)
 }
 
 // GenerateAtPath creates an NFO file at the specified path without computing
@@ -269,7 +274,13 @@ func (g *Generator) ResolveAndGenerate(ctx context.Context, movie *models.Movie,
 	nfoFilename := ResolveNFOFilename(g.templateEngine, movie, nameCfg)
 	nfoPath := filepath.ToSlash(filepath.Join(destDir, nfoFilename))
 
-	if genErr := g.generateAtPath(ctx, movie, nfoPath, videoFilePath, nameCfg.PartSuffix, nameCfg.PartNumber, nameCfg.IsMultiPart, tags); genErr != nil {
+	contentPartSuffix := nameCfg.PartSuffix
+	contentPartNumber := nameCfg.PartNumber
+	if !nameCfg.PerFile {
+		contentPartSuffix = ""
+		contentPartNumber = 0
+	}
+	if genErr := g.generateAtPath(ctx, movie, nfoPath, videoFilePath, contentPartSuffix, contentPartNumber, nameCfg.IsMultiPart, tags); genErr != nil {
 		return "", genErr
 	}
 	return nfoPath, nil

--- a/internal/nfo/generator_coverage_test.go
+++ b/internal/nfo/generator_coverage_test.go
@@ -94,7 +94,7 @@ func TestMovieToNFO_OriginalPath(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "OP-001", ContentID: "op1", OriginalFileName: "original_file.mp4"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Equal(t, "original_file.mp4", nfo.OriginalPath)
 }
 
@@ -104,7 +104,7 @@ func TestMovieToNFO_Tagline(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "TG-001", ContentID: "tg1"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Equal(t, "Best Movie Ever", nfo.Tagline)
 }
 
@@ -114,7 +114,7 @@ func TestMovieToNFO_Credits(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "CR-001", ContentID: "cr1"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Equal(t, "Director A, Writer B", nfo.Credits)
 }
 
@@ -127,7 +127,7 @@ func TestMovieToNFO_AddGenericRole(t *testing.T) {
 		ID: "GR-001", ContentID: "gr1",
 		Actresses: []models.Actress{{FirstName: "Yui", LastName: "Hatano"}},
 	}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	require.Len(t, nfo.Actors, 1)
 	assert.Equal(t, "Actress", nfo.Actors[0].Role)
 }
@@ -141,7 +141,7 @@ func TestMovieToNFO_AltNameRole(t *testing.T) {
 		ID: "ANR-001", ContentID: "anr1",
 		Actresses: []models.Actress{{FirstName: "Yui", LastName: "Hatano", JapaneseName: "波多野結衣"}},
 	}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	require.Len(t, nfo.Actors, 1)
 	assert.Equal(t, "波多野結衣", nfo.Actors[0].Role)
 }
@@ -158,7 +158,7 @@ func TestMovieToNFO_DuplicateActressDedup(t *testing.T) {
 			{DMMID: 100, FirstName: "Yui", LastName: "Hatano"},
 		},
 	}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Len(t, nfo.Actors, 1, "duplicate actresses by DMMID should be deduplicated")
 }
 
@@ -176,7 +176,7 @@ func TestMovieToNFO_UnknownActressSkip(t *testing.T) {
 		ID: "UAS-001", ContentID: "u1",
 		Actresses: []models.Actress{{FirstName: "Unknown", LastName: ""}},
 	}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.NotContains(t, nfo.Tags, "Unknown")
 }
 
@@ -194,7 +194,7 @@ func TestMovieToNFO_UnknownActressFallback(t *testing.T) {
 		ID: "UAF-001", ContentID: "u2",
 		Actresses: []models.Actress{{FirstName: "Unknown", LastName: ""}},
 	}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Contains(t, nfo.Tags, "Unknown")
 }
 
@@ -204,7 +204,7 @@ func TestMovieToNFO_ReleaseYearOnly(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RY-001", ContentID: "ry1", ReleaseYear: 2023}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Equal(t, 2023, nfo.Year)
 	assert.Empty(t, nfo.ReleaseDate, "ReleaseDate should be empty when only ReleaseYear is set")
 }
@@ -216,7 +216,7 @@ func TestMovieToNFO_ReleaseDateSetsYear(t *testing.T) {
 
 	d := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
 	movie := &models.Movie{ID: "RD-001", ContentID: "rd1", ReleaseDate: &d}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Equal(t, 2024, nfo.Year)
 	assert.Equal(t, "2024-06-15", nfo.ReleaseDate)
 }
@@ -227,7 +227,7 @@ func TestMovieToNFO_NoCoverURL(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "NC-001", ContentID: "nc1", Poster: models.PosterState{CoverURL: ""}}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Empty(t, nfo.Thumb)
 }
 

--- a/internal/nfo/generator_coverage_test.go
+++ b/internal/nfo/generator_coverage_test.go
@@ -94,7 +94,7 @@ func TestMovieToNFO_OriginalPath(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "OP-001", ContentID: "op1", OriginalFileName: "original_file.mp4"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Equal(t, "original_file.mp4", nfo.OriginalPath)
 }
 
@@ -104,7 +104,7 @@ func TestMovieToNFO_Tagline(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "TG-001", ContentID: "tg1"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Equal(t, "Best Movie Ever", nfo.Tagline)
 }
 
@@ -114,7 +114,7 @@ func TestMovieToNFO_Credits(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "CR-001", ContentID: "cr1"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Equal(t, "Director A, Writer B", nfo.Credits)
 }
 
@@ -127,7 +127,7 @@ func TestMovieToNFO_AddGenericRole(t *testing.T) {
 		ID: "GR-001", ContentID: "gr1",
 		Actresses: []models.Actress{{FirstName: "Yui", LastName: "Hatano"}},
 	}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	require.Len(t, nfo.Actors, 1)
 	assert.Equal(t, "Actress", nfo.Actors[0].Role)
 }
@@ -141,7 +141,7 @@ func TestMovieToNFO_AltNameRole(t *testing.T) {
 		ID: "ANR-001", ContentID: "anr1",
 		Actresses: []models.Actress{{FirstName: "Yui", LastName: "Hatano", JapaneseName: "波多野結衣"}},
 	}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	require.Len(t, nfo.Actors, 1)
 	assert.Equal(t, "波多野結衣", nfo.Actors[0].Role)
 }
@@ -158,7 +158,7 @@ func TestMovieToNFO_DuplicateActressDedup(t *testing.T) {
 			{DMMID: 100, FirstName: "Yui", LastName: "Hatano"},
 		},
 	}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Len(t, nfo.Actors, 1, "duplicate actresses by DMMID should be deduplicated")
 }
 
@@ -176,7 +176,7 @@ func TestMovieToNFO_UnknownActressSkip(t *testing.T) {
 		ID: "UAS-001", ContentID: "u1",
 		Actresses: []models.Actress{{FirstName: "Unknown", LastName: ""}},
 	}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.NotContains(t, nfo.Tags, "Unknown")
 }
 
@@ -194,7 +194,7 @@ func TestMovieToNFO_UnknownActressFallback(t *testing.T) {
 		ID: "UAF-001", ContentID: "u2",
 		Actresses: []models.Actress{{FirstName: "Unknown", LastName: ""}},
 	}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Contains(t, nfo.Tags, "Unknown")
 }
 
@@ -204,7 +204,7 @@ func TestMovieToNFO_ReleaseYearOnly(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RY-001", ContentID: "ry1", ReleaseYear: 2023}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Equal(t, 2023, nfo.Year)
 	assert.Empty(t, nfo.ReleaseDate, "ReleaseDate should be empty when only ReleaseYear is set")
 }
@@ -216,7 +216,7 @@ func TestMovieToNFO_ReleaseDateSetsYear(t *testing.T) {
 
 	d := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
 	movie := &models.Movie{ID: "RD-001", ContentID: "rd1", ReleaseDate: &d}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Equal(t, 2024, nfo.Year)
 	assert.Equal(t, "2024-06-15", nfo.ReleaseDate)
 }
@@ -227,7 +227,7 @@ func TestMovieToNFO_NoCoverURL(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "NC-001", ContentID: "nc1", Poster: models.PosterState{CoverURL: ""}}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Empty(t, nfo.Thumb)
 }
 

--- a/internal/nfo/generator_coverage_test.go
+++ b/internal/nfo/generator_coverage_test.go
@@ -94,7 +94,7 @@ func TestMovieToNFO_OriginalPath(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "OP-001", ContentID: "op1", OriginalFileName: "original_file.mp4"}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Equal(t, "original_file.mp4", nfo.OriginalPath)
 }
 
@@ -104,7 +104,7 @@ func TestMovieToNFO_Tagline(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "TG-001", ContentID: "tg1"}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Equal(t, "Best Movie Ever", nfo.Tagline)
 }
 
@@ -114,7 +114,7 @@ func TestMovieToNFO_Credits(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "CR-001", ContentID: "cr1"}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Equal(t, "Director A, Writer B", nfo.Credits)
 }
 
@@ -127,7 +127,7 @@ func TestMovieToNFO_AddGenericRole(t *testing.T) {
 		ID: "GR-001", ContentID: "gr1",
 		Actresses: []models.Actress{{FirstName: "Yui", LastName: "Hatano"}},
 	}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	require.Len(t, nfo.Actors, 1)
 	assert.Equal(t, "Actress", nfo.Actors[0].Role)
 }
@@ -141,7 +141,7 @@ func TestMovieToNFO_AltNameRole(t *testing.T) {
 		ID: "ANR-001", ContentID: "anr1",
 		Actresses: []models.Actress{{FirstName: "Yui", LastName: "Hatano", JapaneseName: "波多野結衣"}},
 	}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	require.Len(t, nfo.Actors, 1)
 	assert.Equal(t, "波多野結衣", nfo.Actors[0].Role)
 }
@@ -158,7 +158,7 @@ func TestMovieToNFO_DuplicateActressDedup(t *testing.T) {
 			{DMMID: 100, FirstName: "Yui", LastName: "Hatano"},
 		},
 	}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Len(t, nfo.Actors, 1, "duplicate actresses by DMMID should be deduplicated")
 }
 
@@ -176,7 +176,7 @@ func TestMovieToNFO_UnknownActressSkip(t *testing.T) {
 		ID: "UAS-001", ContentID: "u1",
 		Actresses: []models.Actress{{FirstName: "Unknown", LastName: ""}},
 	}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.NotContains(t, nfo.Tags, "Unknown")
 }
 
@@ -194,7 +194,7 @@ func TestMovieToNFO_UnknownActressFallback(t *testing.T) {
 		ID: "UAF-001", ContentID: "u2",
 		Actresses: []models.Actress{{FirstName: "Unknown", LastName: ""}},
 	}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Contains(t, nfo.Tags, "Unknown")
 }
 
@@ -204,7 +204,7 @@ func TestMovieToNFO_ReleaseYearOnly(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RY-001", ContentID: "ry1", ReleaseYear: 2023}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Equal(t, 2023, nfo.Year)
 	assert.Empty(t, nfo.ReleaseDate, "ReleaseDate should be empty when only ReleaseYear is set")
 }
@@ -216,7 +216,7 @@ func TestMovieToNFO_ReleaseDateSetsYear(t *testing.T) {
 
 	d := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
 	movie := &models.Movie{ID: "RD-001", ContentID: "rd1", ReleaseDate: &d}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Equal(t, 2024, nfo.Year)
 	assert.Equal(t, "2024-06-15", nfo.ReleaseDate)
 }
@@ -227,7 +227,7 @@ func TestMovieToNFO_NoCoverURL(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "NC-001", ContentID: "nc1", Poster: models.PosterState{CoverURL: ""}}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Empty(t, nfo.Thumb)
 }
 

--- a/internal/nfo/generator_partial_test.go
+++ b/internal/nfo/generator_partial_test.go
@@ -152,7 +152,7 @@ func TestMovieToNFO_DisplayTitleFallback_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "DT-001", Title: "Fallback Title", DisplayTitle: ""}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Equal(t, "Fallback Title", nfo.Title)
 }
 
@@ -163,7 +163,7 @@ func TestMovieToNFO_WithContentID_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "CID-001", ContentID: "cid001", DisplayTitle: "CID Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	require.Len(t, nfo.UniqueID, 1)
 	assert.Equal(t, "contentid", nfo.UniqueID[0].Type)
 	assert.Equal(t, "cid001", nfo.UniqueID[0].Value)
@@ -177,7 +177,7 @@ func TestMovieToNFO_ReleaseDateNil_WithYear_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "YEAR-001", ReleaseYear: 2023, DisplayTitle: "Year Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Equal(t, 2023, nfo.Year)
 	assert.Equal(t, "", nfo.ReleaseDate) // No full date available
 	assert.Equal(t, "", nfo.Premiered)   // No full date available
@@ -191,7 +191,7 @@ func TestMovieToNFO_WithReleaseDate_Partial(t *testing.T) {
 
 	rd := time.Date(2023, 6, 15, 0, 0, 0, 0, time.UTC)
 	movie := &models.Movie{ID: "RD-001", ReleaseDate: &rd, DisplayTitle: "RD Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Equal(t, "2023-06-15", nfo.ReleaseDate)
 	assert.Equal(t, "2023-06-15", nfo.Premiered)
 	assert.Equal(t, 2023, nfo.Year)
@@ -204,7 +204,7 @@ func TestMovieToNFO_RuntimeZero_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RT-001", Runtime: 0, DisplayTitle: "RT Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Equal(t, 0, nfo.Runtime)
 }
 
@@ -215,7 +215,7 @@ func TestMovieToNFO_RuntimePositive_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RT-002", Runtime: 120, DisplayTitle: "RT Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Equal(t, 120, nfo.Runtime)
 }
 
@@ -226,7 +226,7 @@ func TestMovieToNFO_RatingPositive_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RATE-001", RatingScore: 8.5, RatingVotes: 100, DisplayTitle: "Rate Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	require.Len(t, nfo.Ratings.Rating, 1)
 	assert.Equal(t, 8.5, nfo.Ratings.Rating[0].Value)
 	assert.Equal(t, 100, nfo.Ratings.Rating[0].Votes)
@@ -242,7 +242,7 @@ func TestMovieToNFO_RatingZero_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RATE-002", RatingScore: 0, DisplayTitle: "No Rate"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	assert.Empty(t, nfo.Ratings.Rating)
 }
 
@@ -665,7 +665,7 @@ func TestMovieToNFO_Tagline_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tagline: "Best movie ever"}
 	g := NewGenerator(fs, cfg)
 
-	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-001", DisplayTitle: "Test"}, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-001", DisplayTitle: "Test"}, "", "", false, nil)
 	assert.Equal(t, "Best movie ever", nfo.Tagline)
 }
 
@@ -675,7 +675,7 @@ func TestMovieToNFO_TaglineEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tagline: ""}
 	g := NewGenerator(fs, cfg)
 
-	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-002", DisplayTitle: "Test"}, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-002", DisplayTitle: "Test"}, "", "", false, nil)
 	assert.Equal(t, "", nfo.Tagline)
 }
 
@@ -685,7 +685,7 @@ func TestMovieToNFO_Credits_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Credits: []string{"Writer A", "Writer B"}}
 	g := NewGenerator(fs, cfg)
 
-	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-001", DisplayTitle: "Test"}, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-001", DisplayTitle: "Test"}, "", "", false, nil)
 	assert.Equal(t, "Writer A, Writer B", nfo.Credits)
 }
 
@@ -695,7 +695,7 @@ func TestMovieToNFO_NoCredits_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Credits: nil}
 	g := NewGenerator(fs, cfg)
 
-	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-002", DisplayTitle: "Test"}, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-002", DisplayTitle: "Test"}, "", "", false, nil)
 	assert.Equal(t, "", nfo.Credits)
 }
 

--- a/internal/nfo/generator_partial_test.go
+++ b/internal/nfo/generator_partial_test.go
@@ -516,7 +516,7 @@ func TestMergeTags_ActressAsTag_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: "Actress A"}}, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, "", []actor{{Name: "Actress A"}}, nil)
 	assert.Contains(t, tags, "Actress A")
 }
 
@@ -531,7 +531,7 @@ func TestMergeTags_ActressAsTag_SkipsUnknown_Partial(t *testing.T) {
 	}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, []actor{
+	tags, _ := g.mergeTags(context.Background(), nil, "", []actor{
 		{Name: "Unknown"},
 		{Name: "Actress B"},
 	}, nil)
@@ -550,7 +550,7 @@ func TestMergeTags_ActressAsTag_FallbackMode_Partial(t *testing.T) {
 	}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: "Unknown"}}, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, "", []actor{{Name: "Unknown"}}, nil)
 	assert.Contains(t, tags, "Unknown")
 }
 
@@ -560,7 +560,7 @@ func TestMergeTags_ActressAsTag_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: ""}}, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, "", []actor{{Name: ""}}, nil)
 	assert.NotContains(t, tags, "")
 }
 
@@ -570,7 +570,7 @@ func TestMergeTags_ActressDedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: "Actress A"}}, []string{"Actress A"})
+	tags, _ := g.mergeTags(context.Background(), nil, "", []actor{{Name: "Actress A"}}, []string{"Actress A"})
 	// Should not duplicate
 	count := 0
 	for _, tag := range tags {
@@ -587,7 +587,7 @@ func TestMergeTags_CallerTags_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"Tag1", "Tag2"})
+	tags, _ := g.mergeTags(context.Background(), nil, "", nil, []string{"Tag1", "Tag2"})
 	assert.Contains(t, tags, "Tag1")
 	assert.Contains(t, tags, "Tag2")
 }
@@ -598,7 +598,7 @@ func TestMergeTags_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"", "Tag1", ""})
+	tags, _ := g.mergeTags(context.Background(), nil, "", nil, []string{"", "Tag1", ""})
 	assert.NotContains(t, tags, "")
 	assert.Contains(t, tags, "Tag1")
 }
@@ -609,7 +609,7 @@ func TestMergeTags_CallerTagDedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"Tag1", "Tag1"})
+	tags, _ := g.mergeTags(context.Background(), nil, "", nil, []string{"Tag1", "Tag1"})
 	count := 0
 	for _, tag := range tags {
 		if tag == "Tag1" {
@@ -625,7 +625,7 @@ func TestMergeTags_ConfigTags_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"ConfigTag1", "ConfigTag2"}}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, nil, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, "", nil, nil)
 	assert.Contains(t, tags, "ConfigTag1")
 	assert.Contains(t, tags, "ConfigTag2")
 }
@@ -636,7 +636,7 @@ func TestMergeTags_ConfigTags_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"", "ConfigTag1"}}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, nil, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, "", nil, nil)
 	assert.NotContains(t, tags, "")
 	assert.Contains(t, tags, "ConfigTag1")
 }
@@ -647,7 +647,7 @@ func TestMergeTags_ConfigTags_Dedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"ExistingTag"}}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"ExistingTag"})
+	tags, _ := g.mergeTags(context.Background(), nil, "", nil, []string{"ExistingTag"})
 	count := 0
 	for _, tag := range tags {
 		if tag == "ExistingTag" {

--- a/internal/nfo/generator_partial_test.go
+++ b/internal/nfo/generator_partial_test.go
@@ -152,7 +152,7 @@ func TestMovieToNFO_DisplayTitleFallback_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "DT-001", Title: "Fallback Title", DisplayTitle: ""}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Equal(t, "Fallback Title", nfo.Title)
 }
 
@@ -163,7 +163,7 @@ func TestMovieToNFO_WithContentID_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "CID-001", ContentID: "cid001", DisplayTitle: "CID Test"}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	require.Len(t, nfo.UniqueID, 1)
 	assert.Equal(t, "contentid", nfo.UniqueID[0].Type)
 	assert.Equal(t, "cid001", nfo.UniqueID[0].Value)
@@ -177,7 +177,7 @@ func TestMovieToNFO_ReleaseDateNil_WithYear_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "YEAR-001", ReleaseYear: 2023, DisplayTitle: "Year Test"}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Equal(t, 2023, nfo.Year)
 	assert.Equal(t, "", nfo.ReleaseDate) // No full date available
 	assert.Equal(t, "", nfo.Premiered)   // No full date available
@@ -191,7 +191,7 @@ func TestMovieToNFO_WithReleaseDate_Partial(t *testing.T) {
 
 	rd := time.Date(2023, 6, 15, 0, 0, 0, 0, time.UTC)
 	movie := &models.Movie{ID: "RD-001", ReleaseDate: &rd, DisplayTitle: "RD Test"}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Equal(t, "2023-06-15", nfo.ReleaseDate)
 	assert.Equal(t, "2023-06-15", nfo.Premiered)
 	assert.Equal(t, 2023, nfo.Year)
@@ -204,7 +204,7 @@ func TestMovieToNFO_RuntimeZero_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RT-001", Runtime: 0, DisplayTitle: "RT Test"}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Equal(t, 0, nfo.Runtime)
 }
 
@@ -215,7 +215,7 @@ func TestMovieToNFO_RuntimePositive_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RT-002", Runtime: 120, DisplayTitle: "RT Test"}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Equal(t, 120, nfo.Runtime)
 }
 
@@ -226,7 +226,7 @@ func TestMovieToNFO_RatingPositive_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RATE-001", RatingScore: 8.5, RatingVotes: 100, DisplayTitle: "Rate Test"}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	require.Len(t, nfo.Ratings.Rating, 1)
 	assert.Equal(t, 8.5, nfo.Ratings.Rating[0].Value)
 	assert.Equal(t, 100, nfo.Ratings.Rating[0].Votes)
@@ -242,7 +242,7 @@ func TestMovieToNFO_RatingZero_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RATE-002", RatingScore: 0, DisplayTitle: "No Rate"}
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	assert.Empty(t, nfo.Ratings.Rating)
 }
 
@@ -516,7 +516,7 @@ func TestMergeTags_ActressAsTag_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(context.Background(), nil, []actor{{Name: "Actress A"}}, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: "Actress A"}}, nil)
 	assert.Contains(t, tags, "Actress A")
 }
 
@@ -531,7 +531,7 @@ func TestMergeTags_ActressAsTag_SkipsUnknown_Partial(t *testing.T) {
 	}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(context.Background(), nil, []actor{
+	tags, _ := g.mergeTags(context.Background(), nil, []actor{
 		{Name: "Unknown"},
 		{Name: "Actress B"},
 	}, nil)
@@ -550,7 +550,7 @@ func TestMergeTags_ActressAsTag_FallbackMode_Partial(t *testing.T) {
 	}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(context.Background(), nil, []actor{{Name: "Unknown"}}, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: "Unknown"}}, nil)
 	assert.Contains(t, tags, "Unknown")
 }
 
@@ -560,7 +560,7 @@ func TestMergeTags_ActressAsTag_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(context.Background(), nil, []actor{{Name: ""}}, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: ""}}, nil)
 	assert.NotContains(t, tags, "")
 }
 
@@ -570,7 +570,7 @@ func TestMergeTags_ActressDedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(context.Background(), nil, []actor{{Name: "Actress A"}}, []string{"Actress A"})
+	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: "Actress A"}}, []string{"Actress A"})
 	// Should not duplicate
 	count := 0
 	for _, tag := range tags {
@@ -587,7 +587,7 @@ func TestMergeTags_CallerTags_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(context.Background(), nil, nil, []string{"Tag1", "Tag2"})
+	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"Tag1", "Tag2"})
 	assert.Contains(t, tags, "Tag1")
 	assert.Contains(t, tags, "Tag2")
 }
@@ -598,7 +598,7 @@ func TestMergeTags_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(context.Background(), nil, nil, []string{"", "Tag1", ""})
+	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"", "Tag1", ""})
 	assert.NotContains(t, tags, "")
 	assert.Contains(t, tags, "Tag1")
 }
@@ -609,7 +609,7 @@ func TestMergeTags_CallerTagDedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(context.Background(), nil, nil, []string{"Tag1", "Tag1"})
+	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"Tag1", "Tag1"})
 	count := 0
 	for _, tag := range tags {
 		if tag == "Tag1" {
@@ -625,7 +625,7 @@ func TestMergeTags_ConfigTags_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"ConfigTag1", "ConfigTag2"}}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(context.Background(), nil, nil, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, nil, nil)
 	assert.Contains(t, tags, "ConfigTag1")
 	assert.Contains(t, tags, "ConfigTag2")
 }
@@ -636,7 +636,7 @@ func TestMergeTags_ConfigTags_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"", "ConfigTag1"}}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(context.Background(), nil, nil, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, nil, nil)
 	assert.NotContains(t, tags, "")
 	assert.Contains(t, tags, "ConfigTag1")
 }
@@ -647,7 +647,7 @@ func TestMergeTags_ConfigTags_Dedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"ExistingTag"}}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(context.Background(), nil, nil, []string{"ExistingTag"})
+	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"ExistingTag"})
 	count := 0
 	for _, tag := range tags {
 		if tag == "ExistingTag" {
@@ -665,7 +665,7 @@ func TestMovieToNFO_Tagline_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tagline: "Best movie ever"}
 	g := NewGenerator(fs, cfg)
 
-	nfo := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-001", DisplayTitle: "Test"}, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-001", DisplayTitle: "Test"}, "", nil)
 	assert.Equal(t, "Best movie ever", nfo.Tagline)
 }
 
@@ -675,7 +675,7 @@ func TestMovieToNFO_TaglineEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tagline: ""}
 	g := NewGenerator(fs, cfg)
 
-	nfo := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-002", DisplayTitle: "Test"}, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-002", DisplayTitle: "Test"}, "", nil)
 	assert.Equal(t, "", nfo.Tagline)
 }
 
@@ -685,7 +685,7 @@ func TestMovieToNFO_Credits_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Credits: []string{"Writer A", "Writer B"}}
 	g := NewGenerator(fs, cfg)
 
-	nfo := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-001", DisplayTitle: "Test"}, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-001", DisplayTitle: "Test"}, "", nil)
 	assert.Equal(t, "Writer A, Writer B", nfo.Credits)
 }
 
@@ -695,7 +695,7 @@ func TestMovieToNFO_NoCredits_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Credits: nil}
 	g := NewGenerator(fs, cfg)
 
-	nfo := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-002", DisplayTitle: "Test"}, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-002", DisplayTitle: "Test"}, "", nil)
 	assert.Equal(t, "", nfo.Credits)
 }
 

--- a/internal/nfo/generator_partial_test.go
+++ b/internal/nfo/generator_partial_test.go
@@ -516,7 +516,7 @@ func TestMergeTags_ActressAsTag_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, "", []actor{{Name: "Actress A"}}, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: "Actress A"}}, nil)
 	assert.Contains(t, tags, "Actress A")
 }
 
@@ -531,7 +531,7 @@ func TestMergeTags_ActressAsTag_SkipsUnknown_Partial(t *testing.T) {
 	}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, "", []actor{
+	tags, _ := g.mergeTags(context.Background(), nil, []actor{
 		{Name: "Unknown"},
 		{Name: "Actress B"},
 	}, nil)
@@ -550,7 +550,7 @@ func TestMergeTags_ActressAsTag_FallbackMode_Partial(t *testing.T) {
 	}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, "", []actor{{Name: "Unknown"}}, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: "Unknown"}}, nil)
 	assert.Contains(t, tags, "Unknown")
 }
 
@@ -560,7 +560,7 @@ func TestMergeTags_ActressAsTag_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, "", []actor{{Name: ""}}, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: ""}}, nil)
 	assert.NotContains(t, tags, "")
 }
 
@@ -570,7 +570,7 @@ func TestMergeTags_ActressDedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, "", []actor{{Name: "Actress A"}}, []string{"Actress A"})
+	tags, _ := g.mergeTags(context.Background(), nil, []actor{{Name: "Actress A"}}, []string{"Actress A"})
 	// Should not duplicate
 	count := 0
 	for _, tag := range tags {
@@ -587,7 +587,7 @@ func TestMergeTags_CallerTags_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, "", nil, []string{"Tag1", "Tag2"})
+	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"Tag1", "Tag2"})
 	assert.Contains(t, tags, "Tag1")
 	assert.Contains(t, tags, "Tag2")
 }
@@ -598,7 +598,7 @@ func TestMergeTags_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, "", nil, []string{"", "Tag1", ""})
+	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"", "Tag1", ""})
 	assert.NotContains(t, tags, "")
 	assert.Contains(t, tags, "Tag1")
 }
@@ -609,7 +609,7 @@ func TestMergeTags_CallerTagDedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, "", nil, []string{"Tag1", "Tag1"})
+	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"Tag1", "Tag1"})
 	count := 0
 	for _, tag := range tags {
 		if tag == "Tag1" {
@@ -625,7 +625,7 @@ func TestMergeTags_ConfigTags_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"ConfigTag1", "ConfigTag2"}}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, "", nil, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, nil, nil)
 	assert.Contains(t, tags, "ConfigTag1")
 	assert.Contains(t, tags, "ConfigTag2")
 }
@@ -636,7 +636,7 @@ func TestMergeTags_ConfigTags_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"", "ConfigTag1"}}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, "", nil, nil)
+	tags, _ := g.mergeTags(context.Background(), nil, nil, nil)
 	assert.NotContains(t, tags, "")
 	assert.Contains(t, tags, "ConfigTag1")
 }
@@ -647,7 +647,7 @@ func TestMergeTags_ConfigTags_Dedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"ExistingTag"}}
 	g := NewGenerator(fs, cfg)
 
-	tags, _ := g.mergeTags(context.Background(), nil, "", nil, []string{"ExistingTag"})
+	tags, _ := g.mergeTags(context.Background(), nil, nil, []string{"ExistingTag"})
 	count := 0
 	for _, tag := range tags {
 		if tag == "ExistingTag" {

--- a/internal/nfo/generator_partial_test.go
+++ b/internal/nfo/generator_partial_test.go
@@ -516,7 +516,7 @@ func TestMergeTags_ActressAsTag_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags([]actor{{Name: "Actress A"}}, nil)
+	tags := g.mergeTags(context.Background(), nil, []actor{{Name: "Actress A"}}, nil)
 	assert.Contains(t, tags, "Actress A")
 }
 
@@ -531,7 +531,7 @@ func TestMergeTags_ActressAsTag_SkipsUnknown_Partial(t *testing.T) {
 	}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags([]actor{
+	tags := g.mergeTags(context.Background(), nil, []actor{
 		{Name: "Unknown"},
 		{Name: "Actress B"},
 	}, nil)
@@ -550,7 +550,7 @@ func TestMergeTags_ActressAsTag_FallbackMode_Partial(t *testing.T) {
 	}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags([]actor{{Name: "Unknown"}}, nil)
+	tags := g.mergeTags(context.Background(), nil, []actor{{Name: "Unknown"}}, nil)
 	assert.Contains(t, tags, "Unknown")
 }
 
@@ -560,7 +560,7 @@ func TestMergeTags_ActressAsTag_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags([]actor{{Name: ""}}, nil)
+	tags := g.mergeTags(context.Background(), nil, []actor{{Name: ""}}, nil)
 	assert.NotContains(t, tags, "")
 }
 
@@ -570,7 +570,7 @@ func TestMergeTags_ActressDedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, ActressAsTag: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags([]actor{{Name: "Actress A"}}, []string{"Actress A"})
+	tags := g.mergeTags(context.Background(), nil, []actor{{Name: "Actress A"}}, []string{"Actress A"})
 	// Should not duplicate
 	count := 0
 	for _, tag := range tags {
@@ -587,7 +587,7 @@ func TestMergeTags_CallerTags_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(nil, []string{"Tag1", "Tag2"})
+	tags := g.mergeTags(context.Background(), nil, nil, []string{"Tag1", "Tag2"})
 	assert.Contains(t, tags, "Tag1")
 	assert.Contains(t, tags, "Tag2")
 }
@@ -598,7 +598,7 @@ func TestMergeTags_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(nil, []string{"", "Tag1", ""})
+	tags := g.mergeTags(context.Background(), nil, nil, []string{"", "Tag1", ""})
 	assert.NotContains(t, tags, "")
 	assert.Contains(t, tags, "Tag1")
 }
@@ -609,7 +609,7 @@ func TestMergeTags_CallerTagDedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(nil, []string{"Tag1", "Tag1"})
+	tags := g.mergeTags(context.Background(), nil, nil, []string{"Tag1", "Tag1"})
 	count := 0
 	for _, tag := range tags {
 		if tag == "Tag1" {
@@ -625,7 +625,7 @@ func TestMergeTags_ConfigTags_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"ConfigTag1", "ConfigTag2"}}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(nil, nil)
+	tags := g.mergeTags(context.Background(), nil, nil, nil)
 	assert.Contains(t, tags, "ConfigTag1")
 	assert.Contains(t, tags, "ConfigTag2")
 }
@@ -636,7 +636,7 @@ func TestMergeTags_ConfigTags_SkipsEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"", "ConfigTag1"}}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(nil, nil)
+	tags := g.mergeTags(context.Background(), nil, nil, nil)
 	assert.NotContains(t, tags, "")
 	assert.Contains(t, tags, "ConfigTag1")
 }
@@ -647,7 +647,7 @@ func TestMergeTags_ConfigTags_Dedup_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tag: []string{"ExistingTag"}}
 	g := NewGenerator(fs, cfg)
 
-	tags := g.mergeTags(nil, []string{"ExistingTag"})
+	tags := g.mergeTags(context.Background(), nil, nil, []string{"ExistingTag"})
 	count := 0
 	for _, tag := range tags {
 		if tag == "ExistingTag" {

--- a/internal/nfo/generator_partial_test.go
+++ b/internal/nfo/generator_partial_test.go
@@ -152,7 +152,7 @@ func TestMovieToNFO_DisplayTitleFallback_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "DT-001", Title: "Fallback Title", DisplayTitle: ""}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Equal(t, "Fallback Title", nfo.Title)
 }
 
@@ -163,7 +163,7 @@ func TestMovieToNFO_WithContentID_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "CID-001", ContentID: "cid001", DisplayTitle: "CID Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	require.Len(t, nfo.UniqueID, 1)
 	assert.Equal(t, "contentid", nfo.UniqueID[0].Type)
 	assert.Equal(t, "cid001", nfo.UniqueID[0].Value)
@@ -177,7 +177,7 @@ func TestMovieToNFO_ReleaseDateNil_WithYear_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "YEAR-001", ReleaseYear: 2023, DisplayTitle: "Year Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Equal(t, 2023, nfo.Year)
 	assert.Equal(t, "", nfo.ReleaseDate) // No full date available
 	assert.Equal(t, "", nfo.Premiered)   // No full date available
@@ -191,7 +191,7 @@ func TestMovieToNFO_WithReleaseDate_Partial(t *testing.T) {
 
 	rd := time.Date(2023, 6, 15, 0, 0, 0, 0, time.UTC)
 	movie := &models.Movie{ID: "RD-001", ReleaseDate: &rd, DisplayTitle: "RD Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Equal(t, "2023-06-15", nfo.ReleaseDate)
 	assert.Equal(t, "2023-06-15", nfo.Premiered)
 	assert.Equal(t, 2023, nfo.Year)
@@ -204,7 +204,7 @@ func TestMovieToNFO_RuntimeZero_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RT-001", Runtime: 0, DisplayTitle: "RT Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Equal(t, 0, nfo.Runtime)
 }
 
@@ -215,7 +215,7 @@ func TestMovieToNFO_RuntimePositive_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RT-002", Runtime: 120, DisplayTitle: "RT Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Equal(t, 120, nfo.Runtime)
 }
 
@@ -226,7 +226,7 @@ func TestMovieToNFO_RatingPositive_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RATE-001", RatingScore: 8.5, RatingVotes: 100, DisplayTitle: "Rate Test"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	require.Len(t, nfo.Ratings.Rating, 1)
 	assert.Equal(t, 8.5, nfo.Ratings.Rating[0].Value)
 	assert.Equal(t, 100, nfo.Ratings.Rating[0].Votes)
@@ -242,7 +242,7 @@ func TestMovieToNFO_RatingZero_Partial(t *testing.T) {
 	g := NewGenerator(fs, cfg)
 
 	movie := &models.Movie{ID: "RATE-002", RatingScore: 0, DisplayTitle: "No Rate"}
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	assert.Empty(t, nfo.Ratings.Rating)
 }
 
@@ -665,7 +665,7 @@ func TestMovieToNFO_Tagline_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tagline: "Best movie ever"}
 	g := NewGenerator(fs, cfg)
 
-	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-001", DisplayTitle: "Test"}, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-001", DisplayTitle: "Test"}, "", "", 0, false, nil)
 	assert.Equal(t, "Best movie ever", nfo.Tagline)
 }
 
@@ -675,7 +675,7 @@ func TestMovieToNFO_TaglineEmpty_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Tagline: ""}
 	g := NewGenerator(fs, cfg)
 
-	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-002", DisplayTitle: "Test"}, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "TL-002", DisplayTitle: "Test"}, "", "", 0, false, nil)
 	assert.Equal(t, "", nfo.Tagline)
 }
 
@@ -685,7 +685,7 @@ func TestMovieToNFO_Credits_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Credits: []string{"Writer A", "Writer B"}}
 	g := NewGenerator(fs, cfg)
 
-	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-001", DisplayTitle: "Test"}, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-001", DisplayTitle: "Test"}, "", "", 0, false, nil)
 	assert.Equal(t, "Writer A, Writer B", nfo.Credits)
 }
 
@@ -695,7 +695,7 @@ func TestMovieToNFO_NoCredits_Partial(t *testing.T) {
 	cfg := &Config{FirstNameOrder: true, Credits: nil}
 	g := NewGenerator(fs, cfg)
 
-	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-002", DisplayTitle: "Test"}, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), &models.Movie{ID: "CR-002", DisplayTitle: "Test"}, "", "", 0, false, nil)
 	assert.Equal(t, "", nfo.Credits)
 }
 

--- a/internal/nfo/generator_test.go
+++ b/internal/nfo/generator_test.go
@@ -58,7 +58,7 @@ func TestMovieToNFO(t *testing.T) {
 		},
 	}
 
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	// Verify basic fields
 	if nfo.ID != "IPX-535" {
@@ -354,7 +354,7 @@ func TestNFOWithoutOptionalFields(t *testing.T) {
 		Title: "Minimal Movie",
 	}
 
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	if nfo.ID != "TEST-001" {
 		t.Errorf("Expected ID 'TEST-001', got '%s'", nfo.ID)
@@ -529,7 +529,7 @@ func TestIncludeOriginalPath(t *testing.T) {
 				OriginalFileName: tt.originalFileName,
 			}
 
-			nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 			if nfo.OriginalPath != tt.expectedPath {
 				t.Errorf("Expected OriginalPath '%s', got '%s'", tt.expectedPath, nfo.OriginalPath)
@@ -676,7 +676,7 @@ func TestActressAsTag(t *testing.T) {
 				Actresses: tt.actresses,
 			}
 
-			nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 			if len(nfo.Tags) != len(tt.expectedTags) {
 				t.Errorf("Expected %d tags, got %d tags: %v", len(tt.expectedTags), len(nfo.Tags), nfo.Tags)
@@ -778,7 +778,7 @@ func TestStaticNFOFields(t *testing.T) {
 		Title: "Test Movie",
 	}
 
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	// Verify static tags were added
 	assert.Contains(t, nfo.Tags, "JAV")
@@ -810,7 +810,7 @@ func TestStaticTagsWithActressAsTag(t *testing.T) {
 		},
 	}
 
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	// Verify both actress name and static tags are present
 	assert.Contains(t, nfo.Tags, "Yui Hatano")
@@ -832,7 +832,7 @@ func TestStaticFieldsEmpty(t *testing.T) {
 		Title: "Test Movie",
 	}
 
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	// Verify no static fields were added
 	assert.Empty(t, nfo.Tags)

--- a/internal/nfo/generator_test.go
+++ b/internal/nfo/generator_test.go
@@ -58,7 +58,7 @@ func TestMovieToNFO(t *testing.T) {
 		},
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	// Verify basic fields
 	if nfo.ID != "IPX-535" {
@@ -354,7 +354,7 @@ func TestNFOWithoutOptionalFields(t *testing.T) {
 		Title: "Minimal Movie",
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	if nfo.ID != "TEST-001" {
 		t.Errorf("Expected ID 'TEST-001', got '%s'", nfo.ID)
@@ -529,7 +529,7 @@ func TestIncludeOriginalPath(t *testing.T) {
 				OriginalFileName: tt.originalFileName,
 			}
 
-			nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 			if nfo.OriginalPath != tt.expectedPath {
 				t.Errorf("Expected OriginalPath '%s', got '%s'", tt.expectedPath, nfo.OriginalPath)
@@ -676,7 +676,7 @@ func TestActressAsTag(t *testing.T) {
 				Actresses: tt.actresses,
 			}
 
-			nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 			if len(nfo.Tags) != len(tt.expectedTags) {
 				t.Errorf("Expected %d tags, got %d tags: %v", len(tt.expectedTags), len(nfo.Tags), nfo.Tags)
@@ -778,7 +778,7 @@ func TestStaticNFOFields(t *testing.T) {
 		Title: "Test Movie",
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	// Verify static tags were added
 	assert.Contains(t, nfo.Tags, "JAV")
@@ -810,7 +810,7 @@ func TestStaticTagsWithActressAsTag(t *testing.T) {
 		},
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	// Verify both actress name and static tags are present
 	assert.Contains(t, nfo.Tags, "Yui Hatano")
@@ -832,7 +832,7 @@ func TestStaticFieldsEmpty(t *testing.T) {
 		Title: "Test Movie",
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	// Verify no static fields were added
 	assert.Empty(t, nfo.Tags)

--- a/internal/nfo/generator_test.go
+++ b/internal/nfo/generator_test.go
@@ -58,7 +58,7 @@ func TestMovieToNFO(t *testing.T) {
 		},
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	// Verify basic fields
 	if nfo.ID != "IPX-535" {
@@ -354,7 +354,7 @@ func TestNFOWithoutOptionalFields(t *testing.T) {
 		Title: "Minimal Movie",
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	if nfo.ID != "TEST-001" {
 		t.Errorf("Expected ID 'TEST-001', got '%s'", nfo.ID)
@@ -529,7 +529,7 @@ func TestIncludeOriginalPath(t *testing.T) {
 				OriginalFileName: tt.originalFileName,
 			}
 
-			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 			if nfo.OriginalPath != tt.expectedPath {
 				t.Errorf("Expected OriginalPath '%s', got '%s'", tt.expectedPath, nfo.OriginalPath)
@@ -676,7 +676,7 @@ func TestActressAsTag(t *testing.T) {
 				Actresses: tt.actresses,
 			}
 
-			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+			nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 			if len(nfo.Tags) != len(tt.expectedTags) {
 				t.Errorf("Expected %d tags, got %d tags: %v", len(tt.expectedTags), len(nfo.Tags), nfo.Tags)
@@ -778,7 +778,7 @@ func TestStaticNFOFields(t *testing.T) {
 		Title: "Test Movie",
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	// Verify static tags were added
 	assert.Contains(t, nfo.Tags, "JAV")
@@ -810,7 +810,7 @@ func TestStaticTagsWithActressAsTag(t *testing.T) {
 		},
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	// Verify both actress name and static tags are present
 	assert.Contains(t, nfo.Tags, "Yui Hatano")
@@ -832,7 +832,7 @@ func TestStaticFieldsEmpty(t *testing.T) {
 		Title: "Test Movie",
 	}
 
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	// Verify no static fields were added
 	assert.Empty(t, nfo.Tags)

--- a/internal/nfo/integration_test.go
+++ b/internal/nfo/integration_test.go
@@ -462,7 +462,7 @@ func TestMultipleActresses(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	if len(nfo.Actors) != 3 {
 		t.Fatalf("Expected 3 actors, got %d", len(nfo.Actors))

--- a/internal/nfo/integration_test.go
+++ b/internal/nfo/integration_test.go
@@ -462,7 +462,7 @@ func TestMultipleActresses(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	if len(nfo.Actors) != 3 {
 		t.Fatalf("Expected 3 actors, got %d", len(nfo.Actors))

--- a/internal/nfo/integration_test.go
+++ b/internal/nfo/integration_test.go
@@ -462,7 +462,7 @@ func TestMultipleActresses(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	if len(nfo.Actors) != 3 {
 		t.Fatalf("Expected 3 actors, got %d", len(nfo.Actors))

--- a/internal/nfo/merge_with_existing.go
+++ b/internal/nfo/merge_with_existing.go
@@ -48,7 +48,7 @@ func (n nfoImplementor) MergeWithExistingNFO(movie *models.Movie, opts MergeWith
 
 	var nameCfg NFONameConfig
 	if nfoConfig != nil {
-		nameCfg = nfoConfig.ToNFONameConfig(isMultiPart, partSuffix)
+		nameCfg = nfoConfig.ToNFONameConfig(isMultiPart, partSuffix, 0)
 	} else {
 		nameCfg = NFONameConfig{
 			IsMultiPart: isMultiPart,

--- a/internal/nfo/merge_with_existing.go
+++ b/internal/nfo/merge_with_existing.go
@@ -48,11 +48,12 @@ func (n nfoImplementor) MergeWithExistingNFO(movie *models.Movie, opts MergeWith
 
 	var nameCfg NFONameConfig
 	if nfoConfig != nil {
-		nameCfg = nfoConfig.ToNFONameConfig(isMultiPart, partSuffix, 0)
+		nameCfg = nfoConfig.ToNFONameConfig(isMultiPart, partSuffix, opts.Match.PartNumber)
 	} else {
 		nameCfg = NFONameConfig{
 			IsMultiPart: isMultiPart,
 			PartSuffix:  partSuffix,
+			PartNumber:  opts.Match.PartNumber,
 		}
 	}
 	foundPath := findNFOFile(fs, filepath.Dir(opts.Match.Path), movie, nameCfg, opts.Match.Path, templateEngine)

--- a/internal/nfo/merger_display_title_test.go
+++ b/internal/nfo/merger_display_title_test.go
@@ -179,3 +179,21 @@ func TestMergeWithExistingNFO_EmptyScrapedTitlePreservesNFOFallback(t *testing.T
 	assert.Equal(t, "Ayaka Tomoda", result.Movie.Title, "stripped NFO <title> serves as base-title fallback")
 	assert.NotEqual(t, "[Unknown Title]", result.Movie.Title)
 }
+
+func TestMergeWithExistingNFO_NilNFOConfig_MultipartPartNumberThreaded(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/source", 0755))
+	nfoContent := "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<movie>\n  <id>ABC-001</id>\n</movie>"
+	require.NoError(t, afero.WriteFile(fs, "/source/ABC-001.nfo", []byte(nfoContent), 0644))
+	nfoImpl := nfoImplementor{
+		fs:             fs,
+		nfoConfig:      nil,
+		templateEngine: template.NewEngine(),
+	}
+	scraped := &models.Movie{ID: "ABC-001", Title: "Test"}
+	result := nfoImpl.MergeWithExistingNFO(scraped, MergeWithExistingOptions{
+		Match:          models.FileMatchInfo{Path: "/source/ABC-001-cd1.mp4", MovieID: "ABC-001", IsMultiPart: true, PartSuffix: "-cd1", PartNumber: 1},
+		ScalarStrategy: PreferNFO,
+	})
+	assert.True(t, result.Merged, "should merge with existing NFO even with nil nfoConfig")
+}

--- a/internal/nfo/nfo_test.go
+++ b/internal/nfo/nfo_test.go
@@ -221,7 +221,7 @@ func TestNFOXMLGeneration(t *testing.T) {
 		tt := tt // Rebind for safe parallel execution
 		t.Run(tt.name, func(t *testing.T) {
 			gen := NewGenerator(afero.NewOsFs(), tt.config)
-			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", false, nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", 0, false, nil)
 
 			// Run all checks
 			for _, check := range tt.checks {
@@ -252,7 +252,7 @@ func TestNFOXMLMarshalling(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	// Marshal to XML
 	xmlData, err := xml.MarshalIndent(nfo, "", "  ")
@@ -317,7 +317,7 @@ func TestNFOFileWriteAndRead(t *testing.T) {
 		tt := tt // Rebind for safe parallel execution
 		t.Run(tt.name, func(t *testing.T) {
 			gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", false, nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", 0, false, nil)
 
 			// Write to temp directory
 			tmpDir := t.TempDir()
@@ -374,7 +374,7 @@ func TestNFOWithEmptyOptionalFields(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	// Verify empty fields are not populated
 	assert.Equal(t, "EMP-001", nfo.ID)
@@ -415,7 +415,7 @@ func TestNFOWithMultipleActresses(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	require.Len(t, nfo.Actors, 10)
 	for i, actor := range nfo.Actors {
@@ -440,7 +440,7 @@ func TestNFOWithManyGenres(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	require.Len(t, nfo.Genres, 9)
 	assert.Contains(t, nfo.Genres, "Drama")
@@ -462,7 +462,7 @@ func TestNFOWithManyScreenshots(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	require.NotNil(t, nfo.Fanart)
 	require.Len(t, nfo.Fanart.Thumbs, 15)
@@ -483,14 +483,14 @@ func TestNFOFanartDisabled(t *testing.T) {
 	cfg.IncludeFanart = false
 
 	gen := NewGenerator(afero.NewOsFs(), cfg)
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	assert.Nil(t, nfo.Fanart)
 
 	// Test enabled (default behavior)
 	cfgEnabled := defaultConfig()
 	genEnabled := NewGenerator(afero.NewOsFs(), cfgEnabled)
-	nfoEnabled, _ := genEnabled.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfoEnabled, _ := genEnabled.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	require.NotNil(t, nfoEnabled.Fanart)
 	assert.Len(t, nfoEnabled.Fanart.Thumbs, 2)
@@ -508,14 +508,14 @@ func TestNFOTrailerDisabled(t *testing.T) {
 	cfg.IncludeTrailer = false
 
 	gen := NewGenerator(afero.NewOsFs(), cfg)
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	assert.Empty(t, nfo.Trailer)
 
 	// Test enabled (default behavior)
 	cfgEnabled := defaultConfig()
 	genEnabled := NewGenerator(afero.NewOsFs(), cfgEnabled)
-	nfoEnabled, _ := genEnabled.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfoEnabled, _ := genEnabled.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	assert.Equal(t, "https://example.com/trailer.mp4", nfoEnabled.Trailer)
 }
@@ -533,7 +533,7 @@ func TestNFOCustomRatingSource(t *testing.T) {
 	cfg.RatingSource = "imdb"
 
 	gen := NewGenerator(afero.NewOsFs(), cfg)
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 
 	require.Len(t, nfo.Ratings.Rating, 1)
 	assert.Equal(t, "imdb", nfo.Ratings.Rating[0].Name)
@@ -704,7 +704,7 @@ func TestMovieToNFO_EdgeCases(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			gen := NewGenerator(afero.NewOsFs(), tt.config)
-			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", false, nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", 0, false, nil)
 
 			for _, check := range tt.checks {
 				check(t, nfo)

--- a/internal/nfo/nfo_test.go
+++ b/internal/nfo/nfo_test.go
@@ -221,7 +221,7 @@ func TestNFOXMLGeneration(t *testing.T) {
 		tt := tt // Rebind for safe parallel execution
 		t.Run(tt.name, func(t *testing.T) {
 			gen := NewGenerator(afero.NewOsFs(), tt.config)
-			nfo := gen.movieToNFO(context.Background(), tt.movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", nil)
 
 			// Run all checks
 			for _, check := range tt.checks {
@@ -252,7 +252,7 @@ func TestNFOXMLMarshalling(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	// Marshal to XML
 	xmlData, err := xml.MarshalIndent(nfo, "", "  ")
@@ -317,7 +317,7 @@ func TestNFOFileWriteAndRead(t *testing.T) {
 		tt := tt // Rebind for safe parallel execution
 		t.Run(tt.name, func(t *testing.T) {
 			gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-			nfo := gen.movieToNFO(context.Background(), tt.movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", nil)
 
 			// Write to temp directory
 			tmpDir := t.TempDir()
@@ -374,7 +374,7 @@ func TestNFOWithEmptyOptionalFields(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	// Verify empty fields are not populated
 	assert.Equal(t, "EMP-001", nfo.ID)
@@ -415,7 +415,7 @@ func TestNFOWithMultipleActresses(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	require.Len(t, nfo.Actors, 10)
 	for i, actor := range nfo.Actors {
@@ -440,7 +440,7 @@ func TestNFOWithManyGenres(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	require.Len(t, nfo.Genres, 9)
 	assert.Contains(t, nfo.Genres, "Drama")
@@ -462,7 +462,7 @@ func TestNFOWithManyScreenshots(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	require.NotNil(t, nfo.Fanart)
 	require.Len(t, nfo.Fanart.Thumbs, 15)
@@ -483,14 +483,14 @@ func TestNFOFanartDisabled(t *testing.T) {
 	cfg.IncludeFanart = false
 
 	gen := NewGenerator(afero.NewOsFs(), cfg)
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	assert.Nil(t, nfo.Fanart)
 
 	// Test enabled (default behavior)
 	cfgEnabled := defaultConfig()
 	genEnabled := NewGenerator(afero.NewOsFs(), cfgEnabled)
-	nfoEnabled := genEnabled.movieToNFO(context.Background(), movie, "", nil)
+	nfoEnabled, _ := genEnabled.movieToNFO(context.Background(), movie, "", nil)
 
 	require.NotNil(t, nfoEnabled.Fanart)
 	assert.Len(t, nfoEnabled.Fanart.Thumbs, 2)
@@ -508,14 +508,14 @@ func TestNFOTrailerDisabled(t *testing.T) {
 	cfg.IncludeTrailer = false
 
 	gen := NewGenerator(afero.NewOsFs(), cfg)
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	assert.Empty(t, nfo.Trailer)
 
 	// Test enabled (default behavior)
 	cfgEnabled := defaultConfig()
 	genEnabled := NewGenerator(afero.NewOsFs(), cfgEnabled)
-	nfoEnabled := genEnabled.movieToNFO(context.Background(), movie, "", nil)
+	nfoEnabled, _ := genEnabled.movieToNFO(context.Background(), movie, "", nil)
 
 	assert.Equal(t, "https://example.com/trailer.mp4", nfoEnabled.Trailer)
 }
@@ -533,7 +533,7 @@ func TestNFOCustomRatingSource(t *testing.T) {
 	cfg.RatingSource = "imdb"
 
 	gen := NewGenerator(afero.NewOsFs(), cfg)
-	nfo := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
 
 	require.Len(t, nfo.Ratings.Rating, 1)
 	assert.Equal(t, "imdb", nfo.Ratings.Rating[0].Name)
@@ -704,7 +704,7 @@ func TestMovieToNFO_EdgeCases(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			gen := NewGenerator(afero.NewOsFs(), tt.config)
-			nfo := gen.movieToNFO(context.Background(), tt.movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", nil)
 
 			for _, check := range tt.checks {
 				check(t, nfo)

--- a/internal/nfo/nfo_test.go
+++ b/internal/nfo/nfo_test.go
@@ -221,7 +221,7 @@ func TestNFOXMLGeneration(t *testing.T) {
 		tt := tt // Rebind for safe parallel execution
 		t.Run(tt.name, func(t *testing.T) {
 			gen := NewGenerator(afero.NewOsFs(), tt.config)
-			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", false, nil)
 
 			// Run all checks
 			for _, check := range tt.checks {
@@ -252,7 +252,7 @@ func TestNFOXMLMarshalling(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	// Marshal to XML
 	xmlData, err := xml.MarshalIndent(nfo, "", "  ")
@@ -317,7 +317,7 @@ func TestNFOFileWriteAndRead(t *testing.T) {
 		tt := tt // Rebind for safe parallel execution
 		t.Run(tt.name, func(t *testing.T) {
 			gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", false, nil)
 
 			// Write to temp directory
 			tmpDir := t.TempDir()
@@ -374,7 +374,7 @@ func TestNFOWithEmptyOptionalFields(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	// Verify empty fields are not populated
 	assert.Equal(t, "EMP-001", nfo.ID)
@@ -415,7 +415,7 @@ func TestNFOWithMultipleActresses(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	require.Len(t, nfo.Actors, 10)
 	for i, actor := range nfo.Actors {
@@ -440,7 +440,7 @@ func TestNFOWithManyGenres(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	require.Len(t, nfo.Genres, 9)
 	assert.Contains(t, nfo.Genres, "Drama")
@@ -462,7 +462,7 @@ func TestNFOWithManyScreenshots(t *testing.T) {
 	}
 
 	gen := NewGenerator(afero.NewOsFs(), defaultConfig())
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	require.NotNil(t, nfo.Fanart)
 	require.Len(t, nfo.Fanart.Thumbs, 15)
@@ -483,14 +483,14 @@ func TestNFOFanartDisabled(t *testing.T) {
 	cfg.IncludeFanart = false
 
 	gen := NewGenerator(afero.NewOsFs(), cfg)
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	assert.Nil(t, nfo.Fanart)
 
 	// Test enabled (default behavior)
 	cfgEnabled := defaultConfig()
 	genEnabled := NewGenerator(afero.NewOsFs(), cfgEnabled)
-	nfoEnabled, _ := genEnabled.movieToNFO(context.Background(), movie, "", nil)
+	nfoEnabled, _ := genEnabled.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	require.NotNil(t, nfoEnabled.Fanart)
 	assert.Len(t, nfoEnabled.Fanart.Thumbs, 2)
@@ -508,14 +508,14 @@ func TestNFOTrailerDisabled(t *testing.T) {
 	cfg.IncludeTrailer = false
 
 	gen := NewGenerator(afero.NewOsFs(), cfg)
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	assert.Empty(t, nfo.Trailer)
 
 	// Test enabled (default behavior)
 	cfgEnabled := defaultConfig()
 	genEnabled := NewGenerator(afero.NewOsFs(), cfgEnabled)
-	nfoEnabled, _ := genEnabled.movieToNFO(context.Background(), movie, "", nil)
+	nfoEnabled, _ := genEnabled.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	assert.Equal(t, "https://example.com/trailer.mp4", nfoEnabled.Trailer)
 }
@@ -533,7 +533,7 @@ func TestNFOCustomRatingSource(t *testing.T) {
 	cfg.RatingSource = "imdb"
 
 	gen := NewGenerator(afero.NewOsFs(), cfg)
-	nfo, _ := gen.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := gen.movieToNFO(context.Background(), movie, "", "", false, nil)
 
 	require.Len(t, nfo.Ratings.Rating, 1)
 	assert.Equal(t, "imdb", nfo.Ratings.Rating[0].Name)
@@ -704,7 +704,7 @@ func TestMovieToNFO_EdgeCases(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			gen := NewGenerator(afero.NewOsFs(), tt.config)
-			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", nil)
+			nfo, _ := gen.movieToNFO(context.Background(), tt.movie, "", "", false, nil)
 
 			for _, check := range tt.checks {
 				check(t, nfo)

--- a/internal/nfo/parser_test.go
+++ b/internal/nfo/parser_test.go
@@ -336,7 +336,7 @@ func TestRoundTrip(t *testing.T) {
 	generator.config.IncludeFanart = true
 	generator.config.IncludeTrailer = true
 	generator.config.AltNameRole = true // Include Japanese names in role field for round-trip
-	nfoStruct, _ := generator.movieToNFO(context.Background(), originalMovie, "", nil)
+	nfoStruct, _ := generator.movieToNFO(context.Background(), originalMovie, "", "", false, nil)
 
 	// Write to temp file
 	tmpDir := t.TempDir()

--- a/internal/nfo/parser_test.go
+++ b/internal/nfo/parser_test.go
@@ -336,7 +336,7 @@ func TestRoundTrip(t *testing.T) {
 	generator.config.IncludeFanart = true
 	generator.config.IncludeTrailer = true
 	generator.config.AltNameRole = true // Include Japanese names in role field for round-trip
-	nfoStruct := generator.movieToNFO(context.Background(), originalMovie, "", nil)
+	nfoStruct, _ := generator.movieToNFO(context.Background(), originalMovie, "", nil)
 
 	// Write to temp file
 	tmpDir := t.TempDir()

--- a/internal/nfo/parser_test.go
+++ b/internal/nfo/parser_test.go
@@ -336,7 +336,7 @@ func TestRoundTrip(t *testing.T) {
 	generator.config.IncludeFanart = true
 	generator.config.IncludeTrailer = true
 	generator.config.AltNameRole = true // Include Japanese names in role field for round-trip
-	nfoStruct, _ := generator.movieToNFO(context.Background(), originalMovie, "", "", false, nil)
+	nfoStruct, _ := generator.movieToNFO(context.Background(), originalMovie, "", "", 0, false, nil)
 
 	// Write to temp file
 	tmpDir := t.TempDir()

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -313,3 +313,25 @@ func TestMovieToNFO_TaglineModifierWithAngleBracketDropped(t *testing.T) {
 	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
 	assert.Equal(t, "", nfo.Tagline)
 }
+
+func TestGenerate_LegacyPathWritesNFOWithoutPartContent(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	g := NewGenerator(fs, &Config{Tagline: "Part <PART>", PerFile: true, FirstNameOrder: true})
+	movie := taglineTestMovie()
+	err := g.Generate(context.Background(), movie, "/out", "-pt1", "", nil)
+	assert.NoError(t, err)
+	matches, _ := afero.Glob(fs, "/out/*.nfo")
+	require.NotEmpty(t, matches)
+	data, readErr := afero.ReadFile(fs, matches[0])
+	require.NoError(t, readErr)
+	// Legacy Generate path zeroes part content, so <PART> renders empty.
+	assert.Contains(t, string(data), "<tagline>Part </tagline>")
+}
+
+func TestGenerate_LegacyPathPropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<ID>", PerFile: true, FirstNameOrder: true, FilenameTemplate: "<ID>"})
+	err := g.Generate(ctx, taglineTestMovie(), "/out", "", "", nil)
+	assert.Error(t, err)
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/javinizer/javinizer-go/internal/models"
 )
@@ -157,7 +158,7 @@ func TestMovieTemplateContext_ThreadsVideoFilePath(t *testing.T) {
 	assert.False(t, ctxEmpty.IsMultiPart)
 }
 
-func TestMergeTags_ConfigTagThreadsVideoFilePath(t *testing.T) {
+func TestMergeTags_MediaTagUnresolvableRendersEmpty(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<RESOLUTION>"}, FirstNameOrder: true})
 	tmplCtx := g.movieTemplateContext(context.Background(), taglineTestMovie(), "/movies/IPX-535.mp4", "", 0, false)
 	tags, err := g.mergeTags(context.Background(), tmplCtx, nil, nil)
@@ -244,4 +245,30 @@ func TestMovieToNFO_TaglineMultilineConditionalRendered(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<IF:TITLE>\nFeatured\n</IF>", FirstNameOrder: true})
 	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
 	assert.Equal(t, "\nFeatured\n", nfo.Tagline)
+}
+
+func TestResolveAndGenerate_PerFileGating(t *testing.T) {
+	t.Run("PerFile true threads part number into written tagline", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		g := NewGenerator(fs, &Config{Tagline: "Part <PART>", FirstNameOrder: true})
+		nameCfg := NFONameConfig{FilenameTemplate: "<ID>", PerFile: true, PartSuffix: "-pt1", PartNumber: 1, IsMultiPart: true}
+		path, err := g.ResolveAndGenerate(context.Background(), taglineTestMovie(), "/out", nameCfg, "", nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, path)
+		data, readErr := afero.ReadFile(fs, path)
+		require.NoError(t, readErr)
+		assert.Contains(t, string(data), "<tagline>Part 1</tagline>")
+	})
+
+	t.Run("PerFile false zeros part number in written tagline", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		g := NewGenerator(fs, &Config{Tagline: "Part <PART>", FirstNameOrder: true})
+		nameCfg := NFONameConfig{FilenameTemplate: "<ID>", PerFile: false, PartSuffix: "-pt1", PartNumber: 1, IsMultiPart: true}
+		path, err := g.ResolveAndGenerate(context.Background(), taglineTestMovie(), "/out", nameCfg, "", nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, path)
+		data, readErr := afero.ReadFile(fs, path)
+		require.NoError(t, readErr)
+		assert.Contains(t, string(data), "<tagline>Part </tagline>")
+	})
 }

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -65,7 +65,7 @@ func TestMovieToNFO_TaglineTemplating(t *testing.T) {
 				movie = &m
 			}
 			g := NewGenerator(afero.NewMemMapFs(), cfg)
-			nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+			nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 			assert.Equal(t, tc.want, nfo.Tagline)
 		})
 	}
@@ -75,14 +75,14 @@ func TestMovieToNFO_TaglineTemplating_DefaultDelimiterRespected(t *testing.T) {
 	// An empty ActressDelimiter config must behave like the other template
 	// surfaces (folder/file formats): fall back to ", ", not render empty.
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<ACTRESSES>"})
-	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
 	assert.Equal(t, "Sakura Momo, Actress Test", nfo.Tagline)
 }
 
 func TestMovieToNFO_TagsTemplating(t *testing.T) {
 	t.Run("static tags pass through unchanged", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"Pool", "Collector"}, FirstNameOrder: true})
-		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, []string{"Manual"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, []string{"Manual"})
 		assert.Contains(t, nfo.Tags, "Pool")
 		assert.Contains(t, nfo.Tags, "Collector")
 		assert.Contains(t, nfo.Tags, "Manual")
@@ -91,21 +91,21 @@ func TestMovieToNFO_TagsTemplating(t *testing.T) {
 
 	t.Run("config tag templates expand per movie", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<ID>", "Pool"}, FirstNameOrder: true})
-		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
 		assert.Contains(t, nfo.Tags, "IPX-535")
 		assert.Contains(t, nfo.Tags, "Pool")
 	})
 
 	t.Run("caller (database) tags pass through verbatim", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{FirstNameOrder: true})
-		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, []string{"<MAKER>"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, []string{"<MAKER>"})
 		assert.Contains(t, nfo.Tags, "<MAKER>")
 		assert.NotContains(t, nfo.Tags, "Idea Pocket")
 	})
 
 	t.Run("broken config tag templates dropped; caller tags kept verbatim", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<IF:ID>oops", "Kept"}, FirstNameOrder: true})
-		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, []string{"<NOTAREALTAG>", "AlsoKept"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, []string{"<NOTAREALTAG>", "AlsoKept"})
 		assert.Contains(t, nfo.Tags, "Kept")
 		assert.Contains(t, nfo.Tags, "<NOTAREALTAG>")
 		assert.Contains(t, nfo.Tags, "AlsoKept")
@@ -114,7 +114,7 @@ func TestMovieToNFO_TagsTemplating(t *testing.T) {
 
 	t.Run("template result deduped against existing tag", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<ID>"}, FirstNameOrder: true})
-		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, []string{"IPX-535"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, []string{"IPX-535"})
 		assert.Equal(t, []string{"IPX-535"}, nfo.Tags)
 	})
 }
@@ -123,7 +123,7 @@ func TestMovieToNFO_CanceledContextPropagatesTagline(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<ID>", FirstNameOrder: true})
-	nfo, err := g.movieToNFO(ctx, taglineTestMovie(), "", "", false, nil)
+	nfo, err := g.movieToNFO(ctx, taglineTestMovie(), "", "", 0, false, nil)
 	assert.Error(t, err)
 	assert.Nil(t, nfo)
 }
@@ -132,7 +132,7 @@ func TestMovieToNFO_DeadlineExceededPropagatesConfigTag(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 	defer cancel()
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<ID>"}, FirstNameOrder: true})
-	nfo, err := g.movieToNFO(ctx, taglineTestMovie(), "", "", false, nil)
+	nfo, err := g.movieToNFO(ctx, taglineTestMovie(), "", "", 0, false, nil)
 	assert.Error(t, err)
 	assert.Nil(t, nfo)
 }
@@ -147,19 +147,19 @@ func TestGenerateAtPath_CanceledContextReturnsError(t *testing.T) {
 
 func TestMovieTemplateContext_ThreadsVideoFilePath(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{FirstNameOrder: true})
-	ctx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4", "-pt1", true)
+	ctx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4", "-pt1", 0, true)
 	assert.Equal(t, "/movies/IPX-535.mp4", ctx.VideoFilePath)
 	assert.Equal(t, "-pt1", ctx.PartSuffix)
 	assert.True(t, ctx.IsMultiPart)
 
-	ctxEmpty := g.movieTemplateContext(taglineTestMovie(), "", "", false)
+	ctxEmpty := g.movieTemplateContext(taglineTestMovie(), "", "", 0, false)
 	assert.Equal(t, "", ctxEmpty.VideoFilePath)
 	assert.False(t, ctxEmpty.IsMultiPart)
 }
 
 func TestMergeTags_ConfigTagThreadsVideoFilePath(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<RESOLUTION>"}, FirstNameOrder: true})
-	tmplCtx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4", "", false)
+	tmplCtx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4", "", 0, false)
 	tags, err := g.mergeTags(context.Background(), tmplCtx, nil, nil)
 	assert.NoError(t, err)
 	_ = tags
@@ -167,7 +167,7 @@ func TestMergeTags_ConfigTagThreadsVideoFilePath(t *testing.T) {
 
 func TestMovieToNFO_ConfigTagWithUnknownTokenDropped(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"Featured: <TITEL>", "Kept"}, FirstNameOrder: true})
-	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
 	assert.NotContains(t, nfo.Tags, "Featured: ")
 	assert.NotContains(t, nfo.Tags, "Featured: <TITEL>")
 	assert.Contains(t, nfo.Tags, "Kept")
@@ -175,28 +175,28 @@ func TestMovieToNFO_ConfigTagWithUnknownTokenDropped(t *testing.T) {
 
 func TestMovieToNFO_TaglineWithUnknownTokenDropped(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "Featured: <TITEL>", FirstNameOrder: true})
-	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
 	assert.Equal(t, "", nfo.Tagline)
 }
 
 func TestMovieToNFO_TaglineConditionalWithElseNotDropped(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<IF:SERIES><SERIES><ELSE>Standalone</IF>", FirstNameOrder: true})
-	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
 	assert.Equal(t, "Standalone", nfo.Tagline)
 }
 
 func TestMovieToNFO_TaglineMultipartSuffixRendered(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<PARTSUFFIX>", FirstNameOrder: true})
-	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", true, nil)
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", 0, true, nil)
 	assert.Equal(t, "-pt1", nfo.Tagline)
 }
 
 func TestMovieToNFO_TaglineMultipartConditional(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<IF:MULTIPART>Part<ELSE>Single</IF>", FirstNameOrder: true})
-	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", true, nil)
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", 0, true, nil)
 	assert.Equal(t, "Part", nfo.Tagline)
 
-	nfoSingle, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
+	nfoSingle, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
 	assert.Equal(t, "Single", nfoSingle.Tagline)
 }
 
@@ -208,4 +208,10 @@ func TestResolveAndGenerate_CanceledContextReturnsError(t *testing.T) {
 	nfoPath, err := g.ResolveAndGenerate(ctx, taglineTestMovie(), "/out", nameCfg, "", nil)
 	assert.Error(t, err)
 	assert.Equal(t, "", nfoPath)
+}
+
+func TestMovieToNFO_TaglinePartNumberRendered(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "Part <PART>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", 1, true, nil)
+	assert.Equal(t, "Part 1", nfo.Tagline)
 }

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -160,3 +160,17 @@ func TestMergeTags_ConfigTagThreadsVideoFilePath(t *testing.T) {
 	assert.NoError(t, err)
 	_ = tags
 }
+
+func TestMovieToNFO_ConfigTagWithUnknownTokenDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"Featured: <TITEL>", "Kept"}, FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
+	assert.NotContains(t, nfo.Tags, "Featured: ")
+	assert.NotContains(t, nfo.Tags, "Featured: <TITEL>")
+	assert.Contains(t, nfo.Tags, "Kept")
+}
+
+func TestMovieToNFO_TaglineWithUnknownTokenDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "Featured: <TITEL>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
+	assert.Equal(t, "", nfo.Tagline)
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -378,3 +378,9 @@ func TestSeedSharedMediaInfo_NilFileInfoNoOp(t *testing.T) {
 	g.seedSharedMediaInfo(context.Background(), nil, "/fake.mp4", tmplCtx)
 	assert.True(t, true)
 }
+
+func TestMovieToNFO_TaglineMalformedTagWithDigitDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "Featured: <TITLE2>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
+	assert.Equal(t, "", nfo.Tagline)
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -1,0 +1,117 @@
+package nfo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+// Issue #184: docs/UI advertised the tagline (and custom tags) as templates,
+// but they were written verbatim. They are now expanded per movie; static
+// text stays byte-identical and broken templates are dropped with a warning
+// instead of failing NFO generation.
+
+func taglineTestMovie() *models.Movie {
+	return &models.Movie{
+		ID:    "IPX-535",
+		Title: "Beautiful Day",
+		Maker: "Idea Pocket",
+		Actresses: []models.Actress{
+			{FirstName: "Momo", LastName: "Sakura", JapaneseName: "桜空もも"},
+			{FirstName: "Test", LastName: "Actress"},
+		},
+	}
+}
+
+func TestMovieToNFO_TaglineTemplating(t *testing.T) {
+	testCases := []struct {
+		name             string
+		tagline          string
+		firstNameOrder   bool
+		actressDelimiter string
+		releaseYear      int
+		movie            *models.Movie
+		want             string
+	}{
+		{"static passthrough", "Brought to you by Javinizer", false, "", 0, taglineTestMovie(), "Brought to you by Javinizer"},
+		{"literal unmatched angle brackets", "A <3 B production", false, "", 0, taglineTestMovie(), "A <3 B production"},
+		{"empty stays empty", "", false, "", 0, taglineTestMovie(), ""},
+		{"ID tag", "<ID>", false, "", 0, taglineTestMovie(), "IPX-535"},
+		{"composed tags", "<ID> [<MAKER>]", false, "", 0, taglineTestMovie(), "IPX-535 [Idea Pocket]"},
+		{"actresses default order and delimiter", "<ACTRESSES>", false, "", 0, taglineTestMovie(), "Sakura Momo, Actress Test"},
+		{"actresses first-name order and custom delimiter", "<ACTRESSES>", true, " / ", 0, taglineTestMovie(), "Momo Sakura / Test Actress"},
+		{"conditional with year present", "<ID><IF:YEAR> (<YEAR>)</IF>", false, "", 2020, taglineTestMovie(), "IPX-535 (2020)"},
+		{"conditional with year absent", "<ID><IF:YEAR> (<YEAR>)</IF>", false, "", 0, taglineTestMovie(), "IPX-535"},
+		{"unknown tag dropped", "<NOTAREALTAG>", false, "", 0, taglineTestMovie(), ""},
+		{"malformed conditional dropped", "<IF:ID>oops", false, "", 0, taglineTestMovie(), ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Tagline:          tc.tagline,
+				FirstNameOrder:   tc.firstNameOrder,
+				ActressDelimiter: tc.actressDelimiter,
+			}
+			movie := tc.movie
+			if tc.releaseYear != 0 {
+				m := *movie
+				m.ReleaseYear = tc.releaseYear
+				movie = &m
+			}
+			g := NewGenerator(afero.NewMemMapFs(), cfg)
+			nfo := g.movieToNFO(context.Background(), movie, "", nil)
+			assert.Equal(t, tc.want, nfo.Tagline)
+		})
+	}
+}
+
+func TestMovieToNFO_TaglineTemplating_DefaultDelimiterRespected(t *testing.T) {
+	// An empty ActressDelimiter config must behave like the other template
+	// surfaces (folder/file formats): fall back to ", ", not render empty.
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<ACTRESSES>"})
+	nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
+	assert.Equal(t, "Sakura Momo, Actress Test", nfo.Tagline)
+}
+
+func TestMovieToNFO_TagsTemplating(t *testing.T) {
+	t.Run("static tags pass through unchanged", func(t *testing.T) {
+		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"Pool", "Collector"}, FirstNameOrder: true})
+		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"Manual"})
+		assert.Contains(t, nfo.Tags, "Pool")
+		assert.Contains(t, nfo.Tags, "Collector")
+		assert.Contains(t, nfo.Tags, "Manual")
+		assert.Len(t, nfo.Tags, 3)
+	})
+
+	t.Run("config tag templates expand per movie", func(t *testing.T) {
+		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<ID>", "Pool"}, FirstNameOrder: true})
+		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
+		assert.Contains(t, nfo.Tags, "IPX-535")
+		assert.Contains(t, nfo.Tags, "Pool")
+	})
+
+	t.Run("caller tag templates expand per movie", func(t *testing.T) {
+		g := NewGenerator(afero.NewMemMapFs(), &Config{FirstNameOrder: true})
+		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"<MAKER>"})
+		assert.Contains(t, nfo.Tags, "Idea Pocket")
+	})
+
+	t.Run("broken tag templates are dropped, siblings kept", func(t *testing.T) {
+		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<IF:ID>oops", "Kept"}, FirstNameOrder: true})
+		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"<NOTAREALTAG>", "AlsoKept"})
+		assert.Contains(t, nfo.Tags, "Kept")
+		assert.Contains(t, nfo.Tags, "AlsoKept")
+		assert.Len(t, nfo.Tags, 2)
+	})
+
+	t.Run("template result deduped against existing tag", func(t *testing.T) {
+		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<ID>"}, FirstNameOrder: true})
+		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"IPX-535"})
+		assert.Equal(t, []string{"IPX-535"}, nfo.Tags)
+	})
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -95,18 +95,20 @@ func TestMovieToNFO_TagsTemplating(t *testing.T) {
 		assert.Contains(t, nfo.Tags, "Pool")
 	})
 
-	t.Run("caller tag templates expand per movie", func(t *testing.T) {
+	t.Run("caller (database) tags pass through verbatim", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{FirstNameOrder: true})
 		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"<MAKER>"})
-		assert.Contains(t, nfo.Tags, "Idea Pocket")
+		assert.Contains(t, nfo.Tags, "<MAKER>")
+		assert.NotContains(t, nfo.Tags, "Idea Pocket")
 	})
 
-	t.Run("broken tag templates are dropped, siblings kept", func(t *testing.T) {
+	t.Run("broken config tag templates dropped; caller tags kept verbatim", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<IF:ID>oops", "Kept"}, FirstNameOrder: true})
 		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"<NOTAREALTAG>", "AlsoKept"})
 		assert.Contains(t, nfo.Tags, "Kept")
+		assert.Contains(t, nfo.Tags, "<NOTAREALTAG>")
 		assert.Contains(t, nfo.Tags, "AlsoKept")
-		assert.Len(t, nfo.Tags, 2)
+		assert.Len(t, nfo.Tags, 3)
 	})
 
 	t.Run("template result deduped against existing tag", func(t *testing.T) {

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -221,3 +221,15 @@ func TestMovieToNFO_TaglineNestedConditionalDropped(t *testing.T) {
 	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
 	assert.Equal(t, "", nfo.Tagline)
 }
+
+func TestMovieToNFO_TaglineStrayElseDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "Featured<ELSE>Other", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
+	assert.Equal(t, "", nfo.Tagline)
+}
+
+func TestMovieToNFO_TaglineInvalidNumericModifierDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<PART:xyz>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", 1, true, nil)
+	assert.Equal(t, "", nfo.Tagline)
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -215,3 +215,9 @@ func TestMovieToNFO_TaglinePartNumberRendered(t *testing.T) {
 	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", 1, true, nil)
 	assert.Equal(t, "Part 1", nfo.Tagline)
 }
+
+func TestMovieToNFO_TaglineNestedConditionalDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<IF:TITLE><IF:ID>deep</IF></IF>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
+	assert.Equal(t, "", nfo.Tagline)
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -65,7 +65,7 @@ func TestMovieToNFO_TaglineTemplating(t *testing.T) {
 				movie = &m
 			}
 			g := NewGenerator(afero.NewMemMapFs(), cfg)
-			nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+			nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 			assert.Equal(t, tc.want, nfo.Tagline)
 		})
 	}
@@ -75,14 +75,14 @@ func TestMovieToNFO_TaglineTemplating_DefaultDelimiterRespected(t *testing.T) {
 	// An empty ActressDelimiter config must behave like the other template
 	// surfaces (folder/file formats): fall back to ", ", not render empty.
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<ACTRESSES>"})
-	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
 	assert.Equal(t, "Sakura Momo, Actress Test", nfo.Tagline)
 }
 
 func TestMovieToNFO_TagsTemplating(t *testing.T) {
 	t.Run("static tags pass through unchanged", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"Pool", "Collector"}, FirstNameOrder: true})
-		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"Manual"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, []string{"Manual"})
 		assert.Contains(t, nfo.Tags, "Pool")
 		assert.Contains(t, nfo.Tags, "Collector")
 		assert.Contains(t, nfo.Tags, "Manual")
@@ -91,21 +91,21 @@ func TestMovieToNFO_TagsTemplating(t *testing.T) {
 
 	t.Run("config tag templates expand per movie", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<ID>", "Pool"}, FirstNameOrder: true})
-		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
 		assert.Contains(t, nfo.Tags, "IPX-535")
 		assert.Contains(t, nfo.Tags, "Pool")
 	})
 
 	t.Run("caller (database) tags pass through verbatim", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{FirstNameOrder: true})
-		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"<MAKER>"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, []string{"<MAKER>"})
 		assert.Contains(t, nfo.Tags, "<MAKER>")
 		assert.NotContains(t, nfo.Tags, "Idea Pocket")
 	})
 
 	t.Run("broken config tag templates dropped; caller tags kept verbatim", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<IF:ID>oops", "Kept"}, FirstNameOrder: true})
-		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"<NOTAREALTAG>", "AlsoKept"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, []string{"<NOTAREALTAG>", "AlsoKept"})
 		assert.Contains(t, nfo.Tags, "Kept")
 		assert.Contains(t, nfo.Tags, "<NOTAREALTAG>")
 		assert.Contains(t, nfo.Tags, "AlsoKept")
@@ -114,7 +114,7 @@ func TestMovieToNFO_TagsTemplating(t *testing.T) {
 
 	t.Run("template result deduped against existing tag", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<ID>"}, FirstNameOrder: true})
-		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"IPX-535"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, []string{"IPX-535"})
 		assert.Equal(t, []string{"IPX-535"}, nfo.Tags)
 	})
 }
@@ -123,7 +123,7 @@ func TestMovieToNFO_CanceledContextPropagatesTagline(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<ID>", FirstNameOrder: true})
-	nfo, err := g.movieToNFO(ctx, taglineTestMovie(), "", nil)
+	nfo, err := g.movieToNFO(ctx, taglineTestMovie(), "", "", false, nil)
 	assert.Error(t, err)
 	assert.Nil(t, nfo)
 }
@@ -132,7 +132,7 @@ func TestMovieToNFO_DeadlineExceededPropagatesConfigTag(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 	defer cancel()
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<ID>"}, FirstNameOrder: true})
-	nfo, err := g.movieToNFO(ctx, taglineTestMovie(), "", nil)
+	nfo, err := g.movieToNFO(ctx, taglineTestMovie(), "", "", false, nil)
 	assert.Error(t, err)
 	assert.Nil(t, nfo)
 }
@@ -147,16 +147,19 @@ func TestGenerateAtPath_CanceledContextReturnsError(t *testing.T) {
 
 func TestMovieTemplateContext_ThreadsVideoFilePath(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{FirstNameOrder: true})
-	ctx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4")
+	ctx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4", "-pt1", true)
 	assert.Equal(t, "/movies/IPX-535.mp4", ctx.VideoFilePath)
+	assert.Equal(t, "-pt1", ctx.PartSuffix)
+	assert.True(t, ctx.IsMultiPart)
 
-	ctxEmpty := g.movieTemplateContext(taglineTestMovie(), "")
+	ctxEmpty := g.movieTemplateContext(taglineTestMovie(), "", "", false)
 	assert.Equal(t, "", ctxEmpty.VideoFilePath)
+	assert.False(t, ctxEmpty.IsMultiPart)
 }
 
 func TestMergeTags_ConfigTagThreadsVideoFilePath(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<RESOLUTION>"}, FirstNameOrder: true})
-	tmplCtx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4")
+	tmplCtx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4", "", false)
 	tags, err := g.mergeTags(context.Background(), tmplCtx, nil, nil)
 	assert.NoError(t, err)
 	_ = tags
@@ -164,7 +167,7 @@ func TestMergeTags_ConfigTagThreadsVideoFilePath(t *testing.T) {
 
 func TestMovieToNFO_ConfigTagWithUnknownTokenDropped(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"Featured: <TITEL>", "Kept"}, FirstNameOrder: true})
-	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
 	assert.NotContains(t, nfo.Tags, "Featured: ")
 	assert.NotContains(t, nfo.Tags, "Featured: <TITEL>")
 	assert.Contains(t, nfo.Tags, "Kept")
@@ -172,6 +175,27 @@ func TestMovieToNFO_ConfigTagWithUnknownTokenDropped(t *testing.T) {
 
 func TestMovieToNFO_TaglineWithUnknownTokenDropped(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "Featured: <TITEL>", FirstNameOrder: true})
-	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
 	assert.Equal(t, "", nfo.Tagline)
+}
+
+func TestMovieToNFO_TaglineConditionalWithElseNotDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<IF:SERIES><SERIES><ELSE>Standalone</IF>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
+	assert.Equal(t, "Standalone", nfo.Tagline)
+}
+
+func TestMovieToNFO_TaglineMultipartSuffixRendered(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<PARTSUFFIX>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", true, nil)
+	assert.Equal(t, "-pt1", nfo.Tagline)
+}
+
+func TestMovieToNFO_TaglineMultipartConditional(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<IF:MULTIPART>Part<ELSE>Single</IF>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", true, nil)
+	assert.Equal(t, "Part", nfo.Tagline)
+
+	nfoSingle, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
+	assert.Equal(t, "Single", nfoSingle.Tagline)
 }

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -272,3 +272,15 @@ func TestResolveAndGenerate_PerFileGating(t *testing.T) {
 		assert.Contains(t, string(data), "<tagline>Part </tagline>")
 	})
 }
+
+func TestMovieToNFO_TaglineBareIfDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "A <IF> B", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
+	assert.Equal(t, "", nfo.Tagline)
+}
+
+func TestMovieToNFO_TaglineElseModifierDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<IF:SERIES>a<ELSE:b>c</IF>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
+	assert.Equal(t, "", nfo.Tagline)
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -147,22 +147,22 @@ func TestGenerateAtPath_CanceledContextReturnsError(t *testing.T) {
 
 func TestMovieTemplateContext_ThreadsVideoFilePath(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{FirstNameOrder: true})
-	ctx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4", "-pt1", 0, true)
+	ctx := g.movieTemplateContext(context.Background(), taglineTestMovie(), "/movies/IPX-535.mp4", "-pt1", 0, true)
 	assert.Equal(t, "/movies/IPX-535.mp4", ctx.VideoFilePath)
 	assert.Equal(t, "-pt1", ctx.PartSuffix)
 	assert.True(t, ctx.IsMultiPart)
 
-	ctxEmpty := g.movieTemplateContext(taglineTestMovie(), "", "", 0, false)
+	ctxEmpty := g.movieTemplateContext(context.Background(), taglineTestMovie(), "", "", 0, false)
 	assert.Equal(t, "", ctxEmpty.VideoFilePath)
 	assert.False(t, ctxEmpty.IsMultiPart)
 }
 
 func TestMergeTags_ConfigTagThreadsVideoFilePath(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<RESOLUTION>"}, FirstNameOrder: true})
-	tmplCtx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4", "", 0, false)
+	tmplCtx := g.movieTemplateContext(context.Background(), taglineTestMovie(), "/movies/IPX-535.mp4", "", 0, false)
 	tags, err := g.mergeTags(context.Background(), tmplCtx, nil, nil)
 	assert.NoError(t, err)
-	_ = tags
+	assert.Empty(t, tags)
 }
 
 func TestMovieToNFO_ConfigTagWithUnknownTokenDropped(t *testing.T) {

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -3,6 +3,7 @@ package nfo
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +65,7 @@ func TestMovieToNFO_TaglineTemplating(t *testing.T) {
 				movie = &m
 			}
 			g := NewGenerator(afero.NewMemMapFs(), cfg)
-			nfo := g.movieToNFO(context.Background(), movie, "", nil)
+			nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 			assert.Equal(t, tc.want, nfo.Tagline)
 		})
 	}
@@ -74,14 +75,14 @@ func TestMovieToNFO_TaglineTemplating_DefaultDelimiterRespected(t *testing.T) {
 	// An empty ActressDelimiter config must behave like the other template
 	// surfaces (folder/file formats): fall back to ", ", not render empty.
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<ACTRESSES>"})
-	nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
 	assert.Equal(t, "Sakura Momo, Actress Test", nfo.Tagline)
 }
 
 func TestMovieToNFO_TagsTemplating(t *testing.T) {
 	t.Run("static tags pass through unchanged", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"Pool", "Collector"}, FirstNameOrder: true})
-		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"Manual"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"Manual"})
 		assert.Contains(t, nfo.Tags, "Pool")
 		assert.Contains(t, nfo.Tags, "Collector")
 		assert.Contains(t, nfo.Tags, "Manual")
@@ -90,21 +91,21 @@ func TestMovieToNFO_TagsTemplating(t *testing.T) {
 
 	t.Run("config tag templates expand per movie", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<ID>", "Pool"}, FirstNameOrder: true})
-		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", nil)
 		assert.Contains(t, nfo.Tags, "IPX-535")
 		assert.Contains(t, nfo.Tags, "Pool")
 	})
 
 	t.Run("caller (database) tags pass through verbatim", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{FirstNameOrder: true})
-		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"<MAKER>"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"<MAKER>"})
 		assert.Contains(t, nfo.Tags, "<MAKER>")
 		assert.NotContains(t, nfo.Tags, "Idea Pocket")
 	})
 
 	t.Run("broken config tag templates dropped; caller tags kept verbatim", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<IF:ID>oops", "Kept"}, FirstNameOrder: true})
-		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"<NOTAREALTAG>", "AlsoKept"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"<NOTAREALTAG>", "AlsoKept"})
 		assert.Contains(t, nfo.Tags, "Kept")
 		assert.Contains(t, nfo.Tags, "<NOTAREALTAG>")
 		assert.Contains(t, nfo.Tags, "AlsoKept")
@@ -113,7 +114,33 @@ func TestMovieToNFO_TagsTemplating(t *testing.T) {
 
 	t.Run("template result deduped against existing tag", func(t *testing.T) {
 		g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<ID>"}, FirstNameOrder: true})
-		nfo := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"IPX-535"})
+		nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", []string{"IPX-535"})
 		assert.Equal(t, []string{"IPX-535"}, nfo.Tags)
 	})
+}
+
+func TestMovieToNFO_CanceledContextPropagatesTagline(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<ID>", FirstNameOrder: true})
+	nfo, err := g.movieToNFO(ctx, taglineTestMovie(), "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, nfo)
+}
+
+func TestMovieToNFO_DeadlineExceededPropagatesConfigTag(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<ID>"}, FirstNameOrder: true})
+	nfo, err := g.movieToNFO(ctx, taglineTestMovie(), "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, nfo)
+}
+
+func TestGenerateAtPath_CanceledContextReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<ID>", FirstNameOrder: true})
+	err := g.GenerateAtPath(ctx, taglineTestMovie(), "/out/test.nfo", "", nil)
+	assert.Error(t, err)
 }

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -284,3 +284,15 @@ func TestMovieToNFO_TaglineElseModifierDropped(t *testing.T) {
 	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
 	assert.Equal(t, "", nfo.Tagline)
 }
+
+func TestMovieToNFO_TaglineDegenerateIfColonDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<IF:>oops", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
+	assert.Equal(t, "", nfo.Tagline)
+}
+
+func TestMovieToNFO_TaglineSignedNumericModifierDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<PART:+2>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", 1, true, nil)
+	assert.Equal(t, "", nfo.Tagline)
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -239,3 +239,9 @@ func TestMovieToNFO_TaglineMultipleElseDropped(t *testing.T) {
 	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
 	assert.Equal(t, "", nfo.Tagline)
 }
+
+func TestMovieToNFO_TaglineMultilineConditionalRendered(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<IF:TITLE>\nFeatured\n</IF>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
+	assert.Equal(t, "\nFeatured\n", nfo.Tagline)
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -2,6 +2,7 @@ package nfo
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/javinizer/javinizer-go/internal/mediainfo"
 	"github.com/javinizer/javinizer-go/internal/models"
 )
 
@@ -334,4 +336,45 @@ func TestGenerate_LegacyPathPropagatesCancellation(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<ID>", PerFile: true, FirstNameOrder: true, FilenameTemplate: "<ID>"})
 	err := g.Generate(ctx, taglineTestMovie(), "/out", "", "", nil)
 	assert.Error(t, err)
+}
+
+func TestMovieToNFO_TaglineResolutionReusesStreamAnalysis(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-*.mp4")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	require.NoError(t, os.WriteFile(tmpFile.Name(), []byte("fake video"), 0644))
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<RESOLUTION>", IncludeStreamDetails: true, FirstNameOrder: true})
+	nfo, err := g.movieToNFO(context.Background(), taglineTestMovie(), tmpFile.Name(), "", 0, false, nil)
+	assert.NoError(t, err)
+	_ = nfo
+}
+
+func TestMovieToNFO_StreamDetailsEnabledSeedsMediaCache(t *testing.T) {
+	stub := &stubMediaAnalyzer{Details: &streamDetails{Video: []videoStream{{Codec: "h264", Width: 1920, Height: 1080}}}}
+	gen := newGeneratorWithAnalyzer(afero.NewMemMapFs(), &Config{Tagline: "<RESOLUTION>", IncludeStreamDetails: true, FirstNameOrder: true}, stub)
+	nfo, err := g_movieToNFO(gen, taglineTestMovie(), "/fake/path.mp4", "", 0, false, nil)
+	assert.NoError(t, err)
+	_ = nfo
+}
+
+func g_movieToNFO(g *Generator, movie *models.Movie, videoFilePath, partSuffix string, partNumber int, isMultiPart bool, tags []string) (*Movie, error) {
+	return g.movieToNFO(context.Background(), movie, videoFilePath, partSuffix, partNumber, isMultiPart, tags)
+}
+
+func TestMovieToNFO_SeedsSharedMediaInfoWhenStreamDetailsEnabled(t *testing.T) {
+	stub := &stubMediaAnalyzer{Details: &streamDetails{Video: []videoStream{{Codec: "h264", Width: 1920, Height: 1080}}}}
+	gen := newGeneratorWithAnalyzer(afero.NewMemMapFs(), &Config{Tagline: "<RESOLUTION>", IncludeStreamDetails: true, FirstNameOrder: true}, stub)
+	gen.mediaInfoAnalyze = func(_ context.Context, _ string) (*mediainfo.VideoInfo, error) {
+		return &mediainfo.VideoInfo{Width: 1920, Height: 1080}, nil
+	}
+	nfo, err := gen.movieToNFO(context.Background(), taglineTestMovie(), "/fake/path.mp4", "", 0, false, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "1080p", nfo.Tagline)
+}
+
+func TestSeedSharedMediaInfo_NilFileInfoNoOp(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{FirstNameOrder: true})
+	tmplCtx := g.movieTemplateContext(context.Background(), taglineTestMovie(), "/fake.mp4", "", 0, false)
+	g.seedSharedMediaInfo(context.Background(), nil, "/fake.mp4", tmplCtx)
+	assert.True(t, true)
 }

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -233,3 +233,9 @@ func TestMovieToNFO_TaglineInvalidNumericModifierDropped(t *testing.T) {
 	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", 1, true, nil)
 	assert.Equal(t, "", nfo.Tagline)
 }
+
+func TestMovieToNFO_TaglineMultipleElseDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<IF:SERIES>a<ELSE>b<ELSE>c</IF>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
+	assert.Equal(t, "", nfo.Tagline)
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -144,3 +144,19 @@ func TestGenerateAtPath_CanceledContextReturnsError(t *testing.T) {
 	err := g.GenerateAtPath(ctx, taglineTestMovie(), "/out/test.nfo", "", nil)
 	assert.Error(t, err)
 }
+
+func TestMovieTemplateContext_ThreadsVideoFilePath(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{FirstNameOrder: true})
+	ctx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4")
+	assert.Equal(t, "/movies/IPX-535.mp4", ctx.VideoFilePath)
+
+	ctxEmpty := g.movieTemplateContext(taglineTestMovie(), "")
+	assert.Equal(t, "", ctxEmpty.VideoFilePath)
+}
+
+func TestMergeTags_ConfigTagThreadsVideoFilePath(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<RESOLUTION>"}, FirstNameOrder: true})
+	tags, err := g.mergeTags(context.Background(), taglineTestMovie(), "/movies/IPX-535.mp4", nil, nil)
+	assert.NoError(t, err)
+	_ = tags
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -199,3 +199,13 @@ func TestMovieToNFO_TaglineMultipartConditional(t *testing.T) {
 	nfoSingle, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", false, nil)
 	assert.Equal(t, "Single", nfoSingle.Tagline)
 }
+
+func TestResolveAndGenerate_CanceledContextReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<ID>", FirstNameOrder: true})
+	nameCfg := NFONameConfig{FilenameTemplate: "<ID>"}
+	nfoPath, err := g.ResolveAndGenerate(ctx, taglineTestMovie(), "/out", nameCfg, "", nil)
+	assert.Error(t, err)
+	assert.Equal(t, "", nfoPath)
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -307,3 +307,9 @@ func TestResolveAndGenerate_PartNumberGatedOnIsMultiPart(t *testing.T) {
 	require.NoError(t, readErr)
 	assert.Contains(t, string(data), "<tagline>Part </tagline>")
 }
+
+func TestMovieToNFO_TaglineModifierWithAngleBracketDropped(t *testing.T) {
+	g := NewGenerator(afero.NewMemMapFs(), &Config{Tagline: "<IF:TITLE><TITLE:</IF>", FirstNameOrder: true})
+	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "", 0, false, nil)
+	assert.Equal(t, "", nfo.Tagline)
+}

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -156,7 +156,8 @@ func TestMovieTemplateContext_ThreadsVideoFilePath(t *testing.T) {
 
 func TestMergeTags_ConfigTagThreadsVideoFilePath(t *testing.T) {
 	g := NewGenerator(afero.NewMemMapFs(), &Config{Tag: []string{"<RESOLUTION>"}, FirstNameOrder: true})
-	tags, err := g.mergeTags(context.Background(), taglineTestMovie(), "/movies/IPX-535.mp4", nil, nil)
+	tmplCtx := g.movieTemplateContext(taglineTestMovie(), "/movies/IPX-535.mp4")
+	tags, err := g.mergeTags(context.Background(), tmplCtx, nil, nil)
 	assert.NoError(t, err)
 	_ = tags
 }

--- a/internal/nfo/tagline_render_test.go
+++ b/internal/nfo/tagline_render_test.go
@@ -296,3 +296,14 @@ func TestMovieToNFO_TaglineSignedNumericModifierDropped(t *testing.T) {
 	nfo, _ := g.movieToNFO(context.Background(), taglineTestMovie(), "", "-pt1", 1, true, nil)
 	assert.Equal(t, "", nfo.Tagline)
 }
+
+func TestResolveAndGenerate_PartNumberGatedOnIsMultiPart(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	g := NewGenerator(fs, &Config{Tagline: "Part <PART>", FirstNameOrder: true})
+	nameCfg := NFONameConfig{FilenameTemplate: "<ID>", PerFile: true, PartSuffix: "", PartNumber: 1, IsMultiPart: false}
+	path, err := g.ResolveAndGenerate(context.Background(), taglineTestMovie(), "/out", nameCfg, "", nil)
+	require.NoError(t, err)
+	data, readErr := afero.ReadFile(fs, path)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), "<tagline>Part </tagline>")
+}

--- a/internal/nfo/transform.go
+++ b/internal/nfo/transform.go
@@ -314,9 +314,10 @@ func (g *Generator) mergeTags(ctx context.Context, movie *models.Movie, actors [
 		}
 	}
 
-	// Caller-provided tags (template-expanded, e.g. "<ID>")
+	// Caller-provided tags are pre-resolved database values written verbatim;
+	// only g.config.Tag is advertised as template-aware.
 	for _, tag := range callerTags {
-		addTag(g.renderConfiguredText(ctx, movie, "tag", tag))
+		addTag(tag)
 	}
 
 	// Config tags (template-expanded — the Web UI advertises them as templates)

--- a/internal/nfo/transform.go
+++ b/internal/nfo/transform.go
@@ -63,6 +63,12 @@ func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movi
 	fi := g.resolveStreamDetails(ctx, videoFilePath)
 	originalPath := g.resolveOriginalPath(movie)
 	tmplCtx := g.movieTemplateContext(ctx, movie, videoFilePath, partSuffix, partNumber, isMultiPart)
+	// When stream details are enabled, the video is already analyzed by
+	// resolveStreamDetails above; seed the template context cache so <RESOLUTION>
+	// and other media tags reuse that analysis instead of re-analyzing.
+	if fi != nil {
+		g.seedSharedMediaInfo(ctx, fi, videoFilePath, tmplCtx)
+	}
 	tagline, err := g.resolveTagline(ctx, tmplCtx)
 	if err != nil {
 		return nfoInput{}, err
@@ -187,6 +193,20 @@ func (g *Generator) resolveOriginalPath(movie *models.Movie) string {
 		return movie.OriginalFileName
 	}
 	return ""
+}
+
+// seedSharedMediaInfo pre-seeds the template context's cached media info when
+// stream details were already extracted, so <RESOLUTION> and other media tags
+// reuse the analysis instead of invoking mediainfo.Analyze a second time on the
+// same file. When stream details are disabled (fi == nil) the template context
+// still analyzes lazily as before.
+func (g *Generator) seedSharedMediaInfo(ctx context.Context, fi *fileInfo, videoFilePath string, tmplCtx *template.Context) {
+	if fi == nil {
+		return
+	}
+	if videoInfo, analyzeErr := g.mediaInfoAnalyze(ctx, videoFilePath); analyzeErr == nil {
+		tmplCtx.SetCachedMediaInfo(videoInfo)
+	}
 }
 
 // resolveTagline renders the configured tagline against the movie. The docs

--- a/internal/nfo/transform.go
+++ b/internal/nfo/transform.go
@@ -62,13 +62,13 @@ func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movi
 	trailerURL := g.resolveTrailer(movie)
 	fi := g.resolveStreamDetails(ctx, videoFilePath)
 	originalPath := g.resolveOriginalPath(movie)
-	tagline, err := g.resolveTagline(ctx, movie)
+	tagline, err := g.resolveTagline(ctx, movie, videoFilePath)
 	if err != nil {
 		return nfoInput{}, err
 	}
 	credits := g.resolveCredits()
 
-	tagList, err := g.mergeTags(ctx, movie, actors, tags)
+	tagList, err := g.mergeTags(ctx, movie, videoFilePath, actors, tags)
 	if err != nil {
 		return nfoInput{}, err
 	}
@@ -194,16 +194,17 @@ func (g *Generator) resolveOriginalPath(movie *models.Movie) string {
 // Static text (no '<') and literal '<' sequences the tag pattern cannot match
 // pass through unchanged; template errors drop the tagline with a warning
 // rather than fail the whole NFO for an optional field.
-func (g *Generator) resolveTagline(ctx context.Context, movie *models.Movie) (string, error) {
-	return g.renderConfiguredText(ctx, movie, "tagline", g.config.Tagline)
+func (g *Generator) resolveTagline(ctx context.Context, movie *models.Movie, videoFilePath string) (string, error) {
+	return g.renderConfiguredText(ctx, movie, videoFilePath, "tagline", g.config.Tagline)
 }
 
 // movieTemplateContext builds the template context for configured text fields
 // (tagline, custom tags), threading the actress-rendering options so that
 // <ACTORS>/<ACTRESSES> resolve identically to folder/file/display-title
 // templates.
-func (g *Generator) movieTemplateContext(movie *models.Movie) *template.Context {
+func (g *Generator) movieTemplateContext(movie *models.Movie, videoFilePath string) *template.Context {
 	ctx := template.NewContextFromMovie(movie)
+	ctx.VideoFilePath = videoFilePath
 	ctx.GroupActress = g.config.GroupActress
 	ctx.GroupActressMin = g.config.GroupActressMin
 	ctx.GroupActressName = g.config.GroupActressName
@@ -218,11 +219,11 @@ func (g *Generator) movieTemplateContext(movie *models.Movie) *template.Context 
 // renderConfiguredText expands a configured text field when it references
 // template tags; static text is returned byte-identical without touching the
 // engine. Returns "" (caller omits the value) on template error.
-func (g *Generator) renderConfiguredText(ctx context.Context, movie *models.Movie, label, tmpl string) (string, error) {
+func (g *Generator) renderConfiguredText(ctx context.Context, movie *models.Movie, videoFilePath, label, tmpl string) (string, error) {
 	if tmpl == "" || !strings.Contains(tmpl, "<") || movie == nil {
 		return tmpl, nil
 	}
-	rendered, err := g.templateEngine.ExecuteWithContext(ctx, tmpl, g.movieTemplateContext(movie))
+	rendered, err := g.templateEngine.ExecuteWithContext(ctx, tmpl, g.movieTemplateContext(movie, videoFilePath))
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return "", err
@@ -302,7 +303,7 @@ func (g *Generator) buildActors(movieActresses []models.Actress) []actor {
 
 // mergeTags combines actress-as-tag entries, caller-provided tags, and config tags,
 // deduplicating by name.
-func (g *Generator) mergeTags(ctx context.Context, movie *models.Movie, actors []actor, callerTags []string) ([]string, error) {
+func (g *Generator) mergeTags(ctx context.Context, movie *models.Movie, videoFilePath string, actors []actor, callerTags []string) ([]string, error) {
 	var tags []string
 	tagSet := make(map[string]bool)
 
@@ -331,7 +332,7 @@ func (g *Generator) mergeTags(ctx context.Context, movie *models.Movie, actors [
 
 	// Config tags (template-expanded — the Web UI advertises them as templates)
 	for _, tag := range g.config.Tag {
-		rendered, err := g.renderConfiguredText(ctx, movie, "tag", tag)
+		rendered, err := g.renderConfiguredText(ctx, movie, videoFilePath, "tag", tag)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/nfo/transform.go
+++ b/internal/nfo/transform.go
@@ -62,7 +62,7 @@ func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movi
 	trailerURL := g.resolveTrailer(movie)
 	fi := g.resolveStreamDetails(ctx, videoFilePath)
 	originalPath := g.resolveOriginalPath(movie)
-	tmplCtx := g.movieTemplateContext(movie, videoFilePath, partSuffix, partNumber, isMultiPart)
+	tmplCtx := g.movieTemplateContext(ctx, movie, videoFilePath, partSuffix, partNumber, isMultiPart)
 	tagline, err := g.resolveTagline(ctx, tmplCtx)
 	if err != nil {
 		return nfoInput{}, err
@@ -203,8 +203,9 @@ func (g *Generator) resolveTagline(ctx context.Context, tmplCtx *template.Contex
 // (tagline, custom tags), threading the actress-rendering options so that
 // <ACTORS>/<ACTRESSES> resolve identically to folder/file/display-title
 // templates.
-func (g *Generator) movieTemplateContext(movie *models.Movie, videoFilePath, partSuffix string, partNumber int, isMultiPart bool) *template.Context {
+func (g *Generator) movieTemplateContext(applyCtx context.Context, movie *models.Movie, videoFilePath, partSuffix string, partNumber int, isMultiPart bool) *template.Context {
 	ctx := template.NewContextFromMovie(movie)
+	ctx.SetExecCtx(applyCtx)
 	ctx.VideoFilePath = videoFilePath
 	ctx.PartSuffix = partSuffix
 	ctx.PartNumber = partNumber

--- a/internal/nfo/transform.go
+++ b/internal/nfo/transform.go
@@ -62,13 +62,14 @@ func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movi
 	trailerURL := g.resolveTrailer(movie)
 	fi := g.resolveStreamDetails(ctx, videoFilePath)
 	originalPath := g.resolveOriginalPath(movie)
-	tagline, err := g.resolveTagline(ctx, movie, videoFilePath)
+	tmplCtx := g.movieTemplateContext(movie, videoFilePath)
+	tagline, err := g.resolveTagline(ctx, tmplCtx)
 	if err != nil {
 		return nfoInput{}, err
 	}
 	credits := g.resolveCredits()
 
-	tagList, err := g.mergeTags(ctx, movie, videoFilePath, actors, tags)
+	tagList, err := g.mergeTags(ctx, tmplCtx, actors, tags)
 	if err != nil {
 		return nfoInput{}, err
 	}
@@ -194,8 +195,8 @@ func (g *Generator) resolveOriginalPath(movie *models.Movie) string {
 // Static text (no '<') and literal '<' sequences the tag pattern cannot match
 // pass through unchanged; template errors drop the tagline with a warning
 // rather than fail the whole NFO for an optional field.
-func (g *Generator) resolveTagline(ctx context.Context, movie *models.Movie, videoFilePath string) (string, error) {
-	return g.renderConfiguredText(ctx, movie, videoFilePath, "tagline", g.config.Tagline)
+func (g *Generator) resolveTagline(ctx context.Context, tmplCtx *template.Context) (string, error) {
+	return g.renderConfiguredText(ctx, tmplCtx, "tagline", g.config.Tagline)
 }
 
 // movieTemplateContext builds the template context for configured text fields
@@ -219,11 +220,11 @@ func (g *Generator) movieTemplateContext(movie *models.Movie, videoFilePath stri
 // renderConfiguredText expands a configured text field when it references
 // template tags; static text is returned byte-identical without touching the
 // engine. Returns "" (caller omits the value) on template error.
-func (g *Generator) renderConfiguredText(ctx context.Context, movie *models.Movie, videoFilePath, label, tmpl string) (string, error) {
-	if tmpl == "" || !strings.Contains(tmpl, "<") || movie == nil {
+func (g *Generator) renderConfiguredText(ctx context.Context, tmplCtx *template.Context, label, tmpl string) (string, error) {
+	if tmpl == "" || !strings.Contains(tmpl, "<") || tmplCtx == nil {
 		return tmpl, nil
 	}
-	rendered, err := g.templateEngine.ExecuteWithContext(ctx, tmpl, g.movieTemplateContext(movie, videoFilePath))
+	rendered, err := g.templateEngine.ExecuteWithContext(ctx, tmpl, tmplCtx)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return "", err
@@ -307,7 +308,7 @@ func (g *Generator) buildActors(movieActresses []models.Actress) []actor {
 
 // mergeTags combines actress-as-tag entries, caller-provided tags, and config tags,
 // deduplicating by name.
-func (g *Generator) mergeTags(ctx context.Context, movie *models.Movie, videoFilePath string, actors []actor, callerTags []string) ([]string, error) {
+func (g *Generator) mergeTags(ctx context.Context, tmplCtx *template.Context, actors []actor, callerTags []string) ([]string, error) {
 	var tags []string
 	tagSet := make(map[string]bool)
 
@@ -336,7 +337,7 @@ func (g *Generator) mergeTags(ctx context.Context, movie *models.Movie, videoFil
 
 	// Config tags (template-expanded — the Web UI advertises them as templates)
 	for _, tag := range g.config.Tag {
-		rendered, err := g.renderConfiguredText(ctx, movie, videoFilePath, "tag", tag)
+		rendered, err := g.renderConfiguredText(ctx, tmplCtx, "tag", tag)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/nfo/transform.go
+++ b/internal/nfo/transform.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"strings"
 
+	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/template"
 )
 
 // nfoRating captures a resolved rating for NFO generation.
@@ -59,11 +61,11 @@ func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movi
 	trailerURL := g.resolveTrailer(movie)
 	fi := g.resolveStreamDetails(ctx, videoFilePath)
 	originalPath := g.resolveOriginalPath(movie)
-	tagline := g.resolveTagline()
+	tagline := g.resolveTagline(ctx, movie)
 	credits := g.resolveCredits()
 
 	// Tag merging: actress-as-tag + caller tags + config tags, deduplicated
-	tagList := g.mergeTags(actors, tags)
+	tagList := g.mergeTags(ctx, movie, actors, tags)
 
 	return nfoInput{
 		id:            movie.ID,
@@ -180,9 +182,46 @@ func (g *Generator) resolveOriginalPath(movie *models.Movie) string {
 	return ""
 }
 
-// resolveTagline returns the configured tagline.
-func (g *Generator) resolveTagline() string {
-	return g.config.Tagline
+// resolveTagline renders the configured tagline against the movie. The docs
+// and Web UI have always advertised template-tag support (custom tagline
+// template), but until now the string was written verbatim — reported as #184.
+// Static text (no '<') and literal '<' sequences the tag pattern cannot match
+// pass through unchanged; template errors drop the tagline with a warning
+// rather than fail the whole NFO for an optional field.
+func (g *Generator) resolveTagline(ctx context.Context, movie *models.Movie) string {
+	return g.renderConfiguredText(ctx, movie, "tagline", g.config.Tagline)
+}
+
+// movieTemplateContext builds the template context for configured text fields
+// (tagline, custom tags), threading the actress-rendering options so that
+// <ACTORS>/<ACTRESSES> resolve identically to folder/file/display-title
+// templates.
+func (g *Generator) movieTemplateContext(movie *models.Movie) *template.Context {
+	ctx := template.NewContextFromMovie(movie)
+	ctx.GroupActress = g.config.GroupActress
+	ctx.GroupActressMin = g.config.GroupActressMin
+	ctx.GroupActressName = g.config.GroupActressName
+	ctx.GroupUnknownActressName = g.config.GroupUnknownActressName
+	ctx.UnknownActressMode = g.config.UnknownActressMode
+	ctx.FirstNameOrder = g.config.FirstNameOrder
+	ctx.ActressLanguageJa = g.config.ActressLanguageJA
+	ctx.ActressDelimiter = g.config.ActressDelimiter
+	return ctx
+}
+
+// renderConfiguredText expands a configured text field when it references
+// template tags; static text is returned byte-identical without touching the
+// engine. Returns "" (caller omits the value) on template error.
+func (g *Generator) renderConfiguredText(ctx context.Context, movie *models.Movie, label, tmpl string) string {
+	if tmpl == "" || !strings.Contains(tmpl, "<") || movie == nil {
+		return tmpl
+	}
+	rendered, err := g.templateEngine.ExecuteWithContext(ctx, tmpl, g.movieTemplateContext(movie))
+	if err != nil {
+		logging.Warnf("nfo: dropping %s %q: template error: %v", label, tmpl, err)
+		return ""
+	}
+	return rendered
 }
 
 // resolveCredits returns the configured credits as a comma-separated string.
@@ -254,7 +293,7 @@ func (g *Generator) buildActors(movieActresses []models.Actress) []actor {
 
 // mergeTags combines actress-as-tag entries, caller-provided tags, and config tags,
 // deduplicating by name.
-func (g *Generator) mergeTags(actors []actor, callerTags []string) []string {
+func (g *Generator) mergeTags(ctx context.Context, movie *models.Movie, actors []actor, callerTags []string) []string {
 	var tags []string
 	tagSet := make(map[string]bool)
 
@@ -275,14 +314,14 @@ func (g *Generator) mergeTags(actors []actor, callerTags []string) []string {
 		}
 	}
 
-	// Caller-provided tags
+	// Caller-provided tags (template-expanded, e.g. "<ID>")
 	for _, tag := range callerTags {
-		addTag(tag)
+		addTag(g.renderConfiguredText(ctx, movie, "tag", tag))
 	}
 
-	// Config tags
+	// Config tags (template-expanded — the Web UI advertises them as templates)
 	for _, tag := range g.config.Tag {
-		addTag(tag)
+		addTag(g.renderConfiguredText(ctx, movie, "tag", tag))
 	}
 
 	return tags

--- a/internal/nfo/transform.go
+++ b/internal/nfo/transform.go
@@ -51,7 +51,7 @@ type nfoInput struct {
 // transformMovieForNFO handles all data transformation: actress formatting and deduplication,
 // stream details extraction, date normalization, rating resolution, and tag merging.
 // The returned nfoInput is fully resolved — buildNFO maps it to *Movie with no further decisions.
-func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movie, videoFilePath, partSuffix string, isMultiPart bool, tags []string) (nfoInput, error) {
+func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movie, videoFilePath, partSuffix string, partNumber int, isMultiPart bool, tags []string) (nfoInput, error) {
 	title := g.resolveTitle(movie)
 	genres := g.resolveGenres(movie)
 	actors := g.buildActors(movie.Actresses)
@@ -62,7 +62,7 @@ func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movi
 	trailerURL := g.resolveTrailer(movie)
 	fi := g.resolveStreamDetails(ctx, videoFilePath)
 	originalPath := g.resolveOriginalPath(movie)
-	tmplCtx := g.movieTemplateContext(movie, videoFilePath, partSuffix, isMultiPart)
+	tmplCtx := g.movieTemplateContext(movie, videoFilePath, partSuffix, partNumber, isMultiPart)
 	tagline, err := g.resolveTagline(ctx, tmplCtx)
 	if err != nil {
 		return nfoInput{}, err
@@ -203,10 +203,11 @@ func (g *Generator) resolveTagline(ctx context.Context, tmplCtx *template.Contex
 // (tagline, custom tags), threading the actress-rendering options so that
 // <ACTORS>/<ACTRESSES> resolve identically to folder/file/display-title
 // templates.
-func (g *Generator) movieTemplateContext(movie *models.Movie, videoFilePath, partSuffix string, isMultiPart bool) *template.Context {
+func (g *Generator) movieTemplateContext(movie *models.Movie, videoFilePath, partSuffix string, partNumber int, isMultiPart bool) *template.Context {
 	ctx := template.NewContextFromMovie(movie)
 	ctx.VideoFilePath = videoFilePath
 	ctx.PartSuffix = partSuffix
+	ctx.PartNumber = partNumber
 	ctx.IsMultiPart = isMultiPart
 	ctx.GroupActress = g.config.GroupActress
 	ctx.GroupActressMin = g.config.GroupActressMin

--- a/internal/nfo/transform.go
+++ b/internal/nfo/transform.go
@@ -231,6 +231,10 @@ func (g *Generator) renderConfiguredText(ctx context.Context, movie *models.Movi
 		logging.Warnf("nfo: dropping %s %q: template error: %v", label, tmpl, err)
 		return "", nil
 	}
+	if vErr := g.templateEngine.ValidateTags(tmpl); vErr != nil {
+		logging.Warnf("nfo: dropping %s %q: %v", label, tmpl, vErr)
+		return "", nil
+	}
 	return rendered, nil
 }
 

--- a/internal/nfo/transform.go
+++ b/internal/nfo/transform.go
@@ -2,6 +2,7 @@ package nfo
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/javinizer/javinizer-go/internal/logging"
@@ -50,7 +51,7 @@ type nfoInput struct {
 // transformMovieForNFO handles all data transformation: actress formatting and deduplication,
 // stream details extraction, date normalization, rating resolution, and tag merging.
 // The returned nfoInput is fully resolved — buildNFO maps it to *Movie with no further decisions.
-func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movie, videoFilePath string, tags []string) nfoInput {
+func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movie, videoFilePath string, tags []string) (nfoInput, error) {
 	title := g.resolveTitle(movie)
 	genres := g.resolveGenres(movie)
 	actors := g.buildActors(movie.Actresses)
@@ -61,11 +62,16 @@ func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movi
 	trailerURL := g.resolveTrailer(movie)
 	fi := g.resolveStreamDetails(ctx, videoFilePath)
 	originalPath := g.resolveOriginalPath(movie)
-	tagline := g.resolveTagline(ctx, movie)
+	tagline, err := g.resolveTagline(ctx, movie)
+	if err != nil {
+		return nfoInput{}, err
+	}
 	credits := g.resolveCredits()
 
-	// Tag merging: actress-as-tag + caller tags + config tags, deduplicated
-	tagList := g.mergeTags(ctx, movie, actors, tags)
+	tagList, err := g.mergeTags(ctx, movie, actors, tags)
+	if err != nil {
+		return nfoInput{}, err
+	}
 
 	return nfoInput{
 		id:            movie.ID,
@@ -91,7 +97,7 @@ func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movi
 		originalPath:  originalPath,
 		tagline:       tagline,
 		credits:       credits,
-	}
+	}, nil
 }
 
 // resolveTitle returns the display title, falling back to the base title.
@@ -188,7 +194,7 @@ func (g *Generator) resolveOriginalPath(movie *models.Movie) string {
 // Static text (no '<') and literal '<' sequences the tag pattern cannot match
 // pass through unchanged; template errors drop the tagline with a warning
 // rather than fail the whole NFO for an optional field.
-func (g *Generator) resolveTagline(ctx context.Context, movie *models.Movie) string {
+func (g *Generator) resolveTagline(ctx context.Context, movie *models.Movie) (string, error) {
 	return g.renderConfiguredText(ctx, movie, "tagline", g.config.Tagline)
 }
 
@@ -212,16 +218,19 @@ func (g *Generator) movieTemplateContext(movie *models.Movie) *template.Context 
 // renderConfiguredText expands a configured text field when it references
 // template tags; static text is returned byte-identical without touching the
 // engine. Returns "" (caller omits the value) on template error.
-func (g *Generator) renderConfiguredText(ctx context.Context, movie *models.Movie, label, tmpl string) string {
+func (g *Generator) renderConfiguredText(ctx context.Context, movie *models.Movie, label, tmpl string) (string, error) {
 	if tmpl == "" || !strings.Contains(tmpl, "<") || movie == nil {
-		return tmpl
+		return tmpl, nil
 	}
 	rendered, err := g.templateEngine.ExecuteWithContext(ctx, tmpl, g.movieTemplateContext(movie))
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return "", err
+		}
 		logging.Warnf("nfo: dropping %s %q: template error: %v", label, tmpl, err)
-		return ""
+		return "", nil
 	}
-	return rendered
+	return rendered, nil
 }
 
 // resolveCredits returns the configured credits as a comma-separated string.
@@ -293,7 +302,7 @@ func (g *Generator) buildActors(movieActresses []models.Actress) []actor {
 
 // mergeTags combines actress-as-tag entries, caller-provided tags, and config tags,
 // deduplicating by name.
-func (g *Generator) mergeTags(ctx context.Context, movie *models.Movie, actors []actor, callerTags []string) []string {
+func (g *Generator) mergeTags(ctx context.Context, movie *models.Movie, actors []actor, callerTags []string) ([]string, error) {
 	var tags []string
 	tagSet := make(map[string]bool)
 
@@ -322,10 +331,14 @@ func (g *Generator) mergeTags(ctx context.Context, movie *models.Movie, actors [
 
 	// Config tags (template-expanded — the Web UI advertises them as templates)
 	for _, tag := range g.config.Tag {
-		addTag(g.renderConfiguredText(ctx, movie, "tag", tag))
+		rendered, err := g.renderConfiguredText(ctx, movie, "tag", tag)
+		if err != nil {
+			return nil, err
+		}
+		addTag(rendered)
 	}
 
-	return tags
+	return tags, nil
 }
 
 // buildNFO maps a fully-resolved nfoInput to a *Movie XML struct.

--- a/internal/nfo/transform.go
+++ b/internal/nfo/transform.go
@@ -51,7 +51,7 @@ type nfoInput struct {
 // transformMovieForNFO handles all data transformation: actress formatting and deduplication,
 // stream details extraction, date normalization, rating resolution, and tag merging.
 // The returned nfoInput is fully resolved — buildNFO maps it to *Movie with no further decisions.
-func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movie, videoFilePath string, tags []string) (nfoInput, error) {
+func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movie, videoFilePath, partSuffix string, isMultiPart bool, tags []string) (nfoInput, error) {
 	title := g.resolveTitle(movie)
 	genres := g.resolveGenres(movie)
 	actors := g.buildActors(movie.Actresses)
@@ -62,7 +62,7 @@ func (g *Generator) transformMovieForNFO(ctx context.Context, movie *models.Movi
 	trailerURL := g.resolveTrailer(movie)
 	fi := g.resolveStreamDetails(ctx, videoFilePath)
 	originalPath := g.resolveOriginalPath(movie)
-	tmplCtx := g.movieTemplateContext(movie, videoFilePath)
+	tmplCtx := g.movieTemplateContext(movie, videoFilePath, partSuffix, isMultiPart)
 	tagline, err := g.resolveTagline(ctx, tmplCtx)
 	if err != nil {
 		return nfoInput{}, err
@@ -203,9 +203,11 @@ func (g *Generator) resolveTagline(ctx context.Context, tmplCtx *template.Contex
 // (tagline, custom tags), threading the actress-rendering options so that
 // <ACTORS>/<ACTRESSES> resolve identically to folder/file/display-title
 // templates.
-func (g *Generator) movieTemplateContext(movie *models.Movie, videoFilePath string) *template.Context {
+func (g *Generator) movieTemplateContext(movie *models.Movie, videoFilePath, partSuffix string, isMultiPart bool) *template.Context {
 	ctx := template.NewContextFromMovie(movie)
 	ctx.VideoFilePath = videoFilePath
+	ctx.PartSuffix = partSuffix
+	ctx.IsMultiPart = isMultiPart
 	ctx.GroupActress = g.config.GroupActress
 	ctx.GroupActressMin = g.config.GroupActressMin
 	ctx.GroupActressName = g.config.GroupActressName

--- a/internal/nfo/uncovered_test.go
+++ b/internal/nfo/uncovered_test.go
@@ -128,7 +128,7 @@ func TestGenerator_MovieToNFO_WithContentID_Uncovered(t *testing.T) {
 		Genres:       []models.Genre{{Name: "Drama"}, {Name: "Romance"}},
 	}
 
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	require.NotNil(t, nfo)
 	assert.Equal(t, "CID-001", nfo.ID)
 	assert.Equal(t, "Content ID Test", nfo.Title)
@@ -151,7 +151,7 @@ func TestGenerator_MovieToNFO_WithFanart_Uncovered(t *testing.T) {
 		Screenshots:  []string{"http://example.com/ss1.jpg", "http://example.com/ss2.jpg"},
 	}
 
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	require.NotNil(t, nfo)
 	assert.NotNil(t, nfo.Fanart)
 	assert.GreaterOrEqual(t, len(nfo.Fanart.Thumbs), 2)
@@ -170,7 +170,7 @@ func TestGenerator_MovieToNFO_FanartDisabled_Uncovered(t *testing.T) {
 		Screenshots:  []string{"http://example.com/ss1.jpg"},
 	}
 
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	require.NotNil(t, nfo)
 	assert.Nil(t, nfo.Fanart)
 }
@@ -187,7 +187,7 @@ func TestGenerator_MovieToNFO_TrailerDisabled_Uncovered(t *testing.T) {
 		TrailerURL:   "http://example.com/trailer.mp4",
 	}
 
-	nfo := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
 	require.NotNil(t, nfo)
 	assert.Empty(t, nfo.Trailer)
 }

--- a/internal/nfo/uncovered_test.go
+++ b/internal/nfo/uncovered_test.go
@@ -128,7 +128,7 @@ func TestGenerator_MovieToNFO_WithContentID_Uncovered(t *testing.T) {
 		Genres:       []models.Genre{{Name: "Drama"}, {Name: "Romance"}},
 	}
 
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	require.NotNil(t, nfo)
 	assert.Equal(t, "CID-001", nfo.ID)
 	assert.Equal(t, "Content ID Test", nfo.Title)
@@ -151,7 +151,7 @@ func TestGenerator_MovieToNFO_WithFanart_Uncovered(t *testing.T) {
 		Screenshots:  []string{"http://example.com/ss1.jpg", "http://example.com/ss2.jpg"},
 	}
 
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	require.NotNil(t, nfo)
 	assert.NotNil(t, nfo.Fanart)
 	assert.GreaterOrEqual(t, len(nfo.Fanart.Thumbs), 2)
@@ -170,7 +170,7 @@ func TestGenerator_MovieToNFO_FanartDisabled_Uncovered(t *testing.T) {
 		Screenshots:  []string{"http://example.com/ss1.jpg"},
 	}
 
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	require.NotNil(t, nfo)
 	assert.Nil(t, nfo.Fanart)
 }
@@ -187,7 +187,7 @@ func TestGenerator_MovieToNFO_TrailerDisabled_Uncovered(t *testing.T) {
 		TrailerURL:   "http://example.com/trailer.mp4",
 	}
 
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", 0, false, nil)
 	require.NotNil(t, nfo)
 	assert.Empty(t, nfo.Trailer)
 }

--- a/internal/nfo/uncovered_test.go
+++ b/internal/nfo/uncovered_test.go
@@ -128,7 +128,7 @@ func TestGenerator_MovieToNFO_WithContentID_Uncovered(t *testing.T) {
 		Genres:       []models.Genre{{Name: "Drama"}, {Name: "Romance"}},
 	}
 
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	require.NotNil(t, nfo)
 	assert.Equal(t, "CID-001", nfo.ID)
 	assert.Equal(t, "Content ID Test", nfo.Title)
@@ -151,7 +151,7 @@ func TestGenerator_MovieToNFO_WithFanart_Uncovered(t *testing.T) {
 		Screenshots:  []string{"http://example.com/ss1.jpg", "http://example.com/ss2.jpg"},
 	}
 
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	require.NotNil(t, nfo)
 	assert.NotNil(t, nfo.Fanart)
 	assert.GreaterOrEqual(t, len(nfo.Fanart.Thumbs), 2)
@@ -170,7 +170,7 @@ func TestGenerator_MovieToNFO_FanartDisabled_Uncovered(t *testing.T) {
 		Screenshots:  []string{"http://example.com/ss1.jpg"},
 	}
 
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	require.NotNil(t, nfo)
 	assert.Nil(t, nfo.Fanart)
 }
@@ -187,7 +187,7 @@ func TestGenerator_MovieToNFO_TrailerDisabled_Uncovered(t *testing.T) {
 		TrailerURL:   "http://example.com/trailer.mp4",
 	}
 
-	nfo, _ := g.movieToNFO(context.Background(), movie, "", nil)
+	nfo, _ := g.movieToNFO(context.Background(), movie, "", "", false, nil)
 	require.NotNil(t, nfo)
 	assert.Empty(t, nfo.Trailer)
 }

--- a/internal/organizer/inplace_miss2_test.go
+++ b/internal/organizer/inplace_miss2_test.go
@@ -29,6 +29,7 @@ func (e *selectiveErrorEngine) ExecuteWithMaxBytes(_ string, _ *template.Context
 func (e *selectiveErrorEngine) TruncateTitle(title string, _ int) string      { return title }
 func (e *selectiveErrorEngine) TruncateTitleBytes(title string, _ int) string { return title }
 func (e *selectiveErrorEngine) ValidatePathLength(path string, _ int) error   { return nil }
+func (e *selectiveErrorEngine) ValidateTags(_ string) error                   { return nil }
 
 // emptyFolderEngine returns empty string from ExecuteWithMaxBytes
 type emptyFolderEngine struct{}
@@ -45,6 +46,7 @@ func (e *emptyFolderEngine) ExecuteWithMaxBytes(_ string, _ *template.Context, _
 func (e *emptyFolderEngine) TruncateTitle(title string, _ int) string      { return title }
 func (e *emptyFolderEngine) TruncateTitleBytes(title string, _ int) string { return title }
 func (e *emptyFolderEngine) ValidatePathLength(path string, _ int) error   { return nil }
+func (e *emptyFolderEngine) ValidateTags(_ string) error                   { return nil }
 
 // --- Plan: ExecuteWithMaxBytes error when Execute succeeds ---
 // Lines 93-95: folderMaxBytes > 0, ExecuteWithMaxBytes fails

--- a/internal/organizer/inplace_miss_test.go
+++ b/internal/organizer/inplace_miss_test.go
@@ -41,6 +41,7 @@ func (e *errorEngine) ExecuteWithMaxBytes(_ string, _ *template.Context, _ int) 
 func (e *errorEngine) TruncateTitle(title string, _ int) string      { return title }
 func (e *errorEngine) TruncateTitleBytes(title string, _ int) string { return title }
 func (e *errorEngine) ValidatePathLength(path string, _ int) error   { return nil }
+func (e *errorEngine) ValidateTags(_ string) error                   { return nil }
 
 // Lines 73-75: buildPlanContext returns error when file template fails
 func TestInPlaceMiss_Plan_BuildPlanContextError(t *testing.T) {

--- a/internal/organizer/miss3_test.go
+++ b/internal/organizer/miss3_test.go
@@ -29,6 +29,7 @@ func (e *errEngineSubfolder) ExecuteWithMaxBytes(tmpl string, ctx *template.Cont
 func (e *errEngineSubfolder) TruncateTitle(title string, _ int) string      { return title }
 func (e *errEngineSubfolder) TruncateTitleBytes(title string, _ int) string { return title }
 func (e *errEngineSubfolder) ValidatePathLength(_ string, _ int) error      { return nil }
+func (e *errEngineSubfolder) ValidateTags(_ string) error                   { return nil }
 
 // errEngineMaxBytes3 returns error on ExecuteWithMaxBytes only.
 type errEngineMaxBytes3 struct{}
@@ -45,6 +46,7 @@ func (e *errEngineMaxBytes3) ExecuteWithMaxBytes(_ string, _ *template.Context, 
 func (e *errEngineMaxBytes3) TruncateTitle(title string, _ int) string      { return title }
 func (e *errEngineMaxBytes3) TruncateTitleBytes(title string, _ int) string { return title }
 func (e *errEngineMaxBytes3) ValidatePathLength(_ string, _ int) error      { return nil }
+func (e *errEngineMaxBytes3) ValidateTags(_ string) error                   { return nil }
 
 // emptyFolderEngine3 produces empty string from ExecuteWithMaxBytes.
 type emptyFolderEngine3 struct{}
@@ -61,6 +63,7 @@ func (e *emptyFolderEngine3) ExecuteWithMaxBytes(_ string, _ *template.Context, 
 func (e *emptyFolderEngine3) TruncateTitle(title string, _ int) string      { return title }
 func (e *emptyFolderEngine3) TruncateTitleBytes(title string, _ int) string { return title }
 func (e *emptyFolderEngine3) ValidatePathLength(_ string, _ int) error      { return nil }
+func (e *emptyFolderEngine3) ValidateTags(_ string) error                   { return nil }
 
 // --- buildPlanContext: fileName empty with Path set (rename off) ---
 

--- a/internal/organizer/uncovered_test.go
+++ b/internal/organizer/uncovered_test.go
@@ -29,6 +29,7 @@ func (e *errEngine) ExecuteWithMaxBytes(_ string, _ *template.Context, _ int) (s
 func (e *errEngine) TruncateTitle(title string, _ int) string      { return title }
 func (e *errEngine) TruncateTitleBytes(title string, _ int) string { return title }
 func (e *errEngine) ValidatePathLength(_ string, _ int) error      { return nil }
+func (e *errEngine) ValidateTags(_ string) error                   { return nil }
 
 // --- resolveBaseFileName: uncovered fallback branches ---
 

--- a/internal/template/context.go
+++ b/internal/template/context.go
@@ -239,6 +239,12 @@ func (c *Context) Clone() *Context {
 	return &clone
 }
 
+// SetExecCtx sets the execution context used for cancellable media analysis. It
+// must be called once at construction, before the Context is shared across
+// goroutines; ExecuteWithContext never mutates it, so concurrent rendering of a
+// shared Context remains race-free. Clone does not carry it over.
+func (c *Context) SetExecCtx(ctx context.Context) { c.execCtx = ctx }
+
 // getMediaInfo lazy-loads and caches video metadata.
 // Thread-safe: uses sync.Once to ensure single initialization even under concurrent access.
 // Preserves pre-existing cached values from Clone() to avoid duplicate expensive analysis.

--- a/internal/template/context.go
+++ b/internal/template/context.go
@@ -245,6 +245,15 @@ func (c *Context) Clone() *Context {
 // shared Context remains race-free. Clone does not carry it over.
 func (c *Context) SetExecCtx(ctx context.Context) { c.execCtx = ctx }
 
+// SetCachedMediaInfo pre-seeds the cached video metadata so getMediaInfo skips
+// its lazy mediainfo.Analyze call. Use when a caller has already analyzed the
+// video (e.g. for stream details) to avoid a duplicate expensive analysis.
+func (c *Context) SetCachedMediaInfo(info *mediainfo.VideoInfo) {
+	if info != nil {
+		c.cachedMediaInfo = info
+	}
+}
+
 // getMediaInfo lazy-loads and caches video metadata.
 // Thread-safe: uses sync.Once to ensure single initialization even under concurrent access.
 // Preserves pre-existing cached values from Clone() to avoid duplicate expensive analysis.

--- a/internal/template/context.go
+++ b/internal/template/context.go
@@ -52,7 +52,8 @@ type Context struct {
 
 	// Media info
 	OriginalFilename string
-	VideoFilePath    string // Path to video file for mediainfo extraction
+	VideoFilePath    string          // Path to video file for mediainfo extraction
+	execCtx          context.Context // per-execution context for cancellation; not cloned
 
 	// Indexing (for screenshots, multi-part, etc.)
 	Index int
@@ -250,7 +251,11 @@ func (c *Context) getMediaInfo() *mediainfo.VideoInfo {
 			c.mediaInfoError = fmt.Errorf("no video file path")
 			return
 		}
-		c.cachedMediaInfo, c.mediaInfoError = mediainfo.Analyze(context.Background(), c.VideoFilePath)
+		analyzeCtx := c.execCtx
+		if analyzeCtx == nil {
+			analyzeCtx = context.Background()
+		}
+		c.cachedMediaInfo, c.mediaInfoError = mediainfo.Analyze(analyzeCtx, c.VideoFilePath)
 	})
 	return c.cachedMediaInfo
 }

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -398,6 +398,12 @@ func (e *Engine) ValidateTags(template string) error {
 	for _, match := range matches {
 		tagName := strings.ToUpper(match[1])
 		if tagName == "IF" {
+			if len(match) > 2 && match[2] != "" {
+				condTag := strings.ToUpper(match[2])
+				if !e.isKnownTag(condTag) {
+					return fmt.Errorf("unknown tag: %s", condTag)
+				}
+			}
 			continue
 		}
 		if !e.isKnownTag(tagName) {

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -114,7 +114,7 @@ func newEngineWithOptions(opts engineOptions) *Engine {
 		tagPattern: regexp.MustCompile(`(?i)<([A-Z_]+)(?::([^>]+))?>`),
 		// Matches: <IF:TAG>content</IF> or <IF:TAG>true<ELSE>false</IF>
 		// Case-insensitive to allow <if:tag>, <IF:TAG>, etc.
-		conditionalPattern:  regexp.MustCompile(`(?i)<IF:([A-Z_]+)>(.*?)(?:<ELSE>(.*?))?</IF>`),
+		conditionalPattern:  regexp.MustCompile(`(?is)<IF:([A-Z_]+)>(.*?)(?:<ELSE>(.*?))?</IF>`),
 		options:             opts,
 		tagRegistry:         newTagRegistry(),
 		translationResolver: newTranslationResolver(opts),
@@ -245,6 +245,9 @@ func (e *Engine) ExecuteWithContext(execCtx context.Context, template string, ct
 	if err := e.Validate(template); err != nil {
 		return "", err
 	}
+
+	ctx.execCtx = execCtx
+	defer func() { ctx.execCtx = nil }()
 
 	result := template
 

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -435,11 +435,13 @@ func (e *Engine) ValidateTags(template string) error {
 // through renderConfiguredText which must not write corrupted values.
 func (e *Engine) validateConditionalNesting(template string) error {
 	depth := 0
+	sawElse := false
 	for _, token := range conditionalStructureRegex.FindAllString(template, -1) {
 		upper := strings.ToUpper(token)
 		switch {
 		case strings.HasPrefix(upper, "<IF:"):
 			depth++
+			sawElse = false
 			if depth > 1 {
 				return fmt.Errorf("nested conditionals are not supported")
 			}
@@ -447,6 +449,10 @@ func (e *Engine) validateConditionalNesting(template string) error {
 			if depth < 1 {
 				return fmt.Errorf("<ELSE> outside of <IF> block")
 			}
+			if sawElse {
+				return fmt.Errorf("multiple <ELSE> in one <IF> block")
+			}
+			sawElse = true
 		default:
 			depth--
 			if depth < 0 {

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -402,15 +402,19 @@ func (e *Engine) ValidateTags(template string) error {
 	for _, match := range matches {
 		tagName := strings.ToUpper(match[1])
 		if tagName == "IF" {
-			if len(match) > 2 && match[2] != "" {
-				condTag := strings.ToUpper(match[2])
-				if !e.isKnownTag(condTag) {
-					return fmt.Errorf("unknown tag: %s", condTag)
-				}
+			if len(match) <= 2 || match[2] == "" {
+				return fmt.Errorf("<IF> missing condition tag")
+			}
+			condTag := strings.ToUpper(match[2])
+			if !e.isKnownTag(condTag) {
+				return fmt.Errorf("unknown tag: %s", condTag)
 			}
 			continue
 		}
 		if tagName == "ELSE" {
+			if len(match) > 2 && match[2] != "" {
+				return fmt.Errorf("<ELSE> takes no modifier")
+			}
 			continue
 		}
 		if !e.isKnownTag(tagName) {

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -406,6 +406,9 @@ func (e *Engine) ValidateTags(template string) error {
 			}
 			continue
 		}
+		if tagName == "ELSE" {
+			continue
+		}
 		if !e.isKnownTag(tagName) {
 			return fmt.Errorf("unknown tag: %s", tagName)
 		}

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -246,9 +246,6 @@ func (e *Engine) ExecuteWithContext(execCtx context.Context, template string, ct
 		return "", err
 	}
 
-	ctx.execCtx = execCtx
-	defer func() { ctx.execCtx = nil }()
-
 	result := template
 
 	// Step 1: Process conditional blocks first
@@ -462,6 +459,9 @@ func (e *Engine) validateConditionalNesting(template string) error {
 				return fmt.Errorf("unexpected </IF>")
 			}
 		}
+	}
+	if depth != 0 {
+		return fmt.Errorf("unclosed <IF> block")
 	}
 	return nil
 }

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -13,9 +13,10 @@ import (
 
 // Package-level compiled regexes for performance
 var (
-	cjkRegex                  = regexp.MustCompile(`[\p{Han}\p{Hiragana}\p{Katakana}\p{Hangul}]`)
-	conditionalTokenRegex     = regexp.MustCompile(`(?i)<IF:[A-Z_]+>|</IF>`)
-	conditionalStructureRegex = regexp.MustCompile(`(?i)<IF:[A-Z_]+>|</IF>|<ELSE>`)
+	cjkRegex                   = regexp.MustCompile(`[\p{Han}\p{Hiragana}\p{Katakana}\p{Hangul}]`)
+	conditionalTokenRegex      = regexp.MustCompile(`(?i)<IF:[A-Z_]+>|</IF>`)
+	conditionalStructureRegex  = regexp.MustCompile(`(?i)<IF:[A-Z_]+>|</IF>|<ELSE>`)
+	degenerateConditionalRegex = regexp.MustCompile(`(?i)<IF:>|<ELSE:>|</ELSE>|</ENDIF>|<ENDIF>`)
 )
 
 // DefaultMaxTemplateBytes, DefaultMaxOutputBytes, and DefaultMaxConditionalDepth are the default size and depth limits for template rendering.
@@ -398,6 +399,9 @@ func (e *Engine) ValidateTags(template string) error {
 	if err := e.validateConditionalNesting(template); err != nil {
 		return err
 	}
+	if degenerateConditionalRegex.MatchString(template) {
+		return fmt.Errorf("malformed conditional token")
+	}
 	matches := e.tagPattern.FindAllStringSubmatch(template, -1)
 	for _, match := range matches {
 		tagName := strings.ToUpper(match[1])
@@ -423,7 +427,7 @@ func (e *Engine) ValidateTags(template string) error {
 		if len(match) > 2 && match[2] != "" {
 			switch tagName {
 			case "PART", "DISC", "INDEX":
-				if !e.translationResolver.isNumericModifier(match[2]) {
+				if !strictDigitModifier(match[2]) {
 					return fmt.Errorf("invalid numeric modifier for %s: %s", tagName, match[2])
 				}
 			}
@@ -468,6 +472,21 @@ func (e *Engine) validateConditionalNesting(template string) error {
 		return fmt.Errorf("unclosed <IF> block")
 	}
 	return nil
+}
+
+// strictDigitModifier reports whether modifier is a non-empty string of ASCII
+// digits (no sign, no spaces), so <PART:+2> is rejected instead of rendering
+// "+1" via fmt's plus-flag reinterpretation.
+func strictDigitModifier(modifier string) bool {
+	if modifier == "" {
+		return false
+	}
+	for i := 0; i < len(modifier); i++ {
+		if modifier[i] < '0' || modifier[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // isKnownTag reports whether tagName resolves through resolveTag without an

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -405,6 +405,9 @@ func (e *Engine) ValidateTags(template string) error {
 	matches := e.tagPattern.FindAllStringSubmatch(template, -1)
 	for _, match := range matches {
 		tagName := strings.ToUpper(match[1])
+		if match[2] != "" && strings.Contains(match[2], "<") {
+			return fmt.Errorf("invalid '<' in tag modifier: %s", match[2])
+		}
 		if tagName == "IF" {
 			if match[2] == "" {
 				return fmt.Errorf("<IF> missing condition tag")

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -394,6 +394,9 @@ func (e *Engine) Validate(template string) error {
 // callers detect typos like <TITEL> that ExecuteWithContext would silently
 // render as empty instead of failing.
 func (e *Engine) ValidateTags(template string) error {
+	if err := e.validateConditionalNesting(template); err != nil {
+		return err
+	}
 	matches := e.tagPattern.FindAllStringSubmatch(template, -1)
 	for _, match := range matches {
 		tagName := strings.ToUpper(match[1])
@@ -412,6 +415,26 @@ func (e *Engine) ValidateTags(template string) error {
 		if !e.isKnownTag(tagName) {
 			return fmt.Errorf("unknown tag: %s", tagName)
 		}
+	}
+	return nil
+}
+
+// validateConditionalNesting rejects nested <IF> blocks because the regex-based
+// conditional processor is single-pass and mis-renders them (e.g.
+// <IF:TITLE><IF:ID>deep</IF></IF> renders as "deep</IF>"). The shared Validate
+// allows nesting up to MaxConditionalDepth, but configured taglines/tags flow
+// through renderConfiguredText which must not write corrupted values.
+func (e *Engine) validateConditionalNesting(template string) error {
+	depth := 0
+	for _, token := range conditionalTokenRegex.FindAllString(template, -1) {
+		if strings.HasPrefix(strings.ToUpper(token), "<IF:") {
+			depth++
+			if depth > 1 {
+				return fmt.Errorf("nested conditionals are not supported")
+			}
+			continue
+		}
+		depth--
 	}
 	return nil
 }

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -16,7 +16,7 @@ var (
 	cjkRegex                   = regexp.MustCompile(`[\p{Han}\p{Hiragana}\p{Katakana}\p{Hangul}]`)
 	conditionalTokenRegex      = regexp.MustCompile(`(?i)<IF:[A-Z_]+>|</IF>`)
 	conditionalStructureRegex  = regexp.MustCompile(`(?i)<IF:[A-Z_]+>|</IF>|<ELSE>`)
-	degenerateConditionalRegex = regexp.MustCompile(`(?i)<IF:>|<ELSE:>|</ELSE>|</ENDIF>|<ENDIF>`)
+	degenerateConditionalRegex = regexp.MustCompile(`(?i)<IF:>|<ELSE[:\s][^>]*>|</IF[:\s][^>]*>|</ELSE>|</ENDIF>|<ENDIF>`)
 )
 
 // DefaultMaxTemplateBytes, DefaultMaxOutputBytes, and DefaultMaxConditionalDepth are the default size and depth limits for template rendering.
@@ -406,7 +406,7 @@ func (e *Engine) ValidateTags(template string) error {
 	for _, match := range matches {
 		tagName := strings.ToUpper(match[1])
 		if tagName == "IF" {
-			if len(match) <= 2 || match[2] == "" {
+			if match[2] == "" {
 				return fmt.Errorf("<IF> missing condition tag")
 			}
 			condTag := strings.ToUpper(match[2])
@@ -416,9 +416,6 @@ func (e *Engine) ValidateTags(template string) error {
 			continue
 		}
 		if tagName == "ELSE" {
-			if len(match) > 2 && match[2] != "" {
-				return fmt.Errorf("<ELSE> takes no modifier")
-			}
 			continue
 		}
 		if !e.isKnownTag(tagName) {
@@ -486,7 +483,8 @@ func strictDigitModifier(modifier string) bool {
 			return false
 		}
 	}
-	return true
+	n, err := strconv.Atoi(modifier)
+	return err == nil && n >= 1 && n <= 9
 }
 
 // isKnownTag reports whether tagName resolves through resolveTag without an

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -13,8 +13,9 @@ import (
 
 // Package-level compiled regexes for performance
 var (
-	cjkRegex              = regexp.MustCompile(`[\p{Han}\p{Hiragana}\p{Katakana}\p{Hangul}]`)
-	conditionalTokenRegex = regexp.MustCompile(`(?i)<IF:[A-Z_]+>|</IF>`)
+	cjkRegex                  = regexp.MustCompile(`[\p{Han}\p{Hiragana}\p{Katakana}\p{Hangul}]`)
+	conditionalTokenRegex     = regexp.MustCompile(`(?i)<IF:[A-Z_]+>|</IF>`)
+	conditionalStructureRegex = regexp.MustCompile(`(?i)<IF:[A-Z_]+>|</IF>|<ELSE>`)
 )
 
 // DefaultMaxTemplateBytes, DefaultMaxOutputBytes, and DefaultMaxConditionalDepth are the default size and depth limits for template rendering.
@@ -415,6 +416,14 @@ func (e *Engine) ValidateTags(template string) error {
 		if !e.isKnownTag(tagName) {
 			return fmt.Errorf("unknown tag: %s", tagName)
 		}
+		if len(match) > 2 && match[2] != "" {
+			switch tagName {
+			case "PART", "DISC", "INDEX":
+				if !e.translationResolver.isNumericModifier(match[2]) {
+					return fmt.Errorf("invalid numeric modifier for %s: %s", tagName, match[2])
+				}
+			}
+		}
 	}
 	return nil
 }
@@ -426,15 +435,24 @@ func (e *Engine) ValidateTags(template string) error {
 // through renderConfiguredText which must not write corrupted values.
 func (e *Engine) validateConditionalNesting(template string) error {
 	depth := 0
-	for _, token := range conditionalTokenRegex.FindAllString(template, -1) {
-		if strings.HasPrefix(strings.ToUpper(token), "<IF:") {
+	for _, token := range conditionalStructureRegex.FindAllString(template, -1) {
+		upper := strings.ToUpper(token)
+		switch {
+		case strings.HasPrefix(upper, "<IF:"):
 			depth++
 			if depth > 1 {
 				return fmt.Errorf("nested conditionals are not supported")
 			}
-			continue
+		case upper == "<ELSE>":
+			if depth < 1 {
+				return fmt.Errorf("<ELSE> outside of <IF> block")
+			}
+		default:
+			depth--
+			if depth < 0 {
+				return fmt.Errorf("unexpected </IF>")
+			}
 		}
-		depth--
 	}
 	return nil
 }

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -82,6 +82,7 @@ type EngineInterface interface {
 	TruncateTitle(title string, maxLen int) string
 	TruncateTitleBytes(title string, maxBytes int) string
 	ValidatePathLength(path string, maxLen int) error
+	ValidateTags(template string) error
 }
 
 var _ EngineInterface = (*Engine)(nil)
@@ -384,6 +385,38 @@ func (e *Engine) Validate(template string) error {
 	}
 
 	return nil
+}
+
+// ValidateTags reports whether every tag token in the template resolves to a
+// known tag. It does not execute the template; it only checks that tag names
+// are registered or are built-in actress/conditional keywords. Returns an
+// error naming the first unknown tag, or nil if all tags are known. This lets
+// callers detect typos like <TITEL> that ExecuteWithContext would silently
+// render as empty instead of failing.
+func (e *Engine) ValidateTags(template string) error {
+	matches := e.tagPattern.FindAllStringSubmatch(template, -1)
+	for _, match := range matches {
+		tagName := strings.ToUpper(match[1])
+		if tagName == "IF" {
+			continue
+		}
+		if !e.isKnownTag(tagName) {
+			return fmt.Errorf("unknown tag: %s", tagName)
+		}
+	}
+	return nil
+}
+
+// isKnownTag reports whether tagName resolves through resolveTag without an
+// "unknown tag" error. It covers the actress-family tags handled in the
+// resolveTag switch and every entry in the tag registry.
+func (e *Engine) isKnownTag(tagName string) bool {
+	switch tagName {
+	case "ACTORS", "ACTRESSES", "ACTRESS", "ACTORNAME", "ACTRESSNAME":
+		return true
+	}
+	_, ok := e.tagRegistry[tagName]
+	return ok
 }
 
 var errOutputLimit = fmt.Errorf("output exceeds maximum")

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -17,6 +17,7 @@ var (
 	conditionalTokenRegex      = regexp.MustCompile(`(?i)<IF:[A-Z_]+>|</IF>`)
 	conditionalStructureRegex  = regexp.MustCompile(`(?i)<IF:[A-Z_]+>|</IF>|<ELSE>`)
 	degenerateConditionalRegex = regexp.MustCompile(`(?i)<IF:>|<ELSE[:\s][^>]*>|</IF[:\s][^>]*>|</ELSE>|</ENDIF>|<ENDIF>`)
+	malformedTagRegex          = regexp.MustCompile(`(?i)<[A-Z_]+[0-9][^>]*>`)
 )
 
 // DefaultMaxTemplateBytes, DefaultMaxOutputBytes, and DefaultMaxConditionalDepth are the default size and depth limits for template rendering.
@@ -401,6 +402,9 @@ func (e *Engine) ValidateTags(template string) error {
 	}
 	if degenerateConditionalRegex.MatchString(template) {
 		return fmt.Errorf("malformed conditional token")
+	}
+	if malformedTagRegex.MatchString(template) {
+		return fmt.Errorf("malformed template tag")
 	}
 	matches := e.tagPattern.FindAllStringSubmatch(template, -1)
 	for _, match := range matches {

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2804,3 +2804,16 @@ func TestEngine_ValidateTags_UnclosedIfRejected(t *testing.T) {
 	assert.Error(t, e.ValidateTags("<IF:ID>oops"))
 	assert.Error(t, e.ValidateTags("<IF:ID>yes<ELSE>no"))
 }
+
+func TestEngine_ValidateTags_BareIfRejected(t *testing.T) {
+	e := NewEngine()
+	assert.Error(t, e.ValidateTags("x <IF> y"))
+	assert.Error(t, e.ValidateTags("<IF>oops"))
+	assert.NoError(t, e.ValidateTags("<IF:ID>ok</IF>"))
+}
+
+func TestEngine_ValidateTags_ElseModifierRejected(t *testing.T) {
+	e := NewEngine()
+	assert.Error(t, e.ValidateTags("<IF:SERIES>a<ELSE:b>c</IF>"))
+	assert.NoError(t, e.ValidateTags("<IF:SERIES>a<ELSE>b</IF>"))
+}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -2842,4 +2843,50 @@ func TestStrictDigitModifier(t *testing.T) {
 	assert.False(t, strictDigitModifier("+2"))
 	assert.False(t, strictDigitModifier("-2"))
 	assert.False(t, strictDigitModifier("2a"))
+}
+
+func TestEngine_ValidateTags_TaintedStructuralKeywordsRejected(t *testing.T) {
+	e := NewEngine()
+	assert.Error(t, e.ValidateTags("<IF:ID>a<ELSE >b</IF>"))
+	assert.Error(t, e.ValidateTags("<IF:ID>a</IF:x>"))
+	assert.Error(t, e.ValidateTags("<ENDIF>"))
+	assert.NoError(t, e.ValidateTags("<IF:ID>a<ELSE>b</IF>"))
+	assert.NoError(t, e.ValidateTags("<IF:ID>x</IF>"))
+}
+
+func TestEngine_ValidateTags_BoundedNumericModifier(t *testing.T) {
+	e := NewEngine()
+	assert.NoError(t, e.ValidateTags("<PART:9>"))
+	assert.Error(t, e.ValidateTags("<PART:10>"))
+	assert.Error(t, e.ValidateTags("<PART:99999999>"))
+}
+
+func TestContext_SetExecCtx_HonoredByMediaInfo(t *testing.T) {
+	ctx := NewContextFromMovie(&models.Movie{ID: "X"})
+	ctx.VideoFilePath = "/nonexistent/video.mp4"
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	ctx.SetExecCtx(canceled)
+	info := ctx.getMediaInfo()
+	assert.Nil(t, info)
+}
+
+func TestContext_SetExecCtx_ConcurrentRenderingRaceFree(t *testing.T) {
+	ctx := NewContextFromMovie(&models.Movie{ID: "X"})
+	ctx.VideoFilePath = ""
+	ctx.SetExecCtx(context.Background())
+	e := NewEngine()
+	done := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func() { _, _ = e.Execute("<ID>", ctx); done <- struct{}{} }()
+	}
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}
+
+func TestEngine_ValidateTags_NonNumericModifierAccepted(t *testing.T) {
+	e := NewEngine()
+	assert.NoError(t, e.ValidateTags("<TITLE:50>"))
+	assert.NoError(t, e.ValidateTags("<ID>"))
 }

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2792,3 +2792,9 @@ func TestEngine_ValidateTags_NumericModifierValidated(t *testing.T) {
 	assert.Error(t, e.ValidateTags("<PART:xyz>"))
 	assert.Error(t, e.ValidateTags("<DISC:abc>"))
 }
+
+func TestEngine_ValidateTags_MultipleElseRejected(t *testing.T) {
+	e := NewEngine()
+	assert.NoError(t, e.ValidateTags("<IF:TITLE>yes<ELSE>no</IF>"))
+	assert.Error(t, e.ValidateTags("<IF:SERIES>a<ELSE>b<ELSE>c</IF>"))
+}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2753,3 +2753,9 @@ func TestEngine_ValidateTags_ConditionalKeywordSkipped(t *testing.T) {
 	e := NewEngine()
 	assert.NoError(t, e.ValidateTags("<IF:ID>keep</IF>"))
 }
+
+func TestEngine_ValidateTags_MisspelledConditional(t *testing.T) {
+	e := NewEngine()
+	assert.NoError(t, e.ValidateTags("<IF:YEAR><YEAR></IF>"))
+	assert.Error(t, e.ValidateTags("<IF:TITEL>Featured<ELSE>Other</IF>"))
+}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2798,3 +2798,9 @@ func TestEngine_ValidateTags_MultipleElseRejected(t *testing.T) {
 	assert.NoError(t, e.ValidateTags("<IF:TITLE>yes<ELSE>no</IF>"))
 	assert.Error(t, e.ValidateTags("<IF:SERIES>a<ELSE>b<ELSE>c</IF>"))
 }
+
+func TestEngine_ValidateTags_UnclosedIfRejected(t *testing.T) {
+	e := NewEngine()
+	assert.Error(t, e.ValidateTags("<IF:ID>oops"))
+	assert.Error(t, e.ValidateTags("<IF:ID>yes<ELSE>no"))
+}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2771,3 +2771,24 @@ func TestEngine_ValidateTags_NestedConditionalRejected(t *testing.T) {
 	assert.NoError(t, e.ValidateTags("<IF:TITLE>yes</IF><IF:ID>also</IF>"))
 	assert.Error(t, e.ValidateTags("<IF:TITLE><IF:ID>deep</IF></IF>"))
 }
+
+func TestEngine_ValidateTags_StrayElseRejected(t *testing.T) {
+	e := NewEngine()
+	assert.Error(t, e.ValidateTags("Featured<ELSE>Other"))
+	assert.Error(t, e.ValidateTags("<ELSE>oops"))
+	assert.NoError(t, e.ValidateTags("<IF:TITLE>yes<ELSE>no</IF>"))
+}
+
+func TestEngine_ValidateTags_StrayEndIfRejected(t *testing.T) {
+	e := NewEngine()
+	assert.Error(t, e.ValidateTags("text</IF>"))
+}
+
+func TestEngine_ValidateTags_NumericModifierValidated(t *testing.T) {
+	e := NewEngine()
+	assert.NoError(t, e.ValidateTags("<PART:2>"))
+	assert.NoError(t, e.ValidateTags("<DISC:3>"))
+	assert.NoError(t, e.ValidateTags("<INDEX:1>"))
+	assert.Error(t, e.ValidateTags("<PART:xyz>"))
+	assert.Error(t, e.ValidateTags("<DISC:abc>"))
+}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2764,3 +2764,10 @@ func TestEngine_ValidateTags_ElseKeywordExempted(t *testing.T) {
 	e := NewEngine()
 	assert.NoError(t, e.ValidateTags("<IF:SERIES><SERIES><ELSE>Standalone</IF>"))
 }
+
+func TestEngine_ValidateTags_NestedConditionalRejected(t *testing.T) {
+	e := NewEngine()
+	assert.NoError(t, e.ValidateTags("<IF:TITLE>yes</IF>"))
+	assert.NoError(t, e.ValidateTags("<IF:TITLE>yes</IF><IF:ID>also</IF>"))
+	assert.Error(t, e.ValidateTags("<IF:TITLE><IF:ID>deep</IF></IF>"))
+}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2890,3 +2890,11 @@ func TestEngine_ValidateTags_NonNumericModifierAccepted(t *testing.T) {
 	assert.NoError(t, e.ValidateTags("<TITLE:50>"))
 	assert.NoError(t, e.ValidateTags("<ID>"))
 }
+
+func TestEngine_ValidateTags_ModifierWithAngleBracketRejected(t *testing.T) {
+	e := NewEngine()
+	assert.Error(t, e.ValidateTags("<TITLE:</IF>"))
+	assert.Error(t, e.ValidateTags("<IF:TITLE><ACTORS:DELIM=<ELSE>></IF>"))
+	assert.NoError(t, e.ValidateTags("<TITLE:50>"))
+	assert.NoError(t, e.ValidateTags("<ACTORS:DELIM=/>"))
+}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2908,3 +2908,12 @@ func TestContext_SetCachedMediaInfo_SkipsLazyAnalysis(t *testing.T) {
 	assert.Equal(t, 1920, info.Width)
 	assert.Nil(t, ctx.mediaInfoError)
 }
+
+func TestEngine_ValidateTags_MalformedTagWithDigitRejected(t *testing.T) {
+	e := NewEngine()
+	assert.Error(t, e.ValidateTags("Featured: <TITLE2>"))
+	assert.Error(t, e.ValidateTags("<ID2>"))
+	assert.NoError(t, e.ValidateTags("A <3 B"))
+	assert.NoError(t, e.ValidateTags("<ID>"))
+	assert.NoError(t, e.ValidateTags("<PART:2>"))
+}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2898,3 +2898,13 @@ func TestEngine_ValidateTags_ModifierWithAngleBracketRejected(t *testing.T) {
 	assert.NoError(t, e.ValidateTags("<TITLE:50>"))
 	assert.NoError(t, e.ValidateTags("<ACTORS:DELIM=/>"))
 }
+
+func TestContext_SetCachedMediaInfo_SkipsLazyAnalysis(t *testing.T) {
+	ctx := NewContextFromMovie(&models.Movie{ID: "X"})
+	ctx.VideoFilePath = "/nonexistent/video.mp4"
+	ctx.SetCachedMediaInfo(&mediainfo.VideoInfo{Width: 1920, Height: 1080})
+	info := ctx.getMediaInfo()
+	require.NotNil(t, info)
+	assert.Equal(t, 1920, info.Width)
+	assert.Nil(t, ctx.mediaInfoError)
+}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2817,3 +2817,29 @@ func TestEngine_ValidateTags_ElseModifierRejected(t *testing.T) {
 	assert.Error(t, e.ValidateTags("<IF:SERIES>a<ELSE:b>c</IF>"))
 	assert.NoError(t, e.ValidateTags("<IF:SERIES>a<ELSE>b</IF>"))
 }
+
+func TestEngine_ValidateTags_DegenerateConditionalsRejected(t *testing.T) {
+	e := NewEngine()
+	assert.Error(t, e.ValidateTags("<IF:>oops"))
+	assert.Error(t, e.ValidateTags("<IF:SERIES>a<ELSE:>b</IF>"))
+	assert.Error(t, e.ValidateTags("</ELSE>"))
+	assert.Error(t, e.ValidateTags("</ENDIF>"))
+	assert.NoError(t, e.ValidateTags("A <3 B"))
+}
+
+func TestEngine_ValidateTags_SignedNumericModifierRejected(t *testing.T) {
+	e := NewEngine()
+	assert.NoError(t, e.ValidateTags("<PART:2>"))
+	assert.Error(t, e.ValidateTags("<PART:+2>"))
+	assert.Error(t, e.ValidateTags("<PART:-2>"))
+	assert.Error(t, e.ValidateTags("<DISC:+1>"))
+}
+
+func TestStrictDigitModifier(t *testing.T) {
+	assert.False(t, strictDigitModifier(""))
+	assert.True(t, strictDigitModifier("2"))
+	assert.True(t, strictDigitModifier("02"))
+	assert.False(t, strictDigitModifier("+2"))
+	assert.False(t, strictDigitModifier("-2"))
+	assert.False(t, strictDigitModifier("2a"))
+}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2738,3 +2738,18 @@ func BenchmarkTemplateRender_Parallel(b *testing.B) {
 		}
 	})
 }
+
+func TestEngine_ValidateTags(t *testing.T) {
+	e := NewEngine()
+	assert.NoError(t, e.ValidateTags("<ID> - <TITLE>"))
+	assert.NoError(t, e.ValidateTags("<ACTRESSES> / <RESOLUTION>"))
+	assert.NoError(t, e.ValidateTags("static text without tags"))
+	assert.NoError(t, e.ValidateTags("<IF:YEAR><YEAR></IF>"))
+	assert.Error(t, e.ValidateTags("<TITEL>"))
+	assert.Error(t, e.ValidateTags("Featured: <TITEL>"))
+}
+
+func TestEngine_ValidateTags_ConditionalKeywordSkipped(t *testing.T) {
+	e := NewEngine()
+	assert.NoError(t, e.ValidateTags("<IF:ID>keep</IF>"))
+}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -2759,3 +2759,8 @@ func TestEngine_ValidateTags_MisspelledConditional(t *testing.T) {
 	assert.NoError(t, e.ValidateTags("<IF:YEAR><YEAR></IF>"))
 	assert.Error(t, e.ValidateTags("<IF:TITEL>Featured<ELSE>Other</IF>"))
 }
+
+func TestEngine_ValidateTags_ElseKeywordExempted(t *testing.T) {
+	e := NewEngine()
+	assert.NoError(t, e.ValidateTags("<IF:SERIES><SERIES><ELSE>Standalone</IF>"))
+}

--- a/internal/workflow/apply_orchestrator.go
+++ b/internal/workflow/apply_orchestrator.go
@@ -429,6 +429,7 @@ func (o *applyOrchImpl) stepNFO(ctx context.Context, cmd ApplyCmd, state *applyP
 	nameCfg := o.applyCfg.NFONameCfg
 	nameCfg.IsMultiPart = cmd.Match.IsMultiPart
 	nameCfg.PartSuffix = partSuffix
+	nameCfg.PartNumber = cmd.Match.PartNumber
 
 	// Use the post-organize video path when the file was moved, so that
 	// stream details (runtime/codec/resolution) can still be extracted.

--- a/internal/workflow/apply_orchestrator_coverage_test.go
+++ b/internal/workflow/apply_orchestrator_coverage_test.go
@@ -45,6 +45,7 @@ type stubNFOGen struct {
 	resolvedPath  string
 	err           error
 	lastVideoPath string
+	lastNameCfg   nfo.NFONameConfig
 }
 
 func (s *stubNFOGen) Generate(_ context.Context, _ *models.Movie, _, _, _ string, _ []string) error {
@@ -55,8 +56,9 @@ func (s *stubNFOGen) GenerateAtPath(_ context.Context, _ *models.Movie, _, _ str
 	return s.err
 }
 
-func (s *stubNFOGen) ResolveAndGenerate(_ context.Context, _ *models.Movie, _ string, _ nfo.NFONameConfig, videoPath string, _ []string) (string, error) {
+func (s *stubNFOGen) ResolveAndGenerate(_ context.Context, _ *models.Movie, _ string, nameCfg nfo.NFONameConfig, videoPath string, _ []string) (string, error) {
 	s.lastVideoPath = videoPath
+	s.lastNameCfg = nameCfg
 	return s.resolvedPath, s.err
 }
 
@@ -1117,4 +1119,31 @@ func TestApplyOrchImpl_Execute_PartialFailureReportsCompletedSteps(t *testing.T)
 	assert.True(t, result.Steps.DisplayTitle, "DisplayTitle should reflect the completed step")
 	assert.True(t, result.Steps.Downloaded, "Downloaded should be true — download succeeded before NFO failed")
 	assert.False(t, result.Steps.NFOGenerated, "NFOGenerated should be false — NFO generation failed")
+}
+
+func TestApplyOrchImpl_Execute_NFOGenerationThreadsMultipart(t *testing.T) {
+	nfoGen := &stubNFOGen{resolvedPath: "/dest/ABC-001.nfo"}
+	impl := &applyOrchImpl{
+		fs:     afero.NewMemMapFs(),
+		nfoGen: nfoGen,
+		nfo:    &applyStubNFO{},
+	}
+	match := models.FileMatchInfo{
+		Path:        "/src/ABC-001-cd1.mp4",
+		MovieID:     "ABC-001",
+		IsMultiPart: true,
+		PartNumber:  1,
+		PartSuffix:  "-cd1",
+	}
+	_, err := impl.Execute(context.Background(), ApplyCmd{
+		Movie:       &models.Movie{ID: "ABC-001", Title: "Test"},
+		Match:       match,
+		DestPath:    "/dest",
+		Organize:    OrganizeOptions{Skip: true},
+		GenerateNFO: true,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, nfoGen.lastNameCfg.PartNumber)
+	assert.Equal(t, "-cd1", nfoGen.lastNameCfg.PartSuffix)
+	assert.True(t, nfoGen.lastNameCfg.IsMultiPart)
 }

--- a/internal/workflow/coverage_uncovered_test.go
+++ b/internal/workflow/coverage_uncovered_test.go
@@ -1296,8 +1296,9 @@ func TestRevertLogConfig_ToNFONameConfig_WithNFOCfg(t *testing.T) {
 	require.NoError(t, err)
 	nfoCfg := nfo.ConfigFromAppConfig(appCfg, nfo.NFONameConfigFromAppConfig(appCfg))
 	cfg := &RevertLogConfig{AllowRevert: true, NFOCfg: nfoCfg}
-	result := cfg.ToNFONameConfig(false, "", 0)
+	result := cfg.ToNFONameConfig(false, "", 2)
 	assert.False(t, result.IsMultiPart)
+	assert.Equal(t, 2, result.PartNumber)
 }
 
 // ============================================================

--- a/internal/workflow/coverage_uncovered_test.go
+++ b/internal/workflow/coverage_uncovered_test.go
@@ -98,7 +98,7 @@ func TestNewWorkflowFactory_ScanOnlyMode_MinimalDeps(t *testing.T) {
 				Trailer:     cfg.Output.Download.DownloadTrailer,
 			},
 		},
-		ApplyCfg:        ApplyConfig{NFONameCfg: nfoCfg.ToNFONameConfig(false, ""), DisplayTitle: cfg.Metadata.NFO.Format.DisplayTitle},
+		ApplyCfg:        ApplyConfig{NFONameCfg: nfoCfg.ToNFONameConfig(false, "", 0), DisplayTitle: cfg.Metadata.NFO.Format.DisplayTitle},
 		DownloadHTTPCfg: downloader.HTTPClientConfig{},
 		Fs:              fs,
 		TemplateEngine:  template.NewEngine(),
@@ -147,7 +147,7 @@ func TestNewWorkflowFactory_ScrapeOnlyMode_NilScraper(t *testing.T) {
 				Trailer:     cfg.Output.Download.DownloadTrailer,
 			},
 		},
-		ApplyCfg:        ApplyConfig{NFONameCfg: nfoCfg.ToNFONameConfig(false, ""), DisplayTitle: cfg.Metadata.NFO.Format.DisplayTitle},
+		ApplyCfg:        ApplyConfig{NFONameCfg: nfoCfg.ToNFONameConfig(false, "", 0), DisplayTitle: cfg.Metadata.NFO.Format.DisplayTitle},
 		DownloadHTTPCfg: downloader.HTTPClientConfig{},
 	}
 	// Per DEEP-8: NewWorkflowFactory succeeds even without a scraper (creates noOp).
@@ -1123,7 +1123,7 @@ func TestWorkflowFactoryConfig_NilScraper(t *testing.T) {
 				Trailer:     cfg.Output.Download.DownloadTrailer,
 			},
 		},
-		ApplyCfg:        ApplyConfig{NFONameCfg: nfoCfg.ToNFONameConfig(false, ""), DisplayTitle: cfg.Metadata.NFO.Format.DisplayTitle},
+		ApplyCfg:        ApplyConfig{NFONameCfg: nfoCfg.ToNFONameConfig(false, "", 0), DisplayTitle: cfg.Metadata.NFO.Format.DisplayTitle},
 		DownloadHTTPCfg: downloader.HTTPClientConfig{},
 		Matcher:         fileMatcher,
 		Repositories: database.Repositories{
@@ -1284,7 +1284,7 @@ func TestApplyDisplayTitleFromSource_NilMovie(t *testing.T) {
 
 func TestRevertLogConfig_ToNFONameConfig_NilNFOCfg(t *testing.T) {
 	cfg := &RevertLogConfig{AllowRevert: true, NFOCfg: nil}
-	result := cfg.ToNFONameConfig(true, "-pt1")
+	result := cfg.ToNFONameConfig(true, "-pt1", 0)
 	assert.True(t, result.IsMultiPart)
 	assert.Equal(t, "-pt1", result.PartSuffix)
 }
@@ -1295,7 +1295,7 @@ func TestRevertLogConfig_ToNFONameConfig_WithNFOCfg(t *testing.T) {
 	require.NoError(t, err)
 	nfoCfg := nfo.ConfigFromAppConfig(appCfg, nfo.NFONameConfigFromAppConfig(appCfg))
 	cfg := &RevertLogConfig{AllowRevert: true, NFOCfg: nfoCfg}
-	result := cfg.ToNFONameConfig(false, "")
+	result := cfg.ToNFONameConfig(false, "", 0)
 	assert.False(t, result.IsMultiPart)
 }
 

--- a/internal/workflow/coverage_uncovered_test.go
+++ b/internal/workflow/coverage_uncovered_test.go
@@ -1284,9 +1284,10 @@ func TestApplyDisplayTitleFromSource_NilMovie(t *testing.T) {
 
 func TestRevertLogConfig_ToNFONameConfig_NilNFOCfg(t *testing.T) {
 	cfg := &RevertLogConfig{AllowRevert: true, NFOCfg: nil}
-	result := cfg.ToNFONameConfig(true, "-pt1", 0)
+	result := cfg.ToNFONameConfig(true, "-pt1", 2)
 	assert.True(t, result.IsMultiPart)
 	assert.Equal(t, "-pt1", result.PartSuffix)
+	assert.Equal(t, 2, result.PartNumber)
 }
 
 func TestRevertLogConfig_ToNFONameConfig_WithNFOCfg(t *testing.T) {

--- a/internal/workflow/revert_log.go
+++ b/internal/workflow/revert_log.go
@@ -93,9 +93,9 @@ func NewRevertLogConfig(allowRevert bool, nfoCfg *nfo.Config) *RevertLogConfig {
 
 // ToNFONameConfig converts RevertLogConfig to nfo.NFONameConfig, filling in
 // the caller-provided multipart fields.
-func (c *RevertLogConfig) ToNFONameConfig(isMultiPart bool, partSuffix string) nfo.NFONameConfig {
+func (c *RevertLogConfig) ToNFONameConfig(isMultiPart bool, partSuffix string, partNumber int) nfo.NFONameConfig {
 	if c.NFOCfg != nil {
-		return c.NFOCfg.ToNFONameConfig(isMultiPart, partSuffix)
+		return c.NFOCfg.ToNFONameConfig(isMultiPart, partSuffix, partNumber)
 	}
 	return nfo.NFONameConfig{
 		IsMultiPart: isMultiPart,
@@ -302,11 +302,12 @@ func (l *dbRevertLog) CaptureSnapshot(ctx context.Context, opID OperationID, cmd
 
 	var nameCfg nfo.NFONameConfig
 	if l.cfg != nil {
-		nameCfg = l.cfg.ToNFONameConfig(isMultiPart, partSuffix)
+		nameCfg = l.cfg.ToNFONameConfig(isMultiPart, partSuffix, cmd.Match.PartNumber)
 	} else {
 		nameCfg = nfo.NFONameConfig{
 			IsMultiPart: isMultiPart,
 			PartSuffix:  partSuffix,
+			PartNumber:  cmd.Match.PartNumber,
 		}
 	}
 

--- a/internal/workflow/revert_log.go
+++ b/internal/workflow/revert_log.go
@@ -100,6 +100,7 @@ func (c *RevertLogConfig) ToNFONameConfig(isMultiPart bool, partSuffix string, p
 	return nfo.NFONameConfig{
 		IsMultiPart: isMultiPart,
 		PartSuffix:  partSuffix,
+		PartNumber:  partNumber,
 	}
 }
 

--- a/internal/workflow/revert_log_miss_test.go
+++ b/internal/workflow/revert_log_miss_test.go
@@ -438,7 +438,7 @@ func TestMiss_NewRevertLogConfig(t *testing.T) {
 // RevertLogConfig.ToNFONameConfig with nil NFOCfg
 func TestMiss_RevertLogConfig_ToNFONameConfig_NilNFOCfg(t *testing.T) {
 	cfg := &RevertLogConfig{AllowRevert: true, NFOCfg: nil}
-	result := cfg.ToNFONameConfig(true, "-pt1")
+	result := cfg.ToNFONameConfig(true, "-pt1", 0)
 	assert.True(t, result.IsMultiPart)
 	assert.Equal(t, "-pt1", result.PartSuffix)
 }
@@ -446,7 +446,7 @@ func TestMiss_RevertLogConfig_ToNFONameConfig_NilNFOCfg(t *testing.T) {
 // RevertLogConfig.ToNFONameConfig with NFOCfg
 func TestMiss_RevertLogConfig_ToNFONameConfig_WithNFOCfg(t *testing.T) {
 	cfg := &RevertLogConfig{AllowRevert: true, NFOCfg: &nfo.Config{FilenameTemplate: "<ID>"}}
-	result := cfg.ToNFONameConfig(false, "")
+	result := cfg.ToNFONameConfig(false, "", 0)
 	assert.False(t, result.IsMultiPart)
 }
 

--- a/internal/workflow/revert_log_miss_test.go
+++ b/internal/workflow/revert_log_miss_test.go
@@ -438,16 +438,18 @@ func TestMiss_NewRevertLogConfig(t *testing.T) {
 // RevertLogConfig.ToNFONameConfig with nil NFOCfg
 func TestMiss_RevertLogConfig_ToNFONameConfig_NilNFOCfg(t *testing.T) {
 	cfg := &RevertLogConfig{AllowRevert: true, NFOCfg: nil}
-	result := cfg.ToNFONameConfig(true, "-pt1", 0)
+	result := cfg.ToNFONameConfig(true, "-pt1", 2)
 	assert.True(t, result.IsMultiPart)
 	assert.Equal(t, "-pt1", result.PartSuffix)
+	assert.Equal(t, 2, result.PartNumber)
 }
 
 // RevertLogConfig.ToNFONameConfig with NFOCfg
 func TestMiss_RevertLogConfig_ToNFONameConfig_WithNFOCfg(t *testing.T) {
 	cfg := &RevertLogConfig{AllowRevert: true, NFOCfg: &nfo.Config{FilenameTemplate: "<ID>"}}
-	result := cfg.ToNFONameConfig(false, "", 0)
+	result := cfg.ToNFONameConfig(false, "", 2)
 	assert.False(t, result.IsMultiPart)
+	assert.Equal(t, 2, result.PartNumber)
 }
 
 // CaptureSnapshot: with NFO file found

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -142,7 +142,7 @@ func (f *testFixture) build() *Workflow {
 
 	return &Workflow{
 		scrape:    newScrapeOrchestrator(scraper, f.movieRepo, f.cfg.Metadata.NFO.Format.DisplayTitle, sharedEngine, nfo.NFONameConfig{}, nil),
-		apply:     newApplyOrchestrator(f.fs, f.org, f.dl, f.nfoGen, nfoIface, ApplyConfig{NFONameCfg: nfoCfg.ToNFONameConfig(false, ""), DisplayTitle: f.cfg.Metadata.NFO.Format.DisplayTitle}, sharedEngine, noOpRevertLog{}, database.NewMovieTagRepository(f.db), nil),
+		apply:     newApplyOrchestrator(f.fs, f.org, f.dl, f.nfoGen, nfoIface, ApplyConfig{NFONameCfg: nfoCfg.ToNFONameConfig(false, "", 0), DisplayTitle: f.cfg.Metadata.NFO.Format.DisplayTitle}, sharedEngine, noOpRevertLog{}, database.NewMovieTagRepository(f.db), nil),
 		compare:   newCompareOrchestrator(f.fs, nfoIface, scraper, nil),
 		preview:   noOpPreviewOrchestrator{},
 		scanMatch: noOpScanAndMatchOrchestrator{},


### PR DESCRIPTION
## Summary

The NFO `tagline` and custom `<tag>` fields were written verbatim instead of being expanded through the template engine — template tags like `<ID>` rendered literally rather than resolving to the actual value, despite the docs and Web UI advertising them as template-aware ("supports template tags").

Both fields are now expanded per movie through the shared template engine, with actress-rendering options (grouping, JA names, name order, custom delimiter) threaded so `<ACTRESSES>`/`<ACTORS>` match folder/file/display-title behavior. Static strings without `<` pass through byte-identical; unknown or malformed templates are dropped with a warning rather than failing NFO generation.

Closes #201
