### PR TITLE
feat(batch): apply-phase coherence + asset lifecycle (poster-write hardening phase 2)

### DIFF
--- a/internal/api/batch/handler_wave_c_cov_test.go
+++ b/internal/api/batch/handler_wave_c_cov_test.go
@@ -334,7 +334,9 @@ func TestPosterCrop_StagingWriteError(t *testing.T) {
 // poster's crops until reconciliation (codex P2 fence-followup).
 func TestPosterCrop_PromoteFailureRetainsWitness(t *testing.T) {
 	deps, job, router := cropJobFixture(t, "CROPE-7")
-	deps.Fs = &brokenFS{Fs: deps.GetFs(), failRenameAt: map[int]bool{2: true, 3: true, 4: true}}
+	// P2: the staged staged-crop install prepends a rename (#1); witness is
+	// now #2, bounded promote retries #3-#5.
+	deps.Fs = &brokenFS{Fs: deps.GetFs(), failRenameAt: map[int]bool{3: true, 4: true, 5: true}}
 	w := postCrop(t, router, job, "CROPE-7", contracts.PosterCropRequest{X: 0, Y: 0, Width: 100, Height: 100})
 	// local codex review P1: commit landed but canonical bytes are still stale —
 	// a false 200 with the fresh URL is forbidden; the deferred state is a 500.

--- a/internal/api/batch/poster_from_url_p2_test.go
+++ b/internal/api/batch/poster_from_url_p2_test.go
@@ -1,0 +1,72 @@
+package batch
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// POSTER-WRITE-HARDENING P2 regression lock-ins (landed shape verified):
+// canonical names are touched ONLY by the in-lock staged promote; the state
+// commit never overlaps the download.
+
+// Success: committed row references the canonical preview; canonical bytes
+// are the downloaded image; no staged or backup residue remains.
+func TestPosterFromURL_StateCommitSeesOnlyStagedPromotedAssets(t *testing.T) {
+	deps, job, router, ts := fromURLFixtureRealJob(t, "P2URL-1")
+	w := postFromURLRequest(t, router, job, "P2URL-1", ts.URL+"/pic.jpg")
+	require.Equal(t, 200, w.Code, "%s", w.Body.String())
+
+	dir := filepath.Join("data/temp", "posters", job.GetID())
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		data, err := afero.ReadFile(deps.GetFs(), filepath.Join(dir, "P2URL-1"+suffix))
+		require.NoError(t, err)
+		require.True(t, len(data) > 100, "canonical %s carries downloaded bytes", suffix)
+	}
+	entries, err := afero.ReadDir(deps.GetFs(), dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".stage-", "no staged residue: %s", e.Name())
+		assert.NotContains(t, e.Name(), ".bak", "no backup residue: %s", e.Name())
+		assert.NotContains(t, e.Name(), ".promote-", "witness swept: %s", e.Name())
+	}
+	stored := storedMovie(t, deps, job, "/path/to/P2URL-1.mp4")
+	require.NotNil(t, stored)
+	assert.Contains(t, stored.Poster.PosterURL, ts.URL)
+	assert.Contains(t, stored.Poster.CroppedPosterURL, "P2URL-1.jpg", "committed state references the canonical preview, never a staged name")
+	assert.NotContains(t, stored.Poster.CroppedPosterURL, ".stage-")
+}
+
+// Re-from-URL onto an installed pair: the newer generation promotes in place
+// — post-commit canonical bytes are the NEW download (prior-generation
+// eviction semantics never touch the just-installed pair).
+func TestPosterFromURL_NoSelfEviction(t *testing.T) {
+	deps, job, router, ts := fromURLFixtureRealJob(t, "P2URL-2")
+	w1 := postFromURLRequest(t, router, job, "P2URL-2", ts.URL+"/pic.jpg")
+	require.Equal(t, 200, w1.Code, "%s", w1.Body.String())
+
+	dir := filepath.Join("data/temp", "posters", job.GetID())
+	first, err := afero.ReadFile(deps.GetFs(), filepath.Join(dir, "P2URL-2-full.jpg"))
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(deps.GetFs(), filepath.Join(dir, "P2URL-2-full.jpg"), []byte("SENTINEL-OLD"), 0o644))
+
+	w2 := postFromURLRequest(t, router, job, "P2URL-2", ts.URL+"/pic.jpg?v=2")
+	require.Equal(t, 200, w2.Code, "%s", w2.Body.String())
+	second, err2 := afero.ReadFile(deps.GetFs(), filepath.Join(dir, "P2URL-2-full.jpg"))
+	require.NoError(t, err2)
+	require.NotEqual(t, "SENTINEL-OLD", string(second), "old sentinel evicted; new generation installed")
+	require.Equal(t, len(first), len(second), "both downloads are the same fixture image")
+
+	// Again: nothing litters the poster dir after the replacement promote.
+	entries, derr := afero.ReadDir(deps.GetFs(), dir)
+	require.NoError(t, derr)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".stage-", e.Name())
+		assert.NotContains(t, e.Name(), ".bak", e.Name())
+		assert.NotContains(t, e.Name(), ".promote-", e.Name())
+		assert.NotContains(t, e.Name(), ".evict-", e.Name())
+	}
+}

--- a/internal/downloader/http.go
+++ b/internal/downloader/http.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/fsutil"
 	"github.com/javinizer/javinizer-go/internal/httpclient"
 	"github.com/spf13/afero"
 )
@@ -176,7 +177,7 @@ func (d *Downloader) download(ctx context.Context, url, destPath string, mediaTy
 		return result, result.Error
 	}
 
-	if err := replaceFile(d.fs, tempPath, destPath); err != nil {
+	if err := fsutil.ReplaceFile(d.fs, tempPath, destPath); err != nil {
 		_ = d.fs.Remove(tempPath)
 		result.Error = fmt.Errorf("failed to replace file: %w", err)
 		result.Duration = time.Since(startTime)

--- a/internal/downloader/media.go
+++ b/internal/downloader/media.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/javinizer/javinizer-go/internal/fsutil"
 	"github.com/javinizer/javinizer-go/internal/imageutil"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
@@ -134,7 +135,7 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 	}
 
 	if overwriteExisting {
-		if err := replaceFile(d.fs, candidate, destPath); err != nil {
+		if err := fsutil.ReplaceFile(d.fs, candidate, destPath); err != nil {
 			fullResult.Error = fmt.Errorf("failed to replace poster: %w", err)
 			fullResult.Downloaded = false
 			fullResult.Replaced = false

--- a/internal/downloader/replacefile.go
+++ b/internal/downloader/replacefile.go
@@ -1,1 +1,0 @@
-package downloader

--- a/internal/downloader/replacefile_unix.go
+++ b/internal/downloader/replacefile_unix.go
@@ -1,9 +1,0 @@
-//go:build !windows
-
-package downloader
-
-import "github.com/spf13/afero"
-
-func replaceFile(fs afero.Fs, src, dst string) error {
-	return fs.Rename(src, dst)
-}

--- a/internal/fsutil/replacefile.go
+++ b/internal/fsutil/replacefile.go
@@ -1,0 +1,1 @@
+package fsutil

--- a/internal/fsutil/replacefile_test.go
+++ b/internal/fsutil/replacefile_test.go
@@ -1,14 +1,30 @@
-package downloader
+package fsutil
 
 import (
+	"errors"
 	"os"
 	"sync/atomic"
 	"testing"
 
 	"github.com/spf13/afero"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// rejectExistingRenameFS mimics a Windows-style rename that refuses existing
+// destinations (ReplaceFile on virtual FS must surface the failure and keep
+// the pre-existing bytes).
+type rejectExistingRenameFS struct {
+	afero.Fs
+}
+
+func (f rejectExistingRenameFS) Rename(oldname, newname string) error {
+	if _, err := f.Fs.Stat(newname); err == nil {
+		return errors.New("replace existing destination rejected")
+	}
+	return f.Fs.Rename(oldname, newname)
+}
 
 type recordingRenameFS struct {
 	afero.Fs
@@ -25,7 +41,7 @@ func TestReplaceFile_ReplacesExistingOnVirtualFS(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fs, "/output/source.tmp", []byte("new"), 0644))
 	require.NoError(t, afero.WriteFile(fs, "/output/destination.jpg", []byte("old"), 0644))
 
-	require.NoError(t, replaceFile(fs, "/output/source.tmp", "/output/destination.jpg"))
+	require.NoError(t, ReplaceFile(fs, "/output/source.tmp", "/output/destination.jpg"))
 	got, err := afero.ReadFile(fs, "/output/destination.jpg")
 	require.NoError(t, err)
 	assert.Equal(t, []byte("new"), got)
@@ -39,7 +55,7 @@ func TestReplaceFile_DispatchesToWrappedBackend(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fs, "/output/source.tmp", []byte("new"), 0644))
 	require.NoError(t, afero.WriteFile(fs, "/output/destination.jpg", []byte("old"), 0644))
 
-	require.NoError(t, replaceFile(fs, "/output/source.tmp", "/output/destination.jpg"))
+	require.NoError(t, ReplaceFile(fs, "/output/source.tmp", "/output/destination.jpg"))
 	assert.Equal(t, int32(1), fs.calls.Load())
 	got, err := afero.ReadFile(base, "/output/destination.jpg")
 	require.NoError(t, err)
@@ -53,7 +69,7 @@ func TestReplaceFile_FailurePreservesDestination(t *testing.T) {
 	old := []byte("old")
 	require.NoError(t, afero.WriteFile(base, "/output/destination.jpg", old, 0644))
 
-	err := replaceFile(fs, "/output/source.tmp", "/output/destination.jpg")
+	err := ReplaceFile(fs, "/output/source.tmp", "/output/destination.jpg")
 	require.Error(t, err)
 	got, readErr := afero.ReadFile(base, "/output/destination.jpg")
 	require.NoError(t, readErr)

--- a/internal/fsutil/replacefile_unix.go
+++ b/internal/fsutil/replacefile_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package fsutil
+
+import "github.com/spf13/afero"
+
+// ReplaceFile atomically (same-filesystem) replaces dst with src via rename.
+// POSIX rename replaces existing destinations in place.
+func ReplaceFile(fs afero.Fs, src, dst string) error {
+	return fs.Rename(src, dst)
+}

--- a/internal/fsutil/replacefile_windows.go
+++ b/internal/fsutil/replacefile_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package downloader
+package fsutil
 
 import (
 	"errors"
@@ -10,9 +10,9 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-var errReplaceUnsupported = errors.New("replace existing destination unsupported")
+var ErrReplaceUnsupported = errors.New("replace existing destination unsupported")
 
-func replaceFile(fs afero.Fs, src, dst string) error {
+func ReplaceFile(fs afero.Fs, src, dst string) error {
 	if _, ok := fs.(*afero.OsFs); ok {
 		srcPtr, err := windows.UTF16PtrFromString(src)
 		if err != nil {
@@ -25,7 +25,7 @@ func replaceFile(fs afero.Fs, src, dst string) error {
 		return windows.MoveFileEx(srcPtr, dstPtr, windows.MOVEFILE_REPLACE_EXISTING)
 	}
 	if err := fs.Rename(src, dst); err != nil {
-		return fmt.Errorf("%w: %v", errReplaceUnsupported, err)
+		return fmt.Errorf("%w: %v", ErrReplaceUnsupported, err)
 	}
 	return nil
 }

--- a/internal/fsutil/replacefile_windows_test.go
+++ b/internal/fsutil/replacefile_windows_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package downloader
+package fsutil
 
 import (
 	"path/filepath"
@@ -19,7 +19,7 @@ func TestReplaceFileWindows_AtomicReplace(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fs, src, []byte("new"), 0644))
 	require.NoError(t, afero.WriteFile(fs, dst, []byte("old"), 0644))
 
-	require.NoError(t, replaceFile(fs, src, dst))
+	require.NoError(t, ReplaceFile(fs, src, dst))
 	got, err := afero.ReadFile(fs, dst)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("new"), got)

--- a/internal/poster/generator.go
+++ b/internal/poster/generator.go
@@ -98,4 +98,71 @@ func (g *ScrapePosterGenerator) GeneratePoster(ctx context.Context, jobID string
 // the same auto-derivation from the download URL when referer is empty.
 // Duplicating it here was redundant and meant both sites had to stay in sync.
 
+// StagingPosterGenerator splits poster generation into an unlocked network
+// stage and an in-lock promote/commit (POSTER-WRITE-HARDENING P2): the edit
+// lock window never covers a network fetch. Generators that lack staging
+// support keep serving GeneratePoster (the legacy in-lock path).
+type StagingPosterGenerator interface {
+	// StagePoster resolves the poster source (poster→cover fallback) and
+	// downloads it to a unique staged identity. Network/unlocked only.
+	StagePoster(ctx context.Context, jobID string, movie *models.Movie) (*StagedPoster, error)
+	// CommitStagedPoster promotes staged bytes to canonical names (fs-only
+	// — the caller's lock must be held) and updates the movie preview URL.
+	CommitStagedPoster(movie *models.Movie, staged *StagedPoster) error
+	// DiscardStaged removes staged residue after a declined/aborted op.
+	DiscardStaged(staged *StagedPoster)
+}
+
+// StagePoster resolves the poster URL (poster→cover fallback) and stages the
+// download under a unique identity. Errors are path-sanitized like
+// GeneratePoster.
+func (g *ScrapePosterGenerator) StagePoster(ctx context.Context, jobID string, movie *models.Movie) (*StagedPoster, error) {
+	if g.manager == nil || movie == nil {
+		return nil, nil
+	}
+	posterURL := movie.Poster.PosterURL
+	if posterURL == "" {
+		posterURL = movie.Poster.CoverURL
+	}
+	if posterURL == "" {
+		return nil, fmt.Errorf("no poster or cover URL available")
+	}
+	staged, err := g.manager.StagePosterDownload(ctx, StagePosterRequest{
+		JobID: jobID, PosterID: movie.ID, URL: posterURL,
+		UserAgent: g.userAgent, Referer: g.referer,
+	})
+	if err != nil {
+		logging.Warnf("[scrape] Failed to stage temp poster: %s (continuing anyway)", stripSensitivePaths(err))
+		return nil, sanitizedErrorFrom(err)
+	}
+	return staged, nil
+}
+
+// CommitStagedPoster promotes the staged pair under canonical names and sets
+// the movie's preview pointer. Call it with the caller's edit lock held,
+// immediately before the state commit.
+func (g *ScrapePosterGenerator) CommitStagedPoster(movie *models.Movie, staged *StagedPoster) error {
+	if g.manager == nil || movie == nil || staged == nil {
+		return nil
+	}
+	res, err := g.manager.PromoteStagedPoster(staged)
+	if err != nil {
+		sanitizedErr := sanitizedErrorFrom(err)
+		logging.Warnf("[scrape] Failed to promote temp poster: %s (continuing anyway)", stripSensitivePaths(err))
+		return sanitizedErr
+	}
+	movie.Poster.CroppedPosterURL = res.CroppedURL
+	return nil
+}
+
+// DiscardStaged removes staged residue (declines/cancel paths).
+func (g *ScrapePosterGenerator) DiscardStaged(staged *StagedPoster) {
+	if g.manager == nil {
+		return
+	}
+	g.manager.DiscardStagedPoster(staged)
+}
+
+var _ StagingPosterGenerator = (*ScrapePosterGenerator)(nil)
+
 var _ PosterGenerator = (*ScrapePosterGenerator)(nil)

--- a/internal/poster/manager.go
+++ b/internal/poster/manager.go
@@ -60,6 +60,14 @@ type PosterManagerInterface interface {
 	// RestoreAssets returns the pair to its snapshot state, removing any
 	// legs created after the snapshot.
 	RestoreAssets(snap *PosterAssetSnapshot) error
+	// StagePosterDownload downloads a poster to a unique staged identity
+	// (network, unlocked — never call under an edit lock).
+	StagePosterDownload(ctx context.Context, req StagePosterRequest) (*StagedPoster, error)
+	// PromoteStagedPoster installs staged bytes under their canonical names
+	// (fs-only — call inside the edit lock, immediately before the commit).
+	PromoteStagedPoster(staged *StagedPoster) (*cropResult, error)
+	// DiscardStagedPoster removes staged residue best-effort.
+	DiscardStagedPoster(staged *StagedPoster)
 }
 
 // ssrfCheckFunc is the function signature for URL SSRF validation.

--- a/internal/poster/manager.go
+++ b/internal/poster/manager.go
@@ -54,6 +54,12 @@ type PosterManagerInterface interface {
 	// DownloadFromURL downloads an image from rawURL and creates both a
 	// full-size and a cropped poster file.
 	DownloadFromURL(ctx context.Context, jobID, posterID, rawURL, userAgent, referer string) (*cropResult, error)
+	// SnapshotAssets captures the (jobID, posterID) asset pair for later
+	// compensation (POSTER-WRITE-HARDENING P2).
+	SnapshotAssets(jobID, posterID string) (*PosterAssetSnapshot, error)
+	// RestoreAssets returns the pair to its snapshot state, removing any
+	// legs created after the snapshot.
+	RestoreAssets(snap *PosterAssetSnapshot) error
 }
 
 // ssrfCheckFunc is the function signature for URL SSRF validation.
@@ -133,8 +139,19 @@ func (pm *PosterManager) CropWithBounds(_ context.Context, jobID, posterID strin
 	right := x + width
 	bottom := y + height
 
-	if err := imageutil.CropPosterWithBounds(pm.fs, sourcePath, croppedPath, left, top, right, bottom, maxPosterHeight); err != nil {
+	// P2: produce under a staged sibling name and install by rename only —
+	// readers-during-replace never see a partial write, and a failed install
+	// restores the previous preview (no .tmp/.bak residue).
+	stagedPath := uniqueStagedSibling(croppedPath, "tmp")
+	if err := imageutil.CropPosterWithBounds(pm.fs, sourcePath, stagedPath, left, top, right, bottom, maxPosterHeight); err != nil {
+		if rmErr := pm.fs.Remove(stagedPath); rmErr != nil && !os.IsNotExist(rmErr) {
+			logging.Warnf("staged crop cleanup failed for %s: %v", stagedPath, rmErr)
+		}
 		return nil, fmt.Errorf("crop failed: %w", err)
+	}
+	if err := pm.installStagedPreview(croppedPath, stagedPath); err != nil {
+		_ = pm.fs.Remove(stagedPath)
+		return nil, err
 	}
 
 	croppedURL := fmt.Sprintf("/api/v1/temp/posters/%s/%s.jpg?v=%d", url.PathEscape(jobID), url.PathEscape(posterID), time.Now().UnixMilli())

--- a/internal/poster/manager_seam_p2_test.go
+++ b/internal/poster/manager_seam_p2_test.go
@@ -1,0 +1,379 @@
+package poster
+
+// P2 staged seam tests: the download lands on a unique staged identity and
+// canonical names are touched ONLY by PromoteStagedPoster (rename-only).
+
+import (
+	"context"
+	"image"
+	"image/jpeg"
+	"net/http"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stageImageServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		img := image.NewRGBA(image.Rect(0, 0, 200, 300))
+		_ = jpeg.Encode(w, img, &jpeg.Options{Quality: 90})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestStagePosterDownload_WritesNothingCanonicalBeforePromote(t *testing.T) {
+	srv := stageImageServer(t)
+	base := afero.NewMemMapFs()
+	spy := &writeSpyFS{Fs: base, writes: map[string]int{}}
+	pm := NewPosterManager(spy, "/tmp/p2", srv.Client()).WithSSRFCheck(func(string) error { return nil })
+
+	staged, err := pm.StagePosterDownload(context.Background(), StagePosterRequest{
+		JobID: "job1", PosterID: "ST-P1", URL: srv.URL + "/img.jpg",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, staged)
+
+	dir := "/tmp/p2/posters/job1"
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		_, serr := base.Stat(dir + "/ST-P1" + suffix)
+		assert.Error(t, serr, "canonical leg untouched during stage: ST-P1%s", suffix)
+	}
+	entries, derr := afero.ReadDir(base, dir)
+	require.NoError(t, derr)
+	stagedCount := 0
+	for _, e := range entries {
+		assert.True(t, strings.HasPrefix(e.Name(), "ST-P1.stage-"), "only staged names during stage: %s", e.Name())
+		assert.Equal(t, 0, spy.countExact(dir+"/ST-P1-full.jpg")+spy.countExact(dir+"/ST-P1.jpg"))
+		_ = e
+		stagedCount++
+	}
+	assert.Equal(t, 2, stagedCount, "both legs staged under the unique identity")
+	assert.Equal(t, 0, spy.countExact(dir+"/ST-P1-full.jpg"), "no canonical full write")
+	assert.Equal(t, 0, spy.countExact(dir+"/ST-P1.jpg"), "no canonical crop write")
+
+	// Promote: canonical pair appears, staged names are gone, and the reported
+	// URL carries the canonical identity.
+	res, err := pm.PromoteStagedPoster(staged)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		_, serr := base.Stat(dir + "/ST-P1" + suffix)
+		assert.NoError(t, serr, "canonical leg promoted: ST-P1%s", suffix)
+	}
+	assert.Contains(t, res.CroppedURL, "ST-P1.jpg")
+	assert.NotContains(t, res.CroppedURL, ".stage-", "canonical URL never references the staged identity")
+	entries2, derr2 := afero.ReadDir(base, dir)
+	require.NoError(t, derr2)
+	for _, e := range entries2 {
+		assert.NotContains(t, e.Name(), ".stage-", "no staged residue after promote")
+	}
+}
+
+// Promote must restore the previous canonical bytes if the second leg's
+// install fails — the pair can never split across generations.
+func TestPromoteStagedPoster_PartialFailureRestoresFirstLeg(t *testing.T) {
+	srv := stageImageServer(t)
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P2-full.jpg", []byte("old-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P2.jpg", []byte("old-crop"), 0o644))
+	pm := NewPosterManager(base, "/tmp/p2", srv.Client()).WithSSRFCheck(func(string) error { return nil })
+
+	// Stage via the public seam, then rehang on a rename-wedged fs.
+	staged, err := pm.StagePosterDownload(context.Background(), StagePosterRequest{
+		JobID: "job1", PosterID: "ST-P2", URL: srv.URL + "/img.jpg",
+	})
+	require.NoError(t, err)
+	// Wedge ONLY the staged→canonical promote rename of the crop leg; the
+	// aside/backup/restore renames (from a .bak sibling) stay live.
+	wedged := renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
+		return strings.Contains(o, ".stage-") && strings.HasSuffix(n, "/ST-P2.jpg")
+	}}
+	pmWedged := NewPosterManager(wedged, "/tmp/p2", nil)
+
+	_, err2 := pmWedged.PromoteStagedPoster(staged)
+	require.ErrorContains(t, err2, "promote staged poster")
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		got, rerr := afero.ReadFile(base, dir+"/ST-P2"+suffix)
+		require.NoError(t, rerr)
+		assert.True(t, string(got) == "old-full" || string(got) == "old-crop",
+			"leg ST-P2%s carries only the ORIGINAL bytes (got %q)", suffix, string(got))
+	}
+}
+
+// Discard removes staged residue; a nil/partially-staged handle is safe.
+func TestStagedPoster_DiscardAndNilSafety(t *testing.T) {
+	srv := stageImageServer(t)
+	base := afero.NewMemMapFs()
+	pm := NewPosterManager(base, "/tmp/p2", srv.Client()).WithSSRFCheck(func(string) error { return nil })
+	staged, err := pm.StagePosterDownload(context.Background(), StagePosterRequest{
+		JobID: "job1", PosterID: "ST-P3", URL: srv.URL + "/img.jpg",
+	})
+	require.NoError(t, err)
+	pm.DiscardStagedPoster(staged)
+	entries, derr := afero.ReadDir(base, "/tmp/p2/posters/job1")
+	require.NoError(t, derr)
+	assert.Empty(t, entries, "discard leaves nothing behind")
+
+	pm.DiscardStagedPoster(nil) // no panic
+	_, perr := pm.PromoteStagedPoster(nil)
+	require.Error(t, perr)
+}
+
+// Generator layer: the split honors the poster→cover fallback and passes
+// sanitized errors through on stage failure.
+func TestScrapePosterGeneratorStageSplit(t *testing.T) {
+	srv := stageImageServer(t)
+	base := afero.NewMemMapFs()
+	pm := NewPosterManager(base, "/tmp/p2", srv.Client()).WithSSRFCheck(func(string) error { return nil })
+	gen := NewScrapePosterGenerator(pm, "", "")
+
+	movie := &models.Movie{ID: "G-1", Poster: models.PosterState{CoverURL: srv.URL + "/cover.jpg"}}
+	staged, err := gen.StagePoster(context.Background(), "job1", movie)
+	require.NoError(t, err, "cover fallback reaches the staged download")
+	require.NotNil(t, staged)
+
+	require.NoError(t, gen.CommitStagedPoster(movie, staged))
+	assert.Contains(t, movie.Poster.CroppedPosterURL, "G-1.jpg")
+	assert.NotContains(t, movie.Poster.CroppedPosterURL, ".stage-")
+	_, serr := base.Stat("/tmp/p2/posters/job1/G-1.jpg")
+	assert.NoError(t, serr)
+
+	// No source at all ⇒ stage error, no residue.
+	_, err2 := gen.StagePoster(context.Background(), "job1", &models.Movie{ID: "G-2"})
+	require.Error(t, err2)
+	entries, _ := afero.ReadDir(base, "/tmp/p2/posters/job1")
+	_ = entries
+}
+
+// --- coverage wedge matrix for the seam's failure arms ---
+
+func TestStagePosterDownload_ValidationAndDownloadErrors(t *testing.T) {
+	srv := stageImageServer(t)
+	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp/p2", srv.Client()).WithSSRFCheck(func(string) error { return nil })
+	if _, err := pm.StagePosterDownload(context.Background(), StagePosterRequest{JobID: "../escape", PosterID: "X-1", URL: srv.URL}); err == nil {
+		t.Fatal("invalid jobID must fail")
+	}
+	if _, err := pm.StagePosterDownload(context.Background(), StagePosterRequest{JobID: "job1", PosterID: "../x", URL: srv.URL}); err == nil {
+		t.Fatal("invalid posterID must fail")
+	}
+	if _, err := pm.StagePosterDownload(context.Background(), StagePosterRequest{JobID: "job1", PosterID: "X-1", URL: "http://%zz"}); err == nil {
+		t.Fatal("undownloadable URL must fail the stage")
+	}
+}
+
+func TestStagedPoster_HandleAccessors(t *testing.T) {
+	var nilHandle *StagedPoster
+	w, h := nilHandle.SourceDimensions()
+	assert.Zero(t, w)
+	assert.Zero(t, h)
+	s := NewStagedPosterHandleForTest("j", "s-1", "t-1", "u")
+	assert.Equal(t, "j", s.jobID)
+	s.sourceWidth, s.sourceHeight = 7, 11
+	w2, h2 := s.SourceDimensions()
+	assert.Equal(t, 7, w2)
+	assert.Equal(t, 11, h2)
+}
+
+// Staged-leg transient stat error aborts the promote coherently.
+func TestPromoteStagedPoster_StagingStatErrorAborts(t *testing.T) {
+	base := afero.NewMemMapFs()
+	require.NoError(t, base.MkdirAll("/tmp/p2/posters/job1", 0o755))
+	require.NoError(t, afero.WriteFile(base, "/tmp/p2/posters/job1/ST-P4.stage-x.jpg", []byte("s"), 0o644))
+	wedged := statFailExactFS{Fs: base, path: "/tmp/p2/posters/job1/ST-P4.stage-x-full.jpg"}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P4.stage-x", "ST-P4", ""))
+	require.ErrorContains(t, err, "promote staging stat")
+}
+
+// Canonical transient stat error on an EXISTING final aborts before aside.
+func TestPromoteStagedPoster_CanonicalStatErrorAborts(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P5.stage-x-full.jpg", []byte("s"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P5-full.jpg", []byte("c"), 0o644))
+	wedged := statFailExactFS{Fs: base, path: dir + "/ST-P5-full.jpg"}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P5.stage-x", "ST-P5", ""))
+	require.ErrorContains(t, err, "promote canonical stat")
+	got, _ := afero.ReadFile(base, dir+"/ST-P5-full.jpg")
+	assert.Equal(t, "c", string(got), "canonical untouched")
+}
+
+// Aside failure: only the wedged leg's backup is pending; already-asided
+// earlier legs restore, and nothing staged lands.
+func TestPromoteStagedPoster_AsideFailureRestoresEarlierLegs(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P6-full.jpg", []byte("c-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P6.jpg", []byte("c-crop"), 0o644))
+	dir2 := dir + "/"
+	require.NoError(t, afero.WriteFile(base, dir2+"ST-P6.stage-x-full.jpg", []byte("s-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir2+"ST-P6.stage-x.jpg", []byte("s-crop"), 0o644))
+	wedged := renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
+		return strings.HasSuffix(n, ".bak") && strings.Contains(o, "ST-P6.jpg")
+	}}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P6.stage-x", "ST-P6", ""))
+	require.ErrorContains(t, err, "set aside")
+	got, _ := afero.ReadFile(base, dir+"/ST-P6-full.jpg")
+	assert.Equal(t, "c-full", string(got), "first leg restored after second leg's aside wedge")
+	got2, _ := afero.ReadFile(base, dir+"/ST-P6.jpg")
+	assert.Equal(t, "c-crop", string(got2))
+}
+
+// Phase-2 failure with NO prior canonical: the partial new final is removed
+// (restore's no-backup arm) and staged bytes are preserved nowhere lurking
+// under canonical names.
+func TestPromoteStagedPoster_Phase2FailureWithoutBackup(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P7.stage-x-full.jpg", []byte("s-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P7.stage-x.jpg", []byte("s-crop"), 0o644))
+	wedged := renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
+		return strings.Contains(o, ".stage-") && strings.HasSuffix(n, "/ST-P7.jpg")
+	}}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P7.stage-x", "ST-P7", ""))
+	require.ErrorContains(t, err, "promote staged poster")
+	_, ferr := base.Stat(dir + "/ST-P7-full.jpg")
+	assert.Error(t, ferr, "no-backup leg's installed new final was removed")
+	_, ferr2 := base.Stat(dir + "/ST-P7.jpg")
+	assert.Error(t, ferr2)
+}
+
+// A wedged RESTORE rename must warn and keep the original bytes findable at
+// the backup path (never silently lost).
+func TestPromoteStagedPoster_RestoreFailureWarnsKeepsBackup(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P8-full.jpg", []byte("c-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P8.jpg", []byte("c-crop"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P8.stage-x-full.jpg", []byte("s-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P8.stage-x.jpg", []byte("s-crop"), 0o644))
+	// Wedge staged→final AND backup→final (restore): both error paths fire.
+	wedged := renameFailWhereFS{Fs: base, fail: func(_, n string) bool {
+		return strings.HasSuffix(n, "/ST-P8-full.jpg")
+	}}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P8.stage-x", "ST-P8", ""))
+	require.ErrorContains(t, err, "promote staged poster")
+}
+
+// Post-success backup sweep failure is warn-only (the promote still wins).
+func TestPromoteStagedPoster_BackupSweepWarnIsNonFatal(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P9-stagez.jpg", []byte("s"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P9.jpg", []byte("c"), 0o644))
+	wedged := removeFailWhereFS{Fs: base, fail: func(n string) bool { return strings.HasSuffix(n, ".bak") }}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	res, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P9-stagez", "ST-P9", dir+"/ST-P9.jpg"))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, dir+"/ST-P9.jpg", res.CroppedPath)
+	got, _ := afero.ReadFile(base, dir+"/ST-P9.jpg")
+	assert.Equal(t, "s", string(got), "promoted bytes landed")
+	entries, _ := afero.ReadDir(base, dir)
+	var bak int
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".bak") {
+			bak++
+		}
+	}
+	assert.Equal(t, 1, bak, "unswept backup lingers harmlessly for inspection")
+}
+
+func TestStagedPoster_DiscardRemoveFailureWarns(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P10.stage-x.jpg", []byte("s"), 0o644))
+	pm := NewPosterManager(removeFailWhereFS{Fs: base, fail: func(string) bool { return true }}, "/tmp/p2", nil)
+	pm.DiscardStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P10.stage-x", "ST-P10", "")) // warn-only, must not panic
+}
+
+// --- generator coverage via a fake manager ---
+
+type fakePosterManager struct {
+	stageErr   error
+	promoteErr error
+	discarded  int
+	handle     *StagedPoster
+	cropRes    *cropResult
+}
+
+func (f *fakePosterManager) CropWithBounds(context.Context, string, string, int, int, int, int, int) (*cropResult, error) {
+	return &cropResult{}, nil
+}
+func (f *fakePosterManager) DownloadFromURL(context.Context, string, string, string, string, string) (*cropResult, error) {
+	return &cropResult{}, nil
+}
+func (f *fakePosterManager) SnapshotAssets(string, string) (*PosterAssetSnapshot, error) {
+	return nil, nil
+}
+func (f *fakePosterManager) RestoreAssets(*PosterAssetSnapshot) error { return nil }
+func (f *fakePosterManager) StagePosterDownload(context.Context, StagePosterRequest) (*StagedPoster, error) {
+	return f.handle, f.stageErr
+}
+func (f *fakePosterManager) PromoteStagedPoster(*StagedPoster) (*cropResult, error) {
+	return f.cropRes, f.promoteErr
+}
+func (f *fakePosterManager) DiscardStagedPoster(*StagedPoster) { f.discarded++ }
+
+func TestGenerator_SplitArmMatrix(t *testing.T) {
+	// nil manager / nil movie early-outs
+	g0 := NewScrapePosterGenerator(nil, "", "")
+	h, err := g0.StagePoster(context.Background(), "j", &models.Movie{ID: "X"})
+	assert.NoError(t, err)
+	assert.Nil(t, h)
+	h, err = g0.StagePoster(context.Background(), "j", nil)
+	assert.NoError(t, err)
+	assert.Nil(t, h)
+	assert.NoError(t, g0.CommitStagedPoster(nil, nil))
+	g0.DiscardStaged(NewStagedPosterHandleForTest("j", "s", "t", "")) // no manager ⇒ silent no-op
+
+	// stage error sanitizes through
+	gm := NewScrapePosterGenerator(&fakePosterManager{stageErr: assertErr}, "", "")
+	_, err = gm.StagePoster(context.Background(), "j", &models.Movie{ID: "X", Poster: models.PosterState{PosterURL: "https://s/p.jpg"}})
+	require.ErrorIs(t, err, assertErr)
+
+	// promote error returns sanitized and leaves the movie untouched
+	movie := &models.Movie{ID: "X", Poster: models.PosterState{PosterURL: "https://s/p.jpg"}}
+	gp := NewScrapePosterGenerator(&fakePosterManager{promoteErr: assertErr}, "", "")
+	err = gp.CommitStagedPoster(movie, NewStagedPosterHandleForTest("j", "s", "t", ""))
+	require.ErrorIs(t, err, assertErr)
+	assert.Empty(t, movie.Poster.CroppedPosterURL)
+
+	// happy promote sets the preview pointer
+	gok := NewScrapePosterGenerator(&fakePosterManager{cropRes: &cropResult{CroppedURL: "/api/x/P-9.jpg"}}, "", "")
+	require.NoError(t, gok.CommitStagedPoster(movie, NewStagedPosterHandleForTest("j", "s", "t", "")))
+	assert.Equal(t, "/api/x/P-9.jpg", movie.Poster.CroppedPosterURL)
+
+	// discard delegates
+	fd := &fakePosterManager{}
+	gd := NewScrapePosterGenerator(fd, "", "")
+	gd.DiscardStaged(NewStagedPosterHandleForTest("j", "s", "t", ""))
+	assert.Equal(t, 1, fd.discarded)
+}
+
+var assertErr = assertAnError{}
+
+type assertAnError struct{}
+
+func (assertAnError) Error() string { return "assert manager wedge" }

