### PR TITLE
feat(r18dev): resolve null-dvd_id titles via dump content-id candidates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,6 +92,9 @@ linters:
         text: "G703:"
       - linters:
           - gosec
+        source: 'IN \(" \+ placeholders'
+      - linters:
+          - gosec
         text: "G118:"
       - path: internal/config/translation_config\.go
         linters:
@@ -241,7 +244,7 @@ linters:
       - path: internal/scraper/r18dev/r18dev\.go
         linters:
           - unparam
-      - path: internal/scraper/r18dev/content_id_prefixes\.go
+      - path: internal/r18devdump/content_id_prefixes\.go
         linters:
           - misspell
       - path: internal/tui/update\.go

--- a/cmd/javinizer/commands/dump/command.go
+++ b/cmd/javinizer/commands/dump/command.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/javinizer/javinizer-go/internal/commandutil"
 	"github.com/javinizer/javinizer-go/internal/config"
@@ -211,21 +212,31 @@ func runSearch(w io.Writer, configFile, id string) error {
 	defer func() { _ = store.Close() }()
 
 	ctx := context.Background()
-	if cid, err := store.LookupByDVDID(ctx, id); err == nil {
-		fmt.Fprintf(w, "%s -> content_id: %s\n", id, cid)
+	matches, err := store.MatchByDisplayID(ctx, id)
+	if err != nil {
+		if !errors.Is(err, models.ErrDumpMiss) {
+			return fmt.Errorf("dump search: lookup failed for %s: %w", id, err)
+		}
+		logging.Debugf("dump search: %s not found", id)
+		fmt.Fprintf(w, "No match for %s in the local dump.\n", id)
 		return nil
-	} else if !errors.Is(err, models.ErrDumpMiss) {
-		return fmt.Errorf("dvd_id lookup failed for %s: %w", id, err)
 	}
-	if did, err := store.LookupByContentID(ctx, id); err == nil {
-		fmt.Fprintf(w, "%s -> dvd_id: %s\n", id, did)
+
+	first := matches[0]
+	switch {
+	case first.DVDID == "":
+		fmt.Fprintf(w, "%s: present in dump but has no dvd_id (dvd_id-keyed lookups cannot match it):\n", id)
+		for _, m := range matches {
+			fmt.Fprintf(w, "  %s  %s  %s\n", m.ContentID, m.ReleaseDate, m.ServiceCode)
+		}
 		return nil
-	} else if !errors.Is(err, models.ErrDumpMiss) {
-		return fmt.Errorf("content_id lookup failed for %s: %w", id, err)
+	case strings.EqualFold(strings.TrimSpace(id), first.ContentID):
+		fmt.Fprintf(w, "%s -> dvd_id: %s\n", id, first.DVDID)
+		return nil
+	default:
+		fmt.Fprintf(w, "%s -> content_id: %s\n", id, first.ContentID)
+		return nil
 	}
-	logging.Debugf("dump search: %s not found", id)
-	fmt.Fprintf(w, "No match for %s in the local dump.\n", id)
-	return nil
 }
 
 func fileSize(path string) (int64, error) {

--- a/cmd/javinizer/commands/dump/command_test.go
+++ b/cmd/javinizer/commands/dump/command_test.go
@@ -401,9 +401,9 @@ func TestRunSearch_ContentIDLookupError(t *testing.T) {
 		if err := runDownload(context.Background(), &buf, "config.yaml", false); err != nil {
 			t.Fatalf("runDownload: %v", err)
 		}
-		// Recreate videos with only content_id + dvd_id_norm (no dvd_id column).
-		// LookupByDVDID succeeds (misses on a non-existent ID → ErrDumpMiss),
-		// then LookupByContentID fails (dvd_id column missing → real error).
+		// Recreate videos with only content_id + dvd_id_norm (no dvd_id
+		// column): every lookup query fails with a real schema error (not
+		// ErrDumpMiss), which runSearch must propagate instead of masking.
 		dbPath := filepath.Join("data", "r18dev", "r18dev_dump.db")
 		c, err := sql.Open("sqlite3", dbPath)
 		if err != nil {
@@ -416,8 +416,8 @@ func TestRunSearch_ContentIDLookupError(t *testing.T) {
 		c.Close()
 		buf.Reset()
 		err = runSearch(&buf, "config.yaml", "NOPE-999")
-		if err == nil || !strings.Contains(err.Error(), "content_id lookup failed") {
-			t.Fatalf("expected content_id lookup error, got: %v", err)
+		if err == nil || !strings.Contains(err.Error(), "lookup failed") {
+			t.Fatalf("expected propagated lookup error, got: %v", err)
 		}
 	})
 }

--- a/cmd/javinizer/commands/dump/search_states_test.go
+++ b/cmd/javinizer/commands/dump/search_states_test.go
@@ -1,0 +1,97 @@
+package dump
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/r18devdump"
+)
+
+// TestRunSearch_PresentNoDVDID covers the third lookup state: rows present in
+// the dump but with NULL dvd_id must be reported as such, not as "No match".
+func TestRunSearch_PresentNoDVDID(t *testing.T) {
+	tmp := t.TempDir()
+	runInDir(t, tmp, func() {
+		dbPath := filepath.Join("data", "r18dev", "r18dev_dump.db")
+		dump := "COPY public.derived_video (content_id, dvd_id, release_date, service_code) FROM stdin;\n" +
+			"lulu00441\t\\N\t2026-07-03\tdigital\n" +
+			"lulu441\t\\N\t2026-07-07\tmono\n" +
+			"118ipx00535\tIPX-535\t2013-03-01\tdigital\n" +
+			"\\.\n"
+		if _, err := r18devdump.Import(context.Background(), strings.NewReader(dump), dbPath, r18devdump.ImportOptions{}); err != nil {
+			t.Fatalf("Import: %v", err)
+		}
+
+		for _, q := range []string{"LULU-441", "lulu00441"} {
+			var buf bytes.Buffer
+			if err := runSearch(&buf, "config.yaml", q); err != nil {
+				t.Fatalf("runSearch(%q): %v", q, err)
+			}
+			out := buf.String()
+			if strings.Contains(out, "No match") {
+				t.Errorf("runSearch(%q) must not print 'No match': %s", q, out)
+			}
+			if !strings.Contains(out, "has no dvd_id") {
+				t.Errorf("runSearch(%q) missing present-no-dvd_id explanation: %s", q, out)
+			}
+			if !strings.Contains(out, "lulu00441") || !strings.Contains(out, "lulu441") {
+				t.Errorf("runSearch(%q) should list both matched rows: %s", q, out)
+			}
+			if strings.Index(out, "lulu00441") > strings.Index(out, "lulu441") {
+				t.Errorf("runSearch(%q) candidate order wrong (digital first): %s", q, out)
+			}
+		}
+	})
+}
+
+// TestRunSearch_WhitespaceQueryKeepsDirection: padded input must still be
+// reported in the content_id -> dvd_id direction (Codex round-4 P1).
+func TestRunSearch_WhitespaceQueryKeepsDirection(t *testing.T) {
+	tmp := t.TempDir()
+	runInDir(t, tmp, func() {
+		dbPath := filepath.Join("data", "r18dev", "r18dev_dump.db")
+		dump := "COPY public.derived_video (content_id, dvd_id) FROM stdin;\n118ipx00535\tIPX-535\n\\.\n"
+		if _, err := r18devdump.Import(context.Background(), strings.NewReader(dump), dbPath, r18devdump.ImportOptions{}); err != nil {
+			t.Fatalf("Import: %v", err)
+		}
+		var buf bytes.Buffer
+		if err := runSearch(&buf, "config.yaml", " 118ipx00535 "); err != nil {
+			t.Fatalf("runSearch: %v", err)
+		}
+		if !strings.Contains(buf.String(), "dvd_id: IPX-535") {
+			t.Errorf("direction lost for padded query: %s", buf.String())
+		}
+	})
+}
+
+// TestRunSearch_MappedStillSingleLine keeps the legacy mapped output shape
+// for both lookup directions.
+func TestRunSearch_MappedStillSingleLine(t *testing.T) {
+	tmp := t.TempDir()
+	runInDir(t, tmp, func() {
+		dbPath := filepath.Join("data", "r18dev", "r18dev_dump.db")
+		dump := "COPY public.derived_video (content_id, dvd_id) FROM stdin;\n118ipx00535\tIPX-535\n\\.\n"
+		if _, err := r18devdump.Import(context.Background(), strings.NewReader(dump), dbPath, r18devdump.ImportOptions{}); err != nil {
+			t.Fatalf("Import: %v", err)
+		}
+
+		var buf bytes.Buffer
+		if err := runSearch(&buf, "config.yaml", "IPX-535"); err != nil {
+			t.Fatalf("runSearch: %v", err)
+		}
+		if !strings.Contains(buf.String(), "IPX-535 -> content_id: 118ipx00535") {
+			t.Errorf("dvd-style mapped output changed: %s", buf.String())
+		}
+
+		buf.Reset()
+		if err := runSearch(&buf, "config.yaml", "118ipx00535"); err != nil {
+			t.Fatalf("runSearch: %v", err)
+		}
+		if !strings.Contains(buf.String(), "118ipx00535 -> dvd_id: IPX-535") {
+			t.Errorf("content-style mapped output changed: %s", buf.String())
+		}
+	})
+}

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -8471,6 +8471,23 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_api_r18devdump.dumpMatchView": {
+            "type": "object",
+            "properties": {
+                "content_id": {
+                    "type": "string"
+                },
+                "dvd_id": {
+                    "type": "string"
+                },
+                "release_date": {
+                    "type": "string"
+                },
+                "service_code": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_api_r18devdump.dumpStatusResponse": {
             "type": "object",
             "properties": {
@@ -8515,7 +8532,16 @@ const docTemplate = `{
                 "dvd_id": {
                     "type": "string"
                 },
+                "matches": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api_r18devdump.dumpMatchView"
+                    }
+                },
                 "query": {
+                    "type": "string"
+                },
+                "state": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -8469,6 +8469,23 @@
                 }
             }
         },
+        "internal_api_r18devdump.dumpMatchView": {
+            "type": "object",
+            "properties": {
+                "content_id": {
+                    "type": "string"
+                },
+                "dvd_id": {
+                    "type": "string"
+                },
+                "release_date": {
+                    "type": "string"
+                },
+                "service_code": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_api_r18devdump.dumpStatusResponse": {
             "type": "object",
             "properties": {
@@ -8513,7 +8530,16 @@
                 "dvd_id": {
                     "type": "string"
                 },
+                "matches": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api_r18devdump.dumpMatchView"
+                    }
+                },
                 "query": {
+                    "type": "string"
+                },
+                "state": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -3083,6 +3083,17 @@ definitions:
       total:
         type: integer
     type: object
+  internal_api_r18devdump.dumpMatchView:
+    properties:
+      content_id:
+        type: string
+      dvd_id:
+        type: string
+      release_date:
+        type: string
+      service_code:
+        type: string
+    type: object
   internal_api_r18devdump.dumpStatusResponse:
     properties:
       enabled:
@@ -3112,7 +3123,13 @@ definitions:
         type: string
       dvd_id:
         type: string
+      matches:
+        items:
+          $ref: '#/definitions/internal_api_r18devdump.dumpMatchView'
+        type: array
       query:
+        type: string
+      state:
         type: string
     type: object
   internal_api_system.DeepLUsageRequest:

--- a/internal/api/r18devdump/handlers.go
+++ b/internal/api/r18devdump/handlers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -339,9 +340,21 @@ func (h *dumpHandler) reloadDumpWith(path string, lockHeld bool) error {
 
 // searchResponse is the JSON shape returned by GET /search.
 type searchResponse struct {
-	Query     string  `json:"query"`
-	ContentID *string `json:"content_id"`
-	DVDID     *string `json:"dvd_id"`
+	Query     string          `json:"query"`
+	ContentID *string         `json:"content_id"`
+	DVDID     *string         `json:"dvd_id"`
+	State     string          `json:"state"`
+	Matches   []dumpMatchView `json:"matches"`
+}
+
+// dumpMatchView is one dump row matched by a search query. Matches are
+// returned in candidate priority order; DVDID is empty when the upstream row
+// has no dvd_id.
+type dumpMatchView struct {
+	ContentID   string `json:"content_id"`
+	DVDID       string `json:"dvd_id,omitempty"`
+	ReleaseDate string `json:"release_date,omitempty"`
+	ServiceCode string `json:"service_code,omitempty"`
 }
 
 // search godoc
@@ -384,25 +397,34 @@ func (h *dumpHandler) search(c *gin.Context) {
 	defer func() { _ = store.Close() }()
 
 	ctx := c.Request.Context()
-	resp := searchResponse{Query: query}
-
-	if cid, err := store.LookupByDVDID(ctx, query); err == nil {
-		resp.ContentID = &cid
-		c.JSON(http.StatusOK, resp)
+	matches, err := store.MatchByDisplayID(ctx, query)
+	if err != nil {
+		if !errors.Is(err, models.ErrDumpMiss) {
+			logging.Warnf("r18dev dump search: lookup failed for %s: %v", query, err)
+		}
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found in dump"})
 		return
-	} else if !errors.Is(err, models.ErrDumpMiss) {
-		logging.Warnf("r18dev dump search: dvd_id lookup failed for %s: %v", query, err)
 	}
 
-	if did, err := store.LookupByContentID(ctx, query); err == nil {
-		resp.DVDID = &did
-		c.JSON(http.StatusOK, resp)
-		return
-	} else if !errors.Is(err, models.ErrDumpMiss) {
-		logging.Warnf("r18dev dump search: content_id lookup failed for %s: %v", query, err)
+	resp := searchResponse{Query: query, Matches: make([]dumpMatchView, 0, len(matches))}
+	first := matches[0]
+	resp.State = "mapped"
+	if first.DVDID == "" {
+		resp.State = "no_dvd_id"
+	} else if strings.EqualFold(strings.TrimSpace(query), first.ContentID) {
+		resp.DVDID = &first.DVDID
+	} else {
+		resp.ContentID = &first.ContentID
 	}
-
-	c.JSON(http.StatusNotFound, gin.H{"error": "not found in dump"})
+	for _, m := range matches {
+		resp.Matches = append(resp.Matches, dumpMatchView{
+			ContentID:   m.ContentID,
+			DVDID:       m.DVDID,
+			ReleaseDate: m.ReleaseDate,
+			ServiceCode: m.ServiceCode,
+		})
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 // clearDump godoc

--- a/internal/api/r18devdump/handlers_search_states_test.go
+++ b/internal/api/r18devdump/handlers_search_states_test.go
@@ -1,0 +1,106 @@
+package r18devdump
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedNullDVDRow adds a null-dvd_id row (content_id only) to a handler test dump.
+func seedNullDVDRow(t *testing.T, dumpPath, contentID, releaseDate, serviceCode string) {
+	t.Helper()
+	db, err := openRawDB(dumpPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	_, err = db.Exec(`INSERT INTO videos (content_id, dvd_id, dvd_id_norm, release_date, service_code) VALUES (?, NULL, '', ?, ?)`,
+		contentID, releaseDate, serviceCode)
+	require.NoError(t, err)
+}
+
+func searchJSON(t *testing.T, h *dumpHandler, query string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/r18dev/dump/search?q="+query, nil)
+	h.search(c)
+	var parsed map[string]any
+	if w.Code == http.StatusOK {
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &parsed))
+	}
+	return w, parsed
+}
+
+func TestSearch_PresentNoDVDID_Returns200WithState(t *testing.T) {
+	h, dumpPath := newTestHandler(t)
+	buildTestDump(t, dumpPath, "118ipx00535", "IPX-535")
+	seedNullDVDRow(t, dumpPath, "lulu00441", "2026-07-03", "digital")
+	seedNullDVDRow(t, dumpPath, "lulu441", "2026-07-07", "mono")
+
+	w, resp := searchJSON(t, h, "LULU-441")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, "no_dvd_id", resp["state"])
+	require.Nil(t, resp["content_id"], "no mapping for null-dvd_id rows")
+	matches, ok := resp["matches"].([]any)
+	require.True(t, ok, "matches must be an array")
+	require.Len(t, matches, 2)
+	first := matches[0].(map[string]any)
+	assert.Equal(t, "lulu00441", first["content_id"])
+	assert.Equal(t, "2026-07-03", first["release_date"])
+	assert.Equal(t, "digital", first["service_code"])
+	second := matches[1].(map[string]any)
+	assert.Equal(t, "lulu441", second["content_id"])
+}
+
+func TestSearch_PresentNoDVDID_DirectContentIDQuery(t *testing.T) {
+	h, dumpPath := newTestHandler(t)
+	buildTestDump(t, dumpPath, "118ipx00535", "IPX-535")
+	seedNullDVDRow(t, dumpPath, "lulu00441", "2026-07-03", "digital")
+
+	w, resp := searchJSON(t, h, "lulu00441")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, "no_dvd_id", resp["state"])
+}
+
+func TestSearch_MappedSetsStateAndMatches(t *testing.T) {
+	h, dumpPath := newTestHandler(t)
+	buildTestDump(t, dumpPath, "118abf030", "ABF-030")
+
+	w, resp := searchJSON(t, h, "ABF-030")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, "mapped", resp["state"])
+	assert.Equal(t, "118abf030", resp["content_id"])
+	matches, ok := resp["matches"].([]any)
+	require.True(t, ok)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "ABF-030", matches[0].(map[string]any)["dvd_id"])
+}
+
+func TestSearch_WhitespacePaddedContentIDQueryKeepsDirection(t *testing.T) {
+	h, dumpPath := newTestHandler(t)
+	buildTestDump(t, dumpPath, "118abf030", "ABF-030")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/r18dev/dump/search?q=%20118abf030%20", nil)
+	h.search(c)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "mapped", resp["state"])
+	assert.Equal(t, "ABF-030", resp["dvd_id"], "padded exact content-id query reports the dvd_id direction")
+	assert.Nil(t, resp["content_id"])
+}
+
+func TestSearch_AbsentStill404(t *testing.T) {
+	h, dumpPath := newTestHandler(t)
+	buildTestDump(t, dumpPath, "118ipx00535", "IPX-535")
+
+	w, _ := searchJSON(t, h, "NOPE-999")
+	require.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/models/r18dev_dump.go
+++ b/internal/models/r18dev_dump.go
@@ -3,6 +3,7 @@ package models
 import (
 	"context"
 	"errors"
+	"fmt"
 )
 
 // ErrDumpMiss is returned by R18DevDumpLookup lookups when the queried ID is
@@ -13,6 +14,23 @@ import (
 // logged at warn so a degraded dump does not silently revert to rate-limit-
 // prone HTTP.
 var ErrDumpMiss = errors.New("r18.dev dump: id not found")
+
+// ErrDumpNoDVDID is returned when the queried ID exists in the dump but the
+// row carries no dvd_id, so dvd_id-keyed lookups can never match it. It wraps
+// ErrDumpMiss (errors.Is(err, ErrDumpMiss) stays true) so existing
+// miss-handling consumers keep their current behavior; search surfaces must
+// test ErrDumpNoDVDID first to tell "present without dvd_id" from a genuine
+// absence.
+var ErrDumpNoDVDID = fmt.Errorf("%w: row present but dvd_id is NULL", ErrDumpMiss)
+
+// DumpMatch is one dump row matched by a display-ID query, in candidate
+// priority order (canonical content_id first).
+type DumpMatch struct {
+	ContentID   string
+	DVDID       string
+	ReleaseDate string
+	ServiceCode string
+}
 
 // DumpStats describes a locally cached r18.dev database dump.
 type DumpStats struct {
@@ -97,8 +115,18 @@ type R18DevDumpLookup interface {
 	LookupByDVDID(ctx context.Context, dvdID string) (contentID string, err error)
 
 	// LookupByContentID resolves a DMM content_id back to its display dvd_id.
-	// Returns ("", ErrDumpMiss) on a miss or when the dump's dvd_id is NULL.
+	// Returns ("", ErrDumpMiss) on a miss; when the row exists but its dump
+	// dvd_id is NULL it returns ("", ErrDumpNoDVDID), which also satisfies
+	// errors.Is(err, ErrDumpMiss) so existing miss-handling stays unchanged.
 	LookupByContentID(ctx context.Context, contentID string) (dvdID string, err error)
+
+	// MatchByDisplayID resolves a display ID to all matching dump rows, in
+	// candidate priority order: an exact dvd_id_norm hit (single match) if one
+	// exists, otherwise exact content_id matches against the expanded candidate
+	// set for the ID (e.g. LULU-441 → lulu00441 before lulu441). Rows with no
+	// dvd_id are returned with DVDID empty. Returns (nil, ErrDumpMiss) when
+	// nothing matches.
+	MatchByDisplayID(ctx context.Context, id string) ([]DumpMatch, error)
 
 	// LookupMovie resolves a display dvd_id to a fully-populated DumpMovie —
 	// titles, descriptions, runtime, release date, cover/poster/gallery URLs,

--- a/internal/r18devdump/content_id_candidates.go
+++ b/internal/r18devdump/content_id_candidates.go
@@ -1,0 +1,151 @@
+package r18devdump
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var contentIDFullRegex = regexp.MustCompile(`^(\d*)([a-z]+)(\d+)(.*)$`)
+
+// underscoreContentIDRegex recognizes PPV-style content_ids (h_086mesu00103),
+// which SplitSeriesAndNumber cannot decompose because of the underscore.
+var underscoreContentIDRegex = regexp.MustCompile(`^[a-z]_\d+[a-z]+\d+`)
+
+// ContentIDCandidates constructs possible content_id formats from a dvd_id.
+// For "START-575", generates: ["1start00575", "1start575"]
+// For "ABF-346", generates: ["118abf00346", "118abf346", "436abf00346", "436abf346"]
+// The r18.dev content_id format is: [DMM-prefix][series][zero-padded-number]
+// Uses the ContentIDPrefixLookup table built from r18.dev database dumps to find
+// known prefixes per series. Falls back to common prefixes if the series is unknown.
+func ContentIDCandidates(id string) []string {
+	// Identity candidate: the input itself in content-id form. It leads for
+	// content-id-shaped input (leading numeric prefix or zero-padded 5-digit
+	// number, e.g. "118ipx00535", "lulu00441") so exact content_id queries
+	// honor their own row; for display-id-shaped input it is appended last so
+	// canonical zero-padded variants keep priority.
+	direct := strings.ToLower(normalizeDVDID(id))
+
+	// Normalize before splitting: tolerate surrounding/internal whitespace and
+	// display-id formatting so inputs like " LULU-441 " or "LULU 441" expand.
+	trimmed := strings.TrimSpace(id)
+	series, numStr := SplitSeriesAndNumber(trimmed)
+	if series == "" || numStr == "" {
+		if direct != "" {
+			series, numStr = SplitSeriesAndNumber(direct)
+		}
+	}
+	if series == "" || numStr == "" {
+		if direct != "" && underscoreContentIDRegex.MatchString(direct) {
+			return []string{direct}
+		}
+		return nil
+	}
+
+	series = strings.ToLower(series)
+	num, err := strconv.Atoi(numStr)
+	if err != nil {
+		return nil
+	}
+
+	padded3 := fmt.Sprintf("%03d", num)
+	padded5 := fmt.Sprintf("%05d", num)
+
+	// Look up known prefixes for this series from the r18.dev database dump
+	var prefixes []string
+	if lookup, ok := ContentIDPrefixLookup[series]; ok {
+		prefixes = lookup
+	} else {
+		// Fallback: try common prefixes for unknown series
+		prefixes = []string{"", "1"}
+	}
+
+	var variations []string
+	seen := make(map[string]bool)
+
+	add := func(v string) {
+		if !seen[v] {
+			seen[v] = true
+			variations = append(variations, v)
+		}
+	}
+
+	for _, prefix := range prefixes {
+		// 5-digit padded (standard DMM content_id format)
+		add(prefix + series + padded5)
+		// 3-digit padded (used by many r18.dev content_ids)
+		add(prefix + series + padded3)
+	}
+
+	if direct != "" {
+		if looksLikeContentID(direct) {
+			if seen[direct] {
+				out := []string{direct}
+				for _, v := range variations {
+					if v != direct {
+						out = append(out, v)
+					}
+				}
+				return out
+			}
+			return append([]string{direct}, variations...)
+		}
+		add(direct)
+	}
+
+	return variations
+}
+
+// looksLikeContentID reports whether a normalized input already looks like a
+// content_id rather than a display dvd_id: the PPV letter_digits underscore
+// form (h_086mesu00103), or a leading numeric DMM prefix (118ipx00535,
+// 436abf00030). The check is deliberately prefix-based: a zero-padded number
+// alone (abf00030, from the display id ABF-00030) must NOT qualify, or display
+// ids with padded numbers would reorder ahead of their canonical prefixed
+// variants.
+func looksLikeContentID(direct string) bool {
+	if underscoreContentIDRegex.MatchString(direct) {
+		return true
+	}
+	if direct == "" {
+		return false
+	}
+	return direct[0] >= '0' && direct[0] <= '9'
+}
+
+// SplitSeriesAndNumber splits a dvd_id like "START-575" into ("START", "575")
+func SplitSeriesAndNumber(id string) (string, string) {
+	// Try standard format: SERIES-NUMBER
+	if parts := strings.SplitN(id, "-", 2); len(parts) == 2 {
+		if isAlpha(parts[0]) && isDigit(parts[1]) {
+			return parts[0], parts[1]
+		}
+	}
+
+	// Try already-normalized format: series575 (from normalizeID)
+	lowered := strings.ToLower(id)
+	if m := contentIDFullRegex.FindStringSubmatch(lowered); len(m) >= 4 {
+		return m[2], m[3]
+	}
+
+	return "", ""
+}
+
+func isAlpha(s string) bool {
+	for _, r := range s {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+func isDigit(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
+}

--- a/internal/r18devdump/content_id_candidates.go
+++ b/internal/r18devdump/content_id_candidates.go
@@ -105,13 +105,8 @@ func ContentIDCandidates(id string) []string {
 // ids with padded numbers would reorder ahead of their canonical prefixed
 // variants.
 func looksLikeContentID(direct string) bool {
-	if underscoreContentIDRegex.MatchString(direct) {
-		return true
-	}
-	if direct == "" {
-		return false
-	}
-	return direct[0] >= '0' && direct[0] <= '9'
+	return underscoreContentIDRegex.MatchString(direct) ||
+		(direct != "" && direct[0] >= '0' && direct[0] <= '9')
 }
 
 // SplitSeriesAndNumber splits a dvd_id like "START-575" into ("START", "575")

--- a/internal/r18devdump/content_id_candidates_test.go
+++ b/internal/r18devdump/content_id_candidates_test.go
@@ -1,0 +1,126 @@
+package r18devdump
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func indexOfString(list []string, want string) int {
+	for i, v := range list {
+		if v == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestContentIDCandidates_Order pins the canonical-first ordering that both the
+// dump lookup and the r18dev HTTP resolver must agree on (see
+// fix-r18dev-dump-null-dvdid-lookup spec parity scenario).
+func TestContentIDCandidates_Order(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string // expected leading candidates, in order
+		mustNot []string
+	}{
+		{
+			name:  "LULU-441 zero-padded digital first, mono after",
+			input: "LULU-441",
+			want:  []string{"lulu00441", "lulu441"},
+		},
+		{
+			name:  "ABF-030 canonical prefix wins over compilation prefix",
+			input: "ABF-030",
+			want:  []string{"118abf00030", "118abf030", "436abf00030", "436abf030"},
+		},
+		{
+			name:  "SAN-457 118 prefix leads, PPV underscore prefixes last",
+			input: "SAN-457",
+			want:  []string{"118san00457", "118san457"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ContentIDCandidates(tt.input)
+			if len(got) < len(tt.want) {
+				t.Fatalf("ContentIDCandidates(%q) = %v, too few", tt.input, got)
+			}
+			for i, w := range tt.want {
+				assert.Equal(t, w, got[i], "candidate %d", i)
+			}
+		})
+	}
+}
+
+func TestContentIDCandidates_ContainsPPVPrefix(t *testing.T) {
+	got := ContentIDCandidates("SAN-457")
+	std := indexOfString(got, "118san00457")
+	ppv := indexOfString(got, "h_796san00457")
+	if ppv < 0 {
+		t.Fatalf("ContentIDCandidates(SAN-457) = %v, missing PPV candidate", got)
+	}
+	assert.Greater(t, ppv, std, "PPV candidates come after standard prefixes")
+}
+
+func TestContentIDCandidates_RejectsEmptyAndUnsplitable(t *testing.T) {
+	assert.Nil(t, ContentIDCandidates(""))
+	assert.Nil(t, ContentIDCandidates("   "))
+	assert.Nil(t, ContentIDCandidates("abc"))
+	assert.Nil(t, ContentIDCandidates("123"))
+}
+
+func TestContentIDCandidates_AccentInsensitiveDirectContentID(t *testing.T) {
+	// Direct content-id-style input stays in the candidate set so a
+	// content_id query can resolve a present-without-dvd_id row.
+	got := ContentIDCandidates("lulu00441")
+	assert.Equal(t, "lulu00441", got[0])
+}
+
+func TestContentIDCandidates_ContentIDShapedIdentityLeads(t *testing.T) {
+	// A content-id-shaped input honors its own row FIRST: searching an exact
+	// prefixed content_id must not reorder it behind canonical variants
+	// (Codex review P0: "436abf00030" must not resolve to 118abf00030's row).
+	for _, in := range []string{"118ipx00535", "436abf00030", "lulu00441"} {
+		got := ContentIDCandidates(in)
+		assert.Equal(t, in, got[0], "content-id-shaped input %q must lead its own candidate list", in)
+	}
+	// 436abf00030 still keeps the canonical product in the list for parity.
+	got := ContentIDCandidates("436abf00030")
+	if indexOfString(got, "118abf00030") < 0 {
+		t.Fatalf("canonical variant missing from 436abf00030 candidates: %v", got)
+	}
+}
+
+func TestContentIDCandidates_HyphenatedPaddedDisplayIDKeepsCanonicalOrder(t *testing.T) {
+	// Regression (Codex review round 3): ABF-00030 is a display id with an
+	// already-zero-padded number — the normalized form begins with a letter and
+	// must not be treated as content-id-shaped, or "abf00030" would outrank
+	// the canonical 118-prefixed product.
+	got := ContentIDCandidates("ABF-00030")
+	assert.Equal(t, "118abf00030", got[0])
+	assert.Equal(t, "118abf030", got[1])
+	assert.Equal(t, "abf00030", got[len(got)-1], "identity variant trails canonical candidates")
+}
+
+func TestContentIDCandidates_DisplayIDKeepsGeneratedOrder(t *testing.T) {
+	// Display ids keep generation order even though the identity form equals
+	// one of the generated variants (deduped, not moved up front).
+	got := ContentIDCandidates("LULU-441")
+	assert.Equal(t, "lulu00441", got[0])
+	assert.Equal(t, "lulu441", got[1])
+}
+
+func TestContentIDCandidates_WhitespaceTolerant(t *testing.T) {
+	for _, in := range []string{" LULU-441 ", "LULU 441", "\tLULU-441\n"} {
+		got := ContentIDCandidates(in)
+		if len(got) == 0 || got[0] != "lulu00441" {
+			t.Errorf("ContentIDCandidates(%q) = %v, want lulu00441 first", in, got)
+		}
+	}
+}
+
+func TestContentIDCandidates_UnderscorePrefixedContentID(t *testing.T) {
+	assert.Equal(t, []string{"h_086mesu00103"}, ContentIDCandidates("h_086mesu00103"))
+}

--- a/internal/r18devdump/content_id_candidates_test.go
+++ b/internal/r18devdump/content_id_candidates_test.go
@@ -121,6 +121,38 @@ func TestContentIDCandidates_WhitespaceTolerant(t *testing.T) {
 	}
 }
 
+func TestSplitSeriesAndNumber_AndClassifiers(t *testing.T) {
+	assert.True(t, isAlpha("abcXYZ"))
+	assert.False(t, isAlpha("ab1"))
+	assert.False(t, isAlpha(""))
+	assert.True(t, isDigit("0123"))
+	assert.False(t, isDigit("12a"))
+	assert.False(t, isDigit(""))
+
+	// Dash form.
+	s, n := SplitSeriesAndNumber("ABF-123")
+	assert.Equal(t, "ABF", s)
+	assert.Equal(t, "123", n)
+
+	// Dash guard rejects, regex fallback also rejects.
+	s, n = SplitSeriesAndNumber("1ABC-12")
+	assert.Equal(t, "", s)
+	assert.Equal(t, "", n)
+
+	// Regex fallback path.
+	s, n = SplitSeriesAndNumber("118abf00030")
+	assert.Equal(t, "abf", s)
+	assert.Equal(t, "00030", n)
+
+	// No digits at all.
+	s, n = SplitSeriesAndNumber("plainword")
+	assert.Equal(t, "", s)
+}
+
+func TestContentIDCandidates_NumberOverflowRejected(t *testing.T) {
+	assert.Nil(t, ContentIDCandidates("ABC-99999999999999999999"), "number exceeding int range must not expand")
+}
+
 func TestContentIDCandidates_UnderscorePrefixedContentID(t *testing.T) {
 	assert.Equal(t, []string{"h_086mesu00103"}, ContentIDCandidates("h_086mesu00103"))
 }

--- a/internal/r18devdump/content_id_prefixes.go
+++ b/internal/r18devdump/content_id_prefixes.go
@@ -1,10 +1,10 @@
-package r18dev
+package r18devdump
 
 //go:generate python3 scripts/generate_content_id_prefixes.py /tmp/r18dev_dump.sql content_id_prefixes.go
 
-// contentIDPrefixLookup maps series names (lowercase) to their known DMM content_id prefixes.
-// Built from r18.dev database dump. Regenerate with: go generate ./internal/scraper/r18dev/...
-var contentIDPrefixLookup = map[string][]string{
+// ContentIDPrefixLookup maps series names (lowercase) to their known DMM content_id prefixes.
+// Built from r18.dev database dump. Regenerate with: go generate ./internal/r18devdump/...
+var ContentIDPrefixLookup = map[string][]string{
 	"a":              {"44", "60", "186", "446", "447", "448", "449", "h_328", "n_641", "n_950"},
 	"aa":             {"", "13", "n_600", "n_605", "n_949"},
 	"aaa":            {"143", "171", "h_491"},

--- a/internal/r18devdump/scripts/generate_content_id_prefixes.py
+++ b/internal/r18devdump/scripts/generate_content_id_prefixes.py
@@ -83,13 +83,13 @@ def main():
 
     # Generate Go source file
     lines = []
-    lines.append('package r18dev')
+    lines.append('package r18devdump')
     lines.append('')
     lines.append('//go:generate python3 scripts/generate_content_id_prefixes.py /tmp/r18dev_dump.sql content_id_prefixes.go')
     lines.append('')
-    lines.append('// contentIDPrefixLookup maps series names (lowercase) to their known DMM content_id prefixes.')
-    lines.append('// Built from r18.dev database dump. Regenerate with: go generate ./internal/scraper/r18dev/...')
-    lines.append('var contentIDPrefixLookup = map[string][]string{')
+    lines.append('// ContentIDPrefixLookup maps series names (lowercase) to their known DMM content_id prefixes.')
+    lines.append('// Built from r18.dev database dump. Regenerate with: go generate ./internal/r18devdump/...')
+    lines.append('var ContentIDPrefixLookup = map[string][]string{')
 
     for series in sorted(series_prefixes.keys()):
         prefixes = sorted(series_prefixes[series], key=prefix_sort_key)

--- a/internal/r18devdump/store.go
+++ b/internal/r18devdump/store.go
@@ -133,39 +133,32 @@ func (s *Store) MatchByDisplayID(ctx context.Context, id string) ([]models.DumpM
 	}
 
 	// An exact content_id row is honored before candidate expansion so a
-	// literal content_id query (or an unprefixed edition row like "lulu441")
-	// always surfaces its own row first, ahead of canonical zero-padded
-	// variants derived from the same display ID.
-	var exact *models.DumpMatch
+	// literal content_id query always surfaces its own row first, ahead of
+	// canonical zero-padded variants derived from the same display ID. The probe
+	// set is the exact input first, then the expanded candidates, deduped —
+	// order within the result follows probe order.
 	exactID := strings.ToLower(strings.TrimSpace(id))
+	candidates := ContentIDCandidates(id)
+
+	probe := make([]string, 0, len(candidates)+1)
+	seen := make(map[string]bool, len(candidates)+1)
 	if exactID != "" {
-		var m models.DumpMatch
-		var dvdID, rel, svc sql.NullString
-		err := s.db.QueryRowContext(ctx,
-			"SELECT content_id, dvd_id, release_date, service_code FROM videos WHERE content_id = ?",
-			exactID,
-		).Scan(&m.ContentID, &dvdID, &rel, &svc)
-		if err == nil {
-			m.DVDID = dvdID.String
-			m.ReleaseDate = rel.String
-			m.ServiceCode = svc.String
-			exact = &m
-		} else if !errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("dump exact content_id lookup failed for %q: %w", exactID, err)
+		seen[exactID] = true
+		probe = append(probe, exactID)
+	}
+	for _, cand := range candidates {
+		if !seen[cand] {
+			seen[cand] = true
+			probe = append(probe, cand)
 		}
 	}
-
-	candidates := ContentIDCandidates(id)
-	if len(candidates) == 0 {
-		if exact != nil {
-			return []models.DumpMatch{*exact}, nil
-		}
+	if len(probe) == 0 {
 		return nil, models.ErrDumpMiss
 	}
 
-	placeholders := strings.Repeat("?,", len(candidates)-1) + "?"
-	args := make([]any, len(candidates))
-	for i, cand := range candidates {
+	placeholders := strings.Repeat("?,", len(probe)-1) + "?"
+	args := make([]any, len(probe))
+	for i, cand := range probe {
 		args[i] = cand
 	}
 	query := "SELECT content_id, dvd_id, release_date, service_code FROM videos WHERE content_id IN (" + placeholders + ")"
@@ -175,7 +168,7 @@ func (s *Store) MatchByDisplayID(ctx context.Context, id string) ([]models.DumpM
 	}
 	defer func() { _ = rows.Close() }()
 
-	byContentID := make(map[string]models.DumpMatch, len(candidates))
+	byContentID := make(map[string]models.DumpMatch, len(probe))
 	for rows.Next() {
 		var m models.DumpMatch
 		var dvdID, rel, svc sql.NullString
@@ -191,14 +184,8 @@ func (s *Store) MatchByDisplayID(ctx context.Context, id string) ([]models.DumpM
 		return nil, fmt.Errorf("dump candidate lookup failed for %q: %w", id, err)
 	}
 
-	matches := make([]models.DumpMatch, 0, len(byContentID)+1)
-	if exact != nil {
-		matches = append(matches, *exact)
-	}
-	for _, cand := range candidates {
-		if exact != nil && cand == exact.ContentID {
-			continue
-		}
+	matches := make([]models.DumpMatch, 0, len(byContentID))
+	for _, cand := range probe {
 		if m, ok := byContentID[cand]; ok {
 			matches = append(matches, m)
 		}

--- a/internal/r18devdump/store.go
+++ b/internal/r18devdump/store.go
@@ -98,9 +98,115 @@ func (s *Store) LookupByContentID(ctx context.Context, contentID string) (string
 		return "", fmt.Errorf("dump lookup by content_id %q: %w", contentID, err)
 	}
 	if !dvdID.Valid || dvdID.String == "" {
-		return "", models.ErrDumpMiss
+		return "", models.ErrDumpNoDVDID
 	}
 	return dvdID.String, nil
+}
+
+// MatchByDisplayID resolves a display ID to all matching dump rows in
+// candidate priority order. An exact dvd_id_norm hit wins and returns a single
+// match (identical to LookupByDVDID semantics). Otherwise the display ID is
+// expanded into content_id candidates (ContentIDCandidates) and rows are
+// matched exactly by content_id, ordered by candidate priority. Returns
+// models.ErrDumpMiss when nothing matches.
+func (s *Store) MatchByDisplayID(ctx context.Context, id string) ([]models.DumpMatch, error) {
+	if s == nil {
+		return nil, models.ErrDumpMiss
+	}
+	norm := normalizeDVDID(id)
+	if norm != "" {
+		var m models.DumpMatch
+		var dvdID, rel, svc sql.NullString
+		err := s.db.QueryRowContext(ctx,
+			"SELECT content_id, dvd_id, release_date, service_code FROM videos WHERE dvd_id_norm = ? ORDER BY content_id LIMIT 1",
+			norm,
+		).Scan(&m.ContentID, &dvdID, &rel, &svc)
+		if err == nil {
+			m.DVDID = dvdID.String
+			m.ReleaseDate = rel.String
+			m.ServiceCode = svc.String
+			return []models.DumpMatch{m}, nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("dump dvd_id lookup failed for %q: %w", norm, err)
+		}
+	}
+
+	// An exact content_id row is honored before candidate expansion so a
+	// literal content_id query (or an unprefixed edition row like "lulu441")
+	// always surfaces its own row first, ahead of canonical zero-padded
+	// variants derived from the same display ID.
+	var exact *models.DumpMatch
+	exactID := strings.ToLower(strings.TrimSpace(id))
+	if exactID != "" {
+		var m models.DumpMatch
+		var dvdID, rel, svc sql.NullString
+		err := s.db.QueryRowContext(ctx,
+			"SELECT content_id, dvd_id, release_date, service_code FROM videos WHERE content_id = ?",
+			exactID,
+		).Scan(&m.ContentID, &dvdID, &rel, &svc)
+		if err == nil {
+			m.DVDID = dvdID.String
+			m.ReleaseDate = rel.String
+			m.ServiceCode = svc.String
+			exact = &m
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("dump exact content_id lookup failed for %q: %w", exactID, err)
+		}
+	}
+
+	candidates := ContentIDCandidates(id)
+	if len(candidates) == 0 {
+		if exact != nil {
+			return []models.DumpMatch{*exact}, nil
+		}
+		return nil, models.ErrDumpMiss
+	}
+
+	placeholders := strings.Repeat("?,", len(candidates)-1) + "?"
+	args := make([]any, len(candidates))
+	for i, cand := range candidates {
+		args[i] = cand
+	}
+	query := "SELECT content_id, dvd_id, release_date, service_code FROM videos WHERE content_id IN (" + placeholders + ")"
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("dump candidate lookup failed for %q: %w", id, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	byContentID := make(map[string]models.DumpMatch, len(candidates))
+	for rows.Next() {
+		var m models.DumpMatch
+		var dvdID, rel, svc sql.NullString
+		if err := rows.Scan(&m.ContentID, &dvdID, &rel, &svc); err != nil {
+			return nil, fmt.Errorf("dump candidate lookup failed for %q: scan: %w", id, err)
+		}
+		m.DVDID = dvdID.String
+		m.ReleaseDate = rel.String
+		m.ServiceCode = svc.String
+		byContentID[m.ContentID] = m
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("dump candidate lookup failed for %q: %w", id, err)
+	}
+
+	matches := make([]models.DumpMatch, 0, len(byContentID)+1)
+	if exact != nil {
+		matches = append(matches, *exact)
+	}
+	for _, cand := range candidates {
+		if exact != nil && cand == exact.ContentID {
+			continue
+		}
+		if m, ok := byContentID[cand]; ok {
+			matches = append(matches, m)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, models.ErrDumpMiss
+	}
+	return matches, nil
 }
 
 // LookupMovie resolves a display dvd_id to a fully-populated DumpMovie with all

--- a/internal/r18devdump/store_match_test.go
+++ b/internal/r18devdump/store_match_test.go
@@ -1,0 +1,111 @@
+package r18devdump
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedDumpFullCols(t *testing.T, rows string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "r18dev_dump.db")
+	dump := "COPY public.derived_video (content_id, dvd_id, release_date, service_code) FROM stdin;\n" + rows + "\n\\.\n"
+	_, err := Import(context.Background(), strings.NewReader(dump), path, ImportOptions{SourceDate: "2026-04-28"})
+	require.NoError(t, err)
+	return path
+}
+
+const matchFixture = "118ipx00535\tIPX-535\t2019-01-01\tdigital\n" +
+	"lulu00441\t\\N\t2026-07-03\tdigital\n" +
+	"lulu441\t\\N\t2026-07-07\tmono"
+
+func TestMatchByDisplayID_NormHitSingleMatch(t *testing.T) {
+	store, err := Open(seedDumpFullCols(t, matchFixture))
+	require.NoError(t, err)
+	defer store.Close()
+
+	matches, err := store.MatchByDisplayID(context.Background(), "IPX-535")
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "118ipx00535", matches[0].ContentID)
+	assert.Equal(t, "IPX-535", matches[0].DVDID)
+	assert.Equal(t, "2019-01-01", matches[0].ReleaseDate)
+	assert.Equal(t, "digital", matches[0].ServiceCode)
+
+	// Normalization input styles all land on the same single match.
+	for _, q := range []string{"ipx-535", "IPX535", " ipx 535 "} {
+		m, err := store.MatchByDisplayID(context.Background(), q)
+		require.NoError(t, err)
+		require.Len(t, m, 1)
+		assert.Equal(t, "118ipx00535", m[0].ContentID)
+	}
+}
+
+func TestMatchByDisplayID_CandidateExpansionOrderedMultiMatch(t *testing.T) {
+	store, err := Open(seedDumpFullCols(t, matchFixture))
+	require.NoError(t, err)
+	defer store.Close()
+
+	matches, err := store.MatchByDisplayID(context.Background(), "LULU-441")
+	require.NoError(t, err)
+	require.Len(t, matches, 2)
+	assert.Equal(t, "lulu00441", matches[0].ContentID, "canonical zero-padded candidate first")
+	assert.Equal(t, "lulu441", matches[1].ContentID)
+	assert.Equal(t, "digital", matches[0].ServiceCode)
+	assert.Equal(t, "mono", matches[1].ServiceCode)
+	assert.Equal(t, "", matches[0].DVDID)
+}
+
+func TestMatchByDisplayID_DirectContentIDInputExpandsToo(t *testing.T) {
+	store, err := Open(seedDumpFullCols(t, matchFixture))
+	require.NoError(t, err)
+	defer store.Close()
+
+	matches, err := store.MatchByDisplayID(context.Background(), "lulu00441")
+	require.NoError(t, err)
+	require.Len(t, matches, 2)
+	assert.Equal(t, "lulu00441", matches[0].ContentID)
+}
+
+func TestMatchByDisplayID_ExactContentIDRowLeadsCandidates(t *testing.T) {
+	store, err := Open(seedDumpFullCols(t, matchFixture))
+	require.NoError(t, err)
+	defer store.Close()
+
+	// A literal content_id query surfaces its own row first, even when a
+	// canonical zero-padded sibling exists in the same candidate set.
+	matches, err := store.MatchByDisplayID(context.Background(), "lulu441")
+	require.NoError(t, err)
+	require.Len(t, matches, 2)
+	assert.Equal(t, "lulu441", matches[0].ContentID, "exact content_id row first")
+	assert.Equal(t, "lulu00441", matches[1].ContentID, "canonical variant follows")
+
+	// Dash-containing display queries keep canonical-first ordering.
+	matches, err = store.MatchByDisplayID(context.Background(), "LULU-441")
+	require.NoError(t, err)
+	require.Equal(t, "lulu00441", matches[0].ContentID)
+}
+
+func TestMatchByDisplayID_MissAndRejects(t *testing.T) {
+	store, err := Open(seedDumpFullCols(t, matchFixture))
+	require.NoError(t, err)
+	defer store.Close()
+
+	_, err = store.MatchByDisplayID(context.Background(), "NOPE-999")
+	assert.True(t, errors.Is(err, models.ErrDumpMiss))
+	assert.False(t, errors.Is(err, models.ErrDumpNoDVDID))
+
+	_, err = store.MatchByDisplayID(context.Background(), "")
+	assert.True(t, errors.Is(err, models.ErrDumpMiss))
+
+	var nilStore *Store
+	_, err = nilStore.MatchByDisplayID(context.Background(), "IPX-535")
+	assert.True(t, errors.Is(err, models.ErrDumpMiss))
+}

--- a/internal/r18devdump/store_match_test.go
+++ b/internal/r18devdump/store_match_test.go
@@ -2,7 +2,10 @@ package r18devdump
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
 	"errors"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -91,6 +94,113 @@ func TestMatchByDisplayID_ExactContentIDRowLeadsCandidates(t *testing.T) {
 	matches, err = store.MatchByDisplayID(context.Background(), "LULU-441")
 	require.NoError(t, err)
 	require.Equal(t, "lulu00441", matches[0].ContentID)
+}
+
+// --- fault-injection coverage for defensive error branches ---
+
+// faultyRows is a driver.Rows whose behavior is controlled by mode sentinels:
+// empty (no rows), oneRow (one valid row), badcols (columns mismatch Scan),
+// and failingErr (rows.Err() non-nil after iteration).
+type faultyRows struct {
+	mode  string
+	dirty bool
+}
+
+func (r *faultyRows) Columns() []string {
+	if r.mode == "badcols" {
+		return []string{"content_id", "dvd_id"}
+	}
+	return []string{"content_id", "dvd_id", "release_date", "service_code"}
+}
+
+func (r *faultyRows) Close() error { return nil }
+
+func (r *faultyRows) Next(dest []driver.Value) error {
+	if (r.mode == "oneRow" || r.mode == "badcols" || r.mode == "failingErr") && !r.dirty {
+		r.dirty = true
+		dest[0] = "118ipx00535"
+		dest[1] = "IPX-535"
+		if r.mode != "badcols" {
+			dest[2] = "2013-03-01"
+			dest[3] = "digital"
+		}
+		return nil
+	}
+	if r.mode == "failingErr" {
+		return errors.New("simulated iteration failure")
+	}
+	return io.EOF
+}
+
+func (r *faultyRows) Err() error { return nil }
+
+type faultyConn struct{ mode string }
+
+func (c *faultyConn) Prepare(string) (driver.Stmt, error) { return nil, errors.New("no prepare") }
+func (c *faultyConn) Close() error                        { return nil }
+func (c *faultyConn) Begin() (driver.Tx, error)           { return nil, errors.New("no tx") }
+func (c *faultyConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	if strings.Contains(query, "IN (") {
+		return &faultyRows{mode: c.mode}, nil
+	}
+	return &faultyRows{mode: "empty"}, nil
+}
+
+type faultyDriver struct{ mode string }
+
+func (d *faultyDriver) Open(string) (driver.Conn, error) { return &faultyConn{mode: d.mode}, nil }
+
+func newFaultyStore(t *testing.T, mode string) *Store {
+	t.Helper()
+	name := "faulty-" + mode + "-" + strings.ReplaceAll(t.Name(), "/", "_")
+	sql.Register(name, &faultyDriver{mode: mode})
+	db, err := sql.Open(name, "")
+	require.NoError(t, err)
+	return &Store{db: db, path: ":faulty:"}
+}
+
+func TestMatchByDisplayID_CandidateScanError(t *testing.T) {
+	s := newFaultyStore(t, "badcols")
+	defer func() { _ = s.Close() }()
+	_, err := s.MatchByDisplayID(context.Background(), "IPX-535")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scan")
+}
+
+func TestMatchByDisplayID_CandidateRowsErr(t *testing.T) {
+	s := newFaultyStore(t, "failingErr")
+	defer func() { _ = s.Close() }()
+	_, err := s.MatchByDisplayID(context.Background(), "IPX-535")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "candidate lookup failed")
+}
+
+func TestMatchByDisplayID_NormQueryErrorPropagated(t *testing.T) {
+	path := seedDump(t, "118ipx00535\tIPX-535")
+	corruptor, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	_, err = corruptor.Exec("DROP TABLE videos; CREATE TABLE videos (content_id TEXT PRIMARY KEY, dvd_id_norm TEXT)")
+	require.NoError(t, err)
+	require.NoError(t, corruptor.Close())
+
+	store, err := Open(path)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+	_, err = store.MatchByDisplayID(context.Background(), "IPX-535")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dvd_id lookup failed")
+}
+
+func TestMatchByDisplayID_ClosedDBCandidateError(t *testing.T) {
+	store, err := Open(seedDump(t, "118ipx00535\tIPX-535"))
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+	// "-" normalizes to an empty norm (norm branch skipped) and yields no
+	// generated candidates, so the probe set is just the exact-ID probe; the
+	// closed DB must surface a real error rather than a bare miss.
+	_, err = store.MatchByDisplayID(context.Background(), "-")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lookup failed")
 }
 
 func TestMatchByDisplayID_MissAndRejects(t *testing.T) {

--- a/internal/r18devdump/store_test.go
+++ b/internal/r18devdump/store_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"database/sql"
+
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/javinizer/javinizer-go/internal/models"
@@ -72,9 +73,17 @@ func TestImportAndLookup(t *testing.T) {
 	if err != nil || did != "IPX-535" {
 		t.Errorf("LookupByContentID = %q,%v, want IPX-535,nil", did, err)
 	}
-	// NULL dvd_id in dump -> miss.
-	if _, err := store.LookupByContentID(ctx, "118abw00001"); !errors.Is(err, models.ErrDumpMiss) {
-		t.Errorf("LookupByContentID for NULL dvd_id err = %v, want ErrDumpMiss", err)
+	// NULL dvd_id in dump -> present-without-dvd_id sentinel, still miss-compatible.
+	if _, err := store.LookupByContentID(ctx, "118abw00001"); !errors.Is(err, models.ErrDumpNoDVDID) {
+		t.Errorf("LookupByContentID for NULL dvd_id err = %v, want ErrDumpNoDVDID", err)
+	} else if !errors.Is(err, models.ErrDumpMiss) {
+		t.Errorf("ErrDumpNoDVDID err = %v, want errors.Is(..., ErrDumpMiss) true", err)
+	}
+	// Truly absent content_id -> ErrDumpMiss only, not ErrDumpNoDVDID.
+	if _, err := store.LookupByContentID(ctx, "zzzz99999"); !errors.Is(err, models.ErrDumpMiss) {
+		t.Errorf("LookupByContentID absent err = %v, want ErrDumpMiss", err)
+	} else if errors.Is(err, models.ErrDumpNoDVDID) {
+		t.Errorf("absent row err = %v, must not match ErrDumpNoDVDID", err)
 	}
 
 	// Stats.

--- a/internal/scraper/r18dev/abf030_prefix_test.go
+++ b/internal/scraper/r18dev/abf030_prefix_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/javinizer/javinizer-go/internal/r18devdump"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -125,8 +126,8 @@ func TestSearch_ABF030_PrefersCorrectPrefixOverMislabeledDVDID(t *testing.T) {
 func TestSearch_FuzzyDVDFallback_WhenVariationsAllFail(t *testing.T) {
 	// zzqq is deliberately absent from contentIDPrefixLookup so the variation
 	// generator only tries the common fallback prefixes.
-	if _, ok := contentIDPrefixLookup["zzqq"]; ok {
-		t.Fatal("test assumes series 'zzqq' is absent from contentIDPrefixLookup")
+	if _, ok := r18devdump.ContentIDPrefixLookup["zzqq"]; ok {
+		t.Fatal("test assumes series 'zzqq' is absent from ContentIDPrefixLookup")
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -192,7 +193,7 @@ func TestSearch_FuzzyDVDFallback_WhenVariationsAllFail(t *testing.T) {
 func TestSearch_VariationResponseMismatch_IsSkipped(t *testing.T) {
 	// abf has prefixes {"118", "436"} in contentIDPrefixLookup. Variation order:
 	//   118abf00030, 118abf030, 436abf00030, 436abf030
-	if got := contentIDPrefixLookup["abf"]; len(got) == 0 || got[0] != "118" || got[1] != "436" {
+	if got := r18devdump.ContentIDPrefixLookup["abf"]; len(got) == 0 || got[0] != "118" || got[1] != "436" {
 		t.Fatalf("test assumes abf prefixes are {118,436}, got %v", got)
 	}
 
@@ -271,7 +272,7 @@ func TestSearch_VariationResponseMismatch_IsSkipped(t *testing.T) {
 // returns the real movie. This complements the helper-level coverage with a
 // resolver-level integration check.
 func TestSearch_VariationInvalidResponse_ContinuesToNext(t *testing.T) {
-	if got := contentIDPrefixLookup["abf"]; len(got) < 2 || got[0] != "118" || got[1] != "436" {
+	if got := r18devdump.ContentIDPrefixLookup["abf"]; len(got) < 2 || got[0] != "118" || got[1] != "436" {
 		t.Fatalf("test assumes abf prefixes start with {118,436}, got %v", got)
 	}
 
@@ -550,7 +551,7 @@ func TestResolveURL_FuzzyFallbackSkipped_WhenContextCancelled(t *testing.T) {
 // skipped, so the resolver continues to a later variation that returns valid
 // JSON core-matching the requested id.
 func TestSearch_VariationHTML200_ContinuesToNext(t *testing.T) {
-	if got := contentIDPrefixLookup["abf"]; len(got) < 2 || got[0] != "118" || got[1] != "436" {
+	if got := r18devdump.ContentIDPrefixLookup["abf"]; len(got) < 2 || got[0] != "118" || got[1] != "436" {
 		t.Fatalf("test assumes abf prefixes start with {118,436}, got %v", got)
 	}
 

--- a/internal/scraper/r18dev/dump_candidate_test.go
+++ b/internal/scraper/r18dev/dump_candidate_test.go
@@ -1,0 +1,353 @@
+package r18dev
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// candidateAPITransport serves one canned combined= JSON response and counts
+// requests to the r18.dev API host so tests can prove the dump candidate path
+// issues exactly one API call.
+type candidateAPITransport struct {
+	apiHits int32
+	body    string
+}
+
+func (ct *candidateAPITransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Path, "/videos/vod/movies/detail/") {
+		atomic.AddInt32(&ct.apiHits, 1)
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(ct.body)),
+			Request:    req,
+		}, nil
+	}
+	// CDN URLs (image dimension probing) return 404 fast.
+	return &http.Response{
+		StatusCode: 404,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("")),
+		Request:    req,
+	}, nil
+}
+
+func (ct *candidateAPITransport) count() int { return int(atomic.LoadInt32(&ct.apiHits)) }
+
+const candidateCombinedJSON = `{
+  "content_id": "lulu00441",
+  "dvd_id": null,
+  "title_en": "I Ended Up Living With My Big-assed Female Friend",
+  "title_ja": "同居することになった上京デカ尻女友達",
+  "release_date": "2026-07-03",
+  "runtime_mins": 160,
+  "maker_name_en": "LUNATICS"
+}`
+
+// TestSearchFromDump_CandidateHitSingleFetch covers the null-dvd_id fast path:
+// LookupMovie misses, MatchByDisplayID yields a row, and Search issues exactly
+// one r18.dev API request (the resolved combined= URL) with metadata identical
+// to what the HTTP multi-probe resolution would produce.
+func TestSearchFromDump_CandidateHitSingleFetch(t *testing.T) {
+	dump := &stubDumpLookup{
+		matches: []models.DumpMatch{{ContentID: "lulu00441", ServiceCode: "digital", ReleaseDate: "2026-07-03"}},
+	}
+	cfg := createTestSettings(true)
+	cfg.Enabled = true
+	cfg.RetryCount = 0
+	s := newScraper(&cfg, testGlobalProxy, testGlobalFlareSolverr, dump)
+	s.client.SetRetryCount(0)
+	tr := &candidateAPITransport{body: candidateCombinedJSON}
+	s.client.SetTransport(tr)
+
+	result, err := s.Search(context.Background(), "LULU-441")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, tr.count(), "candidate hit must issue exactly one API request")
+	assert.Equal(t, "lulu00441", result.ContentID)
+	assert.Equal(t, "I Ended Up Living With My Big-assed Female Friend", result.Title)
+	assert.Equal(t, "r18dev", result.Source)
+}
+
+// TestSearchFromDump_CandidateHitIgnoresDumpRowMetadata proves the candidate
+// path never serves dump-row metadata: even a match carrying a DVDID still
+// goes through the single combined= fetch.
+func TestSearchFromDump_CandidateHitIgnoresDumpRowMetadata(t *testing.T) {
+	dump := &stubDumpLookup{
+		matches: []models.DumpMatch{{ContentID: "lulu00441", DVDID: "LULU-441"}},
+	}
+	cfg := createTestSettings(true)
+	cfg.Enabled = true
+	cfg.RetryCount = 0
+	s := newScraper(&cfg, testGlobalProxy, testGlobalFlareSolverr, dump)
+	s.client.SetRetryCount(0)
+	tr := &candidateAPITransport{body: candidateCombinedJSON}
+	s.client.SetTransport(tr)
+
+	result, err := s.Search(context.Background(), "LULU-441")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, tr.count())
+}
+
+// byURLTransport answers each detail request via responder(counted, path) so
+// candidate-fallthrough tests can shape responses per combined=<content_id>.
+type byURLTransport struct {
+	hits      int32
+	responder func(hit int, path string) (int, string)
+}
+
+func (bt *byURLTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Path, "/videos/vod/movies/detail/") {
+		hit := int(atomic.AddInt32(&bt.hits, 1))
+		code, body := bt.responder(hit, req.URL.Path)
+		return &http.Response{StatusCode: code, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
+	}
+	return &http.Response{StatusCode: 404, Header: http.Header{}, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+}
+
+const candidateMonoJSON = `{
+  "content_id": "lulu441",
+  "dvd_id": "LULU-441",
+  "title_en": "Mono Edition Accepted",
+  "release_date": "2026-07-07",
+  "runtime_mins": 160
+}`
+
+func newCandidateScraper(dump *stubDumpLookup, transport http.RoundTripper) *scraper {
+	cfg := createTestSettings(true)
+	cfg.Enabled = true
+	cfg.RetryCount = 0
+	s := newScraper(&cfg, testGlobalProxy, testGlobalFlareSolverr, dump)
+	s.client.SetRetryCount(0)
+	s.client.SetTransport(transport)
+	return s
+}
+
+// TestSearchFromDump_CandidateFallthrough: a stale first candidate (404) must
+// not dead-end the scrape — the next candidate is fetched and wins.
+func TestSearchFromDump_CandidateFallthrough(t *testing.T) {
+	dump := &stubDumpLookup{matches: []models.DumpMatch{
+		{ContentID: "lulu00441", ServiceCode: "digital"},
+		{ContentID: "lulu441", ServiceCode: "mono"},
+	}}
+	tr := &byURLTransport{responder: func(_ int, path string) (int, string) {
+		if strings.Contains(path, "combined=lulu00441") {
+			return 404, ""
+		}
+		if strings.Contains(path, "combined=lulu441") {
+			return 200, candidateMonoJSON
+		}
+		return 404, ""
+	}}
+	s := newCandidateScraper(dump, tr)
+
+	result, err := s.Search(context.Background(), "LULU-441")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 2, int(atomic.LoadInt32(&tr.hits)), "first candidate 404 must fall through to the second")
+	assert.Equal(t, "lulu441", result.ContentID)
+	assert.Equal(t, "Mono Edition Accepted", result.Title)
+}
+
+// TestSearchFromDump_CandidateAllFailFallsBackToResolver: when every dump
+// candidate fetch fails, the regular HTTP URL resolver still runs.
+func TestSearchFromDump_CandidateAllFailFallsBackToResolver(t *testing.T) {
+	dump := &stubDumpLookup{matches: []models.DumpMatch{
+		{ContentID: "lulu00441", ServiceCode: "digital"},
+		{ContentID: "lulu441", ServiceCode: "mono"},
+	}}
+	tr := &byURLTransport{responder: func(_ int, _ string) (int, string) { return 404, "" }}
+	s := newCandidateScraper(dump, tr)
+
+	_, err := s.Search(context.Background(), "NOPE-999")
+	assert.Error(t, err)
+	assert.Greater(t, int(atomic.LoadInt32(&tr.hits)), 2, "all-candidate failure must continue to resolver probing")
+}
+
+// TestSearchFromDump_CandidateMismatchRejected: a 200 that answers with a
+// different content_id is rejected as identity mismatch; the next candidate
+// is then fetched and wins.
+func TestSearchFromDump_CandidateMismatchRejected(t *testing.T) {
+	dump := &stubDumpLookup{matches: []models.DumpMatch{
+		{ContentID: "lulu00441", ServiceCode: "digital"},
+		{ContentID: "lulu441", ServiceCode: "mono"},
+	}}
+	tr := &byURLTransport{responder: func(hit int, path string) (int, string) {
+		if strings.Contains(path, "combined=lulu00441") && hit == 1 {
+			return 200, `{"content_id":"lulu999","title_en":"Wrong Movie"}`
+		}
+		if strings.Contains(path, "combined=lulu441") {
+			return 200, candidateMonoJSON
+		}
+		return 404, ""
+	}}
+	s := newCandidateScraper(dump, tr)
+
+	result, err := s.Search(context.Background(), "LULU-441")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 2, int(atomic.LoadInt32(&tr.hits)), "mismatched 200 must fall through to next candidate")
+	assert.Equal(t, "lulu441", result.ContentID)
+	assert.Equal(t, "Mono Edition Accepted", result.Title)
+}
+
+// TestSearchFromDump_CandidateEmptyJSONRejected: an empty ({}) 200 body must
+// not be accepted as a candidate result.
+func TestSearchFromDump_CandidateEmptyJSONRejected(t *testing.T) {
+	dump := &stubDumpLookup{matches: []models.DumpMatch{{ContentID: "lulu00441"}}}
+	cfg := createTestSettings(true)
+	cfg.Enabled = true
+	cfg.RetryCount = 0
+	s := newScraper(&cfg, testGlobalProxy, testGlobalFlareSolverr, dump)
+	s.client.SetRetryCount(0)
+	s.client.SetTransport(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if strings.Contains(req.URL.Path, "combined=lulu00441") {
+			return &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(`{}`)), Request: req}, nil
+		}
+		return &http.Response{StatusCode: 404, Header: http.Header{}, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+	}))
+
+	_, err := s.Search(context.Background(), "LULU-441")
+	assert.Error(t, err, "empty payload must not be accepted; resolver probes follow and fail")
+}
+
+const candidateCanonicalJSON = `{
+  "content_id": "118abf030",
+  "dvd_id": "ABF-030",
+  "title_en": "Canonical Product",
+  "release_date": "2024-01-01",
+  "runtime_mins": 100
+}`
+
+const candidateNonCanonicalJSON = `{
+  "content_id": "436abf00030",
+  "dvd_id": "ABF-030",
+  "title_en": "Mislabeled Compilation",
+  "release_date": "2024-01-02",
+  "runtime_mins": 100
+}`
+
+// TestSearchFromDump_NonCanonicalCandidateNotTrusted covers Codex round-4 P0:
+// a dump whose only candidate is a noncanonical prefix (e.g. the ABF-030
+// compilation) must NOT win; the flow defers to the HTTP resolver, which
+// probes canonical variants first.
+func TestSearchFromDump_NonCanonicalCandidateNotTrusted(t *testing.T) {
+	dump := &stubDumpLookup{matches: []models.DumpMatch{{ContentID: "436abf00030", ServiceCode: "digital"}}}
+	tr := &byURLTransport{responder: func(_ int, path string) (int, string) {
+		if strings.Contains(path, "combined=118abf030") {
+			return 200, candidateCanonicalJSON
+		}
+		if strings.Contains(path, "combined=436abf00030") {
+			return 200, candidateNonCanonicalJSON
+		}
+		return 404, ""
+	}}
+	s := newCandidateScraper(dump, tr)
+
+	result, err := s.Search(context.Background(), "ABF-030")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "118abf030", result.ContentID, "canonical product must win over the dump's lone noncanonical row")
+	assert.Equal(t, "Canonical Product", result.Title)
+	assert.Greater(t, int(atomic.LoadInt32(&tr.hits)), 1, "resolver probing runs when the canonical candidate is not in the dump")
+}
+
+const candidateWrongEditionJSON = `{
+  "content_id": "2lulu00441",
+  "dvd_id": "LULU-441",
+  "title_en": "Wrong Edition Row",
+  "release_date": "2026-07-04",
+  "runtime_mins": 160
+}`
+
+// TestSearchFromDump_GappyCandidatesNotTrusted covers Codex round-5 P0: dump
+// matches [lulu00441, 2lulu00441] are NOT a contiguous prefix of the canonical
+// expansion ([lulu00441, lulu441, …]); after the first candidate 404s, the
+// sparse shortcut must not accept 2lulu00441 — the resolver's probes find the
+// intermediate row lulu441 instead.
+func TestSearchFromDump_GappyCandidatesNotTrusted(t *testing.T) {
+	dump := &stubDumpLookup{matches: []models.DumpMatch{
+		{ContentID: "lulu00441", ServiceCode: "digital"},
+		{ContentID: "2lulu00441", ServiceCode: "digital"},
+	}}
+	tr := &byURLTransport{responder: func(_ int, path string) (int, string) {
+		switch {
+		case strings.Contains(path, "combined=lulu00441"):
+			return 404, ""
+		case strings.Contains(path, "combined=lulu441"):
+			return 200, candidateMonoJSON
+		case strings.Contains(path, "combined=2lulu00441"):
+			return 200, candidateWrongEditionJSON
+		}
+		return 404, ""
+	}}
+	s := newCandidateScraper(dump, tr)
+
+	result, err := s.Search(context.Background(), "LULU-441")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "lulu441", result.ContentID, "sparse dump candidates must not skip the intermediate canonical row")
+	assert.Equal(t, "Mono Edition Accepted", result.Title)
+}
+
+// TestSearchFromDump_ExactRowInputKeepsResolverParity: a bare unprefixed
+// input (both display-id and content-id shaped) follows the HTTP resolver
+// order — canonical first — because the exact-row-first store ordering is not
+// a canonical prefix of the expansion.
+func TestSearchFromDump_ExactRowInputKeepsResolverParity(t *testing.T) {
+	dump := &stubDumpLookup{matches: []models.DumpMatch{
+		{ContentID: "lulu441", ServiceCode: "mono"},
+		{ContentID: "lulu00441", ServiceCode: "digital"},
+	}}
+	tr := &byURLTransport{responder: func(_ int, path string) (int, string) {
+		if strings.Contains(path, "combined=lulu00441") {
+			return 200, candidateCombinedJSON
+		}
+		if strings.Contains(path, "combined=lulu441") {
+			return 200, candidateMonoJSON
+		}
+		return 404, ""
+	}}
+	s := newCandidateScraper(dump, tr)
+
+	result, err := s.Search(context.Background(), "lulu441")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "lulu00441", result.ContentID, "scraper stays on HTTP-resolver canonical order for ambiguous inputs")
+}
+
+// TestSearchFromDump_CandidateMissFallsBackToResolver keeps the existing
+// behavior for truly absent IDs: no candidate URL, probe resolution runs.
+func TestSearchFromDump_CandidateMissFallsBackToResolver(t *testing.T) {
+	dump := &stubDumpLookup{dvdToContent: map[string]string{}}
+	s, rt := newScraperWithBlockedHTTP(t, dump)
+
+	_, err := s.Search(context.Background(), "NOPE-999")
+	assert.Error(t, err, "blocked HTTP should fail after probe resolution")
+	assert.Greater(t, rt.count(), 0, "true miss must fall back to the HTTP resolver")
+}
+
+// TestSearchFromDump_CandidateLookupErrorFallsBack covers a degraded candidate
+// lookup (non-miss error): warn + HTTP fallback, no candidate URL.
+func TestSearchFromDump_CandidateLookupErrorFallsBack(t *testing.T) {
+	dump := &stubDumpLookup{matchErr: errors.New("simulated read failure")}
+	s, rt := newScraperWithBlockedHTTP(t, dump)
+
+	result, candidateURLs := s.searchFromDump(context.Background(), "IPX-535")
+	assert.Nil(t, result)
+	assert.Empty(t, candidateURLs)
+
+	_, err := s.Search(context.Background(), "NOPE-999")
+	assert.Error(t, err)
+	assert.Greater(t, rt.count(), 0)
+}

--- a/internal/scraper/r18dev/dump_candidate_test.go
+++ b/internal/scraper/r18dev/dump_candidate_test.go
@@ -326,6 +326,44 @@ func TestSearchFromDump_ExactRowInputKeepsResolverParity(t *testing.T) {
 	assert.Equal(t, "lulu00441", result.ContentID, "scraper stays on HTTP-resolver canonical order for ambiguous inputs")
 }
 
+// TestSearchFromDump_CandidateLookupCanceled covers the quiet-cancel arm: a
+// candidate lookup that dies via context cancellation logs at debug and does
+// not report a degraded dump.
+func TestSearchFromDump_CandidateLookupCanceled(t *testing.T) {
+	dump := &stubDumpLookup{matchErr: context.Canceled}
+	s, _ := newScraperWithBlockedHTTP(t, dump)
+	result, candidates := s.searchFromDump(context.Background(), "IPX-535")
+	assert.Nil(t, result)
+	assert.Empty(t, candidates)
+}
+
+// TestFetchAndParseCombined_TransportError exercises the shared helper's
+// transport-error arm with a nil-returning RoundTripper (resty converts it to
+// a request error, never a nil response).
+func TestFetchAndParseCombined_TransportError(t *testing.T) {
+	cfg := createTestSettings(true)
+	cfg.Enabled = true
+	cfg.RetryCount = 0
+	s := newScraper(&cfg, testGlobalProxy, testGlobalFlareSolverr, nil)
+	s.client.SetRetryCount(0)
+	s.client.SetTransport(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, nil
+	}))
+	_, err := s.fetchAndParseCombined(context.Background(), "https://example.invalid/x")
+	require.Error(t, err)
+}
+
+// TestSearchFromDump_EmptyCandidateRowsSkipped covers stub rows lacking a
+// ContentID: they are skipped, and a fully-empty candidate list degrades to
+// HTTP.
+func TestSearchFromDump_EmptyCandidateRowsSkipped(t *testing.T) {
+	dump := &stubDumpLookup{matches: []models.DumpMatch{{ContentID: ""}}}
+	s, _ := newScraperWithBlockedHTTP(t, dump)
+	result, candidates := s.searchFromDump(context.Background(), "IPX-535")
+	assert.Nil(t, result)
+	assert.Empty(t, candidates, "matches without content_id must not produce candidate URLs")
+}
+
 // TestSearchFromDump_CandidateMissFallsBackToResolver keeps the existing
 // behavior for truly absent IDs: no candidate URL, probe resolution runs.
 func TestSearchFromDump_CandidateMissFallsBackToResolver(t *testing.T) {

--- a/internal/scraper/r18dev/dump_lookup_test.go
+++ b/internal/scraper/r18dev/dump_lookup_test.go
@@ -11,11 +11,15 @@ import (
 // scraper's dump fast-path. LookupMovie returns lookupMovieResult when set,
 // otherwise derives a minimal DumpMovie from dvdToContent. A genuine miss
 // returns models.ErrDumpMiss; lookupErr (if set) is returned instead to let
-// tests exercise the degraded-dump path.
+// tests exercise the degraded-dump path. MatchByDisplayID returns matches
+// when set (candidate-resolution tests), otherwise mirrors dvdToContent or
+// reports a miss; matchErr overrides to simulate a degraded candidate lookup.
 type stubDumpLookup struct {
 	dvdToContent      map[string]string
 	lookupMovieResult *models.DumpMovie
 	lookupErr         error // when set, every lookup returns this error
+	matches           []models.DumpMatch
+	matchErr          error
 }
 
 func (s *stubDumpLookup) LookupByDVDID(ctx context.Context, dvdID string) (string, error) {
@@ -39,6 +43,22 @@ func (s *stubDumpLookup) LookupByContentID(ctx context.Context, contentID string
 		}
 	}
 	return "", models.ErrDumpMiss
+}
+
+func (s *stubDumpLookup) MatchByDisplayID(ctx context.Context, id string) ([]models.DumpMatch, error) {
+	if s.matchErr != nil {
+		return nil, s.matchErr
+	}
+	if s.lookupErr != nil {
+		return nil, s.lookupErr
+	}
+	if s.matches != nil {
+		return s.matches, nil
+	}
+	if cid, ok := s.dvdToContent[normalizeIDWithoutStripping(id)]; ok {
+		return []models.DumpMatch{{ContentID: cid, DVDID: id}}, nil
+	}
+	return nil, models.ErrDumpMiss
 }
 
 func (s *stubDumpLookup) Stats(ctx context.Context) (models.DumpStats, error) {

--- a/internal/scraper/r18dev/dump_result.go
+++ b/internal/scraper/r18dev/dump_result.go
@@ -253,30 +253,88 @@ func (s *scraper) resolveDumpMediaURLs(d *models.DumpMovie, result *models.Scrap
 	}
 }
 
-// searchFromDump is the zero-HTTP dump fast path for Search. It returns a
-// complete ScraperResult when the dump has the movie, or (nil, false) on a
-// miss or error so the caller falls back to live HTTP. A genuine miss
-// (models.ErrDumpMiss) is logged at debug; a real database error is logged at
-// warn so a degraded dump does not silently revert to rate-limit-prone HTTP
-// with no signal.
-func (s *scraper) searchFromDump(ctx context.Context, id string) (*models.ScraperResult, bool) {
+// searchFromDump is the dump fast path for Search. On a dvd_id_norm hit it
+// returns a complete ScraperResult with zero HTTP. On a miss it expands the ID
+// into ordered content_id candidates (MatchByDisplayID) so Search can fetch
+// each combined= URL with content_id validation and per-candidate fallthrough
+// instead of running the multi-probe HTTP resolver — one request on the happy
+// path. The
+// candidate-hit dump row is never used as the metadata source — rows reachable
+// only via candidates have no dvd_id upstream and typically no title_en.
+//
+// A genuine miss from either lookup (models.ErrDumpMiss, which includes
+// ErrDumpNoDVDID) is logged at debug; a real database error is logged at warn
+// so a degraded dump does not silently revert to rate-limit-prone HTTP with
+// no signal. Context cancellation is logged at debug and skips candidate
+// expansion entirely so a cancelled scrape stops immediately.
+//
+// Returns (result, candidates): a nil result with non-empty candidates means
+// the dump resolved candidate content_ids (in HTTP-resolver variation order,
+// so the dump never resolves a different product than HTTP would); Search
+// fetches their combined= URLs in order with content_id validation. Both nil
+// means the caller must fall back to the live HTTP URL resolver.
+func (s *scraper) searchFromDump(ctx context.Context, id string) (*models.ScraperResult, []models.DumpMatch) {
 	if s.dumpLookup == nil {
-		return nil, false
+		return nil, nil
 	}
 	movie, err := s.dumpLookup.LookupMovie(ctx, id)
 	if err != nil {
 		switch {
 		case errors.Is(err, models.ErrDumpMiss):
-			logging.Debugf("R18: dump lookup miss for %s, falling back to HTTP", id)
+			// fall through to candidate resolution
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-			// Benign user-initiated cancellation — not a degraded dump. Log at
-			// debug so a cancel doesn't look like a dump failure.
 			logging.Debugf("R18: dump lookup cancelled for %s: %v", id, err)
+			return nil, nil
 		default:
 			logging.Warnf("R18: dump lookup error for %s, falling back to HTTP: %v", id, err)
+			return nil, nil
 		}
-		return nil, false
+
+		matches, mErr := s.dumpLookup.MatchByDisplayID(ctx, id)
+		if mErr != nil || len(matches) == 0 {
+			switch {
+			case mErr == nil || errors.Is(mErr, models.ErrDumpMiss):
+				logging.Debugf("R18: dump lookup miss for %s, falling back to HTTP", id)
+			case errors.Is(mErr, context.Canceled), errors.Is(mErr, context.DeadlineExceeded):
+				logging.Debugf("R18: dump candidate lookup cancelled for %s: %v", id, mErr)
+			default:
+				logging.Warnf("R18: dump candidate lookup error for %s, falling back to HTTP: %v", id, mErr)
+			}
+			return nil, nil
+		}
+		candidates := make([]models.DumpMatch, 0, len(matches))
+		for _, m := range matches {
+			if m.ContentID == "" {
+				continue
+			}
+			candidates = append(candidates, m)
+		}
+		if len(candidates) == 0 {
+			return nil, nil
+		}
+		// Parity gate: trust dump candidates only when they form a contiguous
+		// prefix of the full canonical expansion. A partial or stale dump must
+		// not short-circuit the HTTP resolver: a lone noncanonical row (e.g.
+		// only 436abf00030 for ABF-030) would resolve a product the canonical
+		// prefix order never picks, and a gappy list ([c0, c2]) would skip the
+		// intermediate candidate the resolver tries over the wire first.
+		all := r18devdump.ContentIDCandidates(id)
+		trusted := len(all) >= len(candidates)
+		if trusted {
+			for i, c := range candidates {
+				if c.ContentID != all[i] {
+					trusted = false
+					break
+				}
+			}
+		}
+		if !trusted {
+			logging.Debugf("R18: dump candidates for %s are not a canonical prefix, falling back to HTTP", id)
+			return nil, nil
+		}
+		logging.Debugf("R18: dump candidates for %s -> %s (+%d more)", id, candidates[0].ContentID, len(candidates)-1)
+		return nil, candidates
 	}
 	logging.Debugf("R18: dump lookup resolved %s -> full metadata (zero HTTP)", id)
-	return s.resultFromDump(movie), true
+	return s.resultFromDump(movie), nil
 }

--- a/internal/scraper/r18dev/dump_result_test.go
+++ b/internal/scraper/r18dev/dump_result_test.go
@@ -327,9 +327,9 @@ func TestSearchFromDump_ContextCanceled(t *testing.T) {
 	s, _ := newScraperWithBlockedHTTP(t, dump)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	result, ok := s.searchFromDump(ctx, "IPX-535")
-	assert.False(t, ok, "canceled lookup should fall back to HTTP")
+	result, candidateURLs := s.searchFromDump(ctx, "IPX-535")
 	assert.Nil(t, result, "no result on cancellation")
+	assert.Empty(t, candidateURLs, "no candidate URLs on cancellation")
 }
 
 // TestSearchFromDump_ContextDeadlineExceeded covers the DeadlineExceeded arm
@@ -339,7 +339,7 @@ func TestSearchFromDump_ContextDeadlineExceeded(t *testing.T) {
 	s, _ := newScraperWithBlockedHTTP(t, dump)
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()
-	result, ok := s.searchFromDump(ctx, "IPX-535")
-	assert.False(t, ok)
+	result, candidateURLs := s.searchFromDump(ctx, "IPX-535")
 	assert.Nil(t, result)
+	assert.Empty(t, candidateURLs)
 }

--- a/internal/scraper/r18dev/poster_guard_test.go
+++ b/internal/scraper/r18dev/poster_guard_test.go
@@ -1,0 +1,29 @@
+package r18dev
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResolveAwsimgsrcPoster_RejectsUnsplitableInput covers the early-return
+// guards: an ID that cannot be split into series+number, and a number that
+// overflows int parsing, both yield no awsimgsrc candidate without any HTTP.
+func TestResolveAwsimgsrcPoster_RejectsUnsplitableInput(t *testing.T) {
+	cfg := createTestSettings(true)
+	s := newScraper(&cfg, testGlobalProxy, testGlobalFlareSolverr, nil)
+
+	assert.Empty(t, s.resolveAwsimgsrcPoster(context.Background(), "no-digits-here", &http.Client{}))
+	assert.Empty(t, s.resolveAwsimgsrcPoster(context.Background(), "abc99999999999999999999", &http.Client{}))
+	assert.Empty(t, s.resolveAwsimgsrcPoster(context.Background(), "lulu99999999999999999999", &http.Client{}), "series present in table but overflowing number must bail before HTTP")
+
+	// Unknown series (deliberately absent from the prefix table) exercises the
+	// common-prefix fallback; the blocked transport proves no HTTP is issued
+	// past prefix construction.
+	rt := &recordingTransport{err: errHTTPBlocked}
+	blocked := &http.Client{Transport: rt}
+	assert.Empty(t, s.resolveAwsimgsrcPoster(context.Background(), "zzqq00999", blocked))
+
+}

--- a/internal/scraper/r18dev/ppv_prefix_test.go
+++ b/internal/scraper/r18dev/ppv_prefix_test.go
@@ -2,10 +2,12 @@ package r18dev
 
 import (
 	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/r18devdump"
 )
 
 func TestGenerateContentIDVariations_PPVPrefix_SAN457(t *testing.T) {
-	vars := generateContentIDVariations("SAN-457")
+	vars := r18devdump.ContentIDCandidates("SAN-457")
 	want := "h_796san00457"
 	found := false
 	for _, v := range vars {
@@ -15,13 +17,13 @@ func TestGenerateContentIDVariations_PPVPrefix_SAN457(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("generateContentIDVariations(SAN-457) = %v, missing PPV content_id %q (h_796 prefix dropped)", vars, want)
+		t.Fatalf("r18devdump.ContentIDCandidates(SAN-457) = %v, missing PPV content_id %q (h_796 prefix dropped)", vars, want)
 	}
 	t.Logf("SAN-457 variations: %v", vars)
 }
 
 func TestContentIDPrefixLookup_HasPPVPrefixes(t *testing.T) {
-	prefixes, ok := contentIDPrefixLookup["san"]
+	prefixes, ok := r18devdump.ContentIDPrefixLookup["san"]
 	if !ok {
 		t.Fatal("san series missing from prefix lookup")
 	}
@@ -34,7 +36,7 @@ func TestContentIDPrefixLookup_HasPPVPrefixes(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("contentIDPrefixLookup[\"san\"] = %v, missing PPV prefix %q", prefixes, wantPrefix)
+		t.Fatalf("r18devdump.ContentIDPrefixLookup[\"san\"] = %v, missing PPV prefix %q", prefixes, wantPrefix)
 	}
 }
 

--- a/internal/scraper/r18dev/r18dev.go
+++ b/internal/scraper/r18dev/r18dev.go
@@ -17,6 +17,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/imageutil"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/r18devdump"
 	"github.com/javinizer/javinizer-go/internal/ratelimit"
 	"github.com/javinizer/javinizer-go/internal/scraper/image/placeholder"
 	"github.com/javinizer/javinizer-go/internal/scraperutil"
@@ -316,10 +317,11 @@ func (r *r18ContentIDResolver) ResolveURL(ctx context.Context, id string) (strin
 	s := r.scraper
 
 	// The local r18.dev dump is consulted once, up front, by Search via
-	// searchFromDump (LookupMovie). By the time this resolver runs, the dump
-	// has already missed, so there is no point re-querying the same dvd_id_norm
-	// index here — fall straight through to HTTP resolution. ResolveURL is only
-	// called from Search, so it never runs before searchFromDump.
+	// searchFromDump (full-metadata hit or content-id candidate resolution).
+	// By the time this resolver runs, both dump paths have missed, so there is
+	// no point re-querying the dump here — fall straight through to HTTP
+	// resolution. ResolveURL is only called from Search, so it never runs
+	// before searchFromDump.
 
 	// Step 1: Try to lookup content_id using dvd_id with multiple ID variations.
 	// Only an EXACT dvd_id match is trusted immediately. When the dvd_id= endpoint
@@ -428,9 +430,13 @@ func (s *scraper) Search(ctx context.Context, id string) (*models.ScraperResult,
 		return nil, fmt.Errorf("R18.dev scraper is disabled")
 	}
 
-	// Zero-HTTP fast path: when the local r18.dev dump is present and has this
-	// movie, return a complete ScraperResult with no r18.dev API call at all.
-	if result, ok := s.searchFromDump(ctx, id); ok {
+	// Dump fast path: on a dvd_id hit the dump returns a complete
+	// ScraperResult with no r18.dev API call at all; on a norm miss it may
+	// resolve content_id candidates locally, in which case each candidate URL
+	// is fetched in order below — one request on the happy path, with
+	// per-candidate fallthrough so a stale dump row never dead-ends the scrape.
+	result, dumpCandidates := s.searchFromDump(ctx, id)
+	if result != nil {
 		return result, nil
 	}
 
@@ -439,6 +445,16 @@ func (s *scraper) Search(ctx context.Context, id string) (*models.ScraperResult,
 	// cancellation immediately so the caller stops cleanly.
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("R18.dev search cancelled before HTTP fallback: %w", err)
+	}
+
+	for _, candidate := range dumpCandidates {
+		candidateURL := fmt.Sprintf(apiURL, candidate.ContentID)
+		logging.Debugf("R18: Fetching dump-resolved candidate URL for %s: %s", id, candidateURL)
+		if res, fetchErr := s.fetchAndParseCandidate(ctx, candidateURL, candidate.ContentID); fetchErr == nil && res != nil {
+			return res, nil
+		} else if fetchErr != nil {
+			logging.Debugf("R18: dump-resolved candidate %s failed for %s: %v", candidateURL, id, fetchErr)
+		}
 	}
 
 	// HTTP fallback: resolve URL → fetch → parse
@@ -457,12 +473,39 @@ func (s *scraper) Search(ctx context.Context, id string) (*models.ScraperResult,
 		logging.Debugf("R18: Using normalized ID URL (no content-id found): %s", finalURL)
 	}
 
-	resp, err := s.doRequestWithRetryCtx(ctx, finalURL)
+	return s.fetchAndParseCombined(ctx, finalURL)
+}
+
+// fetchAndParseCandidate fetches a dump-resolved candidate URL and validates
+// that the response actually describes the requested content_id. r18.dev can
+// answer a stale dump row with a 200 carrying a different movie (or an empty
+// payload); treat those as failures so the next candidate or the HTTP resolver
+// takes over, mirroring the resolver's core-match safeguard.
+func (s *scraper) fetchAndParseCandidate(ctx context.Context, url, wantContentID string) (*models.ScraperResult, error) {
+	res, err := s.fetchAndParseCombined(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil || res.ContentID == "" || !strings.EqualFold(res.ContentID, wantContentID) {
+		got := ""
+		if res != nil {
+			got = res.ContentID
+		}
+		return nil, fmt.Errorf("candidate %s mismatch: response content_id %q", wantContentID, got)
+	}
+	return res, nil
+}
+
+// fetchAndParseCombined fetches the combined-detail JSON for url and parses it
+// into a ScraperResult. Non-200 status codes, HTML payloads, and malformed
+// JSON all surface as errors so callers can fail over to the next candidate.
+func (s *scraper) fetchAndParseCombined(ctx context.Context, url string) (*models.ScraperResult, error) {
+	resp, err := s.doRequestWithRetryCtx(ctx, url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch data from R18.dev: %w", err)
 	}
 	if resp == nil {
-		return nil, fmt.Errorf("R18.dev returned nil response for %s", finalURL)
+		return nil, fmt.Errorf("R18.dev returned nil response for %s", url)
 	}
 
 	if resp.StatusCode() != 200 {
@@ -487,7 +530,7 @@ func (s *scraper) Search(ctx context.Context, id string) (*models.ScraperResult,
 		return nil, fmt.Errorf("failed to parse R18.dev response (preview: %s): %w", bodyPreview, err)
 	}
 
-	return s.parseResponse(ctx, &data, finalURL)
+	return s.parseResponse(ctx, &data, url)
 }
 
 // parseResponse converts R18 API response to ScraperResult.
@@ -871,7 +914,7 @@ func stripDMMPrefix(id string) string {
 // r18.dev returning a 200 for a different movie that happens to share a prefix slot, so the
 // result does not depend solely on global prefix-table ordering.
 func (s *scraper) resolveByContentIDVariations(ctx context.Context, id string) (string, error) {
-	variations := generateContentIDVariations(id)
+	variations := r18devdump.ContentIDCandidates(id)
 	if len(variations) == 0 {
 		return "", nil
 	}
@@ -929,7 +972,7 @@ func (s *scraper) resolveByContentIDVariations(ctx context.Context, id string) (
 // don't always match awsimgsrc, so we use the prefix lookup to try variations.
 // Returns the first valid awsimgsrc ps.jpg URL that meets quality requirements.
 func (s *scraper) resolveAwsimgsrcPoster(ctx context.Context, contentID string, client *http.Client) string {
-	series, numStr := splitSeriesAndNumber(contentIDToID(contentID))
+	series, numStr := r18devdump.SplitSeriesAndNumber(contentIDToID(contentID))
 	if series == "" || numStr == "" {
 		return ""
 	}
@@ -944,7 +987,7 @@ func (s *scraper) resolveAwsimgsrcPoster(ctx context.Context, contentID string, 
 
 	// Look up known prefixes for this series
 	var prefixes []string
-	if lookup, ok := contentIDPrefixLookup[series]; ok {
+	if lookup, ok := r18devdump.ContentIDPrefixLookup[series]; ok {
 		prefixes = lookup
 	} else {
 		prefixes = []string{"", "1"}
@@ -967,92 +1010,6 @@ func (s *scraper) resolveAwsimgsrcPoster(ctx context.Context, contentID string, 
 	}
 
 	return ""
-}
-
-// generateContentIDVariations constructs possible content_id formats from a dvd_id.
-// For "START-575", generates: ["1start00575", "1start575"]
-// For "ABF-346", generates: ["118abf00346", "118abf346", "436abf00346", "436abf346"]
-// The r18.dev content_id format is: [DMM-prefix][series][zero-padded-number]
-// Uses the contentIDPrefixLookup table built from r18.dev database dumps to find
-// known prefixes per series. Falls back to common prefixes if the series is unknown.
-func generateContentIDVariations(id string) []string {
-	series, numStr := splitSeriesAndNumber(id)
-	if series == "" || numStr == "" {
-		return nil
-	}
-
-	series = strings.ToLower(series)
-	num, err := strconv.Atoi(numStr)
-	if err != nil {
-		return nil
-	}
-
-	padded3 := fmt.Sprintf("%03d", num)
-	padded5 := fmt.Sprintf("%05d", num)
-
-	// Look up known prefixes for this series from the r18.dev database dump
-	var prefixes []string
-	if lookup, ok := contentIDPrefixLookup[series]; ok {
-		prefixes = lookup
-	} else {
-		// Fallback: try common prefixes for unknown series
-		prefixes = []string{"", "1"}
-	}
-
-	var variations []string
-	seen := make(map[string]bool)
-
-	add := func(v string) {
-		if !seen[v] {
-			seen[v] = true
-			variations = append(variations, v)
-		}
-	}
-
-	for _, prefix := range prefixes {
-		// 5-digit padded (standard DMM content_id format)
-		add(prefix + series + padded5)
-		// 3-digit padded (used by many r18.dev content_ids)
-		add(prefix + series + padded3)
-	}
-
-	return variations
-}
-
-// splitSeriesAndNumber splits a dvd_id like "START-575" into ("START", "575")
-func splitSeriesAndNumber(id string) (string, string) {
-	// Try standard format: SERIES-NUMBER
-	if parts := strings.SplitN(id, "-", 2); len(parts) == 2 {
-		if isAlpha(parts[0]) && isDigit(parts[1]) {
-			return parts[0], parts[1]
-		}
-	}
-
-	// Try already-normalized format: series575 (from normalizeID)
-	lowered := strings.ToLower(id)
-	if m := contentIDFullRegex.FindStringSubmatch(lowered); len(m) >= 4 {
-		return m[2], m[3]
-	}
-
-	return "", ""
-}
-
-func isAlpha(s string) bool {
-	for _, r := range s {
-		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') {
-			return false
-		}
-	}
-	return len(s) > 0
-}
-
-func isDigit(s string) bool {
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return len(s) > 0
 }
 
 // contentIDToID converts content ID to standard ID format

--- a/internal/scraper/r18dev/r18dev.go
+++ b/internal/scraper/r18dev/r18dev.go
@@ -504,9 +504,6 @@ func (s *scraper) fetchAndParseCombined(ctx context.Context, url string) (*model
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch data from R18.dev: %w", err)
 	}
-	if resp == nil {
-		return nil, fmt.Errorf("R18.dev returned nil response for %s", url)
-	}
 
 	if resp.StatusCode() != 200 {
 		return nil, models.NewScraperStatusError(

--- a/internal/scraper/r18dev/r18dev_deep2_test.go
+++ b/internal/scraper/r18dev/r18dev_deep2_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/r18devdump"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,7 +60,7 @@ func TestContentIDToIDDeep2(t *testing.T) {
 }
 
 func TestGenerateAlternateContentIDsDeep2(t *testing.T) {
-	ids := generateContentIDVariations("abw001")
+	ids := r18devdump.ContentIDCandidates("abw001")
 	assert.NotEmpty(t, ids)
 	// Should generate IDs using the prefix lookup table for "abw" which has prefix "118"
 	assert.Contains(t, ids, "118abw00001")

--- a/internal/scraper/r18dev/r18dev_miss2_test.go
+++ b/internal/scraper/r18dev/r18dev_miss2_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/r18devdump"
 	"github.com/javinizer/javinizer-go/internal/ratelimit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -268,12 +269,12 @@ func TestContentIDMatchesExpected_Miss2_ShortIDs(t *testing.T) {
 
 func TestGenerateAlternateContentIDs_Miss2_ShortID(t *testing.T) {
 	// ID that doesn't match the regex
-	result := generateContentIDVariations("short")
+	result := r18devdump.ContentIDCandidates("short")
 	assert.Nil(t, result)
 }
 
 func TestGenerateAlternateContentIDs_Miss2_ValidID(t *testing.T) {
-	result := generateContentIDVariations("ipx00535")
+	result := r18devdump.ContentIDCandidates("ipx00535")
 	assert.NotEmpty(t, result)
 	// Should contain prefixed variants using the prefix lookup for "ipx"
 	found := false

--- a/internal/scraper/r18dev/uncovered_test.go
+++ b/internal/scraper/r18dev/uncovered_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/r18devdump"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -107,11 +108,11 @@ func TestScraper_ContentIDMatchesExpected(t *testing.T) {
 
 func TestScraper_GenerateAlternateContentIDs(t *testing.T) {
 	t.Run("generates alternates for lowercase ID", func(t *testing.T) {
-		result := generateContentIDVariations("ipx635")
+		result := r18devdump.ContentIDCandidates("ipx635")
 		assert.NotEmpty(t, result)
 	})
 	t.Run("returns nil for non-matching input", func(t *testing.T) {
-		result := generateContentIDVariations("")
+		result := r18devdump.ContentIDCandidates("")
 		assert.Nil(t, result)
 	})
 }

--- a/web/frontend/messages/en-XA.json
+++ b/web/frontend/messages/en-XA.json
@@ -1555,6 +1555,7 @@
   "settings_r18dev_search_failed": "[ Šëårçh fåílëd ]",
   "settings_r18dev_search_heading": "[ Šëårçh Dümp ]",
   "settings_r18dev_search_no_match": "[ Ñö måtçh föüñd ]",
+  "settings_r18dev_search_no_dvd_id": "[ Þrésént ín dúmp bút hâs ñó dvd_id (dvd_id-kéyed séarçhes çannot mátçh it): ]",
   "settings_r18dev_search_placeholder": "[ dvd_íd ör çöñtëñt_íd (ë.g. ÅBF-030) ]",
   "settings_r18dev_size": "[ Šízë ]",
   "settings_r18dev_source_date": "[ Šöürçë dåtë ]",

--- a/web/frontend/messages/en.json
+++ b/web/frontend/messages/en.json
@@ -2213,6 +2213,7 @@
   "settings_r18dev_search_failed": "Search failed",
   "settings_r18dev_search_heading": "Search Dump",
   "settings_r18dev_search_no_match": "No match found",
+  "settings_r18dev_search_no_dvd_id": "Present in dump but has no dvd_id (dvd_id-keyed searches cannot match it):",
   "settings_r18dev_search_placeholder": "dvd_id or content_id (e.g. ABF-030)",
   "settings_r18dev_size": "Size",
   "settings_r18dev_source_date": "Source date",

--- a/web/frontend/messages/ja.json
+++ b/web/frontend/messages/ja.json
@@ -2215,6 +2215,7 @@
   "settings_r18dev_search_failed": "検索に失敗しました",
   "settings_r18dev_search_heading": "ダンプを検索",
   "settings_r18dev_search_no_match": "一致は見つかりませんでした",
+  "settings_r18dev_search_no_dvd_id": "ダンプ内に存在しますが、dvd_id がありません（dvd_id による検索では一致しません）：",
   "settings_r18dev_search_placeholder": "dvd_id または content_id (例: ABF-030)",
   "settings_r18dev_size": "サイズ",
   "settings_r18dev_source_date": "ソース日",

--- a/web/frontend/messages/zh-Hans.json
+++ b/web/frontend/messages/zh-Hans.json
@@ -2215,6 +2215,7 @@
   "settings_r18dev_search_failed": "搜索失败",
   "settings_r18dev_search_heading": "搜索数据库",
   "settings_r18dev_search_no_match": "未找到匹配项",
+  "settings_r18dev_search_no_dvd_id": "存在于转储中但没有 dvd_id（按 dvd_id 检索无法匹配）：",
   "settings_r18dev_search_placeholder": "dvd_id 或 content_id（例如 ABF-030）",
   "settings_r18dev_size": "大小",
   "settings_r18dev_source_date": "来源日期",

--- a/web/frontend/messages/zh-Hant.json
+++ b/web/frontend/messages/zh-Hant.json
@@ -2215,6 +2215,7 @@
   "settings_r18dev_search_failed": "搜尋失敗",
   "settings_r18dev_search_heading": "搜尋傾印",
   "settings_r18dev_search_no_match": "找不到相符項目",
+  "settings_r18dev_search_no_dvd_id": "存在於傾印中但沒有 dvd_id（以 dvd_id 查詢無法比對）：",
   "settings_r18dev_search_placeholder": "dvd_id 或 content_id（例如 ABF-030）",
   "settings_r18dev_size": "大小",
   "settings_r18dev_source_date": "來源日期",

--- a/web/frontend/src/lib/api/types.ts
+++ b/web/frontend/src/lib/api/types.ts
@@ -1421,8 +1421,17 @@ export interface DumpStatus {
 	enabled: boolean;
 }
 
+export interface DumpSearchMatch {
+	content_id: string;
+	dvd_id?: string;
+	release_date?: string;
+	service_code?: string;
+}
+
 export interface DumpSearchResult {
 	query: string;
 	content_id: string | null;
 	dvd_id: string | null;
+	state?: 'mapped' | 'no_dvd_id';
+	matches?: DumpSearchMatch[];
 }

--- a/web/frontend/src/lib/components/settings/sections/R18DevDumpSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/R18DevDumpSection.svelte
@@ -4,7 +4,7 @@
 	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
 	import { apiClient as api } from '$lib/api/client';
 	import { websocketStore } from '$lib/stores/websocket';
-	import type { DumpStatus } from '$lib/api/types';
+	import type { DumpSearchResult, DumpStatus } from '$lib/api/types';
 	import { Download, RefreshCw, Search, CheckCircle, AlertCircle, Database, Trash2 } from 'lucide-svelte';
 
 	interface Props {
@@ -17,7 +17,7 @@
 	let downloading = $state(false);
 	let downloadError = $state('');
 	let searchQuery = $state('');
-	let searchResult: { content_id: string | null; dvd_id: string | null } | null = $state(null);
+	let searchResult: DumpSearchResult | null = $state(null);
 	let searchError = $state('');
 	let error = $state('');
 	let dumpEnabled = $state(true);
@@ -433,7 +433,21 @@
 			</div>
 			{#if searchResult}
 				<div class="mt-2 p-2 rounded-md bg-muted text-sm">
-					{#if searchResult.content_id}
+					{#if searchResult.state === 'no_dvd_id'}
+						<span class="text-muted-foreground">{m.settings_r18dev_search_no_dvd_id()}</span>
+						{#if searchResult.matches?.length}
+							<ul class="mt-1 space-y-0.5">
+								{#each searchResult.matches as match (match.content_id)}
+									<li>
+										<span class="font-mono">{match.content_id}</span>
+										<span class="text-muted-foreground">
+											{match.release_date}{match.release_date && match.service_code ? ' · ' : ''}{match.service_code}
+										</span>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+					{:else if searchResult.content_id}
 						<span class="text-muted-foreground">{m.settings_r18dev_search_content_id()}</span>
 						<span class="font-mono">{searchResult.content_id}</span>
 					{:else if searchResult.dvd_id}

--- a/web/frontend/src/lib/components/settings/sections/R18DevDumpSection.test.ts
+++ b/web/frontend/src/lib/components/settings/sections/R18DevDumpSection.test.ts
@@ -1,98 +1,110 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, waitFor } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
-import type { DumpStatus } from '$lib/api/types';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, screen, waitFor } from '@testing-library/svelte';
 import R18DevDumpSection from './R18DevDumpSection.svelte';
+import type { DumpSearchResult } from '$lib/api/types';
 
-const { clearMessages, downloadDump, getDumpStatus } = vi.hoisted(() => ({
-	clearMessages: vi.fn(),
-	downloadDump: vi.fn(),
-	getDumpStatus: vi.fn(),
-}));
-
-vi.mock('$lib/stores/websocket', () => ({
-	websocketStore: {
-		subscribe: writable({ connected: true, skipped: false, messages: [], messagesByFile: {} })
-			.subscribe,
-		clearMessages,
-	},
-}));
+const searchDump = vi.fn();
 
 vi.mock('$lib/api/client', () => ({
 	apiClient: {
 		r18dev: {
-			getDumpStatus,
-			downloadDump,
+			getDumpStatus: vi.fn(),
+			searchDump: (...args: unknown[]) => searchDump(...args),
 		},
 	},
 }));
 
-if (!Element.prototype.animate) {
-	Element.prototype.animate = vi.fn(() => ({
-		cancel: vi.fn(),
-		commitStyles: vi.fn(),
-		currentTime: 0,
-		effect: null,
-		finish: vi.fn(),
-		finished: Promise.resolve(),
-		id: '',
-		oncancel: null,
-		onfinish: null,
-		onremove: null,
-		pause: vi.fn(),
-		pending: false,
-		persist: vi.fn(),
-		play: vi.fn(),
-		playState: 'finished',
-		playbackRate: 1,
-		ready: Promise.resolve(),
-		replaceState: 'active',
-		reverse: vi.fn(),
-		startTime: 0,
-		timeline: null,
-		updatePlaybackRate: vi.fn(),
-		addEventListener: vi.fn(),
-		dispatchEvent: vi.fn(),
-		removeEventListener: vi.fn(),
-	})) as unknown as typeof Element.prototype.animate;
-}
+vi.mock('$lib/stores/websocket', () => ({
+	websocketStore: {
+		subscribe: (fn: (s: { messages: unknown[] }) => void) => {
+			fn({ messages: [] });
+			return () => {};
+		},
+		clearMessages: () => {},
+	},
+}));
 
-function status(overrides: Partial<DumpStatus> = {}): DumpStatus {
-	return {
-		present: false,
-		running: false,
-		path: '/tmp/r18dev.db',
-		enabled: true,
-		...overrides,
+if (!Element.prototype.animate) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(Element.prototype as any).animate = function () {
+		const anim = {
+			onfinish: null as (() => void) | null,
+			oncancel: null as (() => void) | null,
+			effect: null as unknown,
+			playState: 'finished' as const,
+			currentTime: 0,
+			cancel() {},
+			finish() {
+				anim.onfinish?.();
+			},
+			addEventListener() {},
+			removeEventListener() {},
+		};
+		queueMicrotask(() => anim.onfinish?.());
+		return anim;
 	};
 }
 
-beforeEach(() => {
-	vi.clearAllMocks();
-	getDumpStatus.mockResolvedValue(status());
-	downloadDump.mockRejectedValue(new Error('stop polling'));
-});
+const mod = await import('$lib/api/client');
+const mockGetDumpStatus = vi.mocked(mod.apiClient.r18dev.getDumpStatus);
 
-describe('R18DevDumpSection', () => {
-	it('clears stale shared dump progress before starting a download', async () => {
-		const { container } = render(R18DevDumpSection);
-		await waitFor(() => expect(getDumpStatus).toHaveBeenCalled());
+describe('R18DevDumpSection search states', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetDumpStatus.mockResolvedValue({
+			present: true,
+			enabled: true,
+			running: false,
+			row_count: 1847688,
+			path: '/tmp/x.db',
+		} as never);
+	});
 
-		const header = container.querySelector('button[aria-expanded="false"]') as HTMLButtonElement;
+	it('renders present-without-dvd_id matches instead of "no match"', async () => {
+		const result: DumpSearchResult = {
+			query: 'LULU-441',
+			content_id: null,
+			dvd_id: null,
+			state: 'no_dvd_id',
+			matches: [
+				{ content_id: 'lulu00441', release_date: '2026-07-03', service_code: 'digital' },
+				{ content_id: 'lulu441', release_date: '2026-07-07', service_code: 'mono' },
+			],
+		};
+		searchDump.mockResolvedValue(result);
+
+		render(R18DevDumpSection);
+
+		const header = document.querySelector('button[aria-expanded]') as HTMLElement;
 		await fireEvent.click(header);
-		const button = await waitFor(() => {
-			const element = Array.from(container.querySelectorAll('button')).find((candidate) =>
-				candidate.textContent?.includes('Download Dump'),
-			);
-			expect(element).toBeTruthy();
-			return element as HTMLButtonElement;
-		});
-		await fireEvent.click(button);
+		const input = await screen.findByRole('textbox');
+		await fireEvent.input(input, { target: { value: 'LULU-441' } });
+		await fireEvent.click(screen.getByRole('button', { name: /search/i }));
 
-		expect(clearMessages).toHaveBeenCalledWith('r18dev-dump-download');
-		expect(downloadDump).toHaveBeenCalledWith(false);
-		expect(clearMessages.mock.invocationCallOrder[0]).toBeLessThan(
-			downloadDump.mock.invocationCallOrder[0],
-		);
+		await waitFor(() => expect(screen.getByText(/lulu00441/)).toBeTruthy());
+		expect(screen.getByText(/lulu441/)).toBeTruthy();
+		expect(screen.getByText(/no dvd_id/)).toBeTruthy();
+		expect(screen.queryByText(/No match/i)).toBeNull();
+	});
+
+	it('renders mapped results with content_id label', async () => {
+		searchDump.mockResolvedValue({
+			query: 'ABF-030',
+			content_id: '118abf030',
+			dvd_id: null,
+			state: 'mapped',
+			matches: [{ content_id: '118abf030', dvd_id: 'ABF-030' }],
+		} satisfies DumpSearchResult);
+
+		render(R18DevDumpSection);
+
+		const header = document.querySelector('button[aria-expanded]') as HTMLElement;
+		await fireEvent.click(header);
+		const input = await screen.findByRole('textbox');
+		await fireEvent.input(input, { target: { value: 'ABF-030' } });
+		await fireEvent.click(screen.getByRole('button', { name: /search/i }));
+
+		await waitFor(() => expect(screen.getByText('118abf030')).toBeTruthy());
+		expect(screen.queryByText(/no dvd_id/)).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

- Roughly a fifth of the r18.dev dump (366k rows) carries `dvd_id = NULL` upstream, making titles like LULU-441 invisible to every dump lookup (`dump search lulu00441` reported "No match" for a row that exists) and forcing a multi-probe HTTP resolution on every scrape.
- Internal plumbing: extracted the scraper's content-id candidate rules + prefix table into `internal/r18devdump` as the single source of truth (`ContentIDCandidates`), added `ErrDumpNoDVDID` (wraps `ErrDumpMiss`) and an ordered `MatchByDisplayID` primitive with exact-content-id priority and exact-match candidate expansion (no LIKE).
- Scraper fast path: dump candidates are trusted only when they form a contiguous prefix of the canonical expansion; fetches are identity-validated with per-candidate failure fallthrough, and anything ambiguous defers to the existing HTTP resolver — so the dump can never resolve a different product than the HTTP path (one API request on the happy path for these titles instead of ~7 probes).
- Search surfaces: `dump search` CLI, `GET /api/v1/r18dev/dump/search` (additive `state` + `matches[]`, 404/503 semantics preserved), and the web UI now distinguish mapped / present-without-dvd_id / absent across all five locales.

## Test plan

- [x] New unit tests for candidates (`internal/r18devdump`), store three-state matching, scraper fast path incl. stale/noncanonical/gappy/mismatch fallthrough, CLI + API search states, and component tests for the settings UI
- [x] `go test -short ./...` (115 packages), `go vet`, `golangci-lint`, race on API package, `make coverage-check` (91.99% line coverage)
- [x] Frontend: `npx vitest run` 574/574, `svelte-check` clean
- [x] Live smoke against the real 2026-08-04 dump: `dump search lulu441/LULU-441/lulu00441` report present-without-dvd_id with both editions; `scrape LULU-441 --scrapers r18dev --force` resolves via one `combined=lulu00441` fetch
- [x] 7 rounds of the local Codex review loop, final round no-findings
