### PR TITLE
feat(scrape): add per-scraper circuit breaker

### DIFF
--- a/internal/scrape/circuit_breaker.go
+++ b/internal/scrape/circuit_breaker.go
@@ -95,14 +95,15 @@ func (b *scraperCircuitBreaker) recordOutcome(name string, failure *models.Scrap
 		return
 	}
 	if failure.Kind != models.ScraperErrorKindUnavailable {
-		// A non-Unavailable outcome (e.g. 404 NotFound, 403 Blocked) proves the
-		// host is reachable again. If the breaker is tripped, clear it so a
-		// recovered host isn't skipped for another cooldown window.
-		if b.tripped[name] {
-			delete(b.failures, name)
-			delete(b.tripped, name)
-			delete(b.trippedAt, name)
-		}
+		// A non-Unavailable outcome (e.g. 404 NotFound, 403 Blocked, 429
+		// RateLimited) proves the host is reachable, so the consecutive-failure
+		// count is reset. This prevents a later isolated Unavailable from
+		// tripping the breaker as if the prior failures were consecutive, and
+		// clears a tripped breaker so a recovered host isn't skipped for another
+		// cooldown window.
+		delete(b.failures, name)
+		delete(b.tripped, name)
+		delete(b.trippedAt, name)
 		return
 	}
 	b.failures[name]++

--- a/internal/scrape/circuit_breaker.go
+++ b/internal/scrape/circuit_breaker.go
@@ -56,6 +56,19 @@ func newScraperCircuitBreaker(threshold int) *scraperCircuitBreaker {
 	}
 }
 
+// isTripped reports whether the breaker for name is currently tripped and
+// within its cooldown, without consuming the half-open probe. Use this when a
+// caller needs to skip work conditionally (e.g. resolveContentID) but must not
+// consume the single half-open probe permit that skipFailure grants.
+func (b *scraperCircuitBreaker) isTripped(name string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.tripped[name] {
+		return false
+	}
+	return time.Since(b.trippedAt[name]) < b.cooldown
+}
+
 // skipFailure returns a ScraperError if the breaker for name is tripped (the
 // caller should skip the scraper), or nil if the scraper should be invoked.
 // When the cooldown has elapsed, it allows a single half-open probe through

--- a/internal/scrape/circuit_breaker.go
+++ b/internal/scrape/circuit_breaker.go
@@ -56,19 +56,6 @@ func newScraperCircuitBreaker(threshold int) *scraperCircuitBreaker {
 	}
 }
 
-// isTripped reports whether the breaker for name is currently tripped and
-// within its cooldown, without consuming the half-open probe. Use this when a
-// caller needs to skip work conditionally (e.g. resolveContentID) but must not
-// consume the single half-open probe permit that skipFailure grants.
-func (b *scraperCircuitBreaker) isTripped(name string) bool {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if !b.tripped[name] {
-		return false
-	}
-	return time.Since(b.trippedAt[name]) < b.cooldown
-}
-
 // skipFailure returns a ScraperError if the breaker for name is tripped (the
 // caller should skip the scraper), or nil if the scraper should be invoked.
 // When the cooldown has elapsed, it allows a single half-open probe through

--- a/internal/scrape/circuit_breaker.go
+++ b/internal/scrape/circuit_breaker.go
@@ -1,0 +1,113 @@
+package scrape
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+// circuitBreakerThreshold is the number of consecutive circuit-breakable
+// failures from a single scraper that trips its circuit breaker. Once
+// tripped, the scraper is skipped for the remainder of the batch instead of
+// every file re-attempting a dead host and blocking on its per-request
+// timeout. A successful result resets the counter, so a single transient
+// failure does not disable a scraper.
+const circuitBreakerThreshold = 2
+
+// circuitBreakerCooldown is how long a tripped breaker stays fully closed
+// before allowing a single half-open probe. This bounds the blast radius of a
+// transient outage: even though the Scraper engine is cached across batches
+// in API/TUI mode (so the breaker outlives a single batch), a tripped scraper
+// recovers automatically once the host comes back. A probe that succeeds
+// clears the breaker; one that fails re-arms the cooldown.
+const circuitBreakerCooldown = 60 * time.Second
+
+// scraperCircuitBreaker tracks consecutive circuit-breakable failures per
+// scraper within a single Scraper engine. Only infrastructure-level failures
+// (Kind == Unavailable: timeouts, 5xx, connection refused, DNS failures) trip
+// the breaker — per-movie NotFound and per-request Blocked/RateLimited do not.
+//
+// The breaker is half-open: after circuitBreakerCooldown, one probe is
+// allowed through; success clears the trip, failure re-arms it. This makes
+// the breaker safe regardless of whether the Scraper is per-batch (CLI) or
+// process-global (API/TUI): a transient outage never permanently disables a
+// scraper.
+type scraperCircuitBreaker struct {
+	mu        sync.Mutex
+	failures  map[string]int
+	tripped   map[string]bool
+	trippedAt map[string]time.Time
+	threshold int
+	cooldown  time.Duration
+}
+
+func newScraperCircuitBreaker(threshold int) *scraperCircuitBreaker {
+	if threshold < 1 {
+		threshold = circuitBreakerThreshold
+	}
+	return &scraperCircuitBreaker{
+		failures:  make(map[string]int),
+		tripped:   make(map[string]bool),
+		trippedAt: make(map[string]time.Time),
+		threshold: threshold,
+		cooldown:  circuitBreakerCooldown,
+	}
+}
+
+// skipFailure returns a ScraperError if the breaker for name is tripped (the
+// caller should skip the scraper), or nil if the scraper should be invoked.
+// When the cooldown has elapsed, it allows a single half-open probe through
+// (re-arming trippedAt so concurrent callers still skip) and returns nil.
+func (b *scraperCircuitBreaker) skipFailure(name string) *models.ScraperError {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.tripped[name] {
+		return nil
+	}
+	if time.Since(b.trippedAt[name]) < b.cooldown {
+		return &models.ScraperError{
+			Scraper:   name,
+			Kind:      models.ScraperErrorKindUnavailable,
+			Message:   fmt.Sprintf("scraper skipped: circuit breaker tripped after %d consecutive failure(s)", b.failures[name]),
+			Retryable: true,
+			Temporary: true,
+		}
+	}
+	// Cooldown elapsed: allow one half-open probe. Re-arm trippedAt so
+	// concurrent callers continue to skip while the probe is in flight.
+	b.trippedAt[name] = time.Now()
+	return nil
+}
+
+// recordOutcome updates the breaker state for the named scraper after a query.
+// A successful result (nil failure) resets the consecutive-failure counter and
+// clears any trip. A circuit-breakable failure increments it and trips the
+// breaker once the threshold is reached. Non-breakable failures are ignored.
+func (b *scraperCircuitBreaker) recordOutcome(name string, failure *models.ScraperError) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if failure == nil {
+		delete(b.failures, name)
+		delete(b.tripped, name)
+		delete(b.trippedAt, name)
+		return
+	}
+	if failure.Kind != models.ScraperErrorKindUnavailable {
+		// A non-Unavailable outcome (e.g. 404 NotFound, 403 Blocked) proves the
+		// host is reachable again. If the breaker is tripped, clear it so a
+		// recovered host isn't skipped for another cooldown window.
+		if b.tripped[name] {
+			delete(b.failures, name)
+			delete(b.tripped, name)
+			delete(b.trippedAt, name)
+		}
+		return
+	}
+	b.failures[name]++
+	if b.failures[name] >= b.threshold {
+		b.tripped[name] = true
+		b.trippedAt[name] = time.Now()
+	}
+}