--- a/internal/poster/manager_seam_p2_test.go
+++ b/internal/poster/manager_seam_p2_test.go
@@ -227,7 +227,7 @@ func TestPromoteStagedPoster_AsideFailureRestoresEarlierLegs(t *testing.T) {
 	}}
 	pm := NewPosterManager(wedged, "/tmp/p2", nil)
 	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P6.stage-x", "ST-P6", ""))
-	require.ErrorContains(t, err, "set aside")
+	require.ErrorContains(t, err, "back up")
 	got, _ := afero.ReadFile(base, dir+"/ST-P6-full.jpg")
 	assert.Equal(t, "c-full", string(got), "first leg restored after second leg's aside wedge")
 	got2, _ := afero.ReadFile(base, dir+"/ST-P6.jpg")
@@ -409,4 +409,47 @@ func TestPromoteStagedPoster_CanonicalStatWedgedRestoresAsidedLeg(t *testing.T) 
 		require.NoError(t, serr, "staged leg survives for retry: %s", s)
 		assert.True(t, strings.HasPrefix(string(got), "s-"))
 	}
+}
+
+// Phase-2 failure on a LATER leg with the restore rename wedged: the error
+// reports the restore failure while the earlier leg's bytes stay findable at
+// their .bak copy (nothing silently lost mid-pair).
+func TestPromoteStagedPoster_RestoreRenameWedgedKeepsBackup(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/R-4-full.jpg", []byte("c-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/R-4.jpg", []byte("c-crop"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/R-4.stage-x-full.jpg", []byte("s-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/R-4.stage-x.jpg", []byte("s-crop"), 0o644))
+
+	wedged := renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
+		// crop-leg phase-2 install wedges; the full-leg restore rename wedges too.
+		if strings.Contains(o, ".stage-") && strings.HasSuffix(n, "/R-4.jpg") {
+			return true
+		}
+		return strings.Contains(o, ".bak") && strings.HasSuffix(n, "/R-4-full.jpg")
+	}}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "R-4.stage-x", "R-4", ""))
+	require.ErrorContains(t, err, "promote staged poster")
+
+	// The crop leg was never displaced under the never-absent contract.
+	gotCrop, cerr := afero.ReadFile(base, dir+"/R-4.jpg")
+	require.NoError(t, cerr)
+	assert.Equal(t, "c-crop", string(gotCrop))
+	// The full leg's prior bytes survive at the backup copy (restore rename
+	// wedged; the warn path ran, bytes intact).
+	entries, derr := afero.ReadDir(base, dir)
+	require.NoError(t, derr)
+	var bak []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "R-4-full.jpg.") && strings.HasSuffix(e.Name(), ".bak") {
+			bak = append(bak, filepath.Join(dir, e.Name()))
+		}
+	}
+	require.Len(t, bak, 1)
+	content, rerr := afero.ReadFile(base, bak[0])
+	require.NoError(t, rerr)
+	assert.Equal(t, "c-full", string(content), "prior bytes recoverable from the backup")
 }

--- a/internal/poster/manager_seam_p2_test.go
+++ b/internal/poster/manager_seam_p2_test.go
@@ -377,3 +377,36 @@ var assertErr = assertAnError{}
 type assertAnError struct{}
 
 func (assertAnError) Error() string { return "assert manager wedge" }
+
+// codex P2 (PR211): a transient canonical-stat failure mid-phase-1 must
+// restore the legs ALREADY asided — the pair never tears (older leg gone
+// under a .bak while the later leg stays) under a transient wedge.
+func TestPromoteStagedPoster_CanonicalStatWedgedRestoresAsidedLeg(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/PC-1-full.jpg", []byte("c-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/PC-1.jpg", []byte("c-crop"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/PC-1.stage-x-full.jpg", []byte("s-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/PC-1.stage-x.jpg", []byte("s-crop"), 0o644))
+
+	// The crop leg's canonical Stat fails transiently: the full leg has
+	// already been asided to .bak — the restore must put it back.
+	wedged := statFailExactFS{Fs: base, path: dir + "/PC-1.jpg"}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "PC-1.stage-x", "PC-1", ""))
+	require.ErrorContains(t, err, "promote canonical stat")
+
+	gotFull, ferr := afero.ReadFile(base, dir+"/PC-1-full.jpg")
+	require.NoError(t, ferr, "first leg restored from its backup")
+	assert.Equal(t, "c-full", string(gotFull))
+	gotCrop, cerr := afero.ReadFile(base, dir+"/PC-1.jpg")
+	require.NoError(t, cerr, "untouched second leg intact")
+	assert.Equal(t, "c-crop", string(gotCrop))
+	// staged bytes untouched for a later retry
+	for _, s := range []string{"/PC-1.stage-x-full.jpg", "/PC-1.stage-x.jpg"} {
+		got, serr := afero.ReadFile(base, dir+s)
+		require.NoError(t, serr, "staged leg survives for retry: %s", s)
+		assert.True(t, strings.HasPrefix(string(got), "s-"))
+	}
+}

--- a/internal/poster/manager_seam_p2_test.go
+++ b/internal/poster/manager_seam_p2_test.go
@@ -201,7 +201,8 @@ func TestPromoteStagedPoster_CanonicalStatErrorAborts(t *testing.T) {
 	base := afero.NewMemMapFs()
 	dir := "/tmp/p2/posters/job1"
 	require.NoError(t, base.MkdirAll(dir, 0o755))
-	require.NoError(t, afero.WriteFile(base, dir+"/ST-P5.stage-x-full.jpg", []byte("s"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P5.stage-x-full.jpg", []byte("s-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P5.stage-x.jpg", []byte("s-crop"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-P5-full.jpg", []byte("c"), 0o644))
 	wedged := statFailExactFS{Fs: base, path: dir + "/ST-P5-full.jpg"}
 	pm := NewPosterManager(wedged, "/tmp/p2", nil)
@@ -279,6 +280,7 @@ func TestPromoteStagedPoster_BackupSweepWarnIsNonFatal(t *testing.T) {
 	base := afero.NewMemMapFs()
 	dir := "/tmp/p2/posters/job1"
 	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-P9-stagez-full.jpg", []byte("s-full"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-P9-stagez.jpg", []byte("s"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-P9.jpg", []byte("c"), 0o644))
 	wedged := removeFailWhereFS{Fs: base, fail: func(n string) bool { return strings.HasSuffix(n, ".bak") }}
@@ -452,4 +454,37 @@ func TestPromoteStagedPoster_RestoreRenameWedgedKeepsBackup(t *testing.T) {
 	content, rerr := afero.ReadFile(base, bak[0])
 	require.NoError(t, rerr)
 	assert.Equal(t, "c-full", string(content), "prior bytes recoverable from the backup")
+}
+
+// codex P2 round 7 (PR211): a successful stage ALWAYS produced both legs —
+// a missing staged leg means the stage was disturbed mid-op (temp sweep).
+// Promote must fail instead of installing a partial pair or committing a
+// dangling URL over nothing.
+func TestPromoteStagedPoster_IncompleteStageFails(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	// Stage exists partially (full leg swept between stage and promote).
+	require.NoError(t, afero.WriteFile(base, dir+"/INC-1.stage-x.jpg", []byte("s-crop"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/INC-1-full.jpg", []byte("c-full"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/INC-1.jpg", []byte("c-crop"), 0o644))
+	pm := NewPosterManager(base, "/tmp/p2", nil)
+
+	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "INC-1.stage-x", "INC-1", ""))
+	require.ErrorContains(t, err, "incomplete stage")
+
+	// Canonical untouched.
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		got, rerr := afero.ReadFile(base, dir+"/INC-1"+suffix)
+		require.NoError(t, rerr)
+		assert.True(t, strings.HasPrefix(string(got), "c-"), "unpromoted: %s stays old", suffix)
+	}
+
+	// And an empty stage (both legs gone) errors too.
+	require.NoError(t, afero.WriteFile(base, dir+"/INC-2.jpg", []byte("c-crop"), 0o644))
+	_, err2 := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "INC-2.stage-x", "INC-2", ""))
+	require.ErrorContains(t, err2, "incomplete stage")
+	got, rerr := afero.ReadFile(base, dir+"/INC-2.jpg")
+	require.NoError(t, rerr)
+	assert.Equal(t, "c-crop", string(got))
 }

