### PR TITLE
fix(r18devdump): eliminate import heartbeat data race

### DIFF
--- a/internal/api/r18devdump/handlers.go
+++ b/internal/api/r18devdump/handlers.go
@@ -22,7 +22,7 @@ import (
 	ws "github.com/javinizer/javinizer-go/internal/websocket"
 )
 
-var importHeartbeatInterval = 1500 * time.Millisecond
+const importHeartbeatInterval = 1500 * time.Millisecond
 
 const (
 	dumpJobID = "r18dev-dump-download"
@@ -247,7 +247,7 @@ func (h *dumpHandler) startDownloadOrUpdate(c *gin.Context, updateOnly bool) {
 			// being reported.
 			importDone := make(chan struct{})
 			streamConsumed := make(chan struct{})
-			go h.runImportHeartbeat(streamConsumed, importDone)
+			go h.runImportHeartbeat(streamConsumed, importDone, importHeartbeatInterval)
 			defer close(importDone)
 			r = &eofDetectReader{r: r, onEOF: sync.OnceFunc(func() { close(streamConsumed) })}
 			var unlockReload func()
@@ -572,7 +572,7 @@ func (e *eofDetectReader) Read(p []byte) (int, error) {
 // SQL import runs. It waits until streamConsumed is closed (the download
 // stream hit EOF) before starting, so "importing" frames never overlap with
 // "downloading" frames. It exits when importDone is closed.
-func (h *dumpHandler) runImportHeartbeat(streamConsumed, importDone <-chan struct{}) {
+func (h *dumpHandler) runImportHeartbeat(streamConsumed, importDone <-chan struct{}, interval time.Duration) {
 	select {
 	case <-streamConsumed:
 	case <-importDone:
@@ -584,7 +584,7 @@ func (h *dumpHandler) runImportHeartbeat(streamConsumed, importDone <-chan struc
 	default:
 	}
 	h.broadcastProgress("importing", 0, 0)
-	ticker := time.NewTicker(importHeartbeatInterval)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/internal/api/r18devdump/handlers_test.go
+++ b/internal/api/r18devdump/handlers_test.go
@@ -497,24 +497,20 @@ func TestBroadcastProgress_WithFn(t *testing.T) {
 func TestRunImportHeartbeat_TickerFires(t *testing.T) {
 	h, _, _ := newTestHandlerWithHub(t)
 
-	orig := importHeartbeatInterval
-	importHeartbeatInterval = 1 * time.Millisecond
-
 	streamConsumed := make(chan struct{})
 	importDone := make(chan struct{})
 	close(streamConsumed) // simulate download stream EOF
 
 	exited := make(chan struct{})
 	go func() {
-		h.runImportHeartbeat(streamConsumed, importDone)
+		h.runImportHeartbeat(streamConsumed, importDone, 1*time.Millisecond)
 		close(exited)
 	}()
 
 	// Let the ticker fire several times so the <-ticker.C branch executes.
 	time.Sleep(20 * time.Millisecond)
 	close(importDone)
-	<-exited // wait for the goroutine to exit before restoring the interval
-	importHeartbeatInterval = orig
+	<-exited
 }
 
 func TestRunImportHeartbeat_ImportDoneFirst(t *testing.T) {
@@ -525,7 +521,7 @@ func TestRunImportHeartbeat_ImportDoneFirst(t *testing.T) {
 	close(importDone) // import finishes before stream is consumed
 
 	// Should return immediately without broadcasting.
-	h.runImportHeartbeat(streamConsumed, importDone)
+	h.runImportHeartbeat(streamConsumed, importDone, importHeartbeatInterval)
 }
 
 func TestRunImportHeartbeat_BothClosedBeforeSchedule(t *testing.T) {
@@ -547,7 +543,7 @@ func TestRunImportHeartbeat_BothClosedBeforeSchedule(t *testing.T) {
 		importDone := make(chan struct{})
 		close(streamConsumed)
 		close(importDone)
-		h.runImportHeartbeat(streamConsumed, importDone)
+		h.runImportHeartbeat(streamConsumed, importDone, importHeartbeatInterval)
 	}
 
 	mu.Lock()


### PR DESCRIPTION
## What

Fixes a real data race in `internal/api/r18devdump` flagged by the Race Detector Tests CI job ([run 31541215632/job/93943786243](https://github.com/javinizer/javinizer-go/actions/runs/31541215632/job/93943786243)) in `TestRunImportHeartbeat_TickerFires`.

The failure was intermittent — it surfaced only when a heartbeat goroutine from a prior `TestStartDownload_*` test lingered across a test boundary, but the underlying defect was always present.

## Root cause

The package-level variable `importHeartbeatInterval` (`handlers.go:25`) was read by a heartbeat goroutine at `handlers.go:587` (`ticker := time.NewTicker(importHeartbeatInterval)`) while a test wrote it at `handlers_test.go:501` (`importHeartbeatInterval = 1 * time.Millisecond`), with no synchronization:

```
WARNING: DATA RACE
Write at 0x... by goroutine 128:
  handlers_test.go:501  importHeartbeatInterval = 1 * time.Millisecond
Previous read at 0x... by goroutine 66:
  handlers.go:587  ticker := time.NewTicker(importHeartbeatInterval)
  handlers.go:250  go h.runImportHeartbeat(streamConsumed, importDone)
```

The racing read was introduced in PR #141 (`a80e9adc`); it is pre-existing on `main`, not caused by the recently-merged #206 (frontend-only).

## Changes

Parameterize `runImportHeartbeat` with an `interval time.Duration` argument so the heartbeat goroutine reads a passed-by-value parameter instead of the shared global:

- `handlers.go`: `runImportHeartbeat(streamConsumed, importDone <-chan struct{}, interval time.Duration)` and `ticker := time.NewTicker(interval)`
- Production caller (`handlers.go:250`): `go h.runImportHeartbeat(streamConsumed, importDone, importHeartbeatInterval)` — reads the global once on the caller's goroutine (synchronous), then passes by value
- Test (`TestRunImportHeartbeat_TickerFires`): passes `1*time.Millisecond` directly and no longer mutates the global (removed the `orig` save/restore)
- The other two heartbeat tests pass `importHeartbeatInterval` (they return before the ticker matters)
- Hardening: `var importHeartbeatInterval` → `const importHeartbeatInterval` so any future test mutation is a compile error instead of a latent race

## Verification

- `go test -race -count=5 ./internal/api/r18devdump/` — clean (all heartbeat/download/reload/clear/search tests)
- `go test -race -short ./internal/worker/ ./internal/tui/ ./internal/websocket/ ./internal/api/` — clean
- `go vet ./internal/api/r18devdump/` + `go build ./...` — clean
- Pre-commit hook (gofmt, go vet, `go test -short`, build, swagger) — all passed
- Reviewed by kimi-k3 (max thinking): verdict correct and complete; no P1/P2; the `const` hardening was its optional P3 suggestion

## Scope

Minimal, 2 files, +8/-12 lines. No behavioral change to production (the production caller reads the same value, just at the call site instead of inside the goroutine).