### PR TITLE
fix(review): use canonical movie ID for poster crop source URL

### DIFF
--- a/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.test.ts
+++ b/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.test.ts
@@ -240,3 +240,83 @@ describe('openPosterCropModal — crop source URL formation (poster rendering re
 		expect(url, 'session + v params must be joined with &, not a duplicated ?').toMatch(/[?&]v=12345/);
 	});
 });
+
+describe('openPosterCropModal — canonical movie ID wins over stale result FK (issue: 300MIUM-1360)', () => {
+	// Regression: openPosterCropModal built the crop source URL from
+	// result.movie_id (a stale FK that can diverge from movie.id after a
+	// rescrape/ID canonicalization). The server names poster files by the
+	// canonical movie.id (internal/poster/manager.go: "%s-full.jpg", posterID
+	// where posterID = movie.id), so using result.movie_id requested a
+	// non-existent file -> 404 -> "Poster source is not available".
+	// Reported on review job 6c486399-37c5-44f5-b351-1755e22ef938 where
+	// result.movie_id = "MIUM-1360" but movie.id = "300MIUM-1360".
+
+	afterEach(() => {
+		BaseClient.setSessionID(null);
+	});
+
+	function makeDivergentIdController() {
+		BaseClient.setSessionID('sid-abc');
+		const setCropSourceURL = vi.fn();
+		const movie: Movie = {
+			id: '300MIUM-1360',
+			title: 'Test Movie',
+			poster_url: 'https://dmm/poster.jpg',
+		};
+		const result: FileResult = {
+			result_id: 'res-1',
+			file_path: '/tmp/300MIUM-1360.mp4',
+			movie_id: 'MIUM-1360',
+			status: 'completed',
+			started_at: '',
+			is_multi_part: false,
+			part_number: 0,
+			part_suffix: '',
+			movie: { id: '300MIUM-1360', title: 'Test Movie', poster_url: 'https://dmm/poster.jpg' },
+		};
+		const controller = createPosterCropController({
+			getBrowser: () => true,
+			getJobId: () => 'job-1',
+			getCurrentMovie: () => movie,
+			getCurrentResult: () => result,
+			getShowPosterCropModal: () => false,
+			setShowPosterCropModal: () => {},
+			setPosterCropLoadError: () => {},
+			getCropSourceURL: () => '',
+			setCropSourceURL,
+			getCropImageElement: () => null,
+			setCropImageElement: () => {},
+			getCropMetrics: () => null,
+			setCropMetrics: () => {},
+			getCropBox: () => null,
+			setCropBox: () => {},
+			getMaxPosterHeight: () => null,
+			setMaxPosterHeight: () => {},
+			getCropDragState: () => null,
+			setCropDragState: () => {},
+			getPosterCropStates: () => new Map<string, PosterCropState>(),
+			applyPosterFromUrlAsync: vi.fn(async () => {}),
+			mutatePosterCropAsync: vi.fn(async () => {}),
+			setCropApplying: () => {},
+			now: () => 12345,
+		});
+		return { controller, setCropSourceURL };
+	}
+
+	it('builds the crop source URL from the canonical movie.id, not the stale result.movie_id FK', () => {
+		const { controller, setCropSourceURL } = makeDivergentIdController();
+		controller.openPosterCropModal();
+
+		expect(setCropSourceURL).toHaveBeenCalledTimes(1);
+		const url = setCropSourceURL.mock.calls[0][0] as string;
+		expect(url, 'crop source URL must use the canonical movie.id (300MIUM-1360-full.jpg)').toContain(
+			'/api/v1/temp/posters/job-1/300MIUM-1360-full.jpg',
+		);
+		expect(url, 'crop source URL must NOT use the stale result.movie_id filename').not.toContain(
+			'/MIUM-1360-full.jpg',
+		);
+		expect(url, 'crop source URL must NOT use the stale result.movie_id filename').not.toContain(
+			'/MIUM-1360.jpg',
+		);
+	});
+});