--- a/internal/poster/manager_seam_p2_test.go
+++ b/internal/poster/manager_seam_p2_test.go
@@ -8,12 +8,12 @@ import (
 	"image"
 	"image/jpeg"
 	"net/http"
-
-	"github.com/javinizer/javinizer-go/internal/models"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -286,7 +286,7 @@ func TestPromoteStagedPoster_BackupSweepWarnIsNonFatal(t *testing.T) {
 	res, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P9-stagez", "ST-P9", dir+"/ST-P9.jpg"))
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	assert.Equal(t, dir+"/ST-P9.jpg", res.CroppedPath)
+	assert.Equal(t, filepath.Join(dir, "ST-P9.jpg"), res.CroppedPath, "canonical preview path (platform separators)")
 	got, _ := afero.ReadFile(base, dir+"/ST-P9.jpg")
 	assert.Equal(t, "s", string(got), "promoted bytes landed")
 	entries, _ := afero.ReadDir(base, dir)

--- a/internal/poster/manager_stage.go
+++ b/internal/poster/manager_stage.go
@@ -228,38 +228,36 @@ func (pm *PosterManager) PromoteStagedPoster(staged *StagedPoster) (*cropResult,
 		legs = append(legs, l)
 	}
 
-	// Phase 1: aside the previous canonical legs (staged bytes stay put).
+	// Phase 1: COPY the previous canonical bytes aside (never move). The
+	// canonical leg stays present throughout the promote — a lock-free reader
+	// on /temp/posters can never observe a 404 window (codex P2 round 4).
 	for i := range legs {
 		if _, err := pm.fs.Stat(legs[i].finalPath); err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
-			// codex r1 P3: legs before i are already asided — restore them before
-			// bailing, or the pair splits (byte loss under a transient stat wedge).
-			pm.restorePromotedBackups(legs[:i])
+			pm.sweepPromotedBackups(legs[:i]) // earlier copies are pure litter
 			return nil, fmt.Errorf("promote canonical stat %s: %w", legs[i].finalPath, err)
 		}
 		legs[i].backupPath = uniqueStagedSibling(legs[i].finalPath, "bak")
-		if err := pm.fs.Rename(legs[i].finalPath, legs[i].backupPath); err != nil {
-			pm.restorePromotedBackups(legs[:i])
-			return nil, fmt.Errorf("promote staged poster: set aside %s: %w", legs[i].finalPath, err)
+		if err := fsutil.CopyFileFs(pm.fs, legs[i].finalPath, legs[i].backupPath); err != nil {
+			pm.sweepPromotedBackups(legs[:i])
+			return nil, fmt.Errorf("promote staged poster: back up %s: %w", legs[i].finalPath, err)
 		}
 	}
-	// Phase 2: move staged into canonical (rename-only).
+	// Phase 2: staged bytes land via atomic REPLACE (the canonical entry
+	// never disappears) — POSIX rename replaces; MoveFileEx on Windows.
 	for i := range legs {
-		if err := pm.fs.Rename(legs[i].stagedPath, legs[i].finalPath); err != nil {
-			pm.restorePromotedBackups(legs)
+		if err := fsutil.ReplaceFile(pm.fs, legs[i].stagedPath, legs[i].finalPath); err != nil {
+			// Restored legs return to their pre-promotion bytes; legs never
+			// displaced just shed the backup copies.
+			pm.restorePromotedBackups(legs[:i])
+			pm.sweepPromotedBackups(legs[i:])
 			return nil, fmt.Errorf("promote staged poster: %w", err)
 		}
 	}
 	// Success: drop the per-op backups best-effort.
-	for _, l := range legs {
-		if l.backupPath != "" {
-			if err := pm.fs.Remove(l.backupPath); err != nil {
-				logging.Warnf("poster promote backup sweep %s: %v", l.backupPath, err)
-			}
-		}
-	}
+	pm.sweepPromotedBackups(legs)
 
 	res := &cropResult{SourceFull: true}
 	for _, l := range legs {
@@ -282,15 +280,28 @@ func (pm *PosterManager) PromoteStagedPoster(staged *StagedPoster) (*cropResult,
 func (pm *PosterManager) restorePromotedBackups(legs []promoteLegMove) {
 	for _, l := range legs {
 		if l.backupPath == "" {
-			// Nothing was aside for this leg — remove a possibly installed new final.
+			// Nothing was backed up for this leg — remove a possibly installed new final.
 			_ = pm.fs.Remove(l.finalPath)
 			continue
 		}
-		// Prefer the bytes' identity over the address: delete a partial new
-		// final first so the restore rename lands even on strict filesystems.
+		// Remove the partial new install first so the restore rename lands even
+		// on strict filesystems, then restore the backup in its place.
 		_ = pm.fs.Remove(l.finalPath)
 		if err := pm.fs.Rename(l.backupPath, l.finalPath); err != nil {
 			logging.Warnf("poster promote restore %s failed (%v) — bytes survive at %s", l.finalPath, err, l.backupPath)
+		}
+	}
+}
+
+// sweepPromotedBackups deletes the per-op backup COPIES of legs whose
+// canonical bytes were never displaced (phase-1 copies) or that already
+// landed successfully. Warn-only on wedge (inspect-friendly).
+func (pm *PosterManager) sweepPromotedBackups(legs []promoteLegMove) {
+	for _, l := range legs {
+		if l.backupPath != "" {
+			if err := pm.fs.Remove(l.backupPath); err != nil {
+				logging.Warnf("poster promote backup sweep %s: %v", l.backupPath, err)
+			}
 		}
 	}
 }

--- a/internal/poster/manager_stage.go
+++ b/internal/poster/manager_stage.go
@@ -1,0 +1,127 @@
+package poster
+
+// P2 (apply-writeback-coherence): staged preview install + asset
+// snapshot/restore compensation.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/spf13/afero"
+)
+
+// stagedNameCounter disambiguates staged names allocated within the same
+// clock tick (single-process deployment per design D15).
+var stagedNameCounter atomic.Uint64
+
+// uniqueStagedSibling returns a collision-free sibling path for staged
+// bytes/backups: <dest>.<unixnano>-<counter>.<suffix> — mirroring the
+// downloaders' uniqueTempPath convention, re-landed fresh per the quarry
+// discipline.
+func uniqueStagedSibling(destPath, suffix string) string {
+	return fmt.Sprintf("%s.%d-%d.%s", destPath, time.Now().UnixNano(), stagedNameCounter.Add(1), suffix)
+}
+
+// installStagedPreview moves the current preview aside into a per-operation
+// backup name and renames the staged bytes into place — readers always see
+// either the old or the new bytes, never a partial write. Any failure
+// restores the previous preview best-effort and reports the error; no staged
+// or backup residue survives, success or failure.
+func (pm *PosterManager) installStagedPreview(finalPath, stagedPath string) error {
+	backupPath := ""
+	if _, err := pm.fs.Stat(finalPath); err == nil {
+		backupPath = uniqueStagedSibling(finalPath, "bak")
+		if err := pm.fs.Rename(finalPath, backupPath); err != nil {
+			return fmt.Errorf("failed to set aside previous preview: %w", err)
+		}
+	}
+	if err := pm.fs.Rename(stagedPath, finalPath); err != nil {
+		if backupPath != "" {
+			// Losing the just-staged bytes is preferable to leaving the
+			// destination empty — old content beats none.
+			if rErr := pm.fs.Rename(backupPath, finalPath); rErr != nil {
+				return fmt.Errorf("failed to install staged preview: %w (restore of previous preview also failed: %v)", err, rErr)
+			}
+		}
+		return fmt.Errorf("failed to install staged preview: %w", err)
+	}
+	if backupPath != "" {
+		if err := pm.fs.Remove(backupPath); err != nil {
+			logging.Warnf("poster preview backup sweep failed for %s: %v", backupPath, err)
+		}
+	}
+	return nil
+}
+
+// PosterAssetSnapshot captures the byte state of a (jobID, posterID) asset
+// pair as of SnapshotAssets, for compensation restore on commit failure.
+type PosterAssetSnapshot struct {
+	jobID     string
+	posterID  string
+	fullBytes []byte // nil ⇒ full leg absent at snapshot time
+	cropBytes []byte // nil ⇒ cropped leg absent at snapshot time
+}
+
+// SnapshotAssets captures the current <posterID>-full.jpg and <posterID>.jpg
+// bytes (or their absence) for later RestoreAssets compensation.
+func (pm *PosterManager) SnapshotAssets(jobID, posterID string) (*PosterAssetSnapshot, error) {
+	if err := ValidateJobID(jobID); err != nil {
+		return nil, err
+	}
+	if err := validatePosterID(posterID); err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(pm.tempDir, "posters", jobID)
+	snap := &PosterAssetSnapshot{jobID: jobID, posterID: posterID}
+	if b, err := afero.ReadFile(pm.fs, filepath.Join(dir, posterID+"-full.jpg")); err == nil {
+		snap.fullBytes = b
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("snapshot assets: %w", err)
+	}
+	if b, err := afero.ReadFile(pm.fs, filepath.Join(dir, posterID+".jpg")); err == nil {
+		snap.cropBytes = b
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("snapshot assets: %w", err)
+	}
+	return snap, nil
+}
+
+// RestoreAssets returns the (jobID, posterID) pair to its snapshot state:
+// captured legs are restored byte-for-byte; legs CREATED after the snapshot
+// are removed. Restores install via the same staged machinery so a
+// mid-restore reader never sees partial bytes.
+func (pm *PosterManager) RestoreAssets(snap *PosterAssetSnapshot) error {
+	if snap == nil {
+		return nil
+	}
+	dir := filepath.Join(pm.tempDir, "posters", snap.jobID)
+	if err := pm.restoreLeg(dir, snap.posterID+"-full.jpg", snap.fullBytes); err != nil {
+		return err
+	}
+	return pm.restoreLeg(dir, snap.posterID+".jpg", snap.cropBytes)
+}
+
+// restoreLeg restores one asset to content, or removes it when content is
+// nil (the leg did not exist at snapshot time).
+func (pm *PosterManager) restoreLeg(dir, name string, content []byte) error {
+	target := filepath.Join(dir, name)
+	if content == nil {
+		if err := pm.fs.Remove(target); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("restore assets: remove created leg %s: %w", name, err)
+		}
+		return nil
+	}
+	staged := uniqueStagedSibling(target, "tmp")
+	if err := afero.WriteFile(pm.fs, staged, content, 0o644); err != nil {
+		return fmt.Errorf("restore assets: stage leg %s: %w", name, err)
+	}
+	if err := pm.installStagedPreview(target, staged); err != nil {
+		_ = pm.fs.Remove(staged)
+		return fmt.Errorf("restore assets: install leg %s: %w", name, err)
+	}
+	return nil
+}

--- a/internal/poster/manager_stage.go
+++ b/internal/poster/manager_stage.go
@@ -231,10 +231,6 @@ func (pm *PosterManager) PromoteStagedPoster(staged *StagedPoster) (*cropResult,
 		}
 		legs = append(legs, l)
 	}
-	if len(legs) == 0 {
-		return nil, fmt.Errorf("promote staged poster: incomplete stage — no staged legs to install")
-	}
-
 	// Phase 1: COPY the previous canonical bytes aside (never move). The
 	// canonical leg stays present throughout the promote — a lock-free reader
 	// on /temp/posters can never observe a 404 window (codex P2 round 4).

--- a/internal/poster/manager_stage.go
+++ b/internal/poster/manager_stage.go
@@ -229,6 +229,9 @@ func (pm *PosterManager) PromoteStagedPoster(staged *StagedPoster) (*cropResult,
 			if os.IsNotExist(err) {
 				continue
 			}
+			// codex r1 P3: legs before i are already asided — restore them before
+			// bailing, or the pair splits (byte loss under a transient stat wedge).
+			pm.restorePromotedBackups(legs[:i])
 			return nil, fmt.Errorf("promote canonical stat %s: %w", legs[i].finalPath, err)
 		}
 		legs[i].backupPath = uniqueStagedSibling(legs[i].finalPath, "bak")

--- a/internal/poster/manager_stage.go
+++ b/internal/poster/manager_stage.go
@@ -41,6 +41,11 @@ func (pm *PosterManager) installStagedPreview(finalPath, stagedPath string) erro
 		if err := pm.fs.Rename(finalPath, backupPath); err != nil {
 			return fmt.Errorf("failed to set aside previous preview: %w", err)
 		}
+	} else if !os.IsNotExist(err) {
+		// codex P2: fail closed on an undecidable stat — treating it as
+		// "absent" would let a replacing-rename destroy the previous preview
+		// with no backup staged for restore (parity with PromoteStagedPoster).
+		return fmt.Errorf("failed to probe preview %s before install: %w", finalPath, err)
 	}
 	if err := pm.fs.Rename(stagedPath, finalPath); err != nil {
 		if backupPath != "" {

--- a/internal/poster/manager_stage.go
+++ b/internal/poster/manager_stage.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/javinizer/javinizer-go/internal/fsutil"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/spf13/afero"
 )
@@ -29,30 +30,29 @@ func uniqueStagedSibling(destPath, suffix string) string {
 	return fmt.Sprintf("%s.%d-%d.%s", destPath, time.Now().UnixNano(), stagedNameCounter.Add(1), suffix)
 }
 
-// installStagedPreview moves the current preview aside into a per-operation
-// backup name and renames the staged bytes into place — readers always see
-// either the old or the new bytes, never a partial write. Any failure
-// restores the previous preview best-effort and reports the error; no staged
-// or backup residue survives, success or failure.
+// installStagedPreview installs staged bytes onto finalPath so the canonical
+// path is NEVER absent mid-replace (codex P2): the previous preview is COPIED
+// aside (not moved), and the staged bytes land via fsutil.ReplaceFile, which
+// is rename-based on POSIX and MoveFileEx-based on Windows — both atomic
+// replaces. A lock-free reader (serveTempPoster) sees old bytes until the
+// swap, then new bytes; failure to replace leaves old bytes untouched.
 func (pm *PosterManager) installStagedPreview(finalPath, stagedPath string) error {
 	backupPath := ""
 	if _, err := pm.fs.Stat(finalPath); err == nil {
 		backupPath = uniqueStagedSibling(finalPath, "bak")
-		if err := pm.fs.Rename(finalPath, backupPath); err != nil {
-			return fmt.Errorf("failed to set aside previous preview: %w", err)
+		if err := fsutil.CopyFileFs(pm.fs, finalPath, backupPath); err != nil {
+			return fmt.Errorf("failed to back up previous preview: %w", err)
 		}
 	} else if !os.IsNotExist(err) {
-		// codex P2: fail closed on an undecidable stat — treating it as
-		// "absent" would let a replacing-rename destroy the previous preview
-		// with no backup staged for restore (parity with PromoteStagedPoster).
+		// codex P2: fail closed on an undecidable stat — never replace blind.
 		return fmt.Errorf("failed to probe preview %s before install: %w", finalPath, err)
 	}
-	if err := pm.fs.Rename(stagedPath, finalPath); err != nil {
+	if err := fsutil.ReplaceFile(pm.fs, stagedPath, finalPath); err != nil {
+		// Nothing moved over finalPath (atomic replace either lands or doesn't
+		// — the prior bytes are still there); the backup copy is pure litter.
 		if backupPath != "" {
-			// Losing the just-staged bytes is preferable to leaving the
-			// destination empty — old content beats none.
-			if rErr := pm.fs.Rename(backupPath, finalPath); rErr != nil {
-				return fmt.Errorf("failed to install staged preview: %w (restore of previous preview also failed: %v)", err, rErr)
+			if rmErr := pm.fs.Remove(backupPath); rmErr != nil {
+				logging.Warnf("failed install backup sweep %s: %v", backupPath, rmErr)
 			}
 		}
 		return fmt.Errorf("failed to install staged preview: %w", err)

--- a/internal/poster/manager_stage.go
+++ b/internal/poster/manager_stage.go
@@ -4,9 +4,12 @@ package poster
 // snapshot/restore compensation.
 
 import (
+	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -124,4 +127,176 @@ func (pm *PosterManager) restoreLeg(dir, name string, content []byte) error {
 		return fmt.Errorf("restore assets: install leg %s: %w", name, err)
 	}
 	return nil
+}
+
+// --- P2 staged download/promote seam ---
+
+// StagePosterRequest carries one poster download to be staged OUTSIDE the
+// caller's lock window (the network leg must never hold an edit key).
+type StagePosterRequest struct {
+	JobID     string
+	PosterID  string // canonical target identity
+	URL       string
+	UserAgent string
+	Referer   string
+}
+
+// StagedPoster is the opaque handle StagePosterDownload returns: bytes live
+// under a unique staged identity and only PromoteStagedPoster moves them to
+// the canonical names. All identity is internal — a caller can never reach
+// the filesystem except through PromoteStagedPoster (fs-only).
+type StagedPoster struct {
+	jobID            string
+	stagedID         string
+	targetID         string
+	croppedURLStaged string
+	sourceWidth      int
+	sourceHeight     int
+}
+
+// NewStagedPosterHandleForTest builds a handle directly — usable only from
+// *_test.go callers (other packages, e.g. worker fakes, cannot construct the
+// opaque type otherwise).
+func NewStagedPosterHandleForTest(jobID, stagedID, targetID, stagedCropURL string) *StagedPoster {
+	return &StagedPoster{jobID: jobID, stagedID: stagedID, targetID: targetID, croppedURLStaged: stagedCropURL}
+}
+
+// SourceDimensions returns the measured size of the staged source image.
+func (s *StagedPoster) SourceDimensions() (int, int) {
+	if s == nil {
+		return 0, 0
+	}
+	return s.sourceWidth, s.sourceHeight
+}
+
+// StagePosterDownload downloads the poster to a UNIQUE staged identity
+// (network, unlocked); nothing touches the canonical pair. The stage
+// inherits DownloadFromURL's content validation and preview cropping;
+// promote swaps the staged names for the canonical ones atomically.
+func (pm *PosterManager) StagePosterDownload(ctx context.Context, req StagePosterRequest) (*StagedPoster, error) {
+	if err := ValidateJobID(req.JobID); err != nil {
+		return nil, err
+	}
+	if err := validatePosterID(req.PosterID); err != nil {
+		return nil, err
+	}
+	stagedID := fmt.Sprintf("%s.stage-%d-%d", req.PosterID, time.Now().UnixNano(), stagedNameCounter.Add(1))
+	res, err := pm.DownloadFromURL(ctx, req.JobID, stagedID, req.URL, req.UserAgent, req.Referer)
+	if err != nil {
+		return nil, err
+	}
+	return &StagedPoster{
+		jobID:            req.JobID,
+		stagedID:         stagedID,
+		targetID:         req.PosterID,
+		croppedURLStaged: res.CroppedURL,
+		sourceWidth:      res.SourceWidth,
+		sourceHeight:     res.SourceHeight,
+	}, nil
+}
+
+// promoteLegMove tracks one staged→canonical leg through the promote dance.
+type promoteLegMove struct{ stagedPath, finalPath, backupPath string }
+
+// PromoteStagedPoster installs the staged pair under the canonical names,
+// PAIR-ATOMIC: the previous canonical legs are moved aside FIRST, staged
+// renames follow, and ANY failure restores the whole previous pair so the
+// two legs never split across generations. FS-only — call it INSIDE the
+// caller's lock window immediately before the state commit.
+func (pm *PosterManager) PromoteStagedPoster(staged *StagedPoster) (*cropResult, error) {
+	if staged == nil {
+		return nil, fmt.Errorf("promote staged poster: nil stage")
+	}
+	tempPosterDir := filepath.Join(pm.tempDir, "posters", staged.jobID)
+	var legs []promoteLegMove
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		l := promoteLegMove{
+			stagedPath: filepath.Join(tempPosterDir, staged.stagedID+suffix),
+			finalPath:  filepath.Join(tempPosterDir, staged.targetID+suffix),
+		}
+		if _, err := pm.fs.Stat(l.stagedPath); err != nil {
+			if os.IsNotExist(err) {
+				continue // leg never staged (e.g. crop failed with no fallback)
+			}
+			return nil, fmt.Errorf("promote staging stat %s: %w", l.stagedPath, err)
+		}
+		legs = append(legs, l)
+	}
+
+	// Phase 1: aside the previous canonical legs (staged bytes stay put).
+	for i := range legs {
+		if _, err := pm.fs.Stat(legs[i].finalPath); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("promote canonical stat %s: %w", legs[i].finalPath, err)
+		}
+		legs[i].backupPath = uniqueStagedSibling(legs[i].finalPath, "bak")
+		if err := pm.fs.Rename(legs[i].finalPath, legs[i].backupPath); err != nil {
+			pm.restorePromotedBackups(legs[:i])
+			return nil, fmt.Errorf("promote staged poster: set aside %s: %w", legs[i].finalPath, err)
+		}
+	}
+	// Phase 2: move staged into canonical (rename-only).
+	for i := range legs {
+		if err := pm.fs.Rename(legs[i].stagedPath, legs[i].finalPath); err != nil {
+			pm.restorePromotedBackups(legs)
+			return nil, fmt.Errorf("promote staged poster: %w", err)
+		}
+	}
+	// Success: drop the per-op backups best-effort.
+	for _, l := range legs {
+		if l.backupPath != "" {
+			if err := pm.fs.Remove(l.backupPath); err != nil {
+				logging.Warnf("poster promote backup sweep %s: %v", l.backupPath, err)
+			}
+		}
+	}
+
+	res := &cropResult{SourceFull: true}
+	for _, l := range legs {
+		if strings.HasSuffix(l.finalPath, "-full.jpg") {
+			res.FullPath = l.finalPath
+			res.SourceWidth = staged.sourceWidth
+			res.SourceHeight = staged.sourceHeight
+		} else {
+			res.CroppedPath = l.finalPath
+		}
+	}
+	// The staged crop URL carries the staged identity — swap it for the
+	// canonical one the committed row must reference (never the staged name).
+	res.CroppedURL = strings.Replace(staged.croppedURLStaged, url.PathEscape(staged.stagedID)+".jpg", url.PathEscape(staged.targetID)+".jpg", 1)
+	return res, nil
+}
+
+// restorePromotedBackups best-effort returns every leg's previous bytes from
+// its backup after a failed promote (clears any partial new installs first).
+func (pm *PosterManager) restorePromotedBackups(legs []promoteLegMove) {
+	for _, l := range legs {
+		if l.backupPath == "" {
+			// Nothing was aside for this leg — remove a possibly installed new final.
+			_ = pm.fs.Remove(l.finalPath)
+			continue
+		}
+		// Prefer the bytes' identity over the address: delete a partial new
+		// final first so the restore rename lands even on strict filesystems.
+		_ = pm.fs.Remove(l.finalPath)
+		if err := pm.fs.Rename(l.backupPath, l.finalPath); err != nil {
+			logging.Warnf("poster promote restore %s failed (%v) — bytes survive at %s", l.finalPath, err, l.backupPath)
+		}
+	}
+}
+
+// DiscardStagedPoster removes any staged residue best-effort (e.g. when the
+// fenced commit declines after staging succeeded).
+func (pm *PosterManager) DiscardStagedPoster(staged *StagedPoster) {
+	if staged == nil {
+		return
+	}
+	tempPosterDir := filepath.Join(pm.tempDir, "posters", staged.jobID)
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		if err := pm.fs.Remove(filepath.Join(tempPosterDir, staged.stagedID+suffix)); err != nil && !os.IsNotExist(err) {
+			logging.Warnf("staged poster discard %s-%s: %v", staged.stagedID, suffix, err)
+		}
+	}
 }

--- a/internal/poster/manager_stage.go
+++ b/internal/poster/manager_stage.go
@@ -221,11 +221,18 @@ func (pm *PosterManager) PromoteStagedPoster(staged *StagedPoster) (*cropResult,
 		}
 		if _, err := pm.fs.Stat(l.stagedPath); err != nil {
 			if os.IsNotExist(err) {
-				continue // leg never staged (e.g. crop failed with no fallback)
+				// codex P2 round 7: a successful stage ALWAYS produced both legs
+				// (crop failures fall back to a copy). A missing leg therefore
+				// means the stage was disturbed (temp sweep mid-op); promoting a
+				// remainder would commit a dangling crop URL or mix generations.
+				return nil, fmt.Errorf("promote staged poster: incomplete stage, staged leg absent: %s", l.stagedPath)
 			}
 			return nil, fmt.Errorf("promote staging stat %s: %w", l.stagedPath, err)
 		}
 		legs = append(legs, l)
+	}
+	if len(legs) == 0 {
+		return nil, fmt.Errorf("promote staged poster: incomplete stage — no staged legs to install")
 	}
 
 	// Phase 1: COPY the previous canonical bytes aside (never move). The

--- a/internal/poster/manager_stage_p2_test.go
+++ b/internal/poster/manager_stage_p2_test.go
@@ -191,19 +191,22 @@ type errWedgeType struct{}
 
 func (errWedgeType) Error() string { return "wedged" }
 
-// The aside step itself wedging: the crop aborts BEFORE any byte damage, the
-// previous preview is intact, and the staged temp is cleaned by the caller.
+// The backup-aside step (a COPY under P3's never-absent contract) wedging:
+// the crop aborts BEFORE any byte damage, the previous preview is intact,
+// and the staged temp is cleaned by the caller.
 func TestPosterManager_CropWithBounds_AsideFailureKeepsEverything(t *testing.T) {
 	base := afero.NewMemMapFs()
 	dir := "/tmp/p2/posters/job1"
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-3-full.jpg", jpegBytes(200, 300), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-3.jpg", []byte("old-preview"), 0o644))
-	wedged := renameFailWhereFS{Fs: base, fail: func(_, n string) bool { return strings.Contains(n, ".bak") }}
+	wedged := openFileFailWhereFS{Fs: base, fail: func(n string, flag int) bool {
+		return strings.Contains(n, ".bak") && flag&os.O_CREATE != 0
+	}}
 	pm := NewPosterManager(wedged, "/tmp/p2", nil)
 
 	_, err := pm.CropWithBounds(context.Background(), "job1", "ST-3", 0, 0, 100, 150, 0)
-	require.ErrorContains(t, err, "set aside previous preview")
+	require.ErrorContains(t, err, "back up previous preview")
 	got, rerr := afero.ReadFile(base, dir+"/ST-3.jpg")
 	require.NoError(t, rerr)
 	assert.Equal(t, "old-preview", string(got))
@@ -215,34 +218,34 @@ func TestPosterManager_CropWithBounds_AsideFailureKeepsEverything(t *testing.T) 
 	}
 }
 
-// Total-loss leg: the staged install fails AND the restore fails — the error
-// reports both, and the previous preview is still recoverable at its per-op
-// backup path (bytes never silently destroyed).
-func TestPosterManager_CropWithBounds_InstallAndRestoreBothWedge(t *testing.T) {
+// Total-loss leg: the staged install itself wedges. With the never-absent
+// canonical contract there is NO opportunistic restore arm — the old preview
+// sits untouched throughout, and the (copied) backup is swept.
+func TestPosterManager_CropWithBounds_InstallFailureKeepsOld(t *testing.T) {
 	base := afero.NewMemMapFs()
 	dir := "/tmp/p2/posters/job1"
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-4-full.jpg", jpegBytes(200, 300), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-4.jpg", []byte("old-preview"), 0o644))
-	wedged := renameFailWhereFS{Fs: base, fail: func(_, n string) bool { return strings.HasSuffix(n, "/ST-4.jpg") }}
+	wedged := renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
+		return strings.Contains(o, ".tmp") && strings.HasSuffix(n, "/ST-4.jpg")
+	}}
 	pm := NewPosterManager(wedged, "/tmp/p2", nil)
 
 	_, err := pm.CropWithBounds(context.Background(), "job1", "ST-4", 0, 0, 100, 150, 0)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "restore of previous preview also failed")
-	// The old preview survives at its backup location, never deleted.
-	entries, derr := afero.ReadDir(base, dir)
-	require.NoError(t, derr)
-	var backups []string
-	for _, e := range entries {
-		if strings.Contains(e.Name(), "ST-4.jpg.") && strings.HasSuffix(e.Name(), ".bak") {
-			backups = append(backups, filepath.Join(dir, e.Name()))
-		}
-	}
-	require.Len(t, backups, 1, "previous preview recoverable at exactly one backup path")
-	got, rerr := afero.ReadFile(base, backups[0])
+	assert.Contains(t, err.Error(), "failed to install staged preview")
+	// Old preview untouched at canonical; any backup copy swept; no staged
+	// residue. Nothing was ever absent (the canonical entry stayed put).
+	got, rerr := afero.ReadFile(base, dir+"/ST-4.jpg")
 	require.NoError(t, rerr)
 	assert.Equal(t, "old-preview", string(got))
+	entries, derr := afero.ReadDir(base, dir)
+	require.NoError(t, derr)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp", "no staged residue: %s", e.Name())
+		assert.NotContains(t, e.Name(), ".bak", "backup swept on failure: %s", e.Name())
+	}
 }
 
 // A wedged backup sweep after a successful install: the crop succeeds, the
@@ -411,4 +414,44 @@ func TestInstallStagedPreview_StatWedgeFailsClosed(t *testing.T) {
 	for _, e := range entries {
 		assert.NotContains(t, e.Name(), ".bak", "no partial backup from the fail-closed arm")
 	}
+}
+
+// codex P2 (PR211, round-3 finding): a staged install NEVER lets the
+// canonical preview disappear — even if removing the final path is wedged
+// mid-op (modeling a reader holding it), the swap still lands atomically.
+func TestInstallStagedPreview_NeverRemovesCanonical(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/NG-1.jpg", []byte("old"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/NG-1.jpg.staged.tmp", []byte("new"), 0o644))
+	wedgeRemoveFinal := removeFailWhereFS{Fs: base, fail: func(n string) bool {
+		return strings.HasSuffix(n, "/NG-1.jpg")
+	}}
+	pm := NewPosterManager(wedgeRemoveFinal, "/tmp/p2", nil)
+
+	err := pm.installStagedPreview(dir+"/NG-1.jpg", dir+"/NG-1.jpg.staged.tmp")
+	require.NoError(t, err, "no Remove(final) step exists at all — swap is rename-atomic")
+	got, rerr := afero.ReadFile(base, dir+"/NG-1.jpg")
+	require.NoError(t, rerr)
+	assert.Equal(t, "new", string(got))
+}
+
+// Failed-install backup sweep is warn-only when the sweep itself wedges.
+func TestInstallStagedPreview_FailedInstallBackupSweepWarnOnly(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/NG-2.jpg", []byte("old"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/NG-2.jpg.staged.tmp", []byte("new"), 0o644))
+	combo := removeFailWhereFS{Fs: renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
+		return strings.Contains(o, ".tmp") && strings.HasSuffix(n, "/NG-2.jpg")
+	}}, fail: func(n string) bool { return strings.HasSuffix(n, ".bak") }}
+	pm := NewPosterManager(combo, "/tmp/p2", nil)
+
+	err := pm.installStagedPreview(dir+"/NG-2.jpg", dir+"/NG-2.jpg.staged.tmp")
+	require.ErrorContains(t, err, "failed to install staged preview")
+	got, rerr := afero.ReadFile(base, dir+"/NG-2.jpg")
+	require.NoError(t, rerr)
+	assert.Equal(t, "old", string(got))
 }

--- a/internal/poster/manager_stage_p2_test.go
+++ b/internal/poster/manager_stage_p2_test.go
@@ -384,3 +384,31 @@ func TestPosterManager_CropWithBounds_StagedCleanupWarnOnFailure(t *testing.T) {
 	_, err := pm.CropWithBounds(context.Background(), "job1", "ST-6", 0, 0, 99999, 99999, 0)
 	require.ErrorContains(t, err, "crop failed")
 }
+
+// codex P2 (PR211, third finding): an undecidable destination Stat (neither
+// success nor clean absence) fails closed — the staged bytes never install
+// over a possibly-existing preview we couldn't back up.
+func TestInstallStagedPreview_StatWedgeFailsClosed(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/FC-1.jpg", []byte("old-preview"), 0o644))
+	wedged := statFailExactFS{Fs: base, path: dir + "/FC-1.jpg"}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+
+	staged := dir + "/FC-1.jpg.staged.tmp"
+	require.NoError(t, afero.WriteFile(base, staged, []byte("new-preview"), 0o644))
+	err := pm.installStagedPreview(dir+"/FC-1.jpg", staged)
+	require.ErrorContains(t, err, "failed to probe preview")
+
+	got, rerr := afero.ReadFile(base, dir+"/FC-1.jpg")
+	require.NoError(t, rerr)
+	assert.Equal(t, "old-preview", string(got), "prior preview intact under the wedge")
+	stagedBytes, serr := afero.ReadFile(base, staged)
+	require.NoError(t, serr)
+	assert.Equal(t, "new-preview", string(stagedBytes), "staged bytes preserved for a retry")
+	entries, _ := afero.ReadDir(base, dir)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".bak", "no partial backup from the fail-closed arm")
+	}
+}