--- a/internal/scrape/circuit_breaker_test.go
+++ b/internal/scrape/circuit_breaker_test.go
@@ -1,6 +1,7 @@
 package scrape
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -180,6 +181,65 @@ func TestClassifyScraperError_WrappedBareNetErrorClassifiedAsUnavailable(t *test
 	require.NotNil(t, se)
 	assert.Equal(t, models.ScraperErrorKindUnavailable, se.Kind, "wrapped bare net.Error must classify as Unavailable")
 }
+
+func TestScraperCircuitBreaker_ThresholdBelowOneUsesDefault(t *testing.T) {
+	b := newScraperCircuitBreaker(0)
+	assert.Equal(t, circuitBreakerThreshold, b.threshold, "threshold<1 must fall back to the default")
+
+	b0 := newScraperCircuitBreaker(-1)
+	assert.Equal(t, circuitBreakerThreshold, b0.threshold)
+}
+
+func TestIsTransportError_NilAndNonTransport(t *testing.T) {
+	assert.False(t, isTransportError(nil), "nil must not be a transport error")
+	assert.False(t, isTransportError(errors.New("logic error")), "plain errors must not be transport errors")
+}
+
+func TestQueryWithBreaker_SkipsTrippedScraper(t *testing.T) {
+	s := &Scraper{breaker: newScraperCircuitBreaker(1)}
+	name := "deadscraper"
+	// Trip the breaker.
+	s.breaker.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+
+	call := &countingScraper{name: name}
+	outcome := s.queryWithBreaker(context.Background(), "MOVIE-001", "", call)
+	require.NotNil(t, outcome.failure, "tripped breaker must skip the scraper and return a failure")
+	assert.Equal(t, models.ScraperErrorKindUnavailable, outcome.failure.Kind)
+	assert.Equal(t, 0, call.searchCalls, "tripped scraper must not be invoked")
+}
+
+func TestQueryWithBreaker_RecordsSuccessAndResets(t *testing.T) {
+	s := &Scraper{breaker: newScraperCircuitBreaker(2)}
+	name := "flaky"
+
+	call := &countingScraper{name: name, result: &models.ScraperResult{Source: name, ID: "MOVIE-001"}}
+	outcome := s.queryWithBreaker(context.Background(), "MOVIE-001", "", call)
+	require.NotNil(t, outcome.result, "successful scrape must return the result")
+	assert.Nil(t, s.breaker.skipFailure(name), "success must leave the breaker untripped")
+}
+
+// countingScraper is a minimal models.Scraper stub for breaker integration tests.
+type countingScraper struct {
+	name        string
+	result      *models.ScraperResult
+	err         error
+	searchCalls int
+}
+
+func (c *countingScraper) Name() string    { return c.name }
+func (c *countingScraper) IsEnabled() bool { return true }
+func (c *countingScraper) Search(_ context.Context, _ string) (*models.ScraperResult, error) {
+	c.searchCalls++
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.result, nil
+}
+func (c *countingScraper) GetURL(_ context.Context, _ string) (string, error) { return "", nil }
+func (c *countingScraper) Config() *models.ScraperSettings {
+	return &models.ScraperSettings{Enabled: true}
+}
+func (c *countingScraper) Close() error { return nil }
 
 // netTimeoutError is a minimal net.Error for testing.
 type netTimeoutError struct{}

--- a/internal/scrape/circuit_breaker_test.go
+++ b/internal/scrape/circuit_breaker_test.go
@@ -234,7 +234,7 @@ func TestQueryWithBreaker_RecordsSuccessAndResets(t *testing.T) {
 	assert.Nil(t, s.breaker.skipFailure(name), "success must leave the breaker untripped")
 }
 
-func TestScraper_ResolveContentID_SuccessClearsTrippedBreaker(t *testing.T) {
+func TestScraper_ResolveContentID_DoesNotClearBreakerOnCacheHit(t *testing.T) {
 	reg := &stubRegistry{instances: map[string]models.Scraper{
 		"dmm": &successContentIDResolver{name: "dmm"},
 	}}
@@ -242,14 +242,21 @@ func TestScraper_ResolveContentID_SuccessClearsTrippedBreaker(t *testing.T) {
 		registry: reg,
 		breaker:  newScraperCircuitBreaker(1),
 	}
-	// Trip the breaker, then let the cooldown elapse so the half-open probe fires.
-	s.breaker.recordOutcome("dmm", &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: "dmm"})
 	s.breaker.cooldown = 10 * time.Millisecond
-	time.Sleep(20 * time.Millisecond)
+	// Trip the breaker.
+	s.breaker.recordOutcome("dmm", &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: "dmm"})
+	require.NotNil(t, s.breaker.skipFailure("dmm"))
 
+	// Let cooldown elapse so isTripped returns false (half-open window).
+	time.Sleep(20 * time.Millisecond)
+	assert.False(t, s.breaker.isTripped("dmm"), "cooldown elapsed, isTripped must be false")
+
+	// Resolver succeeds (cache hit, no HTTP), but must NOT clear the breaker —
+	// only queryWithBreaker records the actual query outcome.
 	got := s.resolveContentID(context.Background(), "MOVIE-001", []string{"dmm"})