--- a/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.test.ts
+++ b/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.test.ts
@@ -249,7 +249,12 @@ describe('openPosterCropModal — canonical movie ID wins over stale result FK (
 	// where posterID = movie.id), so using result.movie_id requested a
 	// non-existent file -> 404 -> "Poster source is not available".
 	// Reported on review job 6c486399-37c5-44f5-b351-1755e22ef938 where
-	// result.movie_id = "MIUM-1360" but movie.id = "300MIUM-1360".
+	// result.movie_id = "MIUM-1360" but result.movie.id = "300MIUM-1360".
+	//
+	// Priority is persisted-canonical first: result.movie.id (the server's
+	// canonical record) -> result.movie_id (FK fallback) -> currentMovie.id
+	// (editable overlay, last resort — an unsaved edit to the Movie ID field
+	// must NOT be treated as a server filename; see the unsaved-edit test below).
 
 	afterEach(() => {
 		BaseClient.setSessionID(null);
@@ -317,6 +322,84 @@ describe('openPosterCropModal — canonical movie ID wins over stale result FK (
 		);
 		expect(url, 'crop source URL must NOT use the stale result.movie_id filename').not.toContain(
 			'/MIUM-1360.jpg',
+		);
+	});
+});
+
+describe('openPosterCropModal — persisted movie ID wins over unsaved edit overlay (Codex review)', () => {
+	// Regression (Codex P2): currentMovie is the editable overlay
+	// (editedMovies.get(file_path) || currentResult.movie — see review-state).
+	// If a user edits the Movie ID field but has not saved, currentMovie.id
+	// is the unsaved value while the server's poster file is still named with
+	// the persisted currentResult.movie.id. Preferring currentMovie.id would
+	// request a non-existent <edited-id>-full.jpg -> 404. The fix prefers
+	// currentResult.movie.id (persisted canonical) first.
+
+	afterEach(() => {
+		BaseClient.setSessionID(null);
+	});
+
+	function makeUnsavedEditController() {
+		BaseClient.setSessionID('sid-abc');
+		const setCropSourceURL = vi.fn();
+		// currentMovie reflects an UNSAVED edit: id changed to 'EDITED-001'.
+		const movie: Movie = {
+			id: 'EDITED-001',
+			title: 'Test Movie',
+			poster_url: 'https://dmm/poster.jpg',
+		};
+		// currentResult.movie carries the PERSISTED canonical id '300MIUM-1360'.
+		const result: FileResult = {
+			result_id: 'res-1',
+			file_path: '/tmp/300MIUM-1360.mp4',
+			movie_id: 'MIUM-1360',
+			status: 'completed',
+			started_at: '',
+			is_multi_part: false,
+			part_number: 0,
+			part_suffix: '',
+			movie: { id: '300MIUM-1360', title: 'Test Movie', poster_url: 'https://dmm/poster.jpg' },
+		};
+		const controller = createPosterCropController({
+			getBrowser: () => true,
+			getJobId: () => 'job-1',
+			getCurrentMovie: () => movie,
+			getCurrentResult: () => result,
+			getShowPosterCropModal: () => false,
+			setShowPosterCropModal: () => {},
+			setPosterCropLoadError: () => {},
+			getCropSourceURL: () => '',
+			setCropSourceURL,
+			getCropImageElement: () => null,
+			setCropImageElement: () => {},
+			getCropMetrics: () => null,
+			setCropMetrics: () => {},
+			getCropBox: () => null,
+			setCropBox: () => {},
+			getMaxPosterHeight: () => null,
+			setMaxPosterHeight: () => {},
+			getCropDragState: () => null,
+			setCropDragState: () => {},
+			getPosterCropStates: () => new Map<string, PosterCropState>(),
+			applyPosterFromUrlAsync: vi.fn(async () => {}),
+			mutatePosterCropAsync: vi.fn(async () => {}),
+			setCropApplying: () => {},
+			now: () => 12345,
+		});
+		return { controller, setCropSourceURL };
+	}
+
+	it('builds the crop source URL from the persisted result.movie.id, not the unsaved currentMovie.id edit', () => {
+		const { controller, setCropSourceURL } = makeUnsavedEditController();
+		controller.openPosterCropModal();
+
+		expect(setCropSourceURL).toHaveBeenCalledTimes(1);
+		const url = setCropSourceURL.mock.calls[0][0] as string;
+		expect(url, 'crop source URL must use the persisted result.movie.id (300MIUM-1360-full.jpg)').toContain(
+			'/api/v1/temp/posters/job-1/300MIUM-1360-full.jpg',
+		);
+		expect(url, 'crop source URL must NOT use the unsaved currentMovie.id (EDITED-001-full.jpg)').not.toContain(
+			'/EDITED-001',
 		);
 	});
 });