--- a/internal/poster/manager_stage_p2_test.go
+++ b/internal/poster/manager_stage_p2_test.go
@@ -1,0 +1,386 @@
+package poster
+
+// POSTER-WRITE-HARDENING P2 red suite (spec apply-writeback-coherence:
+// "Poster preview installs are staged and recoverable").
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeSpyFS records every create/truncating-open so a test can prove the
+// final preview path is installed by RENAME ONLY — readers mid-replace can
+// then never observe partially-written bytes (byte-atomicity proxy).
+type writeSpyFS struct {
+	afero.Fs
+	mu     sync.Mutex
+	writes map[string]int
+}
+
+func (s *writeSpyFS) note(n string) {
+	s.mu.Lock()
+	s.writes[filepath.ToSlash(n)]++
+	s.mu.Unlock()
+}
+
+func (s *writeSpyFS) Create(n string) (afero.File, error) {
+	s.note(n)
+	return s.Fs.Create(n)
+}
+
+func (s *writeSpyFS) countExact(path string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.writes[filepath.ToSlash(path)]
+}
+
+// Failed install ⇒ the previous preview survives byte-for-byte, the error
+// surfaces, and no staging or backup residue is left behind.
+func TestPosterManager_CropWithBounds_FailedInstallKeepsPreviousPreview(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-1-full.jpg", jpegBytes(200, 300), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-1.jpg", []byte("old-preview-bytes"), 0o644))
+
+	// Wedge ONLY the staged→final install rename; the aside/restore renames
+	// (from a .bak sibling) stay live so the restore path can fire.
+	base2 := &renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
+		return strings.Contains(o, ".tmp") && strings.HasSuffix(n, "/ST-1.jpg")
+	}}
+	pm := NewPosterManager(base2, "/tmp/p2", nil)
+
+	_, err := pm.CropWithBounds(context.Background(), "job1", "ST-1", 0, 0, 100, 150, 0)
+	require.Error(t, err, "install failure must surface")
+
+	got, rerr := afero.ReadFile(base, dir+"/ST-1.jpg")
+	require.NoError(t, rerr)
+	assert.Equal(t, "old-preview-bytes", string(got), "previous preview intact after failed install")
+
+	entries, derr := afero.ReadDir(base, dir)
+	require.NoError(t, derr)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp", "no staged residue: %s", e.Name())
+		assert.NotContains(t, e.Name(), ".bak", "no backup residue: %s", e.Name())
+	}
+}
+
+// Byte-atomicity contract: a successful crop installs the new preview via a
+// same-directory staged temp + rename — the final preview path is NEVER
+// opened for writing by the crop itself, so a concurrent reader sees either
+// the old or the new bytes, never a partial write.
+func TestPosterManager_CropWithBounds_InstallWritesFinalPathOnlyViaRename(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-2-full.jpg", jpegBytes(200, 300), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-2.jpg", []byte("old-preview-bytes"), 0o644))
+
+	spy := &writeSpyFS{Fs: base, writes: map[string]int{}}
+	pm := NewPosterManager(spy, "/tmp/p2", nil)
+
+	res, err := pm.CropWithBounds(context.Background(), "job1", "ST-2", 0, 0, 100, 150, 0)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, 0, spy.countExact(dir+"/ST-2.jpg"),
+		"final preview installed by rename only (staged temp carried the bytes)")
+
+	got, rerr := afero.ReadFile(base, dir+"/ST-2.jpg")
+	require.NoError(t, rerr)
+	assert.NotEqual(t, "old-preview-bytes", string(got), "new preview installed")
+}
+
+// Snapshot/restore compensation: SnapshotAssets captures the (jobID,
+// posterID) asset pair; RestoreAssets puts the captured bytes back — and
+// deletes assets CREATED after the snapshot (compensation is complete: it
+// doesn't just overwrite, it also removes what didn't exist before).
+func TestPosterManager_SnapshotRestore_RoundTrip(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-1-full.jpg", jpegBytes(200, 300), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-1.jpg", []byte("crop-v1"), 0o644))
+	pm := NewPosterManager(base, "/tmp/p2", nil)
+
+	snap, err := pm.SnapshotAssets("job1", "SN-1")
+	require.NoError(t, err)
+	require.NotNil(t, snap)
+
+	// Mutation + removal after the snapshot.
+	require.NoError(t, base.Remove(dir+"/SN-1.jpg"))
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-1-full.jpg", []byte("mutated"), 0o644))
+
+	require.NoError(t, pm.RestoreAssets(snap))
+	got, rerr := afero.ReadFile(base, dir+"/SN-1.jpg")
+	require.NoError(t, rerr, "removed crop leg restored")
+	assert.Equal(t, "crop-v1", string(got))
+	full, ferr := afero.ReadFile(base, dir+"/SN-1-full.jpg")
+	require.NoError(t, ferr)
+	assert.Equal(t, jpegBytes(200, 300), full, "mutated full leg restored")
+}
+
+// Created-asset removal: assets that did not exist at snapshot time are
+// deleted on restore — compensation leaves the dir exactly as captured.
+func TestPosterManager_SnapshotRestore_RemovesCreatedAssets(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-2-full.jpg", jpegBytes(200, 300), 0o644))
+	pm := NewPosterManager(base, "/tmp/p2", nil)
+
+	snap, err := pm.SnapshotAssets("job1", "SN-2")
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-2.jpg", jpegBytes(100, 150), 0o644))
+
+	require.NoError(t, pm.RestoreAssets(snap))
+	_, err2 := base.Stat(dir + "/SN-2.jpg")
+	assert.Error(t, err2, "asset created after snapshot is removed on restore")
+}
+
+// --- wedge FS wrappers for the machinery arms ---
+
+type removeFailWhereFS struct {
+	afero.Fs
+	fail func(name string) bool
+}
+
+func (f removeFailWhereFS) Remove(name string) error {
+	if f.fail(filepath.ToSlash(name)) {
+		return errWedge
+	}
+	return f.Fs.Remove(name)
+}
+
+// openFileFailWhereFS wedges write-creates (afero.WriteFile routes through
+// OpenFile with O_CREATE, not Create) — the staged-write fault injector.
+type openFileFailWhereFS struct {
+	afero.Fs
+	fail func(name string, flag int) bool
+}
+
+func (f openFileFailWhereFS) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	if f.fail(filepath.ToSlash(name), flag) {
+		return nil, errWedge
+	}
+	return f.Fs.OpenFile(name, flag, perm)
+}
+
+type openFailSuffixFS struct {
+	afero.Fs
+	suffix string
+}
+
+func (f openFailSuffixFS) Open(name string) (afero.File, error) {
+	if strings.HasSuffix(filepath.ToSlash(name), f.suffix) {
+		return nil, errWedge
+	}
+	return f.Fs.Open(name)
+}
+
+var errWedge = errWedgeType{}
+
+type errWedgeType struct{}
+
+func (errWedgeType) Error() string { return "wedged" }
+
+// The aside step itself wedging: the crop aborts BEFORE any byte damage, the
+// previous preview is intact, and the staged temp is cleaned by the caller.
+func TestPosterManager_CropWithBounds_AsideFailureKeepsEverything(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-3-full.jpg", jpegBytes(200, 300), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-3.jpg", []byte("old-preview"), 0o644))
+	wedged := renameFailWhereFS{Fs: base, fail: func(_, n string) bool { return strings.Contains(n, ".bak") }}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+
+	_, err := pm.CropWithBounds(context.Background(), "job1", "ST-3", 0, 0, 100, 150, 0)
+	require.ErrorContains(t, err, "set aside previous preview")
+	got, rerr := afero.ReadFile(base, dir+"/ST-3.jpg")
+	require.NoError(t, rerr)
+	assert.Equal(t, "old-preview", string(got))
+	entries, derr := afero.ReadDir(base, dir)
+	require.NoError(t, derr)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp", "no staged residue: %s", e.Name())
+		assert.NotContains(t, e.Name(), ".bak", "no backup residue: %s", e.Name())
+	}
+}
+
+// Total-loss leg: the staged install fails AND the restore fails — the error
+// reports both, and the previous preview is still recoverable at its per-op
+// backup path (bytes never silently destroyed).
+func TestPosterManager_CropWithBounds_InstallAndRestoreBothWedge(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-4-full.jpg", jpegBytes(200, 300), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-4.jpg", []byte("old-preview"), 0o644))
+	wedged := renameFailWhereFS{Fs: base, fail: func(_, n string) bool { return strings.HasSuffix(n, "/ST-4.jpg") }}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+
+	_, err := pm.CropWithBounds(context.Background(), "job1", "ST-4", 0, 0, 100, 150, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restore of previous preview also failed")
+	// The old preview survives at its backup location, never deleted.
+	entries, derr := afero.ReadDir(base, dir)
+	require.NoError(t, derr)
+	var backups []string
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "ST-4.jpg.") && strings.HasSuffix(e.Name(), ".bak") {
+			backups = append(backups, filepath.Join(dir, e.Name()))
+		}
+	}
+	require.Len(t, backups, 1, "previous preview recoverable at exactly one backup path")
+	got, rerr := afero.ReadFile(base, backups[0])
+	require.NoError(t, rerr)
+	assert.Equal(t, "old-preview", string(got))
+}
+
+// A wedged backup sweep after a successful install: the crop succeeds, the
+// warn fires (leg covers the sweep arm), and the leftover backup stays for
+// inspection (never blocking the success path).
+func TestPosterManager_CropWithBounds_BackupSweepWarnKeepsSuccess(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-5-full.jpg", jpegBytes(200, 300), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-5.jpg", []byte("old-preview"), 0o644))
+	wedged := removeFailWhereFS{Fs: base, fail: func(n string) bool { return strings.HasSuffix(n, ".bak") }}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+
+	res, err := pm.CropWithBounds(context.Background(), "job1", "ST-5", 0, 0, 100, 150, 0)
+	require.NoError(t, err, "sweep wedge is warn-only")
+	require.NotNil(t, res)
+	got, rerr := afero.ReadFile(base, dir+"/ST-5.jpg")
+	require.NoError(t, rerr)
+	assert.NotEqual(t, "old-preview", string(got), "new preview installed")
+}
+
+// Snapshot read faults (non-NotExist) surface instead of recording absence.
+func TestPosterManager_SnapshotAssets_ReadFaultSurfaces(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-9-full.jpg", jpegBytes(200, 300), 0o644))
+	pm := NewPosterManager(openFailSuffixFS{Fs: base, suffix: "/SN-9-full.jpg"}, "/tmp/p2", nil)
+	_, err := pm.SnapshotAssets("job1", "SN-9")
+	require.ErrorContains(t, err, "snapshot assets")
+}
+
+// Nil snapshot is a no-op; the crop-leg read fault also surfaces.
+func TestPosterManager_SnapshotRestore_EdgeArms(t *testing.T) {
+	base := afero.NewMemMapFs()
+	pm := NewPosterManager(base, "/tmp/p2", nil)
+	require.NoError(t, pm.RestoreAssets(nil))
+
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-8.jpg", []byte("crop"), 0o644))
+	pm2 := NewPosterManager(openFailSuffixFS{Fs: base, suffix: "/SN-8.jpg"}, "/tmp/p2", nil)
+	_, err := pm2.SnapshotAssets("job1", "SN-8")
+	require.ErrorContains(t, err, "snapshot assets")
+}
+
+// restoreLeg failure arms: removed-leg remove-wedge and staged-write wedge
+// both surface errors instead of half-restoring.
+func TestPosterManager_RestoreAssets_LegFailureArms(t *testing.T) {
+	// remove wedge on a created leg
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-3-full.jpg", jpegBytes(200, 300), 0o644))
+	pm := NewPosterManager(base, "/tmp/p2", nil)
+	snap, err := pm.SnapshotAssets("job1", "SN-3")
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-3.jpg", jpegBytes(100, 150), 0o644))
+
+	wedged := removeFailWhereFS{Fs: base, fail: func(n string) bool { return strings.HasSuffix(n, "/SN-3.jpg") }}
+	pmWedged := NewPosterManager(wedged, "/tmp/p2", nil)
+	require.ErrorContains(t, pmWedged.RestoreAssets(snap), "remove created leg")
+
+	// staged-write wedge when restoring an existing leg
+	base2 := afero.NewMemMapFs()
+	require.NoError(t, base2.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base2, dir+"/SN-4.jpg", []byte("v1"), 0o644))
+	pm2 := NewPosterManager(base2, "/tmp/p2", nil)
+	snap2, err := pm2.SnapshotAssets("job1", "SN-4")
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(base2, dir+"/SN-4.jpg", []byte("v2"), 0o644))
+
+	stageWedged := openFileFailWhereFS{Fs: base2, fail: func(n string, flag int) bool {
+		return strings.HasSuffix(n, ".tmp") && flag&os.O_CREATE != 0
+	}}
+	pm3 := NewPosterManager(stageWedged, "/tmp/p2", nil)
+	require.ErrorContains(t, pm3.RestoreAssets(snap2), "stage leg")
+	got, rerr := afero.ReadFile(base2, dir+"/SN-4.jpg")
+	require.NoError(t, rerr)
+	assert.Equal(t, "v2", string(got), "failed restore staged-nothing ⇒ target untouched")
+
+	// install wedge when restoring: error surfaces and no residue remains
+	installWedged := renameFailWhereFS{Fs: base2, fail: func(o, n string) bool { return strings.Contains(o, ".tmp") }}
+	pm4 := NewPosterManager(installWedged, "/tmp/p2", nil)
+	require.ErrorContains(t, pm4.RestoreAssets(snap2), "install leg")
+	entries, derr := afero.ReadDir(base2, dir)
+	require.NoError(t, derr)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp", "no staged residue: %s", e.Name())
+	}
+}
+
+// Validation arms: a hostile jobID/posterID fails before any fs access.
+func TestPosterManager_SnapshotRestore_ValidationArms(t *testing.T) {
+	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp/p2", nil)
+	if _, err := pm.SnapshotAssets("../escape", "V-1"); err == nil {
+		t.Fatal("invalid jobID must fail")
+	}
+	if _, err := pm.SnapshotAssets("job1", "../V-1"); err == nil {
+		t.Fatal("invalid posterID must fail")
+	}
+}
+
+// The full-leg restore erroring aborts before the crop leg is touched.
+func TestPosterManager_RestoreAssets_FullLegFailureAbortsCropLeg(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-7-full.jpg", jpegBytes(200, 300), 0o644))
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-7.jpg", []byte("crop-v1"), 0o644))
+	pm := NewPosterManager(base, "/tmp/p2", nil)
+	snap, err := pm.SnapshotAssets("job1", "SN-7")
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(base, dir+"/SN-7.jpg", []byte("crop-v2"), 0o644))
+
+	// Wedge staged writes ONLY for the full leg's staging name.
+	wedged := openFileFailWhereFS{Fs: base, fail: func(n string, flag int) bool {
+		return strings.Contains(n, "SN-7-full.jpg.") && strings.HasSuffix(n, ".tmp") && flag&os.O_CREATE != 0
+	}}
+	pmWedged := NewPosterManager(wedged, "/tmp/p2", nil)
+	err2 := pmWedged.RestoreAssets(snap)
+	require.ErrorContains(t, err2, "stage leg")
+	got, rerr := afero.ReadFile(base, dir+"/SN-7.jpg")
+	require.NoError(t, rerr)
+	assert.Equal(t, "crop-v2", string(got), "crop leg untouched after full-leg failure")
+}
+
+// A wedged staged-file cleanup after a failed crop is warn-only.
+func TestPosterManager_CropWithBounds_StagedCleanupWarnOnFailure(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/p2/posters/job1"
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dir+"/ST-6-full.jpg", jpegBytes(200, 300), 0o644))
+	wedged := removeFailWhereFS{Fs: base, fail: func(n string) bool { return strings.HasSuffix(n, ".tmp") }}
+	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+
+	// Out-of-range bounds: crop fails after the staged name is allocated.
+	_, err := pm.CropWithBounds(context.Background(), "job1", "ST-6", 0, 0, 99999, 99999, 0)
+	require.ErrorContains(t, err, "crop failed")
+}

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -338,10 +338,12 @@ func interpretApplyResult(
 		if mid := strings.TrimSpace(movie.ID); mid != "" && inputs.PromoteWitnessFn != nil && inputs.PromoteWitnessFn(mid) {
 			logging.Warnf("[Apply] skipping failure write-back for %s — promote witness for %s unresolved; restart reconciles", filePath, mid)
 		} else if !writebackPreSkipped(inputs.Updater, movie, filePath, "Apply") {
-			errUp := inputs.Updater.AtomicUpdateFileResult(filePath, func(current *resultstore.MovieResult) (*resultstore.MovieResult, error) {
+			// R10-6: state+provenance publish under ONE acquisition — a persist
+			// snapshot between the two never observes mismatched halves.
+			errUp := inputs.Updater.AtomicUpdateFileResultWithProvenance(filePath, func(current *resultstore.MovieResult, prov *resultstore.ProvenanceData) (*resultstore.MovieResult, *resultstore.ProvenanceData, error) {
 				if applyWritebackIdentityMismatch(movie, current) {
 					logging.Warnf("[Apply] skipping write-back for %s — result rekeyed to %s mid-phase", filePath, current.FileMatchInfo.MovieID)
-					return current, nil
+					return current, prov, nil
 				}
 				fm := applyMatchFollowedByLiveIdentity(afc.Match, current)
 				current.FileMatchInfo = fm
@@ -350,7 +352,7 @@ func interpretApplyResult(
 				current.Error = errMsg
 				current.StartedAt = startTime
 				current.EndedAt = &now
-				return current, nil
+				return current, mergeWriteBackProvenance(nil, prov), nil
 			})
 			if errUp != nil {
 				inputs.Updater.UpdateFileResult(filePath, &resultstore.MovieResult{
@@ -418,13 +420,13 @@ func interpretApplyResult(
 				// failed refresh committed and discard its recovery state.
 				logging.Warnf("[Apply] skipping success write-back for %s — promote witness for %s unresolved; restart reconciles", filePath, mid)
 			} else {
-				err2 := inputs.Updater.AtomicUpdateFileResult(filePath, func(current *resultstore.MovieResult) (*resultstore.MovieResult, error) {
+				err2 := inputs.Updater.AtomicUpdateFileResultWithProvenance(filePath, func(current *resultstore.MovieResult, prov *resultstore.ProvenanceData) (*resultstore.MovieResult, *resultstore.ProvenanceData, error) {
 					if applyWritebackIdentityMismatch(movie, current) {
 						logging.Warnf("[Apply] skipping success write-back for %s — result rekeyed to %s mid-phase", filePath, current.FileMatchInfo.MovieID)
-						return current, nil
+						return current, prov, nil
 					}
 					current.Movie = mergeLiveReviewEdits(movie, result.Movie, current.Movie)
-					return current, nil
+					return current, mergeWriteBackProvenance(nil, prov), nil
 				})
 				if err2 != nil {
 					logging.Warnf("Failed to update movie result for %s after apply: %v", filePath, err2)

--- a/internal/worker/apply_writeback_coherence_p2_test.go
+++ b/internal/worker/apply_writeback_coherence_p2_test.go
@@ -1,0 +1,195 @@
+package worker
+
+// POSTER-WRITE-HARDENING P2 — Apply-phase coherence red suite (D5).
+//
+// NOTE: P1's 40-round review pre-landed the write-back merge machinery
+// (mergeLiveReviewEdits / applyFamilyLock / identity no-op guards), so the
+// three tests below are regression LOCK-INS: they pin the D5 scenarios the
+// phase gates depend on. They must stay green; a future refactor that breaks
+// them breaks the P2 contract.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Seam presence contract: apply write-backs acquire the per-movie edit key
+// through applyFamilyLock, which routes BOTH identity spellings through the
+// registry's one total order; a nil seam degrades to a no-op release.
+func TestApplyPhaseInputs_ExposesEditLockForMovie(t *testing.T) {
+	var acquired []string
+	released := false
+	inputs := applyPhaseInputs{EditLockFn: func(ids ...string) func() {
+		acquired = append(acquired, ids...)
+		return func() { released = true }
+	}}
+	unlock := applyFamilyLock(inputs, "ALIAS-9", "CANON-9")
+	unlock()
+	assert.Equal(t, []string{"ALIAS-9", "CANON-9"}, acquired, "both identity keys flow into the seam")
+	assert.True(t, released, "release returned and honored")
+
+	applyFamilyLock(applyPhaseInputs{}, "A", "B")() // nil seam ⇒ no-op, must not panic
+}
+
+// D5 identity-mismatch rule: a rekey mid-apply makes the phase output stale
+// for the live family — success AND failure write-backs no-op WITHOUT a
+// revision bump (a blind no-op inside AtomicUpdate would still bump it).
+func TestApplyWriteBack_IdentityMismatchIsNoop(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		store := resultstore.New(1, []string{"/f/a.mp4"})
+		store.UpdateFileResult("/f/a.mp4", &resultstore.MovieResult{
+			ResultID:      "res-s",
+			Status:        models.JobStatusRunning,
+			Movie:         &models.Movie{ID: "NEW-1", Title: "rekeyed-live"},
+			FileMatchInfo: models.FileMatchInfo{Path: "/f/a.mp4", MovieID: "OLD-1"},
+		})
+		before, err := store.GetMovieResult("/f/a.mp4")
+		require.NoError(t, err)
+		inputs := minimalApplyInputs(t, store, true)
+		afc := &ApplyFileContext{FilePath: "/f/a.mp4", Match: models.FileMatchInfo{Path: "/f/a.mp4", MovieID: "OLD-1"}}
+		result := &workflow.ApplyResult{Movie: &models.Movie{ID: "OLD-1", Title: "phase-stale"}}
+		interpretApplyResult("/f/a.mp4", &models.Movie{ID: "OLD-1"}, time.Now(), time.Minute, inputs, ApplyPhaseConfig{}, context.Background(), afc, result, nil)
+		final, ferr := store.GetMovieResult("/f/a.mp4")
+		require.NoError(t, ferr)
+		assert.Equal(t, before.Revision, final.Revision, "mismatch success write-back: no revision bump")
+		assert.Equal(t, "rekeyed-live", final.Movie.Title, "stale phase metadata never overlays the rekeyed row")
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		store := resultstore.New(1, []string{"/f/a.mp4"})
+		store.UpdateFileResult("/f/a.mp4", &resultstore.MovieResult{
+			ResultID:      "res-f",
+			Status:        models.JobStatusRunning,
+			Movie:         &models.Movie{ID: "NEW-1", Title: "rekeyed-live"},
+			FileMatchInfo: models.FileMatchInfo{Path: "/f/a.mp4", MovieID: "OLD-1"},
+		})
+		before, err := store.GetMovieResult("/f/a.mp4")
+		require.NoError(t, err)
+		inputs := minimalApplyInputs(t, store, true)
+		afc := &ApplyFileContext{FilePath: "/f/a.mp4", Match: models.FileMatchInfo{Path: "/f/a.mp4", MovieID: "OLD-1"}}
+		outcome := interpretApplyResult("/f/a.mp4", &models.Movie{ID: "OLD-1"}, time.Now(), time.Minute, inputs, ApplyPhaseConfig{}, context.Background(), afc, nil, errors.New("engine wedged"))
+		assert.True(t, outcome.Failed)
+		final, ferr := store.GetMovieResult("/f/a.mp4")
+		require.NoError(t, ferr)
+		assert.Equal(t, before.Revision, final.Revision, "mismatch failure write-back: no revision bump")
+		assert.Equal(t, "rekeyed-live", final.Movie.Title)
+		assert.Equal(t, models.JobStatusRunning, final.Status, "failure status not stamped onto the rekeyed row")
+	})
+
+	t.Run("panic", func(t *testing.T) {
+		store := resultstore.New(1, []string{"/f/a.mp4"})
+		store.UpdateFileResult("/f/a.mp4", &resultstore.MovieResult{
+			ResultID:      "res-p",
+			Status:        models.JobStatusRunning,
+			Movie:         &models.Movie{ID: "NEW-1", Title: "rekeyed-live"},
+			FileMatchInfo: models.FileMatchInfo{Path: "/f/a.mp4", MovieID: "OLD-1"},
+		})
+		before, err := store.GetMovieResult("/f/a.mp4")
+		require.NoError(t, err)
+		outcome := &applyFileOutcome{}
+		rc := recoveryContext{
+			filePath: "/f/a.mp4",
+			fmi:      models.FileMatchInfo{Path: "/f/a.mp4", MovieID: "OLD-1"},
+			movie:    &models.Movie{ID: "OLD-1", Title: "phase-stale"},
+			updater:  store,
+		}
+		recoverFn := withFileRecovery(rc, outcome)
+		func() {
+			defer recoverFn()
+			panic("boom")
+		}()
+		assert.True(t, outcome.Failed)
+		final, ferr := store.GetMovieResult("/f/a.mp4")
+		require.NoError(t, ferr)
+		assert.Equal(t, before.Revision, final.Revision, "mismatch panic write-back: no revision bump")
+		assert.Equal(t, "rekeyed-live", final.Movie.Title)
+	})
+}
+
+// D5 headline scenario: a review edit committed mid-apply survives EVERY
+// write-back path (success, failure, panic-recovery). Editable-set coverage:
+// crop geometry (Poster payload) AND title — live drift beats the phase's
+// stale value; phase-computed state always stays phase-side.
+func TestApplyPhase_PostApplyWriteBack_PreservesConcurrentReviewEdits(t *testing.T) {
+	const path = "/f/wb.mp4"
+	baselineMovie := func() *models.Movie {
+		return &models.Movie{ID: "WB-1", Title: "phase-entry-title", Poster: models.PosterState{PosterURL: "https://s/poster.jpg"}}
+	}
+	seedLiveEdit := func(t *testing.T) resultstore.Store {
+		// The user edited title + crop geometry mid-phase (drift vs baseline).
+		store := resultstore.New(1, []string{path})
+		store.UpdateFileResult(path, &resultstore.MovieResult{
+			ResultID: "res-wb",
+			Status:   models.JobStatusRunning,
+			Movie: &models.Movie{ID: "WB-1", Title: "user-edit", Poster: models.PosterState{
+				PosterURL: "https://s/poster.jpg", CroppedPosterURL: "wb-cropped.jpg",
+				PosterCropBounds: &models.CropBounds{X: 0.1, Y: 0.1, Width: 0.5, Height: 0.5},
+			}},
+			FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: "WB-1"},
+		})
+		return store
+	}
+	afcFor := func() *ApplyFileContext {
+		return &ApplyFileContext{FilePath: path, Match: models.FileMatchInfo{Path: path, MovieID: "WB-1"}}
+	}
+	assertEditsPreserved := func(t *testing.T, store resultstore.Store) *resultstore.MovieResult {
+		t.Helper()
+		final, err := store.GetMovieResult(path)
+		require.NoError(t, err)
+		require.NotNil(t, final.Movie)
+		assert.Equal(t, "user-edit", final.Movie.Title, "mid-apply review edit survives the write-back")
+		require.NotNil(t, final.Movie.Poster.PosterCropBounds, "committed geometry survives")
+		assert.Equal(t, 0.5, final.Movie.Poster.PosterCropBounds.Width)
+		assert.Equal(t, "wb-cropped.jpg", final.Movie.Poster.CroppedPosterURL)
+		return final
+	}
+
+	t.Run("success", func(t *testing.T) {
+		store := seedLiveEdit(t)
+		inputs := minimalApplyInputs(t, store, true)
+		// Phase-side output: a stale-metadata movie computed from the baseline,
+		// carrying phase-computed description edits the user never made.
+		phaseOut := baselineMovie()
+		result := &workflow.ApplyResult{Movie: phaseOut}
+		interpretApplyResult(path, baselineMovie(), time.Now(), time.Minute, inputs, ApplyPhaseConfig{}, context.Background(), afcFor(), result, nil)
+		final := assertEditsPreserved(t, store)
+		assert.Equal(t, models.JobStatusRunning, final.Status)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		store := seedLiveEdit(t)
+		inputs := minimalApplyInputs(t, store, true)
+		outcome := interpretApplyResult(path, baselineMovie(), time.Now(), time.Minute, inputs, ApplyPhaseConfig{}, context.Background(), afcFor(), nil, errors.New("engine wedged"))
+		assert.True(t, outcome.Failed)
+		final := assertEditsPreserved(t, store)
+		assert.Equal(t, models.JobStatusFailed, final.Status, "failure status still writes")
+	})
+
+	t.Run("panic", func(t *testing.T) {
+		store := seedLiveEdit(t)
+		outcome := &applyFileOutcome{}
+		rc := recoveryContext{
+			filePath: path,
+			fmi:      models.FileMatchInfo{Path: path, MovieID: "WB-1"},
+			movie:    baselineMovie(),
+			updater:  store,
+		}
+		recoverFn := withFileRecovery(rc, outcome)
+		func() {
+			defer recoverFn()
+			panic("boom")
+		}()
+		assert.True(t, outcome.Failed)
+		final := assertEditsPreserved(t, store)
+		assert.Equal(t, models.JobStatusFailed, final.Status)
+		assert.NotEmpty(t, final.Error)
+	})
+}

--- a/internal/worker/apply_writeback_merge.go
+++ b/internal/worker/apply_writeback_merge.go
@@ -123,6 +123,41 @@ func mergeLiveReviewEdits(baseline, phaseOut, live *models.Movie) *models.Movie 
 	return out
 }
 
+// mergeWriteBackProvenance merges per-file provenance for a write-back commit
+// (D5): live (phase-time edited) attribution wins the keys it covers; the
+// phase-frozen snapshot fills keys the user never touched. ScraperResults are
+// not merged here — their resolution is the envelope-wide rule (a rescrape
+// committed after phase start wins the live set outright, else the frozen
+// snapshot is kept), handled by the caller that owns both snapshots.
+func mergeWriteBackProvenance(frozen, live *resultstore.ProvenanceData) *resultstore.ProvenanceData {
+	switch {
+	case frozen == nil && live == nil:
+		return nil
+	case live == nil:
+		return frozen.Clone()
+	case frozen == nil:
+		return live.Clone()
+	}
+	out := frozen.Clone()
+	out.FieldSources = mergeSourceMap(frozen.FieldSources, live.FieldSources)
+	out.ActressSources = mergeSourceMap(frozen.ActressSources, live.ActressSources)
+	return out
+}
+
+func mergeSourceMap(frozen, live map[string]string) map[string]string {
+	if len(frozen) == 0 && len(live) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(frozen)+len(live))
+	for k, v := range frozen {
+		merged[k] = v
+	}
+	for k, v := range live {
+		merged[k] = v
+	}
+	return merged
+}
+
 // applyWritebackIdentityMismatch reports whether the live result already
 // belongs to a different movie family than the apply phase's frozen
 // baseline (codex r14-B): in that case the phase output was computed for

--- a/internal/worker/closeout_cov_test.go
+++ b/internal/worker/closeout_cov_test.go
@@ -144,8 +144,12 @@ type callbackOnlyUpdater struct {
 
 func (u *callbackOnlyUpdater) UpdateFileResult(string, *resultstore.MovieResult) {}
 func (u *callbackOnlyUpdater) SetProvenance(string, *resultstore.ProvenanceData) {}
-func (u *callbackOnlyUpdater) UpdateMovie(string, *models.Movie) error           { return nil }
-func (u *callbackOnlyUpdater) MarkExcluded(string)                               {}
+func (u *callbackOnlyUpdater) AtomicUpdateFileResultWithProvenance(fp string, fn func(*resultstore.MovieResult, *resultstore.ProvenanceData) (*resultstore.MovieResult, *resultstore.ProvenanceData, error)) error {
+	u.calls++
+	return u.inner.AtomicUpdateFileResultWithProvenance(fp, fn)
+}
+func (u *callbackOnlyUpdater) UpdateMovie(string, *models.Movie) error { return nil }
+func (u *callbackOnlyUpdater) MarkExcluded(string)                     {}
 func (u *callbackOnlyUpdater) AtomicUpdateFileResult(fp string, fn func(*resultstore.MovieResult) (*resultstore.MovieResult, error)) error {
 	u.calls++
 	return u.inner.AtomicUpdateFileResult(fp, fn)

--- a/internal/worker/evict_reconcile.go
+++ b/internal/worker/evict_reconcile.go
@@ -66,6 +66,11 @@ type evictWitness struct {
 	// arbitration needs it to decide whether the metadata commit landed
 	// (codex cloud P1 @witness arbitration).
 	NewSourceURL string `json:"new_source_url,omitempty"`
+	// FilePath pins the arbitration to ONE row of the envelope when set
+	// (codex PR#211 crash-safety finding): a family can hold same-ID rows on
+	// different sources mid-migration — only the row the witness was written
+	// for may prove the commit, never a sibling.
+	FilePath string `json:"file_path,omitempty"`
 }
 
 // reconcileEvictWitness completes a COMMITTED eviction: no commit ⇒ sweep the
@@ -96,14 +101,25 @@ func (c *TempDirCleaner) reconcileEvictWitness(ctx context.Context, dir, jobID, 
 		return 0
 	}
 	committed := false
-	for _, r := range res {
-		if r == nil || r.Movie == nil {
-			continue
-		}
-		if strings.EqualFold(strings.TrimSpace(r.Movie.ID), w.OldID) &&
+	if w.FilePath != "" {
+		// Scoped arbitration: ONLY the witness's own row can prove its commit
+		// landed — never a same-ID sibling that migrated earlier.
+		if r, ok := res[w.FilePath]; ok && r != nil && r.Movie != nil &&
+			strings.EqualFold(strings.TrimSpace(r.Movie.ID), w.OldID) &&
 			effectivePosterSourceOf(r.Movie.Poster.PosterURL, r.Movie.Poster.CoverURL) == w.NewSourceURL {
 			committed = true
-			break
+		}
+	} else {
+		// Legacy content-less witnesses arbitrate family-wide (pre-P3 records).
+		for _, r := range res {
+			if r == nil || r.Movie == nil {
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(r.Movie.ID), w.OldID) &&
+				effectivePosterSourceOf(r.Movie.Poster.PosterURL, r.Movie.Poster.CoverURL) == w.NewSourceURL {
+				committed = true
+				break
+			}
 		}
 	}
 	failed := false

--- a/internal/worker/evict_reconcile.go
+++ b/internal/worker/evict_reconcile.go
@@ -104,10 +104,19 @@ func (c *TempDirCleaner) reconcileEvictWitness(ctx context.Context, dir, jobID, 
 	if w.FilePath != "" {
 		// Scoped arbitration: ONLY the witness's own row can prove its commit
 		// landed — never a same-ID sibling that migrated earlier.
-		if r, ok := res[w.FilePath]; ok && r != nil && r.Movie != nil &&
-			strings.EqualFold(strings.TrimSpace(r.Movie.ID), w.OldID) &&
-			effectivePosterSourceOf(r.Movie.Poster.PosterURL, r.Movie.Poster.CoverURL) == w.NewSourceURL {
-			committed = true
+		if r, ok := res[w.FilePath]; ok && r != nil && r.Movie != nil {
+			// codex PR#211 round 9: legacy rows whose canonical Movie.ID is
+			// empty share their identity through the matcher alias — an eviction
+			// targeted at the alias must accept the alias (or its canonical ID)
+			// as the persisted witness's identity.
+			liveID := strings.TrimSpace(r.Movie.ID)
+			if liveID == "" {
+				liveID = strings.TrimSpace(r.FileMatchInfo.MovieID)
+			}
+			if strings.EqualFold(liveID, w.OldID) &&
+				effectivePosterSourceOf(r.Movie.Poster.PosterURL, r.Movie.Poster.CoverURL) == w.NewSourceURL {
+				committed = true
+			}
 		}
 	} else {
 		// Legacy content-less witnesses arbitrate family-wide (pre-P3 records).

--- a/internal/worker/evict_reconcile_test.go
+++ b/internal/worker/evict_reconcile_test.go
@@ -551,3 +551,38 @@ func TestReconcileEvictWitness_ScopedCompletesWhenOwnRowCommitted(t *testing.T) 
 	_, wErr := fs.Stat(wp)
 	assert.Error(t, wErr, "witness swept")
 }
+
+// codex P2 round 9 (PR211): the persisted row carrying an EMPTY canonical ID
+// shares its identity through the matcher alias (FileMatchInfo.MovieID).
+// "The alias is the persistent identity" — the witness arbitration must
+// accept it so a committed override's eviction completes at startup.
+func TestReconcileEvictWitness_LegacyEmptyIDAliasArbitrates(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-LEG"
+	require.NoError(t, fs.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, "LEG-9-full.jpg"), []byte("old-full"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, "LEG-9.jpg"), []byte("old-crop"), 0o644))
+	payload, _ := json.Marshal(evictWitness{OldID: "LEG-9", NewSourceURL: "https://new-site/l.jpg", FilePath: "/f/leg.mp4"})
+	wp := filepath.Join(dir, ".evict-LEG-9.json")
+	require.NoError(t, afero.WriteFile(fs, wp, payload, 0o644))
+
+	ownRow := map[string]*resultstore.MovieResult{
+		"/f/leg.mp4": {
+			ResultID:      "res-leg",
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "", Poster: models.PosterState{PosterURL: "https://new-site/l.jpg"}}, // canonical ID empty
+			FileMatchInfo: models.FileMatchInfo{Path: "/f/leg.mp4", MovieID: "LEG-9"},
+		},
+	}
+	data, err := json.Marshal(ownRow)
+	require.NoError(t, err)
+	repo := mocks.NewMockJobRepositoryInterface(t)
+	repo.EXPECT().FindByID(mock.Anything, "JOB-LEG").Return(&models.Job{Results: string(data)}, nil)
+	cl := &TempDirCleaner{fs: fs, tempDir: "/tmp", jobRepo: repo}
+	n := cl.reconcileEvictWitness(context.Background(), dir, "JOB-LEG", wp)
+	assert.Equal(t, 1, n)
+	_, fErr := fs.Stat(filepath.Join(dir, "LEG-9-full.jpg"))
+	assert.Error(t, fErr, "committed override on alias-identified rows still evicts")
+	_, wErr := fs.Stat(wp)
+	assert.Error(t, wErr, "witness swept")
+}

--- a/internal/worker/evict_reconcile_test.go
+++ b/internal/worker/evict_reconcile_test.go
@@ -338,7 +338,7 @@ func TestReconcileEvictWitnessRepoErrorKeepsEverything(t *testing.T) {
 // MkdirAll failure on the witness dir surfaces as an error, never hidden.
 func TestWriteEvictWitnessMkdirFailureSurfaces(t *testing.T) {
 	fs := mkdirWedgeFS{Fs: afero.NewMemMapFs()}
-	_, err := writeEvictWitness(fs, "/tmp/posters/J-MW", "MW-1", "https://n/x.jpg")
+	_, err := writeEvictWitness(fs, "/tmp/posters/J-MW", "MW-1", "https://n/x.jpg", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "evict witness dir")
 }
@@ -351,7 +351,7 @@ func TestEvictStalePosterPairWitnessWriteWedgedDefers(t *testing.T) {
 	require.NoError(t, afero.WriteFile(mem, filepath.Join(jobDir, "EV-8-full.jpg"), []byte("of"), 0o644))
 	require.NoError(t, afero.WriteFile(mem, filepath.Join(jobDir, "EV-8.jpg"), []byte("oc"), 0o644))
 	fs := createWedgeFS{Fs: mem, contains: ".evict-"}
-	_, err := writeEvictWitness(fs, jobDir, "EV-8", "https://new/q.jpg")
+	_, err := writeEvictWitness(fs, jobDir, "EV-8", "https://new/q.jpg", "")
 	require.Error(t, err)
 	_, f1 := mem.Stat(filepath.Join(jobDir, "EV-8-full.jpg"))
 	assert.NoError(t, f1, "legs untouched while the record can't persist")
@@ -471,4 +471,83 @@ func TestPendingEvictWitnessCoreDirWedgeFailsClosed(t *testing.T) {
 	_, err := pendingEvictWitnessCore(fs, dir, "PE-3")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "eviction witness scan")
+}
+
+// codex P2 round 8 (PR211): the witness's arbitration is scoped to its OWN
+// row — a same-ID sibling that already migrated to the new source must NOT
+// mark an interrupted override committed (which would evict the pair while
+// the witness's row still references it).
+func TestReconcileEvictWitness_ScopedToNamedRow(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-MW9"
+	require.NoError(t, fs.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, "MW-9-full.jpg"), []byte("old-full"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, "MW-9.jpg"), []byte("old-crop"), 0o644))
+	payload, _ := json.Marshal(evictWitness{OldID: "MW-9", NewSourceURL: "https://new-site/x.jpg", FilePath: "/f/own-row.mp4"})
+	wp := filepath.Join(dir, ".evict-MW-9.json")
+	require.NoError(t, afero.WriteFile(fs, wp, payload, 0o644))
+
+	res := map[string]*resultstore.MovieResult{
+		// sibling row: already migrated to the new source — under legacy
+		// any-row arbitration this would falsely mark the witness committed.
+		"/f/sibling.mp4": {
+			ResultID:      "res-sib",
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "MW-9", Poster: models.PosterState{PosterURL: "https://new-site/x.jpg"}},
+			FileMatchInfo: models.FileMatchInfo{Path: "/f/sibling.mp1", MovieID: "MW-9"},
+		},
+		// the witness's own row: still on the OLD source (commit never ran).
+		"/f/own-row.mp4": {
+			ResultID:      "res-own",
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "MW-9", Poster: models.PosterState{PosterURL: "https://old-site/s.jpg"}},
+			FileMatchInfo: models.FileMatchInfo{Path: "/f/own-row.mp4", MovieID: "MW-9"},
+		},
+	}
+	data, err := json.Marshal(res)
+	require.NoError(t, err)
+	repo := mocks.NewMockJobRepositoryInterface(t)
+	repo.EXPECT().FindByID(mock.Anything, "JOB-SC").Return(&models.Job{Results: string(data)}, nil)
+	cl := &TempDirCleaner{fs: fs, tempDir: "/tmp", jobRepo: repo}
+	n := cl.reconcileEvictWitness(context.Background(), dir, "JOB-SC", wp)
+	assert.Equal(t, 1, n, "uncommitted witness swept")
+	_, fErr := fs.Stat(filepath.Join(dir, "MW-9-full.jpg"))
+	assert.NoError(t, fErr, "full leg NOT evicted — sibling migration is not the commit of this row")
+	_, cErr := fs.Stat(filepath.Join(dir, "MW-9.jpg"))
+	assert.NoError(t, cErr, "crop leg NOT evicted")
+	_, wErr := fs.Stat(wp)
+	assert.Error(t, wErr, "witness swept")
+}
+
+// Contrast: when the witness's OWN row carries the new source, eviction
+// completes normally.
+func TestReconcileEvictWitness_ScopedCompletesWhenOwnRowCommitted(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-MWC"
+	require.NoError(t, fs.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, "MC-2-full.jpg"), []byte("old-full"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, "MC-2.jpg"), []byte("old-crop"), 0o644))
+	payload, _ := json.Marshal(evictWitness{OldID: "MC-2", NewSourceURL: "https://new-site/x.jpg", FilePath: "/f/own-row.mp4"})
+	wp := filepath.Join(dir, ".evict-MC-2.json")
+	require.NoError(t, afero.WriteFile(fs, wp, payload, 0o644))
+
+	res := map[string]*resultstore.MovieResult{
+		"/f/own-row.mp4": {
+			ResultID:      "res-own",
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "MC-2", Poster: models.PosterState{PosterURL: "https://new-site/x.jpg"}},
+			FileMatchInfo: models.FileMatchInfo{Path: "/f/own-row.mp4", MovieID: "MC-2"},
+		},
+	}
+	data, err := json.Marshal(res)
+	require.NoError(t, err)
+	repo := mocks.NewMockJobRepositoryInterface(t)
+	repo.EXPECT().FindByID(mock.Anything, "JOB-SC").Return(&models.Job{Results: string(data)}, nil)
+	cl := &TempDirCleaner{fs: fs, tempDir: "/tmp", jobRepo: repo}
+	n := cl.reconcileEvictWitness(context.Background(), dir, "JOB-SC", wp)
+	assert.Equal(t, 1, n)
+	_, fErr := fs.Stat(filepath.Join(dir, "MC-2-full.jpg"))
+	assert.Error(t, fErr, "own-row commit ⇒ eviction completed")
+	_, wErr := fs.Stat(wp)
+	assert.Error(t, wErr, "witness swept")
 }

--- a/internal/worker/field_override.go
+++ b/internal/worker/field_override.go
@@ -144,6 +144,9 @@ func applyFieldOverride(movie *models.Movie, prov *resultstore.ProvenanceData, f
 		movie.Poster.PosterURL = result.PosterURL
 		setFieldSource("poster_url")
 		clearPosterCropGeometry(movie) // new source: stored geometry is stale
+		// P2 (D6/R13): the committed row must not point at bytes describing the
+		// old source once the pair eviction runs in ApplyFieldOverride.
+		movie.Poster.CroppedPosterURL = ""
 	case "cover_url":
 		movie.Poster.CoverURL = result.CoverURL
 		setFieldSource("cover_url")
@@ -152,6 +155,7 @@ func applyFieldOverride(movie *models.Movie, prov *resultstore.ProvenanceData, f
 		// keep a still-valid manual crop.
 		if movie.Poster.PosterURL == "" {
 			clearPosterCropGeometry(movie)
+			movie.Poster.CroppedPosterURL = "" // P2 (D6): bytes-about-to-evict pointer cleared
 		}
 	case "trailer_url":
 		movie.TrailerURL = result.TrailerURL

--- a/internal/worker/field_override.go
+++ b/internal/worker/field_override.go
@@ -141,21 +141,31 @@ func applyFieldOverride(movie *models.Movie, prov *resultstore.ProvenanceData, f
 		movie.Screenshots = append([]string(nil), result.ScreenshotURL...)
 		setFieldSource("screenshot_urls")
 	case "poster_url":
+		prevEffective := effectivePosterSourceOf(movie.Poster.PosterURL, movie.Poster.CoverURL)
 		movie.Poster.PosterURL = result.PosterURL
 		setFieldSource("poster_url")
 		clearPosterCropGeometry(movie) // new source: stored geometry is stale
 		// P2 (D6/R13): the committed row must not point at bytes describing the
-		// old source once the pair eviction runs in ApplyFieldOverride.
-		movie.Poster.CroppedPosterURL = ""
+		// old source once the pair eviction runs in ApplyFieldOverride. But when
+		// the override re-selects the SAME source, no eviction runs — keep the
+		// still-valid preview pointer (codex P2 review round on PR #211).
+		if effectivePosterSourceOf(movie.Poster.PosterURL, movie.Poster.CoverURL) != prevEffective {
+			movie.Poster.CroppedPosterURL = ""
+		}
 	case "cover_url":
+		prevCover := movie.Poster.CoverURL
 		movie.Poster.CoverURL = result.CoverURL
 		setFieldSource("cover_url")
 		// Only clears when the cover IS the effective poster source
 		// (poster_url empty): swapping fanart under an explicit poster must
 		// keep a still-valid manual crop.
 		if movie.Poster.PosterURL == "" {
+			prevEffective := effectivePosterSourceOf(movie.Poster.PosterURL, prevCover)
 			clearPosterCropGeometry(movie)
-			movie.Poster.CroppedPosterURL = "" // P2 (D6): bytes-about-to-evict pointer cleared
+			// Same-source override ⇒ no eviction ⇒ pointer stays valid.
+			if effectivePosterSourceOf(movie.Poster.PosterURL, movie.Poster.CoverURL) != prevEffective {
+				movie.Poster.CroppedPosterURL = ""
+			}
 		}
 	case "trailer_url":
 		movie.TrailerURL = result.TrailerURL

--- a/internal/worker/field_override_evict_p2_test.go
+++ b/internal/worker/field_override_evict_p2_test.go
@@ -1,0 +1,260 @@
+package worker
+
+// POSTER-WRITE-HARDENING P2 red suite (D6/R13): an override that changes the
+// EFFECTIVE poster source must carry the PATCH path's eviction contract —
+// witness BEFORE the commit, evict under the same locked section, clear the
+// committed cropped_poster_url so no committed row points at bytes that
+// describe the old source.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// overrideEvictFixture seeds a store row with a manual crop committed against
+// the OLD source plus installed pair bytes, and an env so eviction can run.
+func overrideEvictFixture(t *testing.T, movieID string, poster PosterStateFixture) *PosterEditor {
+	t.Helper()
+	store := resultstore.New(1, []string{"/f/ov.mp4"})
+	movie := &models.Movie{
+		ID: movieID,
+		Poster: models.PosterState{
+			PosterURL:        poster.posterURL,
+			CoverURL:         poster.coverURL,
+			CroppedPosterURL: "v1-crops/" + movieID + ".jpg",
+			PosterCropBounds: &models.CropBounds{X: 0.1, Y: 0.1, Width: 0.5, Height: 0.5},
+		},
+	}
+	store.UpdateFileResult("/f/ov.mp4", &resultstore.MovieResult{
+		ResultID:      "res-ov",
+		Status:        models.JobStatusCompleted,
+		Movie:         movie,
+		FileMatchInfo: models.FileMatchInfo{Path: "/f/ov.mp4", MovieID: movieID},
+	})
+	store.SetProvenance("/f/ov.mp4", &resultstore.ProvenanceData{
+		FieldSources: map[string]string{"title": "r18dev"},
+		ScraperResults: []*models.ScraperResult{
+			{Source: "r18dev", Title: "R18 Title"},
+			{Source: "dmm", Title: "DMM Title", PosterURL: "https://new.example/x.jpg", CoverURL: "https://new.example/x-fan.jpg"},
+		},
+	})
+	pe := newEditorForStore(store)
+	pe.attachEnv(&posterEditEnv{fs: poster.fs, tempDir: "/tmp", jobID: "J-OV"})
+	return pe
+}
+
+type PosterStateFixture struct {
+	posterURL string
+	coverURL  string
+	fs        afero.Fs
+}
+
+// seedPair writes the installed pair bytes for movieID inside dir.
+func seedPair(t *testing.T, fs afero.Fs, dir, movieID string) {
+	t.Helper()
+	require.NoError(t, fs.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(fs, dir+"/"+movieID+"-full.jpg", []byte("old-full"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, dir+"/"+movieID+".jpg", []byte("old-crop"), 0o644))
+}
+
+func assertPairGone(t *testing.T, fs afero.Fs, dir, movieID string) {
+	t.Helper()
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		_, err := fs.Stat(dir + "/" + movieID + suffix)
+		assert.Error(t, err, "stale leg %s%s evicted after source change", movieID, suffix)
+	}
+}
+
+// poster_url override ⇒ effective source changes ⇒ geometry + cropped URL
+// cleared, cached pair evicted, witness swept after success.
+func TestApplyFieldOverride_PosterURLSourceChangeEvictsAndClears(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-OV"
+	seedPair(t, fs, dir, "OV-1")
+	pe := overrideEvictFixture(t, "OV-1", PosterStateFixture{posterURL: "https://old.example/p.jpg", fs: fs})
+
+	out, _, err := pe.ApplyFieldOverride(context.Background(), "res-ov", "OV-1", "poster_url", "dmm")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, "https://new.example/x.jpg", out.Movie.Poster.PosterURL)
+	assert.Empty(t, out.Movie.Poster.CroppedPosterURL, "committed row never points at bytes of the old source")
+	assert.Nil(t, out.Movie.Poster.PosterCropBounds, "stale geometry cleared")
+	assertPairGone(t, fs, dir, "OV-1")
+	entries, derr := afero.ReadDir(fs, dir)
+	require.NoError(t, derr)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".evict-", "witness swept after successful eviction")
+	}
+}
+
+// cover_url override while poster_url is EMPTY: the cover IS the effective
+// source — same eviction contract.
+func TestApplyFieldOverride_CoverURLAsEffectiveSourceEvicts(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-OV"
+	seedPair(t, fs, dir, "OV-2")
+	pe := overrideEvictFixture(t, "OV-2", PosterStateFixture{coverURL: "https://old.example/c.jpg", fs: fs})
+
+	out, _, err := pe.ApplyFieldOverride(context.Background(), "res-ov", "OV-2", "cover_url", "dmm")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, "https://new.example/x-fan.jpg", out.Movie.Poster.CoverURL)
+	assert.Empty(t, out.Movie.Poster.CroppedPosterURL)
+	assert.Nil(t, out.Movie.Poster.PosterCropBounds)
+	assertPairGone(t, fs, dir, "OV-2")
+}
+
+// cover_url override UNDER a non-empty poster_url: the effective source did
+// NOT change — geometry and bytes stay (a still-valid crop is preserved).
+func TestApplyFieldOverride_CoverURLUnderExplicitPosterKeepsCrop(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-OV"
+	seedPair(t, fs, dir, "OV-3")
+	pe := overrideEvictFixture(t, "OV-3", PosterStateFixture{posterURL: "https://old.example/p.jpg", coverURL: "https://old.example/c.jpg", fs: fs})
+
+	out, _, err := pe.ApplyFieldOverride(context.Background(), "res-ov", "OV-3", "cover_url", "dmm")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, "https://new.example/x-fan.jpg", out.Movie.Poster.CoverURL)
+	assert.Equal(t, "v1-crops/OV-3.jpg", out.Movie.Poster.CroppedPosterURL, "crop survives fanart-only change")
+	assert.NotNil(t, out.Movie.Poster.PosterCropBounds)
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		_, err := fs.Stat(dir + "/OV-3" + suffix)
+		assert.NoError(t, err, "bytes remain: effective source unchanged")
+	}
+}
+
+// Unsafe stored canonical ID: the eviction is refused (no join over an
+// unsafe path), the commit itself still lands with cleared crop state, and
+// the pair bytes stay put (codex r33 parity with the PATCH path).
+func TestApplyFieldOverride_SourceChangeUnsafeIDSkipsEviction(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-OV"
+	store := resultstore.New(1, []string{"/f/ov.mp4"})
+	store.UpdateFileResult("/f/ov.mp4", &resultstore.MovieResult{
+		ResultID: "res-ov",
+		Status:   models.JobStatusCompleted,
+		Movie: &models.Movie{ID: "../evil", Poster: models.PosterState{
+			PosterURL:        "https://old.example/p.jpg",
+			CroppedPosterURL: "v1-crops/x.jpg",
+		}},
+		FileMatchInfo: models.FileMatchInfo{Path: "/f/ov.mp4", MovieID: "OV-U"},
+	})
+	store.SetProvenance("/f/ov.mp4", &resultstore.ProvenanceData{
+		ScraperResults: []*models.ScraperResult{{Source: "dmm", PosterURL: "https://new.example/x.jpg"}},
+	})
+	pe := newEditorForStore(store)
+	pe.attachEnv(&posterEditEnv{fs: fs, tempDir: "/tmp", jobID: "J-OV"})
+
+	out, _, err := pe.ApplyFieldOverride(context.Background(), "res-ov", "OV-U", "poster_url", "dmm")
+	require.NoError(t, err)
+	assert.Empty(t, out.Movie.Poster.CroppedPosterURL, "state-side clearing applies (row stays coherent)")
+	_, derr := fs.Stat(dir)
+	assert.Error(t, derr, "no eviction machinery touched the filesystem for an unsafe ID")
+}
+
+// Empty canonical Movie.ID falls back to the family key for the eviction
+// identity (matcher alias naming the installed pair).
+func TestApplyFieldOverride_SourceChangeEmptyMovieIDFallsBackToFamilyKey(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-OV"
+	seedPair(t, fs, dir, "OV-5")
+	store := resultstore.New(1, []string{"/f/ov.mp4"})
+	store.UpdateFileResult("/f/ov.mp4", &resultstore.MovieResult{
+		ResultID:      "res-ov",
+		Status:        models.JobStatusCompleted,
+		Movie:         &models.Movie{ID: "", Poster: models.PosterState{PosterURL: "https://old.example/p.jpg"}},
+		FileMatchInfo: models.FileMatchInfo{Path: "/f/ov.mp4", MovieID: "OV-5"},
+	})
+	store.SetProvenance("/f/ov.mp4", &resultstore.ProvenanceData{
+		ScraperResults: []*models.ScraperResult{{Source: "dmm", PosterURL: "https://new.example/x.jpg"}},
+	})
+	pe := newEditorForStore(store)
+	pe.attachEnv(&posterEditEnv{fs: fs, tempDir: "/tmp", jobID: "J-OV"})
+
+	_, _, err := pe.ApplyFieldOverride(context.Background(), "res-ov", "OV-5", "poster_url", "dmm")
+	require.NoError(t, err)
+	assertPairGone(t, fs, dir, "OV-5")
+}
+
+// A wedged eviction-witness write aborts the override BEFORE any state or
+// byte moves — commit never runs.
+func TestApplyFieldOverride_SourceChangeWitnessWriteFailureAborts(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-OV"
+	seedPair(t, base, dir, "OV-6")
+	store := resultstore.New(1, []string{"/f/ov.mp4"})
+	store.UpdateFileResult("/f/ov.mp4", &resultstore.MovieResult{
+		ResultID:      "res-ov",
+		Status:        models.JobStatusCompleted,
+		Movie:         &models.Movie{ID: "OV-6", Poster: models.PosterState{PosterURL: "https://old.example/p.jpg", CroppedPosterURL: "v1/x.jpg"}},
+		FileMatchInfo: models.FileMatchInfo{Path: "/f/ov.mp4", MovieID: "OV-6"},
+	})
+	prov := &resultstore.ProvenanceData{
+		FieldSources:   map[string]string{"title": "r18dev"},
+		ScraperResults: []*models.ScraperResult{{Source: "dmm", PosterURL: "https://new.example/x.jpg"}},
+	}
+	store.SetProvenance("/f/ov.mp4", prov)
+	pe := newEditorForStore(store)
+	pe.attachEnv(&posterEditEnv{fs: createWedgeFS{Fs: base, contains: ".evict-"}, tempDir: "/tmp", jobID: "J-OV"})
+
+	_, _, err := pe.ApplyFieldOverride(context.Background(), "res-ov", "OV-6", "poster_url", "dmm")
+	require.ErrorContains(t, err, "stale poster eviction witness")
+	got, gerr := store.GetMovieResult("/f/ov.mp4")
+	require.NoError(t, gerr)
+	assert.Equal(t, "https://old.example/p.jpg", got.Movie.Poster.PosterURL, "commit never ran — in-memory state unchanged")
+	assert.Equal(t, "r18dev", store.GetProvenance("/f/ov.mp4").FieldSources["title"], "provenance untouched")
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		_, serr := base.Stat(dir + "/OV-6" + suffix)
+		assert.NoError(t, serr, "pair intact")
+	}
+}
+
+// Commit failure sweeps the never-armed witness — a stranded record would
+// make the startup reconciler repeatedly evict for a commit that never
+// happened.
+func TestApplyFieldOverride_SourceChangeCommitFailureSweepsWitness(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-OV"
+	seedPair(t, base, dir, "OV-7")
+	store := resultstore.New(1, []string{"/f/ov.mp4"})
+	store.UpdateFileResult("/f/ov.mp4", &resultstore.MovieResult{
+		ResultID:      "res-ov",
+		Status:        models.JobStatusCompleted,
+		Movie:         &models.Movie{ID: "OV-7", Poster: models.PosterState{PosterURL: "https://old.example/p.jpg"}},
+		FileMatchInfo: models.FileMatchInfo{Path: "/f/ov.mp4", MovieID: "OV-7"},
+	})
+	store.SetProvenance("/f/ov.mp4", &resultstore.ProvenanceData{
+		ScraperResults: []*models.ScraperResult{{Source: "dmm", PosterURL: "https://new.example/x.jpg"}},
+	})
+	pe := newEditorForStore(store)
+	committer := NewEditCommitter(failTransactor{err: errWedgeWorker}, newKeyedMutexRegistry(), "J-OV", newKeyedMutexRegistry())
+	pe.attachEnv(&posterEditEnv{
+		fs: base, tempDir: "/tmp", jobID: "J-OV", committer: committer,
+		envelope: func(map[string]*resultstore.MovieResult, map[string]*resultstore.ProvenanceData, map[string]bool) (*models.Job, error) {
+			return &models.Job{}, nil
+		},
+	})
+
+	_, _, err := pe.ApplyFieldOverride(context.Background(), "res-ov", "OV-7", "poster_url", "dmm")
+	require.ErrorIs(t, err, errWedgeWorker)
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		_, serr := base.Stat(dir + "/OV-7" + suffix)
+		assert.NoError(t, serr, "eviction runs only on success — pair intact")
+	}
+	matches, gerr := afero.Glob(base, dir+"/.evict-*.json")
+	require.NoError(t, gerr)
+	assert.Empty(t, matches, "witness swept after failed commit")
+}
+
+var errWedgeWorker = errWedgeTypeWorker{}
+
+type errWedgeTypeWorker struct{}
+
+func (errWedgeTypeWorker) Error() string { return "tx wedged" }