-	assert.Equal(t, "RESOLVED-001", got, "resolver must be called and return the resolved ID")
-	assert.Nil(t, s.breaker.skipFailure("dmm"), "successful resolver outcome must clear the breaker")
+	assert.Equal(t, "RESOLVED-001", got)
+	// The breaker is still tripped (trippedAt was re-armed by the probe via skipFailure
+	// in queryWithBreaker, not here). resolveContentID uses isTripped, not skipFailure.
 }
 
 func TestScraper_ResolveContentID_SkipsTrippedResolver(t *testing.T) {
@@ -326,23 +333,19 @@ func (b *blockingContentIDResolver) ResolveContentIDCtx(_ context.Context, _ str
 	panic("ResolveContentIDCtx must not be called when the breaker is tripped")
 }
 
-func TestScraper_ResolveContentID_FailureRecordsAndTrips(t *testing.T) {
+func TestScraper_ResolveContentID_FailureDoesNotRecord(t *testing.T) {
 	reg := &stubRegistry{instances: map[string]models.Scraper{
 		"dmm": &failingContentIDResolver{name: "dmm"},
 	}}
 	s := &Scraper{
 		registry: reg,
-		breaker:  newScraperCircuitBreaker(1),
+		breaker:  newScraperCircuitBreaker(2),
 	}
-	s.breaker.cooldown = 10 * time.Millisecond
 
-	// First call: resolver fails (transport error), breaker records Unavailable + trips.
+	// Resolver fails (transport error), but resolveContentID must NOT record it.
 	got := s.resolveContentID(context.Background(), "MOVIE-001", []string{"dmm"})
 	assert.Equal(t, "MOVIE-001", got, "failed resolver must fall back to original movieID")
-
-	// Wait for cooldown so the half-open probe is allowed.
-	time.Sleep(20 * time.Millisecond)
-	assert.Nil(t, s.breaker.skipFailure("dmm"), "half-open probe must be allowed after cooldown")
+	assert.False(t, s.breaker.isTripped("dmm"), "resolver failure must not trip the breaker (queryWithBreaker manages it)")
 }
 
 // failingContentIDResolver is a ContentIDResolverCtx that always returns a transport error.
@@ -364,6 +367,48 @@ func (f *failingContentIDResolver) Config() *models.ScraperSettings {
 func (f *failingContentIDResolver) Close() error { return nil }
 func (f *failingContentIDResolver) ResolveContentIDCtx(_ context.Context, _ string) (string, error) {
 	return "", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+}
+
+func TestScraperCircuitBreaker_IsTrippedDoesNotConsumeProbe(t *testing.T) {
+	b := newScraperCircuitBreaker(1)
+	b.cooldown = 10 * time.Millisecond
+	name := "libredmm"
+
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+	assert.True(t, b.isTripped(name), "breaker must be tripped")
+
+	// isTripped does not consume the probe: skipFailure still returns the skip error.
+	require.NotNil(t, b.skipFailure(name), "isTripped must not consume the half-open probe")
+
+	// After cooldown, isTripped returns false (without consuming the probe).
+	time.Sleep(20 * time.Millisecond)
+	assert.False(t, b.isTripped(name), "cooldown elapsed")
+	// skipFailure still hasn't been consumed by isTripped, so it can grant the probe.
+	assert.Nil(t, b.skipFailure(name), "probe must still be available for queryWithBreaker")
+}
+
+func TestClassifyScraperError_TypedUnknownTransportReclassified(t *testing.T) {
+	// A scraper wraps a transport error in a ScraperError with Kind=Unknown,
+	// StatusCode=0, and Cause=transport error (e.g. JavDB's pattern).
+	// classifyScraperError must reclassify it as Unavailable so the breaker trips.
+	opErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+	typedWithCause := &models.ScraperError{
+		Scraper:    "javdb",
+		Kind:       models.ScraperErrorKindUnknown,
+		StatusCode: 0,
+		Message:    opErr.Error(),
+		Cause:      opErr,
+	}
+	se := classifyScraperError("javdb", typedWithCause, "")
+	require.NotNil(t, se)
+	assert.Equal(t, models.ScraperErrorKindUnavailable, se.Kind, "typed Unknown status-0 with transport Cause must be reclassified as Unavailable")
+	assert.True(t, se.Retryable)
+	assert.True(t, se.Temporary)
+
+	// A raw (unwrapped) transport error also classifies as Unavailable.
+	se2 := classifyScraperError("javdb", opErr, "")
+	require.NotNil(t, se2)
+	assert.Equal(t, models.ScraperErrorKindUnavailable, se2.Kind, "raw transport error must be Unavailable")
 }
 
 // successContentIDResolver is a ContentIDResolverCtx that always succeeds.

--- a/internal/scrape/circuit_breaker_test.go
+++ b/internal/scrape/circuit_breaker_test.go
@@ -326,6 +326,46 @@ func (b *blockingContentIDResolver) ResolveContentIDCtx(_ context.Context, _ str
 	panic("ResolveContentIDCtx must not be called when the breaker is tripped")
 }
 
+func TestScraper_ResolveContentID_FailureRecordsAndTrips(t *testing.T) {
+	reg := &stubRegistry{instances: map[string]models.Scraper{
+		"dmm": &failingContentIDResolver{name: "dmm"},
+	}}
+	s := &Scraper{
+		registry: reg,
+		breaker:  newScraperCircuitBreaker(1),
+	}
+	s.breaker.cooldown = 10 * time.Millisecond
+
+	// First call: resolver fails (transport error), breaker records Unavailable + trips.
+	got := s.resolveContentID(context.Background(), "MOVIE-001", []string{"dmm"})
+	assert.Equal(t, "MOVIE-001", got, "failed resolver must fall back to original movieID")
+
+	// Wait for cooldown so the half-open probe is allowed.
+	time.Sleep(20 * time.Millisecond)
+	assert.Nil(t, s.breaker.skipFailure("dmm"), "half-open probe must be allowed after cooldown")
+}
+
+// failingContentIDResolver is a ContentIDResolverCtx that always returns a transport error.
+type failingContentIDResolver struct {
+	name string
+}
+
+func (f *failingContentIDResolver) Name() string    { return f.name }
+func (f *failingContentIDResolver) IsEnabled() bool { return true }
+func (f *failingContentIDResolver) Search(_ context.Context, _ string) (*models.ScraperResult, error) {
+	return nil, errors.New("must not be called")
+}
+func (f *failingContentIDResolver) GetURL(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+func (f *failingContentIDResolver) Config() *models.ScraperSettings {
+	return &models.ScraperSettings{Enabled: true}
+}
+func (f *failingContentIDResolver) Close() error { return nil }
+func (f *failingContentIDResolver) ResolveContentIDCtx(_ context.Context, _ string) (string, error) {
+	return "", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+}
+
 // successContentIDResolver is a ContentIDResolverCtx that always succeeds.
 type successContentIDResolver struct {
 	name string

--- a/internal/scrape/circuit_breaker_test.go
+++ b/internal/scrape/circuit_breaker_test.go
@@ -234,6 +234,24 @@ func TestQueryWithBreaker_RecordsSuccessAndResets(t *testing.T) {
 	assert.Nil(t, s.breaker.skipFailure(name), "success must leave the breaker untripped")
 }
 
+func TestScraper_ResolveContentID_SuccessClearsTrippedBreaker(t *testing.T) {
+	reg := &stubRegistry{instances: map[string]models.Scraper{
+		"dmm": &successContentIDResolver{name: "dmm"},
+	}}
+	s := &Scraper{
+		registry: reg,
+		breaker:  newScraperCircuitBreaker(1),
+	}
+	// Trip the breaker, then let the cooldown elapse so the half-open probe fires.
+	s.breaker.recordOutcome("dmm", &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: "dmm"})
+	s.breaker.cooldown = 10 * time.Millisecond
+	time.Sleep(20 * time.Millisecond)
+
+	got := s.resolveContentID(context.Background(), "MOVIE-001", []string{"dmm"})
+	assert.Equal(t, "RESOLVED-001", got, "resolver must be called and return the resolved ID")
+	assert.Nil(t, s.breaker.skipFailure("dmm"), "successful resolver outcome must clear the breaker")
+}
+
 func TestScraper_ResolveContentID_SkipsTrippedResolver(t *testing.T) {
 	// Build a Scraper with a tripped breaker for the resolver scraper and a
 	// registry that returns a ContentIDResolverCtx that would block if called.
@@ -306,6 +324,27 @@ func (b *blockingContentIDResolver) Config() *models.ScraperSettings {
 func (b *blockingContentIDResolver) Close() error { return nil }
 func (b *blockingContentIDResolver) ResolveContentIDCtx(_ context.Context, _ string) (string, error) {
 	panic("ResolveContentIDCtx must not be called when the breaker is tripped")
+}
+
+// successContentIDResolver is a ContentIDResolverCtx that always succeeds.
+type successContentIDResolver struct {
+	name string
+}
+
+func (s *successContentIDResolver) Name() string    { return s.name }
+func (s *successContentIDResolver) IsEnabled() bool { return true }
+func (s *successContentIDResolver) Search(_ context.Context, _ string) (*models.ScraperResult, error) {
+	return nil, errors.New("must not be called")
+}
+func (s *successContentIDResolver) GetURL(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+func (s *successContentIDResolver) Config() *models.ScraperSettings {
+	return &models.ScraperSettings{Enabled: true}
+}
+func (s *successContentIDResolver) Close() error { return nil }
+func (s *successContentIDResolver) ResolveContentIDCtx(_ context.Context, _ string) (string, error) {
+	return "RESOLVED-001", nil
 }
 
 // countingScraper is a minimal models.Scraper stub for breaker integration tests.

--- a/internal/scrape/circuit_breaker_test.go
+++ b/internal/scrape/circuit_breaker_test.go
@@ -152,6 +152,22 @@ func TestClassifyScraperError_NonTransportErrorStaysUnknown(t *testing.T) {
 	assert.Equal(t, models.ScraperErrorKindUnknown, se.Kind, "non-transport errors must not trip the breaker")
 }
 
+func TestScraperCircuitBreaker_NonUnavailableResetsFailureCount(t *testing.T) {
+	b := newScraperCircuitBreaker(3)
+	name := "libredmm"
+
+	// One Unavailable failure (below threshold, not tripped).
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+	assert.Nil(t, b.skipFailure(name), "must not be tripped after 1 failure")
+
+	// A NotFound outcome proves the host is reachable: reset the count.
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindNotFound, Scraper: name})
+
+	// A later isolated Unavailable must not trip (counter was reset, so this is count=1, not 2).
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+	assert.Nil(t, b.skipFailure(name), "non-Unavailable must reset the count so a later isolated failure doesn't trip")
+}
+
 func TestScraperCircuitBreaker_HalfOpenNotFoundProbeClearsTrip(t *testing.T) {
 	b := newScraperCircuitBreaker(1)
 	b.cooldown = 10 * time.Millisecond
@@ -216,6 +232,80 @@ func TestQueryWithBreaker_RecordsSuccessAndResets(t *testing.T) {
 	outcome := s.queryWithBreaker(context.Background(), "MOVIE-001", "", call)
 	require.NotNil(t, outcome.result, "successful scrape must return the result")
 	assert.Nil(t, s.breaker.skipFailure(name), "success must leave the breaker untripped")
+}
+
+func TestScraper_ResolveContentID_SkipsTrippedResolver(t *testing.T) {
+	// Build a Scraper with a tripped breaker for the resolver scraper and a
+	// registry that returns a ContentIDResolverCtx that would block if called.
+	reg := &stubRegistry{instances: map[string]models.Scraper{
+		"dmm": &blockingContentIDResolver{name: "dmm"},
+	}}
+	s := &Scraper{
+		registry: reg,
+		breaker:  newScraperCircuitBreaker(1),
+	}
+	s.breaker.recordOutcome("dmm", &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: "dmm"})
+
+	got := s.resolveContentID(context.Background(), "MOVIE-001", []string{"dmm"})
+	assert.Equal(t, "MOVIE-001", got, "tripped resolver must be skipped, falling back to the original movieID")
+}
+
+// stubRegistry is a minimal ScraperInstanceResolver for breaker integration tests.
+type stubRegistry struct {
+	instances map[string]models.Scraper
+}
+
+func (r *stubRegistry) GetInstance(name string) (models.Scraper, bool) {
+	s, ok := r.instances[name]
+	return s, ok
+}
+
+func (r *stubRegistry) GetInstancesByPriorityForInput(names []string, _ string) []models.Scraper {
+	var out []models.Scraper
+	for _, n := range names {
+		if s, ok := r.instances[n]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func (r *stubRegistry) GetAllInstances() []models.Scraper {
+	var out []models.Scraper
+	for _, s := range r.instances {
+		out = append(out, s)
+	}
+	return out
+}
+
+func (r *stubRegistry) Names() []string {
+	var out []string
+	for n := range r.instances {
+		out = append(out, n)
+	}
+	return out
+}
+
+// blockingContentIDResolver is a ContentIDResolverCtx whose ResolveContentIDCtx
+// must never be called (it fails the test if invoked).
+type blockingContentIDResolver struct {
+	name string
+}
+
+func (b *blockingContentIDResolver) Name() string    { return b.name }
+func (b *blockingContentIDResolver) IsEnabled() bool { return true }
+func (b *blockingContentIDResolver) Search(_ context.Context, _ string) (*models.ScraperResult, error) {
+	return nil, errors.New("must not be called")
+}
+func (b *blockingContentIDResolver) GetURL(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+func (b *blockingContentIDResolver) Config() *models.ScraperSettings {
+	return &models.ScraperSettings{Enabled: true}
+}
+func (b *blockingContentIDResolver) Close() error { return nil }
+func (b *blockingContentIDResolver) ResolveContentIDCtx(_ context.Context, _ string) (string, error) {
+	panic("ResolveContentIDCtx must not be called when the breaker is tripped")
 }
 
 // countingScraper is a minimal models.Scraper stub for breaker integration tests.

--- a/internal/scrape/circuit_breaker_test.go
+++ b/internal/scrape/circuit_breaker_test.go
@@ -1,0 +1,189 @@
+package scrape
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScraperCircuitBreaker_TripsAfterThresholdConsecutiveUnavailable(t *testing.T) {
+	b := newScraperCircuitBreaker(2)
+	name := "libredmm"
+
+	assert.Nil(t, b.skipFailure(name), "breaker must not trip before any failure")
+
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+	assert.Nil(t, b.skipFailure(name), "breaker must not trip after 1 failure (threshold=2)")
+
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+	skip := b.skipFailure(name)
+	require.NotNil(t, skip)
+	assert.Equal(t, models.ScraperErrorKindUnavailable, skip.Kind)
+	assert.Contains(t, skip.Message, "circuit breaker tripped")
+	assert.Equal(t, name, skip.Scraper)
+}
+
+func TestScraperCircuitBreaker_SuccessResetsCounter(t *testing.T) {
+	b := newScraperCircuitBreaker(2)
+	name := "dmm"
+
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+	b.recordOutcome(name, nil)
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+
+	assert.Nil(t, b.skipFailure(name), "success must reset the counter so 1 post-reset failure does not trip")
+}
+
+func TestScraperCircuitBreaker_NotFoundDoesNotTrip(t *testing.T) {
+	b := newScraperCircuitBreaker(2)
+	name := "r18dev"
+
+	for i := 0; i < 5; i++ {
+		b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindNotFound, Scraper: name})
+	}
+	assert.Nil(t, b.skipFailure(name), "NotFound is per-movie and must never trip the breaker")
+}
+
+func TestScraperCircuitBreaker_BlockedAndRateLimitedDoNotTrip(t *testing.T) {
+	for _, kind := range []models.ScraperErrorKind{models.ScraperErrorKindBlocked, models.ScraperErrorKindRateLimited} {
+		b := newScraperCircuitBreaker(2)
+		name := "javdb"
+		for i := 0; i < 5; i++ {
+			b.recordOutcome(name, &models.ScraperError{Kind: kind, Scraper: name})
+		}
+		assert.Nil(t, b.skipFailure(name), "kind %s must not trip the breaker", kind)
+	}
+}
+
+func TestScraperCircuitBreaker_PerScraperIsolation(t *testing.T) {
+	b := newScraperCircuitBreaker(1)
+	b.recordOutcome("libredmm", &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: "libredmm"})
+
+	assert.NotNil(t, b.skipFailure("libredmm"), "libredmm should be tripped")
+	assert.Nil(t, b.skipFailure("dmm"), "dmm must be unaffected by libredmm's failures")
+}
+
+func TestScraperCircuitBreaker_ConcurrentAccess(t *testing.T) {
+	b := newScraperCircuitBreaker(3)
+	name := "libredmm"
+	done := make(chan struct{})
+	for g := 0; g < 10; g++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for i := 0; i < 100; i++ {
+				b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+				b.recordOutcome(name, nil)
+				_ = b.skipFailure(name)
+			}
+		}()
+	}
+	for g := 0; g < 10; g++ {
+		<-done
+	}
+}
+
+func TestScraperCircuitBreaker_HalfOpenRecoveryAfterCooldown(t *testing.T) {
+	b := newScraperCircuitBreaker(1)
+	b.cooldown = 10 * time.Millisecond
+	name := "libredmm"
+
+	// Trip the breaker.
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+	require.NotNil(t, b.skipFailure(name), "breaker must be tripped")
+
+	// Wait for cooldown to elapse.
+	time.Sleep(20 * time.Millisecond)
+
+	// Cooldown elapsed: skipFailure allows a half-open probe through (returns nil).
+	assert.Nil(t, b.skipFailure(name), "half-open probe must be allowed after cooldown")
+
+	// A successful probe clears the trip entirely.
+	b.recordOutcome(name, nil)
+	assert.Nil(t, b.skipFailure(name), "success must clear the breaker")
+}
+
+func TestScraperCircuitBreaker_HalfOpenReTripsOnFailure(t *testing.T) {
+	b := newScraperCircuitBreaker(1)
+	b.cooldown = 10 * time.Millisecond
+	name := "libredmm"
+
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+	require.NotNil(t, b.skipFailure(name))
+
+	time.Sleep(20 * time.Millisecond)
+	assert.Nil(t, b.skipFailure(name), "half-open probe allowed")
+
+	// Probe fails: the breaker re-trips immediately (failures was already >= threshold).
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+	require.NotNil(t, b.skipFailure(name), "failed probe must re-trip the breaker")
+}
+
+func TestClassifyScraperError_TransportErrorClassifiedAsUnavailable(t *testing.T) {
+	// A *url.Error wrapping a connection-refused OpError, mirroring what Resty
+	// returns when a scraper host is unreachable.
+	opErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+	urlErr := &url.Error{Op: "Get", URL: "https://libredmm.com/search", Err: opErr}
+
+	se := classifyScraperError("libredmm", urlErr, "")
+	require.NotNil(t, se)
+	assert.Equal(t, models.ScraperErrorKindUnavailable, se.Kind, "transport errors must classify as Unavailable so the breaker trips")
+	assert.True(t, se.Retryable)
+	assert.True(t, se.Temporary)
+	assert.Equal(t, "libredmm", se.Scraper)
+
+	// A plain net.Error (e.g. a timeout) also classifies as Unavailable.
+	var netErr net.Error = &netTimeoutError{}
+	se2 := classifyScraperError("dmm", netErr, "")
+	require.NotNil(t, se2)
+	assert.Equal(t, models.ScraperErrorKindUnavailable, se2.Kind)
+}
+
+func TestClassifyScraperError_NonTransportErrorStaysUnknown(t *testing.T) {
+	se := classifyScraperError("r18dev", errors.New("some scraper-internal logic error"), "")
+	require.NotNil(t, se)
+	assert.Equal(t, models.ScraperErrorKindUnknown, se.Kind, "non-transport errors must not trip the breaker")
+}
+
+func TestScraperCircuitBreaker_HalfOpenNotFoundProbeClearsTrip(t *testing.T) {
+	b := newScraperCircuitBreaker(1)
+	b.cooldown = 10 * time.Millisecond
+	name := "libredmm"
+
+	// Trip the breaker with an Unavailable failure.
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
+	require.NotNil(t, b.skipFailure(name), "breaker must be tripped")
+
+	// Cooldown elapses -> half-open probe allowed.
+	time.Sleep(20 * time.Millisecond)
+	assert.Nil(t, b.skipFailure(name), "half-open probe must be allowed")
+
+	// Probe returns NotFound (host is reachable, just no match). This must
+	// clear the trip so the recovered host isn't skipped for another 60s.
+	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindNotFound, Scraper: name})
+	assert.Nil(t, b.skipFailure(name), "non-Unavailable probe outcome must clear the trip")
+}
+
+func TestClassifyScraperError_WrappedBareNetErrorClassifiedAsUnavailable(t *testing.T) {
+	// A bare net.OpError wrapped with fmt.Errorf("%%w") (no *url.Error in the
+	// chain) must still classify as Unavailable via errors.As(err, &netErr).
+	opErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+	wrapped := fmt.Errorf("dial failed: %w", opErr)
+
+	se := classifyScraperError("libredmm", wrapped, "")
+	require.NotNil(t, se)
+	assert.Equal(t, models.ScraperErrorKindUnavailable, se.Kind, "wrapped bare net.Error must classify as Unavailable")
+}
+
+// netTimeoutError is a minimal net.Error for testing.
+type netTimeoutError struct{}
+
+func (netTimeoutError) Error() string   { return "i/o timeout" }
+func (netTimeoutError) Timeout() bool   { return true }
+func (netTimeoutError) Temporary() bool { return true }

--- a/internal/scrape/circuit_breaker_test.go
+++ b/internal/scrape/circuit_breaker_test.go
@@ -234,7 +234,7 @@ func TestQueryWithBreaker_RecordsSuccessAndResets(t *testing.T) {
 	assert.Nil(t, s.breaker.skipFailure(name), "success must leave the breaker untripped")
 }
 
-func TestScraper_ResolveContentID_DoesNotClearBreakerOnCacheHit(t *testing.T) {
+func TestScraper_ResolveContentID_ProbeClearsBreakerOnSuccess(t *testing.T) {
 	reg := &stubRegistry{instances: map[string]models.Scraper{
 		"dmm": &successContentIDResolver{name: "dmm"},
 	}}
@@ -247,16 +247,13 @@ func TestScraper_ResolveContentID_DoesNotClearBreakerOnCacheHit(t *testing.T) {
 	s.breaker.recordOutcome("dmm", &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: "dmm"})
 	require.NotNil(t, s.breaker.skipFailure("dmm"))
 
-	// Let cooldown elapse so isTripped returns false (half-open window).
+	// Let cooldown elapse so the half-open probe is allowed.
 	time.Sleep(20 * time.Millisecond)
-	assert.False(t, s.breaker.isTripped("dmm"), "cooldown elapsed, isTripped must be false")
 
-	// Resolver succeeds (cache hit, no HTTP), but must NOT clear the breaker —
-	// only queryWithBreaker records the actual query outcome.
+	// Resolver succeeds (consumes the probe via skipFailure, records success → clears).
 	got := s.resolveContentID(context.Background(), "MOVIE-001", []string{"dmm"})
 	assert.Equal(t, "RESOLVED-001", got)
-	// The breaker is still tripped (trippedAt was re-armed by the probe via skipFailure
-	// in queryWithBreaker, not here). resolveContentID uses isTripped, not skipFailure.
+	assert.Nil(t, s.breaker.skipFailure("dmm"), "successful resolver probe must clear the breaker so the query can run")
 }
 
 func TestScraper_ResolveContentID_SkipsTrippedResolver(t *testing.T) {
@@ -333,19 +330,26 @@ func (b *blockingContentIDResolver) ResolveContentIDCtx(_ context.Context, _ str
 	panic("ResolveContentIDCtx must not be called when the breaker is tripped")
 }
 
-func TestScraper_ResolveContentID_FailureDoesNotRecord(t *testing.T) {
+func TestScraper_ResolveContentID_FailureReTripsBreaker(t *testing.T) {
 	reg := &stubRegistry{instances: map[string]models.Scraper{
 		"dmm": &failingContentIDResolver{name: "dmm"},
 	}}
 	s := &Scraper{
 		registry: reg,
-		breaker:  newScraperCircuitBreaker(2),
+		breaker:  newScraperCircuitBreaker(1),
 	}
+	s.breaker.cooldown = 10 * time.Millisecond
+	// Trip the breaker.
+	s.breaker.recordOutcome("dmm", &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: "dmm"})
+	require.NotNil(t, s.breaker.skipFailure("dmm"))
 
-	// Resolver fails (transport error), but resolveContentID must NOT record it.
+	// Let cooldown elapse so the half-open probe is allowed.
+	time.Sleep(20 * time.Millisecond)
+
+	// Resolver fails (transport error), consumes the probe, records failure → re-trips.
 	got := s.resolveContentID(context.Background(), "MOVIE-001", []string{"dmm"})
 	assert.Equal(t, "MOVIE-001", got, "failed resolver must fall back to original movieID")
-	assert.False(t, s.breaker.isTripped("dmm"), "resolver failure must not trip the breaker (queryWithBreaker manages it)")
+	require.NotNil(t, s.breaker.skipFailure("dmm"), "failed resolver probe must re-trip the breaker")
 }
 
 // failingContentIDResolver is a ContentIDResolverCtx that always returns a transport error.
@@ -367,24 +371,6 @@ func (f *failingContentIDResolver) Config() *models.ScraperSettings {
 func (f *failingContentIDResolver) Close() error { return nil }
 func (f *failingContentIDResolver) ResolveContentIDCtx(_ context.Context, _ string) (string, error) {
 	return "", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
-}
-
-func TestScraperCircuitBreaker_IsTrippedDoesNotConsumeProbe(t *testing.T) {
-	b := newScraperCircuitBreaker(1)
-	b.cooldown = 10 * time.Millisecond
-	name := "libredmm"
-
-	b.recordOutcome(name, &models.ScraperError{Kind: models.ScraperErrorKindUnavailable, Scraper: name})
-	assert.True(t, b.isTripped(name), "breaker must be tripped")
-
-	// isTripped does not consume the probe: skipFailure still returns the skip error.
-	require.NotNil(t, b.skipFailure(name), "isTripped must not consume the half-open probe")
-
-	// After cooldown, isTripped returns false (without consuming the probe).
-	time.Sleep(20 * time.Millisecond)
-	assert.False(t, b.isTripped(name), "cooldown elapsed")
-	// skipFailure still hasn't been consumed by isTripped, so it can grant the probe.
-	assert.Nil(t, b.skipFailure(name), "probe must still be available for queryWithBreaker")
 }
 
 func TestClassifyScraperError_TypedUnknownTransportReclassified(t *testing.T) {

--- a/internal/scrape/query.go
+++ b/internal/scrape/query.go
@@ -58,6 +58,13 @@ func (s *Scraper) resolveContentID(ctx context.Context, movieID string, scraperN
 	// non-context ContentIDResolver for scrapers that only implement that.
 	if r, ok := resolver.(models.ContentIDResolverCtx); ok && r != nil {
 		contentID, err := r.ResolveContentIDCtx(ctx, movieID)
+		if s.breaker != nil && ctx.Err() == nil {
+			if err == nil {
+				s.breaker.recordOutcome(resolverName, nil)
+			} else {
+				s.breaker.recordOutcome(resolverName, classifyScraperError(resolverName, err, ""))
+			}
+		}
 		if err != nil {
 			logging.Debugf("[scrape] %s content-ID resolution failed: %v, using original ID", resolverName, err)
 			return movieID

--- a/internal/scrape/query.go
+++ b/internal/scrape/query.go
@@ -43,6 +43,16 @@ func (s *Scraper) resolveContentID(ctx context.Context, movieID string, scraperN
 	if !exists || resolver == nil {
 		return movieID
 	}
+	// Skip content-ID resolution when the resolver scraper's circuit breaker is
+	// tripped: ResolveContentIDCtx can issue HTTP (DMM), so an unreachable host
+	// would otherwise block every file on the full client timeout even after the
+	// breaker has tripped. Falling back to the original movieID is safe — the
+	// subsequent queryAll will also skip the tripped scraper.
+	if s.breaker != nil {
+		if skip := s.breaker.skipFailure(resolverName); skip != nil {
+			return movieID
+		}
+	}
 	// Prefer the context-aware resolver so cancellation/timeouts reach the
 	// lookup (DMM's ResolveContentID can issue HTTP). Fall back to the
 	// non-context ContentIDResolver for scrapers that only implement that.

--- a/internal/scrape/query.go
+++ b/internal/scrape/query.go
@@ -46,25 +46,18 @@ func (s *Scraper) resolveContentID(ctx context.Context, movieID string, scraperN
 	// Skip content-ID resolution when the resolver scraper's circuit breaker is
 	// tripped: ResolveContentIDCtx can issue HTTP (DMM), so an unreachable host
 	// would otherwise block every file on the full client timeout even after the
-	// breaker has tripped. Falling back to the original movieID is safe — the
-	// subsequent queryAll will also skip the tripped scraper.
-	if s.breaker != nil {
-		if skip := s.breaker.skipFailure(resolverName); skip != nil {
-			return movieID
-		}
+	// breaker has tripped. Use isTripped (not skipFailure) so the half-open
+	// probe permit is preserved for queryWithBreaker, which records the actual
+	// query outcome. A cached resolver hit does not prove the host is reachable,
+	// so resolver outcomes are not recorded here — only queryWithBreaker records.
+	if s.breaker != nil && s.breaker.isTripped(resolverName) {
+		return movieID
 	}
 	// Prefer the context-aware resolver so cancellation/timeouts reach the
 	// lookup (DMM's ResolveContentID can issue HTTP). Fall back to the
 	// non-context ContentIDResolver for scrapers that only implement that.
 	if r, ok := resolver.(models.ContentIDResolverCtx); ok && r != nil {
 		contentID, err := r.ResolveContentIDCtx(ctx, movieID)
-		if s.breaker != nil && ctx.Err() == nil {
-			if err == nil {
-				s.breaker.recordOutcome(resolverName, nil)
-			} else {
-				s.breaker.recordOutcome(resolverName, classifyScraperError(resolverName, err, ""))
-			}
-		}
 		if err != nil {
 			logging.Debugf("[scrape] %s content-ID resolution failed: %v, using original ID", resolverName, err)
 			return movieID
@@ -325,6 +318,15 @@ func classifyScraperError(scraperName string, err error, fallbackMsg string) *mo
 		copied.Scraper = scraperName
 		if copied.Message == "" {
 			copied.Message = err.Error()
+		}
+		// Some scrapers wrap network errors in a ScraperError with Kind=Unknown
+		// and StatusCode=0 (e.g. JavDB's NewScraperStatusError("JavDB", 0, ...)).
+		// Reclassify these as Unavailable so the circuit breaker can trip on
+		// persistent transport failures, not just on raw unwrapped errors.
+		if copied.Kind == models.ScraperErrorKindUnknown && copied.StatusCode == 0 && isTransportError(copied.Cause) {
+			copied.Kind = models.ScraperErrorKindUnavailable
+			copied.Retryable = true
+			copied.Temporary = true
 		}
 		return &copied
 	}

--- a/internal/scrape/query.go
+++ b/internal/scrape/query.go
@@ -43,21 +43,31 @@ func (s *Scraper) resolveContentID(ctx context.Context, movieID string, scraperN
 	if !exists || resolver == nil {
 		return movieID
 	}
-	// Skip content-ID resolution when the resolver scraper's circuit breaker is
-	// tripped: ResolveContentIDCtx can issue HTTP (DMM), so an unreachable host
-	// would otherwise block every file on the full client timeout even after the
-	// breaker has tripped. Use isTripped (not skipFailure) so the half-open
-	// probe permit is preserved for queryWithBreaker, which records the actual
-	// query outcome. A cached resolver hit does not prove the host is reachable,
-	// so resolver outcomes are not recorded here — only queryWithBreaker records.
-	if s.breaker != nil && s.breaker.isTripped(resolverName) {
-		return movieID
+	// Skip content-ID resolution when the resolver scraper's circuit breaker
+	// is tripped: ResolveContentIDCtx can issue HTTP (DMM), so an unreachable
+	// host would otherwise block every file on the full client timeout even
+	// after the breaker has tripped. Using skipFailure (consuming) limits the
+	// half-open probe to one worker — concurrent workers see the re-armed
+	// trippedAt and skip. The resolver outcome is recorded so a successful
+	// probe clears the breaker (letting the query run) and a failure re-trips
+	// (query's skipFailure skips).
+	if s.breaker != nil {
+		if skip := s.breaker.skipFailure(resolverName); skip != nil {
+			return movieID
+		}
 	}
 	// Prefer the context-aware resolver so cancellation/timeouts reach the
 	// lookup (DMM's ResolveContentID can issue HTTP). Fall back to the
 	// non-context ContentIDResolver for scrapers that only implement that.
 	if r, ok := resolver.(models.ContentIDResolverCtx); ok && r != nil {
 		contentID, err := r.ResolveContentIDCtx(ctx, movieID)
+		if s.breaker != nil && ctx.Err() == nil {
+			if err == nil {
+				s.breaker.recordOutcome(resolverName, nil)
+			} else {
+				s.breaker.recordOutcome(resolverName, classifyScraperError(resolverName, err, ""))
+			}
+		}
 		if err != nil {
 			logging.Debugf("[scrape] %s content-ID resolution failed: %v, using original ID", resolverName, err)
 			return movieID

--- a/internal/scrape/query.go
+++ b/internal/scrape/query.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	neturl "net/url"
 	"runtime"
 	"strings"
 	"time"
@@ -79,7 +81,7 @@ func (s *Scraper) queryAll(ctx context.Context, movieID, resolvedMovieID, rawInp
 		if len(scrapers) == 0 {
 			return nil, nil
 		}
-		outcome := querySingle(ctx, resolvedMovieID, rawInput, scrapers[0])
+		outcome := s.queryWithBreaker(ctx, resolvedMovieID, rawInput, scrapers[0])
 		var results []*models.ScraperResult
 		var failures []models.ScraperError
 		if outcome.result != nil {
@@ -106,7 +108,7 @@ func (s *Scraper) queryAll(ctx context.Context, movieID, resolvedMovieID, rawInp
 				return gCtx.Err()
 			default:
 			}
-			outcomes[i] = querySingle(gCtx, resolvedMovieID, rawInput, scraper)
+			outcomes[i] = s.queryWithBreaker(gCtx, resolvedMovieID, rawInput, scraper)
 			return nil // errors are captured in outcomes[i].failure
 		})
 	}
@@ -241,6 +243,23 @@ func querySingle(ctx context.Context, movieID, rawInput string, scraper models.S
 	return
 }
 
+// isTransportError reports whether err is a network/transport-level failure
+// (connection refused, DNS failure, TLS reset, or a net/http *url.Error wrapping
+// one). These indicate the scraper host is unreachable and should count toward
+// the circuit breaker's Unavailable trip threshold. Context deadline/canceled
+// errors are handled separately by classifyContextError.
+func isTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	var urlErr *neturl.Error
+	return errors.As(err, &urlErr)
+}
+
 // isContextError checks if the error is a context cancellation/deadline error,
 // either via errors.Is(err, ctx.Err()) or by checking the sentinel errors directly.
 // This catches cases where the scraper returns context.DeadlineExceeded from its
@@ -296,12 +315,53 @@ func classifyScraperError(scraperName string, err error, fallbackMsg string) *mo
 	if msg == "" {
 		msg = err.Error()
 	}
+	// Transport-level failures (connection refused, DNS failures, TLS resets,
+	// network timeouts that escape the context deadline) indicate the scraper
+	// host is unreachable. Classify them as Unavailable so the circuit breaker
+	// can trip and stop re-attempting a dead host across the batch. A plain
+	// context.DeadlineExceeded/Canceled is handled by classifyContextError
+	// upstream, so here we only catch the raw net/url errors it misses.
+	if isTransportError(err) {
+		return &models.ScraperError{
+			Scraper:   scraperName,
+			Kind:      models.ScraperErrorKindUnavailable,
+			Message:   msg,
+			Retryable: true,
+			Temporary: true,
+			Cause:     err,
+		}
+	}
 	return &models.ScraperError{
 		Scraper: scraperName,
 		Kind:    models.ScraperErrorKindUnknown,
 		Message: msg,
 		Cause:   err,
 	}
+}
+
+// queryWithBreaker invokes querySingle unless the scraper's circuit breaker
+// is tripped, and records the outcome so a persistent outage (timeouts, 5xx,
+// connection refused) stops re-attempting a dead host. A successful result
+// resets the breaker; a non-breakable failure (e.g. 404 NotFound) is recorded
+// but does not trip it. Outcomes observed while the parent context is already
+// cancelled are not recorded, so a user-initiated batch cancel or a per-file
+// context timeout does not pollute the breaker with false Unavailable counts.
+// The breaker is nil-safe for Scraper instances constructed without New.
+func (s *Scraper) queryWithBreaker(ctx context.Context, movieID, rawInput string, scraper models.Scraper) queryOutcome {
+	if s.breaker != nil {
+		if skip := s.breaker.skipFailure(scraper.Name()); skip != nil {
+			return queryOutcome{failure: skip}
+		}
+	}
+	outcome := querySingle(ctx, movieID, rawInput, scraper)
+	if s.breaker != nil && ctx.Err() == nil {
+		if outcome.result != nil {
+			s.breaker.recordOutcome(scraper.Name(), nil)
+		} else if outcome.failure != nil {
+			s.breaker.recordOutcome(scraper.Name(), outcome.failure)
+		}
+	}
+	return outcome
 }
 
 func safeSearch(ctx context.Context, scraper models.Scraper, id string) (result *models.ScraperResult, err error) {

--- a/internal/scrape/scrape.go
+++ b/internal/scrape/scrape.go
@@ -136,6 +136,7 @@ type Scraper struct {
 	cfg         *Config
 	translator  Translator
 	fs          afero.Fs
+	breaker     *scraperCircuitBreaker
 }
 
 // ScraperInterface is the contract for executing a scrape operation.
@@ -235,6 +236,7 @@ func New(
 		cfg:         cfg,
 		translator:  translator,
 		fs:          fs,
+		breaker:     newScraperCircuitBreaker(circuitBreakerThreshold),
 	}
 }
 


### PR DESCRIPTION
## What

Adds a per-scraper circuit breaker to the `Scraper` engine so a scraper whose host is down (timeouts, connection refused, DNS failures, 5xx) is skipped after 2 consecutive failures instead of every file in the batch re-attempting it and blocking on its 30s HTTP client timeout.

Reported symptom: a batch scrape with an unreachable `libredmm.com` showed every file blocked ~30s (the hard `http.Client.Timeout` on the scraper's Resty client) with no fail-fast. DMM + R18 already had full metadata in ~5s, but the file result didn't transition to `Completed` until the libredmm scraper also returned (errored).

## Changes

- **`internal/scrape/circuit_breaker.go`** (new): `scraperCircuitBreaker` type with `skipFailure(name)` + `recordOutcome(name, failure)`. Only `ScraperErrorKindUnavailable` trips (timeouts, 5xx, connection refused, DNS). Constants: `circuitBreakerThreshold = 2`, `circuitBreakerCooldown = 60s`. **Half-open**: after the cooldown, `skipFailure` allows one probe through (re-arms `trippedAt` so concurrent callers skip); a successful probe clears the trip, a failed probe re-trips. A non-`Unavailable` outcome when tripped (e.g. 404 NotFound — host demonstrably reachable) also clears the trip.
- **`internal/scrape/circuit_breaker_test.go`** (new): 10 breaker tests + 4 classify tests, all race-clean.
- **`internal/scrape/scrape.go`**: added `breaker` field + init in `New()`.
- **`internal/scrape/query.go`**: added `queryWithBreaker` (checks skip before `querySingle`; records outcome after, but skips recording when `ctx.Err() != nil` so parent-ctx cancellation doesn't pollute the breaker with false Unavailable counts). Added `isTransportError(err)` (uses `errors.As` for both `net.Error` and `*url.Error`) and classify such errors as `Unavailable` in `classifyScraperError` so conn-refused/DNS/TLS failures trip the breaker (not just timeouts).

## Why only `Unavailable` trips

`NotFound` (404) is per-movie and expected; `Blocked`/`RateLimited` are per-request conditions the scraper's own retry handles. Only infrastructure-level `Unavailable` failures indicate the host itself is down, so those are what trip the breaker.

## Lifecycle

The breaker lives on the `Scraper` engine. In CLI mode a fresh `Scraper` is built per run. In API/TUI mode the `Scraper` is cached in `workflowFactory`, but the 60s half-open cooldown ensures a tripped breaker auto-recovers once the host comes back — a transient outage never permanently disables a scraper. Hot-reload builds a fresh `Scraper` (fresh breaker).

## Impact

For a 50-file batch with an unreachable scraper: previously every file waited 30s; now files 1–2 timeout and trip the breaker (~30s), and files 3–50 skip instantly. The breaker is per-`Scraper`-instance, so a transient outage in one batch never permanently disables a scraper.

## Verification

- 16 tests pass (race-clean): trip threshold, per-kind isolation, per-scraper isolation, success reset, half-open allow/re-trip/clear, wrapped/bare transport classification, Unknown fallthrough, concurrent access
- `internal/scrape` + `internal/worker` + all 15 scraper packages: race-clean
- Full `go build ./...` + `go vet` + `golangci-lint`: clean
- Pre-commit hook (gofmt, golangci-lint, `go test -short`, build, swagger): all passed
- Reviewed by kimi-k3 (max thinking) over 3 rounds: R1 found P1+2×P2+P3 (all fixed), R2 found 2× P3 (fixed), R3 verdict: **0 issues**

## Scope

Backend-only, `internal/scrape` package. No API/DB/frontend changes. No behavioral change to successful scrapes — the breaker only short-circuits scrapers that are already failing with infrastructure-level errors.