--- a/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.ts
+++ b/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.ts
@@ -117,7 +117,7 @@ export function createPosterCropController(deps: PosterCropControllerDeps) {
 	function handlePosterCropImageError() {
 		const currentMovie = deps.getCurrentMovie();
 		if (currentMovie && deps.getCropSourceURL().includes('-full.jpg')) {
-			const posterMovieId = currentMovie.id || deps.getCurrentResult()?.movie_id;
+			const posterMovieId = deps.getCurrentResult()?.movie?.id || deps.getCurrentResult()?.movie_id || currentMovie.id;
 			const fallbackURL = `/api/v1/temp/posters/${deps.getJobId()}/${posterMovieId}.jpg${sessionParam()}`;
 			deps.setCropSourceURL(`${fallbackURL}${fallbackURL.includes('?') ? '&' : '?'}v=${now()}`);
 			return;
@@ -141,7 +141,7 @@ export function createPosterCropController(deps: PosterCropControllerDeps) {
 		) {
 			sourceURL = `/api/v1/temp/image?url=${encodeURIComponent(currentMovie.poster_url)}${sessionParam().replace('?', '&')}`;
 		} else {
-			const posterMovieId = currentMovie.id || currentResult?.movie_id;
+			const posterMovieId = currentResult?.movie?.id || currentResult?.movie_id || currentMovie.id;
 			const fullPosterURL = `/api/v1/temp/posters/${deps.getJobId()}/${posterMovieId}-full.jpg${sessionParam()}`;
 			sourceURL = fullPosterURL;
 		}

--- a/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.ts
+++ b/web/frontend/src/routes/review/[jobId]/logic/poster-crop-controller.ts
@@ -117,7 +117,7 @@ export function createPosterCropController(deps: PosterCropControllerDeps) {
 	function handlePosterCropImageError() {
 		const currentMovie = deps.getCurrentMovie();
 		if (currentMovie && deps.getCropSourceURL().includes('-full.jpg')) {
-			const posterMovieId = deps.getCurrentResult()?.movie_id ?? currentMovie.id;
+			const posterMovieId = currentMovie.id || deps.getCurrentResult()?.movie_id;
 			const fallbackURL = `/api/v1/temp/posters/${deps.getJobId()}/${posterMovieId}.jpg${sessionParam()}`;
 			deps.setCropSourceURL(`${fallbackURL}${fallbackURL.includes('?') ? '&' : '?'}v=${now()}`);
 			return;
@@ -141,7 +141,7 @@ export function createPosterCropController(deps: PosterCropControllerDeps) {
 		) {
 			sourceURL = `/api/v1/temp/image?url=${encodeURIComponent(currentMovie.poster_url)}${sessionParam().replace('?', '&')}`;
 		} else {
-			const posterMovieId = currentResult?.movie_id ?? currentMovie.id;
+			const posterMovieId = currentMovie.id || currentResult?.movie_id;
 			const fullPosterURL = `/api/v1/temp/posters/${deps.getJobId()}/${posterMovieId}-full.jpg${sessionParam()}`;
 			sourceURL = fullPosterURL;
 		}


### PR DESCRIPTION
## What

Fixes the broken poster crop source image in the review page's **Adjust Poster Crop** modal. For movies whose `result.movie_id` FK diverges from the canonical `movie.id` (e.g. after rescrape/ID canonicalization), the crop source `<img>` requested a non-existent poster file → 404 → "Poster source is not available for manual cropping".

Reported on review job `6c486399-37c5-44f5-b351-1755e22ef938` where `result.movie_id = "MIUM-1360"` but `movie.id = "300MIUM-1360"`.

## Root cause

The crop source URL was built preferring the stale `result.movie_id` FK over the canonical `movie.id`:

```ts
const posterMovieId = currentResult?.movie_id ?? currentMovie.id;
const fullPosterURL = `/api/v1/temp/posters/${jobId}/${posterMovieId}-full.jpg...`;
```

The server names poster files by the **canonical movie ID** (`internal/poster/manager.go`: `fmt.Sprintf("%s-full.jpg", posterID)` where `posterID = movie.id`), so using `result.movie_id` requested `MIUM-1360-full.jpg` → 404. The error fallback stripped `-full` → `MIUM-1360.jpg` → also 404.

This is why movies like ORECO-371 (where `result.movie_id === movie.id`) worked, but 300MIUM-1360 didn't. The codebase already knows these IDs can diverge — `poster-crop-sync.ts`'s `rescrapeClearedMovieKeys` clears *both* `r.movie_id` and `r.movie.id`.

## Changes

In `poster-crop-controller.ts`, prefer the canonical `currentMovie.id` (which the server uses to name the poster file) over the stale `currentResult.movie_id` FK — in both places that build the temp-poster URL:

- `openPosterCropModal()` — crop source URL
- `handlePosterCropImageError()` — 404 fallback URL

```ts
const posterMovieId = currentMovie.id || currentResult?.movie_id;
```

Added a regression test (`poster-crop-controller.test.ts`) with `movie_id: 'MIUM-1360'` / `movie.id: '300MIUM-1360'` asserting the source URL uses `300MIUM-1360-full.jpg` and not the stale filename.

## Verification

- `poster-crop-controller.test.ts`: 8/8 pass (incl. new divergent-ID regression test)
- `src/routes/review` full suite: 124/124 pass
- Go poster/temp/batch/worker suites (`Poster|Crop|TempPoster|ServeTemp|ClearMissing`): all ok
- `svelte-check`: 0 errors, 0 warnings
- Pre-commit hook (gofmt, go vet, `go test -short`, build, swagger, svelte-check): all passed
- **Live dev-server smoke test**: ran the patched frontend (Vite dev proxy → `archserver.local:8082`, authenticated) against the real job, navigated to 300MIUM-1360, opened Manage Images → Adjust Crop → crop source `<img>` loaded `300MIUM-1360-full.jpg` at 840×472, no error. The stale `MIUM-1360-full.jpg` returns 404 (confirmed via fetch probe against the authenticated session).

## Scope

Minimal, frontend-only, no API/DB change. Existing URL-formation tests (where `movie_id === movie.id`) stay green.