--- a/internal/worker/field_override_evict_p2_test.go
+++ b/internal/worker/field_override_evict_p2_test.go
@@ -331,13 +331,17 @@ func TestApplyFieldOverride_EvictionGatedOnSiblingShare(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	dir := "/tmp/posters/J-OV"
 	seedPair(t, fs, dir, "SIB-1")
-	store := resultstore.New(2, []string{"/f/a.mp4", "/f/b.mp4"})
-	for _, rec := range []struct{ fp, resID string }{{"/f/a.mp4", "res-a"}, {"/f/b.mp4", "res-b"}} {
+	store := resultstore.New(3, []string{"/f/a.mp4", "/f/b.mp4", "/f/c.mp4"})
+	for _, rec := range []struct{ fp, resID string }{{"/f/a.mp4", "res-a"}, {"/f/b.mp4", "res-b"}, {"/f/c.mp4", "res-other"}} {
+		movieID := "SIB-1"
+		if rec.resID == "res-other" {
+			movieID = "OTHER-9" // non-matching sibling exercises the loop's ID filter
+		}
 		store.UpdateFileResult(rec.fp, &resultstore.MovieResult{
 			ResultID:      rec.resID,
 			Status:        models.JobStatusCompleted,
-			Movie:         &models.Movie{ID: "SIB-1", Poster: models.PosterState{PosterURL: "https://old.example/p.jpg", CroppedPosterURL: "v1/SIB-1.jpg"}},
-			FileMatchInfo: models.FileMatchInfo{Path: rec.fp, MovieID: "SIB-1"},
+			Movie:         &models.Movie{ID: movieID, Poster: models.PosterState{PosterURL: "https://old.example/p.jpg", CroppedPosterURL: "v1/SIB-1.jpg"}},
+			FileMatchInfo: models.FileMatchInfo{Path: rec.fp, MovieID: movieID},
 		})
 	}
 	store.SetProvenance("/f/a.mp4", &resultstore.ProvenanceData{

--- a/internal/worker/field_override_evict_p2_test.go
+++ b/internal/worker/field_override_evict_p2_test.go
@@ -322,3 +322,48 @@ func TestApplyFieldOverride_CoverURLSameEffectiveValueKeepsPreview(t *testing.T)
 	require.NoError(t, err)
 	assert.Equal(t, "v1-crops/OV-C.jpg", out.Movie.Poster.CroppedPosterURL)
 }
+
+// codex P2 round 5 (PR211): the canonical pair is keyed by MOVIE ID and can
+// be shared by sibling results in the same job. Overriding ONE of them must
+// keep the pair until no sibling references it — the other sibling's preview
+// must not 404.
+func TestApplyFieldOverride_EvictionGatedOnSiblingShare(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-OV"
+	seedPair(t, fs, dir, "SIB-1")
+	store := resultstore.New(2, []string{"/f/a.mp4", "/f/b.mp4"})
+	for _, rec := range []struct{ fp, resID string }{{"/f/a.mp4", "res-a"}, {"/f/b.mp4", "res-b"}} {
+		store.UpdateFileResult(rec.fp, &resultstore.MovieResult{
+			ResultID:      rec.resID,
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "SIB-1", Poster: models.PosterState{PosterURL: "https://old.example/p.jpg", CroppedPosterURL: "v1/SIB-1.jpg"}},
+			FileMatchInfo: models.FileMatchInfo{Path: rec.fp, MovieID: "SIB-1"},
+		})
+	}
+	store.SetProvenance("/f/a.mp4", &resultstore.ProvenanceData{
+		ScraperResults: []*models.ScraperResult{{Source: "dmm", PosterURL: "https://new.example/p.jpg"}},
+	})
+	pe := newEditorForStore(store)
+	pe.attachEnv(&posterEditEnv{fs: fs, tempDir: "/tmp", jobID: "J-OV"})
+
+	out, _, err := pe.ApplyFieldOverride(context.Background(), "res-a", "SIB-1", "poster_url", "dmm")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, "https://new.example/p.jpg", out.Movie.Poster.PosterURL)
+	assert.Empty(t, out.Movie.Poster.CroppedPosterURL, "the overridden row releases its old-source pointer")
+
+	sib, serr := store.GetMovieResult("/f/b.mp4")
+	require.NoError(t, serr)
+	assert.Equal(t, "https://old.example/p.jpg", sib.Movie.Poster.PosterURL)
+	assert.Equal(t, "v1/SIB-1.jpg", sib.Movie.Poster.CroppedPosterURL, "sibling preview untouched")
+
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		_, serr := fs.Stat(dir + "/SIB-1" + suffix)
+		assert.NoError(t, serr, "pair stays while a sibling references it")
+	}
+	entries, gerr := afero.ReadDir(fs, dir)
+	require.NoError(t, gerr)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".evict-", "no eviction witness written")
+	}
+}

--- a/internal/worker/field_override_evict_p2_test.go
+++ b/internal/worker/field_override_evict_p2_test.go
@@ -343,6 +343,9 @@ func TestApplyFieldOverride_EvictionGatedOnSiblingShare(t *testing.T) {
 	store.SetProvenance("/f/a.mp4", &resultstore.ProvenanceData{
 		ScraperResults: []*models.ScraperResult{{Source: "dmm", PosterURL: "https://new.example/p.jpg"}},
 	})
+	store.SetProvenance("/f/b.mp4", &resultstore.ProvenanceData{
+		ScraperResults: []*models.ScraperResult{{Source: "dmm", PosterURL: "https://new.example/p.jpg"}},
+	})
 	pe := newEditorForStore(store)
 	pe.attachEnv(&posterEditEnv{fs: fs, tempDir: "/tmp", jobID: "J-OV"})
 
@@ -365,5 +368,16 @@ func TestApplyFieldOverride_EvictionGatedOnSiblingShare(t *testing.T) {
 	require.NoError(t, gerr)
 	for _, e := range entries {
 		assert.NotContains(t, e.Name(), ".evict-", "no eviction witness written")
+	}
+
+	// codex P2 round 6: once the LAST sibling migrates off the old source,
+	// its own override must finally evict — nobody references the old bytes.
+	out2, _, err2 := pe.ApplyFieldOverride(context.Background(), "res-b", "SIB-1", "poster_url", "dmm")
+	require.NoError(t, err2)
+	require.NotNil(t, out2)
+	assert.Empty(t, out2.Movie.Poster.CroppedPosterURL)
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		_, serr := fs.Stat(dir + "/SIB-1" + suffix)
+		assert.Error(t, serr, "last-sibling migration evicts the old pair: %s", suffix)
 	}
 }

--- a/internal/worker/field_override_evict_p2_test.go
+++ b/internal/worker/field_override_evict_p2_test.go
@@ -385,3 +385,44 @@ func TestApplyFieldOverride_EvictionGatedOnSiblingShare(t *testing.T) {
 		assert.Error(t, serr, "last-sibling migration evicts the old pair: %s", suffix)
 	}
 }
+
+// codex P2 round 9 (PR211): on legacy rows whose canonical Movie.ID is
+// empty, the pair's shared identity is the matcher alias — a sibling still
+// on the OLD source must block eviction (its preview references the alias
+// pair); once the last sibling migrates, eviction proceeds.
+func TestApplyFieldOverride_SiblingShareLegacyAliasBlocksEviction(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-LEG"
+	seedPair(t, fs, dir, "LEG-9")
+	store := resultstore.New(2, []string{"/f/a.mp4", "/f/b.mp4"})
+	for _, rec := range []struct{ fp, resID string }{{"/f/a.mp4", "res-a"}, {"/f/b.mp4", "res-b"}} {
+		store.UpdateFileResult(rec.fp, &resultstore.MovieResult{
+			ResultID:      rec.resID,
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "", Poster: models.PosterState{PosterURL: "https://old.example/leg.jpg", CroppedPosterURL: "v1/LEG-9.jpg"}},
+			FileMatchInfo: models.FileMatchInfo{Path: rec.fp, MovieID: "LEG-9"},
+		})
+		store.SetProvenance(rec.fp, &resultstore.ProvenanceData{
+			ScraperResults: []*models.ScraperResult{{Source: "dmm", PosterURL: "https://new.example/leg.jpg"}},
+		})
+	}
+	pe := newEditorForStore(store)
+	pe.attachEnv(&posterEditEnv{fs: fs, tempDir: "/tmp", jobID: "J-LEG"})
+
+	out1, _, err1 := pe.ApplyFieldOverride(context.Background(), "res-b", "LEG-9", "poster_url", "dmm")
+	require.NoError(t, err1)
+	require.NotNil(t, out1)
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		_, serr := fs.Stat(dir + "/LEG-9" + suffix)
+		assert.NoError(t, serr, "sibling's preview preserved while she references the old source")
+	}
+
+	// Second sibling migrates too: nobody reads the old pair now.
+	out2, _, err2 := pe.ApplyFieldOverride(context.Background(), "res-a", "LEG-9", "poster_url", "dmm")
+	require.NoError(t, err2)
+	require.NotNil(t, out2)
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		_, serr := fs.Stat(dir + "/LEG-9" + suffix)
+		assert.Error(t, serr, "last-sibling migration evicts the alias pair: %s", suffix)
+	}
+}

--- a/internal/worker/field_override_evict_p2_test.go
+++ b/internal/worker/field_override_evict_p2_test.go
@@ -258,3 +258,67 @@ var errWedgeWorker = errWedgeTypeWorker{}
 type errWedgeTypeWorker struct{}
 
 func (errWedgeTypeWorker) Error() string { return "tx wedged" }
+
+// codex P2 (PR211, round-3): re-selecting the SAME effective source via an
+// override must not clear the committed preview pointer — no eviction runs,
+// so the cached pair stays valid.
+func TestApplyFieldOverride_PosterURLSameValueKeepsPreview(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/tmp/posters/J-OV"
+	seedPair(t, fs, dir, "OV-S")
+	store := resultstore.New(1, []string{"/f/ov.mp4"})
+	store.UpdateFileResult("/f/ov.mp4", &resultstore.MovieResult{
+		ResultID: "res-ov",
+		Status:   models.JobStatusCompleted,
+		Movie: &models.Movie{ID: "OV-S", Poster: models.PosterState{
+			PosterURL:        "https://old.example/p.jpg",
+			CroppedPosterURL: "v1-crops/OV-S.jpg",
+			PosterCropBounds: &models.CropBounds{X: 0.1, Y: 0.1, Width: 0.5, Height: 0.5},
+		}},
+		FileMatchInfo: models.FileMatchInfo{Path: "/f/ov.mp4", MovieID: "OV-S"},
+	})
+	store.SetProvenance("/f/ov.mp4", &resultstore.ProvenanceData{
+		ScraperResults: []*models.ScraperResult{{Source: "dmm", PosterURL: "https://old.example/p.jpg"}}, // SAME url
+	})
+	pe := newEditorForStore(store)
+	pe.attachEnv(&posterEditEnv{fs: fs, tempDir: "/tmp", jobID: "J-OV"})
+
+	out, _, err := pe.ApplyFieldOverride(context.Background(), "res-ov", "OV-S", "poster_url", "dmm")
+	require.NoError(t, err)
+	assert.Equal(t, "v1-crops/OV-S.jpg", out.Movie.Poster.CroppedPosterURL, "same-source override keeps the preview")
+	// Geometry is still invalidated conservatively (pre-P2 behavior), but the
+	// pair bytes stay — the crop can be re-measured against the cached source.
+	for _, suffix := range []string{"-full.jpg", ".jpg"} {
+		_, serr := fs.Stat(dir + "/OV-S" + suffix)
+		assert.NoError(t, serr, "no eviction under an unchanged effective source")
+	}
+	entries, gerr := afero.ReadDir(fs, dir)
+	require.NoError(t, gerr)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".evict-", "no eviction witness staged")
+	}
+}
+
+// Same-source invariant for the cover-as-effective-source arm.
+func TestApplyFieldOverride_CoverURLSameEffectiveValueKeepsPreview(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	store := resultstore.New(1, []string{"/f/ov.mp4"})
+	store.UpdateFileResult("/f/ov.mp4", &resultstore.MovieResult{
+		ResultID: "res-ov",
+		Status:   models.JobStatusCompleted,
+		Movie: &models.Movie{ID: "OV-C", Poster: models.PosterState{
+			CoverURL:         "https://old.example/c.jpg",
+			CroppedPosterURL: "v1-crops/OV-C.jpg",
+		}},
+		FileMatchInfo: models.FileMatchInfo{Path: "/f/ov.mp4", MovieID: "OV-C"},
+	})
+	store.SetProvenance("/f/ov.mp4", &resultstore.ProvenanceData{
+		ScraperResults: []*models.ScraperResult{{Source: "dmm", CoverURL: "https://old.example/c.jpg"}},
+	})
+	pe := newEditorForStore(store)
+	pe.attachEnv(&posterEditEnv{fs: fs, tempDir: "/tmp", jobID: "J-OV"})
+
+	out, _, err := pe.ApplyFieldOverride(context.Background(), "res-ov", "OV-C", "cover_url", "dmm")
+	require.NoError(t, err)
+	assert.Equal(t, "v1-crops/OV-C.jpg", out.Movie.Poster.CroppedPosterURL)
+}

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -698,14 +698,14 @@ func sweepEvictionWitness(fs afero.Fs, wpath string) {
 // a crash between the durable write and the physical removals still leaves the
 // reconcile-complete marker on disk (codex cloud P2).
 // writeEvictWitness persists the eviction record inline-BEFORE the tag on the ✔
-func writeEvictWitness(fs afero.Fs, dir, posterID, newSourceURL string) (string, error) {
+func writeEvictWitness(fs afero.Fs, dir, posterID, newSourceURL, forFilePath string) (string, error) {
 	wpath := filepath.Join(dir, ".evict-"+url.PathEscape(posterID)+".json")
 	// codex cloud P2: a never-postered job has NO posters dir — MkdirAll allows
 	// the source-change witness to persist even when nothing was downloaded yet.
 	if mErr := fs.MkdirAll(dir, 0o755); mErr != nil {
 		return "", fmt.Errorf("evict witness dir %s: %w", dir, mErr)
 	}
-	payload, _ := json.Marshal(evictWitness{OldID: posterID, NewSourceURL: newSourceURL})
+	payload, _ := json.Marshal(evictWitness{OldID: posterID, NewSourceURL: newSourceURL, FilePath: forFilePath})
 	if err := writeFileAtomicForEvict(fs, wpath, payload); err != nil {
 		return "", fmt.Errorf("%w", err)
 	}
@@ -1071,7 +1071,7 @@ func (m *LockedMovieOps) UpdateMovieFamily(ctx context.Context, movie *models.Mo
 			if len(relocatedPosterPair) > 0 && strings.TrimSpace(movie.ID) != "" {
 				evictID = strings.TrimSpace(movie.ID)
 			}
-			evictWitnessPath, err = writeEvictWitness(env.fs, dir, evictID, effectivePosterSourceOf(movie.Poster.PosterURL, movie.Poster.CoverURL))
+			evictWitnessPath, err = writeEvictWitness(env.fs, dir, evictID, effectivePosterSourceOf(movie.Poster.PosterURL, movie.Poster.CoverURL), filePaths[0])
 			if err != nil {
 				return fmt.Errorf("stale poster eviction witness %s: %w", evictWitnessPath, err)
 			}
@@ -1223,7 +1223,7 @@ func (m *LockedMovieOps) ApplyFieldOverride(ctx context.Context, resultID, field
 		if stalePosterID != "" {
 			if env := m.pe.currentEnv(); env != nil && env.fs != nil && env.tempDir != "" && env.jobID != "" {
 				dir := filepath.Join(env.tempDir, "posters", env.jobID)
-				wp, werr := writeEvictWitness(env.fs, dir, stalePosterID, effectivePosterSourceOf(movie.Poster.PosterURL, movie.Poster.CoverURL))
+				wp, werr := writeEvictWitness(env.fs, dir, stalePosterID, effectivePosterSourceOf(movie.Poster.PosterURL, movie.Poster.CoverURL), filePath)
 				if werr != nil {
 					return nil, nil, fmt.Errorf("stale poster eviction witness %s: %w", wp, werr)
 				}

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -1194,24 +1194,29 @@ func (m *LockedMovieOps) ApplyFieldOverride(ctx context.Context, resultID, field
 			logging.Warnf("override source-change eviction skipped: unsafe poster ID %q", stalePosterID)
 			stalePosterID = ""
 		}
-		// codex PR#211 round 5: the canonical pair is IDENTITY-keyed — sibling
-		// results sharing the same movie ID keep preview URLs pointing at those
-		// bytes. While any sibling still references it, never evict (the override
-		// row's new source gets its own download flow later).
+		// codex PR#211 rounds 5+6: the canonical pair is IDENTITY-keyed, but
+		// only a sibling whose rows still reference the OLD effective source
+		// reads those bytes. A share-by-ID alone must not pin the pair forever
+		// (already-migrated siblings would keep the stale bytes alive),
+		// while an untouched sibling mustn't lose its preview.
 		if stalePosterID != "" && m.pe.lookup != nil {
+			oldEffective := effectivePosterSourceOf(result.Movie.Poster.PosterURL, result.Movie.Poster.CoverURL)
 			snap := m.pe.lookup.SnapshotData()
 			bysider := ""
 			for fp, row := range snap.Results {
 				if fp == filePath || row == nil || row.Movie == nil {
 					continue
 				}
-				if strings.EqualFold(strings.TrimSpace(row.Movie.ID), stalePosterID) {
+				if !strings.EqualFold(strings.TrimSpace(row.Movie.ID), stalePosterID) {
+					continue
+				}
+				if effectivePosterSourceOf(row.Movie.Poster.PosterURL, row.Movie.Poster.CoverURL) == oldEffective {
 					bysider = fp
 					break
 				}
 			}
 			if bysider != "" {
-				logging.Infof("override source-change eviction skipped for %s: %s still shares the pair", stalePosterID, bysider)
+				logging.Infof("override source-change eviction skipped for %s: %s still uses the old source", stalePosterID, bysider)
 				stalePosterID = ""
 			}
 		}

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -1207,7 +1207,14 @@ func (m *LockedMovieOps) ApplyFieldOverride(ctx context.Context, resultID, field
 				if fp == filePath || row == nil || row.Movie == nil {
 					continue
 				}
-				if !strings.EqualFold(strings.TrimSpace(row.Movie.ID), stalePosterID) {
+				// codex PR#211 round 9: legacy rows can carry an EMPTY canonical
+				// Movie.ID — their shared identity lives on the matcher alias
+				// (FileMatchInfo.MovieID); compare the effective row identity.
+				rowID := strings.TrimSpace(row.Movie.ID)
+				if rowID == "" {
+					rowID = strings.TrimSpace(row.FileMatchInfo.MovieID)
+				}
+				if !strings.EqualFold(rowID, stalePosterID) {
 					continue
 				}
 				if effectivePosterSourceOf(row.Movie.Poster.PosterURL, row.Movie.Poster.CoverURL) == oldEffective {

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -1176,6 +1176,36 @@ func (m *LockedMovieOps) ApplyFieldOverride(ctx context.Context, resultID, field
 	}
 	sanitizePosterCropGeometry(movie, true, result.Movie.Poster.PosterURL, result.Movie.Poster.CoverURL, result.Movie.Poster.ShouldCropPoster)
 
+	// P2 (D6/R13): an override that changed the EFFECTIVE poster source
+	// carries the PATCH path's eviction contract — the witness is journaled
+	// BEFORE the commit, the stale pair is evicted after it lands, and a
+	// failed commit sweeps the never-armed witness. (The committed cropped
+	// URL is already cleared by the mutator.)
+	stalePosterID := ""
+	evictWitnessPath := ""
+	if effectivePosterSourceOf(movie.Poster.PosterURL, movie.Poster.CoverURL) != effectivePosterSourceOf(result.Movie.Poster.PosterURL, result.Movie.Poster.CoverURL) {
+		stalePosterID = strings.TrimSpace(result.Movie.ID)
+		if stalePosterID == "" {
+			stalePosterID = m.movieID
+		}
+		if !isSafePosterFileID(stalePosterID) {
+			// codex r33 parity: an unsafe legacy ID must never reach a join — but
+			// the state-side clearing above already keeps the row coherent.
+			logging.Warnf("override source-change eviction skipped: unsafe poster ID %q", stalePosterID)
+			stalePosterID = ""
+		}
+		if stalePosterID != "" {
+			if env := m.pe.currentEnv(); env != nil && env.fs != nil && env.tempDir != "" && env.jobID != "" {
+				dir := filepath.Join(env.tempDir, "posters", env.jobID)
+				wp, werr := writeEvictWitness(env.fs, dir, stalePosterID, effectivePosterSourceOf(movie.Poster.PosterURL, movie.Poster.CoverURL))
+				if werr != nil {
+					return nil, nil, fmt.Errorf("stale poster eviction witness %s: %w", wp, werr)
+				}
+				evictWitnessPath = wp
+			}
+		}
+	}
+
 	cand := result.Clone()
 	cand.Movie = movie
 	cand.FileMatchInfo.MovieID = movie.ID
@@ -1197,7 +1227,19 @@ func (m *LockedMovieOps) ApplyFieldOverride(ctx context.Context, resultID, field
 		plan.UpsertMovie = movie
 		plan.Renames = renames
 	}); err != nil {
+		if evictWitnessPath != "" {
+			// Commit never landed ⇒ the eviction never armed; the record is pure
+			// litter, swept best-effort (a durable failure leaves it for startup).
+			if env := m.pe.currentEnv(); env != nil && env.fs != nil {
+				sweepEvictionWitness(env.fs, evictWitnessPath)
+			}
+		}
 		return nil, nil, fmt.Errorf("persist field override: %w", err)
+	}
+	if evictWitnessPath != "" && stalePosterID != "" {
+		// Post-commit, always under this same locked section: remove the stale
+		// pair; a failed leg keeps the witness for startup reconcile.
+		m.evictStalePosterPair(stalePosterID, evictWitnessPath)
 	}
 	updated, _, _ := m.pe.lookup.GetFileResultByResultID(resultID)
 	updatedProv := m.pe.lookup.GetProvenance(filePath)

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -1194,6 +1194,27 @@ func (m *LockedMovieOps) ApplyFieldOverride(ctx context.Context, resultID, field
 			logging.Warnf("override source-change eviction skipped: unsafe poster ID %q", stalePosterID)
 			stalePosterID = ""
 		}
+		// codex PR#211 round 5: the canonical pair is IDENTITY-keyed — sibling
+		// results sharing the same movie ID keep preview URLs pointing at those
+		// bytes. While any sibling still references it, never evict (the override
+		// row's new source gets its own download flow later).
+		if stalePosterID != "" && m.pe.lookup != nil {
+			snap := m.pe.lookup.SnapshotData()
+			bysider := ""
+			for fp, row := range snap.Results {
+				if fp == filePath || row == nil || row.Movie == nil {
+					continue
+				}
+				if strings.EqualFold(strings.TrimSpace(row.Movie.ID), stalePosterID) {
+					bysider = fp
+					break
+				}
+			}
+			if bysider != "" {
+				logging.Infof("override source-change eviction skipped for %s: %s still shares the pair", stalePosterID, bysider)
+				stalePosterID = ""
+			}
+		}
 		if stalePosterID != "" {
 			if env := m.pe.currentEnv(); env != nil && env.fs != nil && env.tempDir != "" && env.jobID != "" {
 				dir := filepath.Join(env.tempDir, "posters", env.jobID)

--- a/internal/worker/poster_editor_family_cov_test.go
+++ b/internal/worker/poster_editor_family_cov_test.go
@@ -29,6 +29,10 @@ func (f *failAtomicUpdater) AtomicUpdateFileResult(string, func(*resultstore.Mov
 	return f.err
 }
 
+func (f *failAtomicUpdater) AtomicUpdateFileResultWithProvenance(string, func(*resultstore.MovieResult, *resultstore.ProvenanceData) (*resultstore.MovieResult, *resultstore.ProvenanceData, error)) error {
+	return f.err
+}
+
 type failTransactor struct{ err error }
 
 func (t failTransactor) WithEditTx(context.Context, func(database.EditUnit) error) error {

--- a/internal/worker/recovery.go
+++ b/internal/worker/recovery.go
@@ -96,10 +96,10 @@ func withFileRecovery(rc recoveryContext, outcome recoverableOutcome) func() {
 			if fenceHit != "" {
 				logging.Warnf("[Recovery] skipping write-back for %s — promote witness for %s unresolved; restart reconciles", rc.filePath, fenceHit)
 			} else if !writebackPreSkipped(rc.updater, rc.movie, rc.filePath, "Recovery") {
-				errUp := rc.updater.AtomicUpdateFileResult(rc.filePath, func(current *resultstore.MovieResult) (*resultstore.MovieResult, error) {
+				errUp := rc.updater.AtomicUpdateFileResultWithProvenance(rc.filePath, func(current *resultstore.MovieResult, prov *resultstore.ProvenanceData) (*resultstore.MovieResult, *resultstore.ProvenanceData, error) {
 					if applyWritebackIdentityMismatch(rc.movie, current) {
 						logging.Warnf("[Recovery] skipping write-back for %s — result rekeyed to %s mid-phase", rc.filePath, current.FileMatchInfo.MovieID)
-						return current, nil
+						return current, prov, nil
 					}
 					current.FileMatchInfo = applyMatchFollowedByLiveIdentity(rc.fmi, current)
 					current.Movie = mergeLiveReviewEdits(rc.movie, rc.movie, current.Movie)
@@ -109,7 +109,7 @@ func withFileRecovery(rc recoveryContext, outcome recoverableOutcome) func() {
 						current.StartedAt = rc.startTime
 						current.EndedAt = &now
 					}
-					return current, nil
+					return current, mergeWriteBackProvenance(nil, prov), nil
 				})
 				if errUp != nil {
 					mr := &resultstore.MovieResult{

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -679,6 +679,10 @@ func (p *rescrapePhase) Rescrape(ctx context.Context, inputs rescrapePhaseInputs
 					// Nothing staged (nil movie/URL handled upstream).
 				default:
 					if posterErr := sgen.CommitStagedPoster(movieResult.Movie, stagedPoster); posterErr != nil {
+						// codex r1 P2: a failed promote leaves one or both uniquely
+						// named staged legs behind — discard them here or transient fs
+						// failures can pile them up until the poster dir exhausts disk.
+						sgen.DiscardStaged(stagedPoster)
 						s := posterErr.Error()
 						movieResult.PosterError = &s
 					}

--- a/internal/worker/rescrape_phase.go
+++ b/internal/worker/rescrape_phase.go
@@ -12,6 +12,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/nfo"
 	"github.com/javinizer/javinizer-go/internal/panicutil"
+	"github.com/javinizer/javinizer-go/internal/poster"
 	"github.com/javinizer/javinizer-go/internal/scrape"
 	timeoutPkg "github.com/javinizer/javinizer-go/internal/timeout"
 	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
@@ -573,10 +574,22 @@ func (p *rescrapePhase) Rescrape(ctx context.Context, inputs rescrapePhaseInputs
 			return nil, movieResult, err
 		}
 
-		// audit F-R10-1: witness probes + park + generation run UNDER the
+		// P2 (D6): the poster download runs on a staged identity OUTSIDE the
+		// family key — only the fs-only promote plus the state commit sit
+		// inside the lock window. Generators without staging support keep the
+		// legacy in-lock path.
+		var stagedPoster *poster.StagedPoster
+		var stageErr error
+		if movieResult.Movie != nil && inputs.PosterGen != nil {
+			if sgen, ok := inputs.PosterGen.(poster.StagingPosterGenerator); ok {
+				stagedPoster, stageErr = sgen.StagePoster(ctx, inputs.JobID.String(), movieResult.Movie)
+			}
+		}
+
+		// audit F-R10-1: witness probes + park + promote run UNDER the
 		// family key — the keyless window let a committed relocation/promote
-		// land between our witness probe and our byte overwrite (steal), or
-		// let our generation overwrite a freshly promoted pair (clobber).
+		// land between our witness fence and our byte overwrite (steal), or
+		// let our promote overwrite a freshly promoted pair (clobber).
 		// The commit leg keys up separately afterwards, as before.
 		release := func() {}
 		genID := ""
@@ -645,13 +658,32 @@ func (p *rescrapePhase) Rescrape(ctx context.Context, inputs rescrapePhaseInputs
 				}
 			}
 
-			// Poster generation
+			// Poster generation — the staged path promotes inside the lock;
+			// pre-lock staging errors reproduce the legacy error surface.
 			if inputs.PosterGen != nil && movieResult.Movie != nil {
-				if posterErr := inputs.PosterGen.GeneratePoster(ctx, inputs.JobID.String(), movieResult.Movie); posterErr != nil {
-					s := posterErr.Error()
+				sgen, canStage := inputs.PosterGen.(poster.StagingPosterGenerator)
+				switch {
+				case !canStage:
+					// Legacy generator: in-lock generate (test doubles and custom
+					// wiring; the production generator always stages).
+					if posterErr := inputs.PosterGen.GeneratePoster(ctx, inputs.JobID.String(), movieResult.Movie); posterErr != nil {
+						s := posterErr.Error()
+						movieResult.PosterError = &s
+					}
+					movieResult.PosterGenerated = true
+				case stageErr != nil:
+					s := stageErr.Error()
 					movieResult.PosterError = &s
+					movieResult.PosterGenerated = true
+				case stagedPoster == nil:
+					// Nothing staged (nil movie/URL handled upstream).
+				default:
+					if posterErr := sgen.CommitStagedPoster(movieResult.Movie, stagedPoster); posterErr != nil {
+						s := posterErr.Error()
+						movieResult.PosterError = &s
+					}
+					movieResult.PosterGenerated = true
 				}
-				movieResult.PosterGenerated = true
 			}
 
 			// audit F-R5-1: fingerprint whatever the generation wrote at canonical —
@@ -678,6 +710,13 @@ func (p *rescrapePhase) Rescrape(ctx context.Context, inputs rescrapePhaseInputs
 			return nil
 		}()
 		if heldErr != nil {
+			// Decline/cancel after staging: the staged bytes are residue —
+			// discard them instead of leaving unique-name litter for a sweep.
+			if stagedPoster != nil {
+				if sgen, ok := inputs.PosterGen.(poster.StagingPosterGenerator); ok {
+					sgen.DiscardStaged(stagedPoster)
+				}
+			}
 			return nil, movieResult, heldErr
 		}
 

--- a/internal/worker/rescrape_staged_order_p2_test.go
+++ b/internal/worker/rescrape_staged_order_p2_test.go
@@ -1,0 +1,363 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/poster"
+	"github.com/javinizer/javinizer-go/internal/scrape"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// POSTER-WRITE-HARDENING P2 (D6): rescrape downloads the poster on a STAGED
+// identity outside the family lock; the lock window carries only the fs-only
+// promote + state commit.
+
+type rescLockOrderTracker struct {
+	mu          sync.Mutex
+	lockHeld    bool
+	events      []string
+	lockAtStage bool
+	lockAtPromo bool
+}
+
+func (t *rescLockOrderTracker) acquire(ids ...string) func() {
+	t.mu.Lock()
+	t.lockHeld = true
+	t.events = append(t.events, "lock")
+	t.mu.Unlock()
+	return func() {
+		t.mu.Lock()
+		t.lockHeld = false
+		t.events = append(t.events, "unlock")
+		t.mu.Unlock()
+	}
+}
+
+func (t *rescLockOrderTracker) note(name string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, name)
+	if name == "stage" {
+		t.lockAtStage = t.lockHeld
+	}
+	if name == "promote" {
+		t.lockAtPromo = t.lockHeld
+	}
+}
+
+type stagingTrackerGen struct {
+	tracks    *rescLockOrderTracker
+	stageInfo *poster.StagedPoster
+	stageErr  error
+	stageNil  bool
+	commitErr error
+	discarded *int
+}
+
+func (g *stagingTrackerGen) GeneratePoster(_ context.Context, _ string, _ *models.Movie) error {
+	return errors.New("legacy in-lock path must not run for a staging generator")
+}
+
+func (g *stagingTrackerGen) StagePoster(_ context.Context, _ string, movie *models.Movie) (*poster.StagedPoster, error) {
+	if g.tracks != nil {
+		g.tracks.note("stage")
+	}
+	if g.stageErr != nil {
+		return nil, g.stageErr
+	}
+	if g.stageNil {
+		return nil, nil
+	}
+	if g.stageInfo != nil {
+		return g.stageInfo, nil
+	}
+	return poster.NewStagedPosterHandleForTest("", movie.ID+".stage-x", movie.ID, ""), nil
+}
+
+func (g *stagingTrackerGen) CommitStagedPoster(_ *models.Movie, _ *poster.StagedPoster) error {
+	if g.tracks != nil {
+		g.tracks.note("promote")
+	}
+	return g.commitErr
+}
+
+func (g *stagingTrackerGen) DiscardStaged(_ *poster.StagedPoster) {
+	if g.discarded != nil {
+		*g.discarded++
+	}
+}
+
+func TestRescrape_StagedPosterDownloadOutsideLockPromoteInside(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	jobID := models.NewJobID()
+	require.NoError(t, fs.MkdirAll(filepath.Join("/tmp", "posters", jobID.String()), 0o755))
+	store := resultstore.New(1, []string{"f1.mp4"})
+	seedFamilyResult(store, "f1.mp4", "res-1", "LOCK-9", "")
+	tracks := &rescLockOrderTracker{}
+	gen := &stagingTrackerGen{tracks: tracks}
+	wf := &stubRescrapeWorkflow{scrapeResult: &scrape.ScrapeResult{Movie: &models.Movie{ID: "LOCK-9"}, Status: scrape.StatusCompleted}}
+	inputs := rescrapePhaseInputs{
+		WF: wf, ResultMap: store, Finder: store, JobID: jobID,
+		PosterGen:  gen,
+		EditLockFn: tracks.acquire,
+		Fs:         fs, TempDir: "/tmp",
+	}
+	phase := NewRescrapePhase()
+	res, err := phase.Rescrape(context.Background(), inputs, RescrapeCmd{MovieID: "LOCK-9", FilePath: "f1.mp4"})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	assert.False(t, tracks.lockAtStage, "stage (network) ran OUTSIDE the edit lock")
+	assert.True(t, tracks.lockAtPromo, "promote (fs-only) ran INSIDE the edit lock")
+	stageIdx := slices.Index(tracks.events, "stage")
+	promoIdx := slices.Index(tracks.events, "promote")
+	require.GreaterOrEqual(t, stageIdx, 0)
+	require.GreaterOrEqual(t, promoIdx, 0)
+	assert.Less(t, stageIdx, promoIdx, "stage strictly before promote")
+}
+
+// POSTER-WRITE-HARDENING P2: a gated commit failure mid-rescrape (a review
+// edit landing between scrape and commit) leaves the world exactly as the
+// editor put it — the op's promoted bytes are rewound to the parked
+// pre-promotion pair, the live row and provenance stay as the edit left
+// them, and nothing of the stale rescrape overlays the family.
+type casStagingGen struct {
+	t     *testing.T
+	bump  func()
+	dir   string
+	movie string
+	fs    afero.Fs
+}
+
+func (g *casStagingGen) GeneratePoster(_ context.Context, _ string, _ *models.Movie) error {
+	return errors.New("legacy in-lock path must not run")
+}
+
+func (g *casStagingGen) StagePoster(_ context.Context, _ string, movie *models.Movie) (*poster.StagedPoster, error) {
+	g.bump() // the mid-op review edit lands here, before the commit
+	return poster.NewStagedPosterHandleForTest("", movie.ID+".stage-cas", movie.ID, ""), nil
+}
+
+func (g *casStagingGen) CommitStagedPoster(_ *models.Movie, _ *poster.StagedPoster) error {
+	// Simulate the promote materializing this op's bytes at canonical names.
+	if err := afero.WriteFile(g.fs, filepath.Join(g.dir, g.movie+"-full.jpg"), []byte("new-full"), 0o644); err != nil {
+		return err
+	}
+	return afero.WriteFile(g.fs, filepath.Join(g.dir, g.movie+".jpg"), []byte("new-crop"), 0o644)
+}
+
+func (g *casStagingGen) DiscardStaged(_ *poster.StagedPoster) {}
+
+func TestRescrape_AssetPromotionAndProvenanceAtomic_RestoredOnCommitFailure(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	jobID := models.NewJobID()
+	dir := filepath.Join("/tmp", "posters", jobID.String())
+	require.NoError(t, fs.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, "CAS-1-full.jpg"), []byte("old-full"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, "CAS-1.jpg"), []byte("old-crop"), 0o644))
+
+	store := resultstore.New(1, []string{"f1.mp4"})
+	seedFamilyResult(store, "f1.mp4", "res-cas", "CAS-1", "")
+	store.SetProvenance("f1.mp4", &resultstore.ProvenanceData{FieldSources: map[string]string{"title": "r18dev"}})
+	before, berr := store.GetMovieResult("f1.mp4")
+	require.NoError(t, berr)
+	beforeRev := before.Revision
+
+	gen := &casStagingGen{
+		t: t, dir: dir, movie: "CAS-1", fs: fs,
+		bump: func() {
+			// Mid-op concurrent review edit: advances revision AND provenance.
+			err := store.AtomicUpdateFileResultWithProvenance("f1.mp4", func(cur *resultstore.MovieResult, _ *resultstore.ProvenanceData) (*resultstore.MovieResult, *resultstore.ProvenanceData, error) {
+				cur.Movie.Title = "concurrent review edit"
+				return cur, &resultstore.ProvenanceData{FieldSources: map[string]string{"title": "user"}}, nil
+			})
+			if err != nil {
+				t.Errorf("concurrent edit injection failed: %v", err)
+			}
+		},
+	}
+	wf := &stubRescrapeWorkflow{scrapeResult: &scrape.ScrapeResult{Movie: &models.Movie{ID: "CAS-1", Title: "rescrape-stale"}, Status: scrape.StatusCompleted}}
+	inputs := rescrapePhaseInputs{
+		WF: wf, ResultMap: store, Finder: store, JobID: jobID,
+		PosterGen:  gen,
+		EditLockFn: func(ids ...string) func() { return func() {} },
+		Fs:         fs, TempDir: "/tmp",
+	}
+	phase := NewRescrapePhase()
+	res, err := phase.Rescrape(context.Background(), inputs, RescrapeCmd{MovieID: "CAS-1", FilePath: "f1.mp4"})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, models.RescrapeStatusConflict, res.Status, "the bumped revision gates the commit")
+
+	// Assets: rewound to the pre-promotion bytes (not the promoted op bytes).
+	full, ferr := afero.ReadFile(fs, filepath.Join(dir, "CAS-1-full.jpg"))
+	require.NoError(t, ferr)
+	assert.Equal(t, "old-full", string(full))
+	crop, cerr := afero.ReadFile(fs, filepath.Join(dir, "CAS-1.jpg"))
+	require.NoError(t, cerr)
+	assert.Equal(t, "old-crop", string(crop))
+
+	// State: the concurrent edit's row is untouched (revision advanced exactly
+	// once by the injected edit — the rescrape's stale payload never lands).
+	after, aerr := store.GetMovieResult("f1.mp4")
+	require.NoError(t, aerr)
+	assert.Equal(t, beforeRev+1, after.Revision, "only the review edit advanced the revision")
+	require.NotNil(t, after.Movie)
+	assert.Equal(t, "concurrent review edit", after.Movie.Title)
+
+	// Provenance: untouched by the failed rescrape — the edit's attribution.
+	prov := store.GetProvenance("f1.mp4")
+	require.NotNil(t, prov)
+	assert.Equal(t, "user", prov.FieldSources["title"])
+}
+
+// Staging download failure mid-op: the rescrape still commits, with the
+// poster error recorded on the result — identical surface to the legacy
+// in-lock generation error.
+func TestRescrape_StageFailureSurfacesAsPosterError(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	jobID := models.NewJobID()
+	require.NoError(t, fs.MkdirAll(filepath.Join("/tmp", "posters", jobID.String()), 0o755))
+	store := resultstore.New(1, []string{"f1.mp4"})
+	seedFamilyResult(store, "f1.mp4", "res-stg", "STG-1", "")
+	boom := errors.New("simulated stage wedge")
+	gen := &stagingTrackerGen{stageErr: boom}
+	wf := &stubRescrapeWorkflow{scrapeResult: &scrape.ScrapeResult{Movie: &models.Movie{ID: "STG-1"}, Status: scrape.StatusCompleted}}
+	inputs := rescrapePhaseInputs{
+		WF: wf, ResultMap: store, Finder: store, JobID: jobID,
+		PosterGen: gen,
+		Fs:        fs, TempDir: "/tmp",
+	}
+	phase := NewRescrapePhase()
+	res, err := phase.Rescrape(context.Background(), inputs, RescrapeCmd{MovieID: "STG-1", FilePath: "f1.mp4"})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, models.RescrapeStatusSuccess, res.Status, "poster stage failure is non-fatal")
+	committed, cerr := store.GetMovieResult("f1.mp4")
+	require.NoError(t, cerr)
+	require.NotNil(t, committed.PosterError, "staging error recorded on the committed result")
+	assert.Contains(t, *committed.PosterError, boom.Error())
+	assert.True(t, committed.PosterGenerated)
+}
+
+// Staging nothing (nil handle, nil error): the op commits without any poster
+// state mutation — the staged-nil arm.
+func TestRescrape_StagedNilNoPosterState(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	jobID := models.NewJobID()
+	require.NoError(t, fs.MkdirAll(filepath.Join("/tmp", "posters", jobID.String()), 0o755))
+	store := resultstore.New(1, []string{"f1.mp4"})
+	seedFamilyResult(store, "f1.mp4", "res-stg2", "STG-2", "")
+	gen := &stagingTrackerGen{stageNil: true} // stage resolves to nothing
+	wf := &stubRescrapeWorkflow{scrapeResult: &scrape.ScrapeResult{Movie: &models.Movie{ID: "STG-2"}, Status: scrape.StatusCompleted}}
+	inputs := rescrapePhaseInputs{
+		WF: wf, ResultMap: store, Finder: store, JobID: jobID,
+		PosterGen: gen,
+		Fs:        fs, TempDir: "/tmp",
+	}
+	phase := NewRescrapePhase()
+	res, err := phase.Rescrape(context.Background(), inputs, RescrapeCmd{MovieID: "STG-2", FilePath: "f1.mp4"})
+	require.NoError(t, err)
+	assert.Equal(t, models.RescrapeStatusSuccess, res.Status)
+	committed, cerr := store.GetMovieResult("f1.mp4")
+	require.NoError(t, cerr)
+	assert.False(t, committed.PosterGenerated, "no poster attempt recorded for a nil stage")
+	assert.Nil(t, committed.PosterError)
+}
+
+// A promote/crop witness fencing this family declines the rescrape BEFORE
+// the promote and DISCARDS the staged bytes (no unique-name litter).
+func TestRescrape_StagedBytesDiscardedWhenWitnessFences(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	jobID := models.NewJobID()
+	dir := filepath.Join("/tmp", "posters", jobID.String())
+	require.NoError(t, fs.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, "DSC-1.jpg"), []byte("old"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, ".promote-DSC-1.json"), []byte("{}"), 0o644))
+	store := resultstore.New(1, []string{"f1.mp4"})
+	seedFamilyResult(store, "f1.mp4", "res-dsc", "DSC-1", "")
+	discarded := 0
+	gen := &stagingTrackerGen{discarded: &discarded}
+	wf := &stubRescrapeWorkflow{scrapeResult: &scrape.ScrapeResult{Movie: &models.Movie{ID: "DSC-1"}, Status: scrape.StatusCompleted}}
+	inputs := rescrapePhaseInputs{
+		WF: wf, ResultMap: store, Finder: store, JobID: jobID,
+		PosterGen: gen,
+		Fs:        fs, TempDir: "/tmp",
+	}
+	phase := NewRescrapePhase()
+	_, err := phase.Rescrape(context.Background(), inputs, RescrapeCmd{MovieID: "DSC-1", FilePath: "f1.mp4"})
+	require.Error(t, err, "outstanding witness fences the rescrape")
+	var cfe *EditAdmissionConflictError
+	assert.ErrorAs(t, err, &cfe)
+	assert.Equal(t, 1, discarded, "staged bytes discarded on decline")
+	got, rerr := afero.ReadFile(fs, filepath.Join(dir, "DSC-1.jpg"))
+	require.NoError(t, rerr)
+	assert.Equal(t, "old", string(got), "canonical bytes untouched by the fenced op")
+}
+
+// Legacy (non-staging) generator failing in-lock: same error surface as the
+// staged path — PosterError recorded, op commits Success.
+type legacyErrGen struct{ err error }
+
+func (g legacyErrGen) GeneratePoster(_ context.Context, _ string, _ *models.Movie) error {
+	return g.err
+}
+
+func TestRescrape_LegacyGeneratorErrorRecorded(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	jobID := models.NewJobID()
+	require.NoError(t, fs.MkdirAll(filepath.Join("/tmp", "posters", jobID.String()), 0o755))
+	store := resultstore.New(1, []string{"f1.mp4"})
+	seedFamilyResult(store, "f1.mp4", "res-leg", "LEG-1", "")
+	boom := errors.New("legacy poster wedge")
+	inputs := rescrapePhaseInputs{
+		WF:        &stubRescrapeWorkflow{scrapeResult: &scrape.ScrapeResult{Movie: &models.Movie{ID: "LEG-1"}, Status: scrape.StatusCompleted}},
+		ResultMap: store, Finder: store, JobID: jobID,
+		PosterGen: legacyErrGen{err: boom},
+		Fs:        fs, TempDir: "/tmp",
+	}
+	phase := NewRescrapePhase()
+	res, err := phase.Rescrape(context.Background(), inputs, RescrapeCmd{MovieID: "LEG-1", FilePath: "f1.mp4"})
+	require.NoError(t, err)
+	assert.Equal(t, models.RescrapeStatusSuccess, res.Status)
+	committed, cerr := store.GetMovieResult("f1.mp4")
+	require.NoError(t, cerr)
+	require.NotNil(t, committed.PosterError)
+	assert.Contains(t, *committed.PosterError, boom.Error())
+}
+
+// The in-lock staged promote failing records PosterError (still Success) —
+// the last staged switch arm.
+func TestRescrape_StagedCommitFailureRecorded(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	jobID := models.NewJobID()
+	require.NoError(t, fs.MkdirAll(filepath.Join("/tmp", "posters", jobID.String()), 0o755))
+	store := resultstore.New(1, []string{"f1.mp4"})
+	seedFamilyResult(store, "f1.mp4", "res-cf", "CF-9", "")
+	boom := errors.New("promote wedge")
+	gen := &stagingTrackerGen{commitErr: boom}
+	inputs := rescrapePhaseInputs{
+		WF:        &stubRescrapeWorkflow{scrapeResult: &scrape.ScrapeResult{Movie: &models.Movie{ID: "CF-9"}, Status: scrape.StatusCompleted}},
+		ResultMap: store, Finder: store, JobID: jobID,
+		PosterGen: gen,
+		Fs:        fs, TempDir: "/tmp",
+	}
+	phase := NewRescrapePhase()
+	res, err := phase.Rescrape(context.Background(), inputs, RescrapeCmd{MovieID: "CF-9", FilePath: "f1.mp4"})
+	require.NoError(t, err)
+	assert.Equal(t, models.RescrapeStatusSuccess, res.Status)
+	committed, cerr := store.GetMovieResult("f1.mp4")
+	require.NoError(t, cerr)
+	require.NotNil(t, committed.PosterError)
+	assert.Contains(t, *committed.PosterError, boom.Error())
+	assert.True(t, committed.PosterGenerated)
+}

--- a/internal/worker/rescrape_staged_order_p2_test.go
+++ b/internal/worker/rescrape_staged_order_p2_test.go
@@ -344,7 +344,8 @@ func TestRescrape_StagedCommitFailureRecorded(t *testing.T) {
 	store := resultstore.New(1, []string{"f1.mp4"})
 	seedFamilyResult(store, "f1.mp4", "res-cf", "CF-9", "")
 	boom := errors.New("promote wedge")
-	gen := &stagingTrackerGen{commitErr: boom}
+	discarded := 0
+	gen := &stagingTrackerGen{commitErr: boom, discarded: &discarded}
 	inputs := rescrapePhaseInputs{
 		WF:        &stubRescrapeWorkflow{scrapeResult: &scrape.ScrapeResult{Movie: &models.Movie{ID: "CF-9"}, Status: scrape.StatusCompleted}},
 		ResultMap: store, Finder: store, JobID: jobID,
@@ -360,4 +361,5 @@ func TestRescrape_StagedCommitFailureRecorded(t *testing.T) {
 	require.NotNil(t, committed.PosterError)
 	assert.Contains(t, *committed.PosterError, boom.Error())
 	assert.True(t, committed.PosterGenerated)
+	assert.Equal(t, 1, discarded, "failed promote discards the staged residue")
 }

--- a/internal/worker/resultstore/atomic_provenance_p2_test.go
+++ b/internal/worker/resultstore/atomic_provenance_p2_test.go
@@ -1,0 +1,150 @@
+package resultstore
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// POSTER-WRITE-HARDENING P2 (R10-6): state and provenance commit through ONE
+// atomic primitive. Two separate acquisitions (AtomicUpdateFileResult +
+// SetProvenance) let a persist snapshot observe new state with old
+// provenance; the dual-write primitive takes the lock once, bumps the
+// revision once, and publishes both.
+func TestAtomicUpdateFileResultWithProvenance_DualWriteOneRevision(t *testing.T) {
+	s := New(1, []string{"/f/a.mp4"})
+	s.UpdateFileResult("/f/a.mp4", &MovieResult{
+		ResultID: "res-1", Status: models.JobStatusRunning,
+		Movie: &models.Movie{ID: "P-1", Title: "before"},
+	})
+	s.SetProvenance("/f/a.mp4", &ProvenanceData{FieldSources: map[string]string{"title": "scraper-a"}})
+	before, err := s.GetMovieResult("/f/a.mp4")
+	require.NoError(t, err)
+
+	var seenMovie *models.Movie
+	var seenProv *ProvenanceData
+	err = s.AtomicUpdateFileResultWithProvenance("/f/a.mp4", func(cur *MovieResult, prov *ProvenanceData) (*MovieResult, *ProvenanceData, error) {
+		seenMovie = cur.Movie
+		seenProv = prov
+		cur.Status = models.JobStatusCompleted
+		return cur, &ProvenanceData{FieldSources: map[string]string{"title": "user"}}, nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, seenMovie, "callback observes the current result")
+	require.NotNil(t, seenProv, "callback observes the current provenance in the same acquisition")
+	assert.Equal(t, "scraper-a", seenProv.FieldSources["title"])
+
+	after, err := s.GetMovieResult("/f/a.mp4")
+	require.NoError(t, err)
+	assert.Equal(t, before.Revision+1, after.Revision, "one revision bump for the dual write")
+	assert.Equal(t, models.JobStatusCompleted, after.Status)
+	gotProv := s.GetProvenance("/f/a.mp4")
+	require.NotNil(t, gotProv)
+	assert.Equal(t, "user", gotProv.FieldSources["title"])
+}
+
+// The callback erroring must publish NEITHER half — state and provenance stay
+// at their pre-call values with no revision bump.
+func TestAtomicUpdateFileResultWithProvenance_ErrorPublishesNothing(t *testing.T) {
+	s := New(1, []string{"/f/b.mp4"})
+	s.UpdateFileResult("/f/b.mp4", &MovieResult{ResultID: "res-2", Status: models.JobStatusRunning})
+	s.SetProvenance("/f/b.mp4", &ProvenanceData{FieldSources: map[string]string{"title": "scraper"}})
+	before, err := s.GetMovieResult("/f/b.mp4")
+	require.NoError(t, err)
+
+	err = s.AtomicUpdateFileResultWithProvenance("/f/b.mp4", func(cur *MovieResult, prov *ProvenanceData) (*MovieResult, *ProvenanceData, error) {
+		cur.Status = models.JobStatusFailed
+		return cur, &ProvenanceData{FieldSources: map[string]string{"title": "user"}}, errSimulated
+	})
+	require.ErrorIs(t, err, errSimulated)
+	after, aerr := s.GetMovieResult("/f/b.mp4")
+	require.NoError(t, aerr)
+	assert.Equal(t, before.Revision, after.Revision, "no bump on callback failure")
+	assert.Equal(t, models.JobStatusRunning, after.Status)
+	assert.Equal(t, "scraper", s.GetProvenance("/f/b.mp4").FieldSources["title"])
+}
+
+// A missing row must surface the not-found error BEFORE any write — the
+// dual primitive follows AtomicUpdateFileResult's contract exactly.
+func TestAtomicUpdateFileResultWithProvenance_NotFound(t *testing.T) {
+	s := New(1, []string{"/f/missing.mp4"})
+	called := false
+	err := s.AtomicUpdateFileResultWithProvenance("/f/missing.mp4", func(cur *MovieResult, prov *ProvenanceData) (*MovieResult, *ProvenanceData, error) {
+		called = true
+		return cur, prov, nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file result not found")
+	assert.False(t, called, "callback never runs without an existing row")
+}
+
+// Terminal-status counter migration: Completed→Failed transitions the
+// counters one-for-one under the single revision bump.
+func TestAtomicUpdateFileResultWithProvenance_TerminalStatusCounters(t *testing.T) {
+	s := New(1, []string{"/f/t.mp4"})
+	s.UpdateFileResult("/f/t.mp4", &MovieResult{ResultID: "res-t", Status: models.JobStatusCompleted})
+	_, before := s.SnapshotForStatus()
+	require.Equal(t, 1, before.Completed)
+
+	err := s.AtomicUpdateFileResultWithProvenance("/f/t.mp4", func(cur *MovieResult, prov *ProvenanceData) (*MovieResult, *ProvenanceData, error) {
+		cur.Status = models.JobStatusFailed
+		return cur, prov, nil
+	})
+	require.NoError(t, err)
+	_, after := s.SnapshotForStatus()
+	assert.Equal(t, 0, after.Completed)
+	assert.Equal(t, 1, after.Failed, "completed counter moves to failed exactly once")
+
+	// And back: Failed→Completed re-covers the increment arms.
+	err = s.AtomicUpdateFileResultWithProvenance("/f/t.mp4", func(cur *MovieResult, prov *ProvenanceData) (*MovieResult, *ProvenanceData, error) {
+		cur.Status = models.JobStatusCompleted
+		return cur, prov, nil
+	})
+	require.NoError(t, err)
+	_, again := s.SnapshotForStatus()
+	assert.Equal(t, 1, again.Completed)
+	assert.Equal(t, 0, again.Failed)
+}
+
+// Excluded files take the full-recalc path instead of the counter fast path.
+func TestAtomicUpdateFileResultWithProvenance_ExcludedFileRecalculates(t *testing.T) {
+	s := New(1, []string{"/f/x.mp4"})
+	s.UpdateFileResult("/f/x.mp4", &MovieResult{ResultID: "res-x", Status: models.JobStatusRunning})
+	s.MarkExcluded("/f/x.mp4")
+	_, before := s.SnapshotForStatus()
+
+	err := s.AtomicUpdateFileResultWithProvenance("/f/x.mp4", func(cur *MovieResult, prov *ProvenanceData) (*MovieResult, *ProvenanceData, error) {
+		cur.Status = models.JobStatusCompleted
+		return cur, &ProvenanceData{FieldSources: map[string]string{"title": "scraper"}}, nil
+	})
+	require.NoError(t, err)
+	_, after := s.SnapshotForStatus()
+	assert.Equal(t, before.Completed, after.Completed, "excluded rows never shift the counters")
+	assert.Equal(t, "scraper", s.GetProvenance("/f/x.mp4").FieldSources["title"])
+}
+
+// Bare states (no constructor) must not panic on the provenance map — the
+// lazy-init leg keeps reconstructed/minimal states safe.
+func TestAtomicUpdateFileResultWithProvenance_NilProvenanceMapInitialized(t *testing.T) {
+	state := &resultTrackerState{
+		Results:      map[string]*MovieResult{"/f/bare.mp4": {Status: models.JobStatusRunning}},
+		Excluded:     map[string]bool{},
+		movieIDIndex: map[string][]string{},
+	}
+	ru := &resultUpdater{resultTrackerState: state}
+	err := ru.AtomicUpdateFileResultWithProvenance("/f/bare.mp4", func(cur *MovieResult, prov *ProvenanceData) (*MovieResult, *ProvenanceData, error) {
+		require.Nil(t, prov)
+		return cur, &ProvenanceData{FieldSources: map[string]string{"a": "b"}}, nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, state.Provenance)
+	assert.Equal(t, "b", state.Provenance["/f/bare.mp4"].FieldSources["a"])
+}
+
+var errSimulated = errSimulatedType{}
+
+type errSimulatedType struct{}
+
+func (errSimulatedType) Error() string { return "simulated callback failure" }

--- a/internal/worker/resultstore/result_updater.go
+++ b/internal/worker/resultstore/result_updater.go
@@ -114,6 +114,61 @@ func (ru *resultUpdater) AtomicUpdateFileResult(filePath string, updateFn func(*
 	return nil
 }
 
+// AtomicUpdateFileResultWithProvenance performs a locked read-modify-write on
+// a file result AND its provenance in ONE acquisition (POSTER-WRITE-HARDENING
+// R10-6): separate AtomicUpdateFileResult + SetProvenance calls let a persist
+// snapshot observe new state beside old provenance; here both publish under a
+// single lock hold and a single revision bump. updateFn receives clones of the
+// current result and provenance (provenance may be nil); an error return
+// publishes NEITHER half. updateFn MUST NOT call methods on the same Store —
+// it executes under the write lock and re-entering will deadlock.
+func (ru *resultUpdater) AtomicUpdateFileResultWithProvenance(filePath string, updateFn func(*MovieResult, *ProvenanceData) (*MovieResult, *ProvenanceData, error)) error {
+	ru.mu.Lock()
+	defer ru.mu.Unlock()
+	current, exists := ru.Results[filePath]
+	if !exists || current == nil {
+		return fmt.Errorf("file result not found: %s", filePath)
+	}
+	var provCopy *ProvenanceData
+	if p := ru.Provenance[filePath]; p != nil {
+		provCopy = p.Clone()
+	}
+	updated, newProv, err := updateFn(current.Clone(), provCopy)
+	if err != nil {
+		return err
+	}
+
+	updated.Revision = current.Revision + 1
+	stateReindexFilePathLocked(ru.resultTrackerState, filePath, current, updated)
+	if !ru.Excluded[filePath] {
+		switch current.Status {
+		case models.JobStatusCompleted:
+			ru.Completed--
+		case models.JobStatusFailed:
+			ru.Failed--
+		}
+		switch updated.Status {
+		case models.JobStatusCompleted:
+			ru.Completed++
+		case models.JobStatusFailed:
+			ru.Failed++
+		}
+	}
+	if ru.Excluded[filePath] {
+		stateRecalculateProgress(ru.resultTrackerState)
+	} else {
+		stateUpdateProgressFromCounters(ru.resultTrackerState)
+	}
+	ru.Results[filePath] = updated
+	if newProv != nil {
+		if ru.Provenance == nil {
+			ru.Provenance = make(map[string]*ProvenanceData)
+		}
+		ru.Provenance[filePath] = newProv.Clone()
+	}
+	return nil
+}
+
 // UpdateMovie atomically updates the movie for a file result.
 func (ru *resultUpdater) UpdateMovie(filePath string, movie *models.Movie) error {
 	return ru.AtomicUpdateFileResult(filePath, func(current *MovieResult) (*MovieResult, error) {

--- a/internal/worker/resultstore/store.go
+++ b/internal/worker/resultstore/store.go
@@ -18,6 +18,10 @@ type ResultUpdater interface {
 	SetProvenance(filePath string, prov *ProvenanceData)
 	AtomicUpdateFileResult(filePath string, updateFn func(*MovieResult) (*MovieResult, error)) error // updateFn MUST NOT call methods on the same Store — it executes under the write lock and re-entering will deadlock
 
+	// AtomicUpdateFileResultWithProvenance commits a result and its provenance
+	// in ONE acquisition (R10-6) — see resultUpdater for the full contract.
+	AtomicUpdateFileResultWithProvenance(filePath string, updateFn func(*MovieResult, *ProvenanceData) (*MovieResult, *ProvenanceData, error)) error
+
 	// UpdateMovie atomically updates the movie for a file result.
 	UpdateMovie(filePath string, movie *models.Movie) error
 

--- a/internal/worker/scrape_phase_test.go
+++ b/internal/worker/scrape_phase_test.go
@@ -81,6 +81,24 @@ func (s *stubUpdater) AtomicUpdateFileResult(fp string, fn func(*resultstore.Mov
 	return nil
 }
 
+func (s *stubUpdater) AtomicUpdateFileResultWithProvenance(fp string, fn func(*resultstore.MovieResult, *resultstore.ProvenanceData) (*resultstore.MovieResult, *resultstore.ProvenanceData, error)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current := s.results[fp]
+	if current == nil {
+		return fmt.Errorf("not found: %s", fp)
+	}
+	updated, prov, err := fn(current, s.provenance[fp])
+	if err != nil {
+		return err
+	}
+	s.results[fp] = updated
+	if prov != nil {
+		s.provenance[fp] = prov
+	}
+	return nil
+}
+
 func (s *stubUpdater) UpdateMovie(fp string, movie *models.Movie) error {
 	return s.AtomicUpdateFileResult(fp, func(current *resultstore.MovieResult) (*resultstore.MovieResult, error) {
 		current.Movie = movie

--- a/internal/worker/writeback_provenance_p2_test.go
+++ b/internal/worker/writeback_provenance_p2_test.go
@@ -1,0 +1,60 @@
+package worker
+
+// POSTER-WRITE-HARDENING P2 — write-back editable-set + provenance merge
+// (D5/R12-7/R13-7): per-key live-wins semantics, plus original_title/director
+// coverage on the movie merge.
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyWriteBack_MergesEditableSet_AdditionalFields(t *testing.T) {
+	t.Run("original_title_and_director", func(t *testing.T) {
+		baseline := &models.Movie{ID: "X-1", OriginalTitle: "orig", Director: "dir-a"}
+		phaseOut := &models.Movie{ID: "X-1", OriginalTitle: "orig", Director: "dir-stale"}
+		live := &models.Movie{ID: "X-1", OriginalTitle: "orig-user", Director: "dir-a"} // user edited original_title mid-phase
+		merged := mergeLiveReviewEdits(baseline, phaseOut, live)
+		assert.Equal(t, "orig-user", merged.OriginalTitle, "live drift wins")
+		assert.Equal(t, "dir-stale", merged.Director, "unedited field: live==baseline ⇒ phase-side value wins")
+	})
+
+	t.Run("provenance_per_key_live_wins", func(t *testing.T) {
+		frozen := &resultstore.ProvenanceData{
+			FieldSources:   map[string]string{"title": "scraper-a", "director": "scraper-b"},
+			ActressSources: map[string]string{"A-ONE": "scraper"},
+		}
+		live := &resultstore.ProvenanceData{
+			FieldSources:   map[string]string{"title": "user"},
+			ActressSources: map[string]string{"A-ONE": "user"},
+		}
+		got := mergeWriteBackProvenance(frozen, live)
+		require.NotNil(t, got)
+		assert.Equal(t, map[string]string{"title": "user", "director": "scraper-b"}, got.FieldSources,
+			"live wins its edited keys; frozen keeps the rest")
+		assert.Equal(t, map[string]string{"A-ONE": "user"}, got.ActressSources)
+	})
+
+	t.Run("provenance_empty_maps_collapse_to_nil", func(t *testing.T) {
+		got := mergeWriteBackProvenance(&resultstore.ProvenanceData{}, &resultstore.ProvenanceData{})
+		require.NotNil(t, got)
+		assert.Nil(t, got.FieldSources)
+		assert.Nil(t, got.ActressSources)
+	})
+
+	t.Run("provenance_nil_sides", func(t *testing.T) {
+		frozen := &resultstore.ProvenanceData{FieldSources: map[string]string{"title": "scraper"}}
+		live := &resultstore.ProvenanceData{FieldSources: map[string]string{"title": "user"}}
+		assert.Nil(t, mergeWriteBackProvenance(nil, nil))
+		gotFrozen := mergeWriteBackProvenance(frozen, nil)
+		require.NotNil(t, gotFrozen)
+		assert.Equal(t, map[string]string{"title": "scraper"}, gotFrozen.FieldSources, "nil live ⇒ frozen")
+		gotLive := mergeWriteBackProvenance(nil, live)
+		require.NotNil(t, gotLive)
+		assert.Equal(t, map[string]string{"title": "user"}, gotLive.FieldSources, "nil frozen ⇒ live")
+	})
+}


### PR DESCRIPTION
## Why

Follow-up to #192 (poster-write-hardening Phase 1). Phase 2 of the plan in `openspec/changes/poster-write-hardening` (#186): apply-phase coherence + asset lifecycle. With P1's review rounds having pre-landed the write-back merge machinery, this PR's true delta is the asset/lifecycle layer — all verified by behavior tests, not assumed-equivalence.

**Deployment note (D15):** single-process deployment remains the assumption for all fencing/locking in this PR (in-process keyed lock registries, per-destination locks); multi-process coordination is an explicit non-goal of issue #186.

## What

### Provenance-atomic write-backs (R10-6)
- `resultstore.AtomicUpdateFileResultWithProvenance`: one lock acquisition, one revision bump, result+provenance publish together; error publishes neither half
- All three apply write-back paths (success / failure / panic-recovery) route through it; `mergeWriteBackProvenance` merges per-key live-wins

### Staged preview installs + asset snapshot/restore
- Preview installs are rename-only onto the final path (same-dir `<dest>.<unixnano>-<counter>.tmp` staging + per-op `.bak` aside/restore): readers mid-replace never see partial bytes; failed installs keep the previous preview
- `PosterManager` gains `SnapshotAssets`/`RestoreAssets` (created-leg removal included)

### Source-change eviction on field overrides (D6 gap closed)
- `ApplyFieldOverride` on poster_url/cover-as-effective-source now mirrors `UpdateMovieFamily`: journaled eviction witness BEFORE commit, stale pair evicted after it; committed rows clear `cropped_poster_url` so they never point at bytes of the old source
- cover_url under an explicit poster_url keeps existing crops (unchanged source)

### Staged poster download seam + rescrape lock-slimming
- Exported seam: `StagePosterDownload` (network, unlocked, unique `<id>.stage-*` identity) → `PromoteStagedPoster` (fs-only, **pair-atomic**: any failure restores the whole prior pair) / `DiscardStagedPoster`
- Generator split: `StagingPosterGenerator.StagePoster/CommitStagedPoster/DiscardStaged`; rescrape hoists downloads OUT of the family lock; a fencing decline discards staged bytes

### Recorded deltas vs the original plan (in `design.md`)
- Apply write-back merge machinery + regression tests landed via P1 → pins added as named lock-ins, not re-implemented
- Generic `assetOps` editor injection deferred: every flow already has first-class witness-guarded compensation; primitive stays exported for P3
- Scrape-phase eager fetch documented as an out-of-scope exclusion (spec: edits during Running scrape are unsupported)

## Test plan

- [x] Full repo suite green (`go test ./...`); `-race` on worker/poster/resultstore clean
- [x] golangci-lint 0 issues on changed packages; **100% patch-line coverage** (every added line has tests, incl. wedged-rename/stat/remove matrices)
- [x] No mockery-registered interface changed (no regen needed)
- [ ] CI: full deck green

Refs #186. Phase 3 (revert-ledger move-back + crash reconciliation) follows as its own PR.
