### PR TITLE
fix(downloader): replace http.Client.Timeout with stall-based idle watchdog

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -473,7 +473,7 @@ output:
     download_extrafanart: true                  # Download screenshots to extrafanart folder
     download_trailer: true
     download_actress: true
-    download_timeout: 60
+    download_timeout: 120 # idle/stall timeout: abort if no bytes received for this duration (0 = no idle timeout)
     # Download proxy override (optional):
     # - If disabled, downloads use scrapers.proxy automatically when scraper proxy is enabled.
     # - Enable only when you need a separate proxy just for downloads.

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -1369,7 +1369,7 @@ output:
   download_extrafanart: true
   download_trailer: true
   download_actress: true
-  download_timeout: 60
+  download_timeout: 120
 ```
 
 ### Database Defaults

--- a/docs/10-troubleshooting.md
+++ b/docs/10-troubleshooting.md
@@ -286,7 +286,7 @@ For Docker/Unraid deployments:
 - Check your internet connection
 - Verify the image URL is accessible (it may be region-locked or behind a CDN that needs `scrapers.referer`/proxy)
 - Check available disk space
-- Confirm the download is enabled in `config.yaml` (`output.download_cover`, `output.download_poster`) and raise `output.download_timeout` (default 60s) if downloads time out
+- Confirm the download is enabled in `config.yaml` (`output.download_cover`, `output.download_poster`) and raise `output.download_timeout` (default 120s — idle/stall timeout: aborts if no bytes received for this duration) if downloads stall. Note: `download_timeout` is NOT a total deadline — large trailer downloads can take longer than this as long as bytes keep flowing. If the worker context (`performance.worker_timeout`) is too short, increase that instead.
 - Retry the operation
 
 ### "Downloaded file is corrupt"

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -6975,7 +6975,7 @@ const docTemplate = `{
                     ]
                 },
                 "download_timeout": {
-                    "description": "Timeout in seconds for HTTP downloads (default: 60)",
+                    "description": "Idle/stall timeout in seconds for media downloads. Aborts if no bytes received for this duration. 0 = no idle timeout (rely on worker context). Default: 120",
                     "type": "integer"
                 },
                 "download_trailer": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -6973,7 +6973,7 @@
                     ]
                 },
                 "download_timeout": {
-                    "description": "Timeout in seconds for HTTP downloads (default: 60)",
+                    "description": "Idle/stall timeout in seconds for media downloads. Aborts if no bytes received for this duration. 0 = no idle timeout (rely on worker context). Default: 120",
                     "type": "integer"
                 },
                 "download_trailer": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1966,7 +1966,9 @@ definitions:
         - $ref: '#/definitions/github_com_javinizer_javinizer-go_internal_models.ProxyConfig'
         description: Separate proxy for downloads (optional)
       download_timeout:
-        description: 'Timeout in seconds for HTTP downloads (default: 60)'
+        description: 'Idle/stall timeout in seconds for media downloads. Aborts if
+          no bytes received for this duration. 0 = no idle timeout (rely on worker
+          context). Default: 120'
         type: integer
       download_trailer:
         type: boolean

--- a/internal/api/batch/handler_edge_cov_test.go
+++ b/internal/api/batch/handler_edge_cov_test.go
@@ -156,7 +156,7 @@ func fromURLFixture(t *testing.T, movieID string) (*coreDepsOut, *worker.BatchJo
 
 	rt := testkit.GetTestRuntime(deps)
 	rt.GetRuntime().GetPosterManager(func() poster.PosterManagerInterface {
-		return poster.NewPosterManager(deps.GetFs(), "data/temp", &http.Client{}).
+		return poster.NewPosterManager(deps.GetFs(), "data/temp", &http.Client{}, 0).
 			WithSSRFCheck(func(string) error { return nil })
 	})
 

--- a/internal/api/batch/handler_wave_c_cov_test.go
+++ b/internal/api/batch/handler_wave_c_cov_test.go
@@ -289,7 +289,7 @@ func TestPosterFromURL_GenericDownloadErrorIs500(t *testing.T) {
 	rt2 := testkit.GetTestRuntime(deps)
 	rt2.GetRuntime().InvalidatePosterManager()
 	rt2.GetRuntime().GetPosterManager(func() poster.PosterManagerInterface {
-		return poster.NewPosterManager(deps.GetFs(), "data/temp", &http.Client{}).WithSSRFCheck(func(string) error { return nil })
+		return poster.NewPosterManager(deps.GetFs(), "data/temp", &http.Client{}, 0).WithSSRFCheck(func(string) error { return nil })
 	})
 	w := postFromURLRequest(t, router, job, "URLC-7", ts.URL+"/pic.jpg")
 	assert.Equal(t, 500, w.Code, "%s", w.Body.String())
@@ -378,7 +378,7 @@ func fromURLFixtureRealJob(t *testing.T, movieID string) (*coreDepsOut, *worker.
 
 	rt := testkit.GetTestRuntime(deps)
 	rt.GetRuntime().GetPosterManager(func() poster.PosterManagerInterface {
-		return poster.NewPosterManager(deps.GetFs(), "data/temp", &http.Client{}).
+		return poster.NewPosterManager(deps.GetFs(), "data/temp", &http.Client{}, 0).
 			WithSSRFCheck(func(string) error { return nil })
 	})
 

--- a/internal/api/batch/movie_edit_poster_crop_test.go
+++ b/internal/api/batch/movie_edit_poster_crop_test.go
@@ -162,7 +162,7 @@ func TestPosterFromURL_SuccessClearsGeometry(t *testing.T) {
 	// Pre-seed BEFORE any handler call crops/populates the shared cache.
 	rt := testkit.GetTestRuntime(deps)
 	rt.GetRuntime().GetPosterManager(func() poster.PosterManagerInterface {
-		return poster.NewPosterManager(deps.GetFs(), "data/temp", &http.Client{}).
+		return poster.NewPosterManager(deps.GetFs(), "data/temp", &http.Client{}, 0).
 			WithSSRFCheck(func(string) error { return nil })
 	})
 

--- a/internal/api/core/poster_timeout.go
+++ b/internal/api/core/poster_timeout.go
@@ -1,0 +1,25 @@
+package core
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+)
+
+func setPosterHeaderTimeout(client *http.Client, idleTimeout time.Duration) {
+	if t, ok := client.Transport.(*http.Transport); ok && idleTimeout > 0 {
+		t.ResponseHeaderTimeout = idleTimeout
+		t.TLSHandshakeTimeout = idleTimeout
+		if t.DialContext != nil {
+			origDial := t.DialContext
+			t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				dialCtx, cancel := context.WithTimeout(ctx, idleTimeout)
+				defer cancel()
+				return origDial(dialCtx, network, addr)
+			}
+		} else {
+			t.DialContext = (&net.Dialer{Timeout: idleTimeout}).DialContext
+		}
+	}
+}

--- a/internal/api/core/poster_timeout.go
+++ b/internal/api/core/poster_timeout.go
@@ -12,9 +12,6 @@ func setPosterHeaderTimeout(client *http.Client, idleTimeout time.Duration) {
 		t.ResponseHeaderTimeout = idleTimeout
 		t.TLSHandshakeTimeout = idleTimeout
 		origDial := t.DialContext
-		if origDial == nil {
-			origDial = (&net.Dialer{Timeout: idleTimeout}).DialContext
-		}
 		t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 			dialCtx, cancel := context.WithTimeout(ctx, idleTimeout)
 			defer cancel()

--- a/internal/api/core/poster_timeout.go
+++ b/internal/api/core/poster_timeout.go
@@ -11,15 +11,14 @@ func setPosterHeaderTimeout(client *http.Client, idleTimeout time.Duration) {
 	if t, ok := client.Transport.(*http.Transport); ok && idleTimeout > 0 {
 		t.ResponseHeaderTimeout = idleTimeout
 		t.TLSHandshakeTimeout = idleTimeout
-		if t.DialContext != nil {
-			origDial := t.DialContext
-			t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				dialCtx, cancel := context.WithTimeout(ctx, idleTimeout)
-				defer cancel()
-				return origDial(dialCtx, network, addr)
-			}
-		} else {
-			t.DialContext = (&net.Dialer{Timeout: idleTimeout}).DialContext
+		origDial := t.DialContext
+		if origDial == nil {
+			origDial = (&net.Dialer{Timeout: idleTimeout}).DialContext
+		}
+		t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			dialCtx, cancel := context.WithTimeout(ctx, idleTimeout)
+			defer cancel()
+			return origDial(dialCtx, network, addr)
 		}
 	}
 }

--- a/internal/api/core/poster_timeout_coverage_test.go
+++ b/internal/api/core/poster_timeout_coverage_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"testing"
@@ -22,6 +23,8 @@ func TestSetPosterHeaderTimeout_WithDialContext(t *testing.T) {
 	if transport.DialContext == nil {
 		t.Error("DialContext should not be nil after wrapping")
 	}
+	ctx := context.Background()
+	_, _ = transport.DialContext(ctx, "tcp", "localhost:1")
 }
 
 func TestSetPosterHeaderTimeout_NilDialContext(t *testing.T) {

--- a/internal/api/core/poster_timeout_coverage_test.go
+++ b/internal/api/core/poster_timeout_coverage_test.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestSetPosterHeaderTimeout_WithDialContext(t *testing.T) {
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{Timeout: 30 * time.Second}).DialContext,
+	}
+	client := &http.Client{Transport: transport}
+	setPosterHeaderTimeout(client, 10*time.Second)
+	if transport.ResponseHeaderTimeout != 10*time.Second {
+		t.Errorf("expected ResponseHeaderTimeout=10s, got %v", transport.ResponseHeaderTimeout)
+	}
+	if transport.TLSHandshakeTimeout != 10*time.Second {
+		t.Errorf("expected TLSHandshakeTimeout=10s, got %v", transport.TLSHandshakeTimeout)
+	}
+	if transport.DialContext == nil {
+		t.Error("DialContext should not be nil after wrapping")
+	}
+}
+
+func TestSetPosterHeaderTimeout_NilDialContext(t *testing.T) {
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	setPosterHeaderTimeout(client, 10*time.Second)
+	if transport.DialContext == nil {
+		t.Error("DialContext should be set when originally nil")
+	}
+}

--- a/internal/api/core/poster_timeout_test.go
+++ b/internal/api/core/poster_timeout_test.go
@@ -1,0 +1,30 @@
+package core
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestSetPosterHeaderTimeout_WithTimeout(t *testing.T) {
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	setPosterHeaderTimeout(client, 60*time.Second)
+	if transport.ResponseHeaderTimeout != 60*time.Second {
+		t.Errorf("expected ResponseHeaderTimeout=60s, got %v", transport.ResponseHeaderTimeout)
+	}
+}
+
+func TestSetPosterHeaderTimeout_ZeroTimeout(t *testing.T) {
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	setPosterHeaderTimeout(client, 0)
+	if transport.ResponseHeaderTimeout != 0 {
+		t.Errorf("expected ResponseHeaderTimeout=0, got %v", transport.ResponseHeaderTimeout)
+	}
+}
+
+func TestSetPosterHeaderTimeout_NilTransport(t *testing.T) {
+	client := &http.Client{Transport: nil}
+	setPosterHeaderTimeout(client, 60*time.Second)
+}

--- a/internal/api/core/runtime_manager.go
+++ b/internal/api/core/runtime_manager.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
-	"net/http"
 	"sync"
 	"time"
 
@@ -657,8 +655,6 @@ func (r *APIRuntime) GetPosterManager() poster.PosterManagerInterface {
 	})
 }
 
-// Server lifecycle methods (ServerCtx, Shutdown) are defined in server_lifecycle.go.
-
 // SetConfig sets the full application config and rebuilds the APIConfig snapshot.
 // This is a convenience method for test setup. Production code should use
 // APIRuntime.ReplaceReloadable() instead.
@@ -676,10 +672,6 @@ func (r *APIRuntime) SetConfig(cfg *config.Config) {
 	r.invalidateFactoriesLocked(cfg)
 }
 
-// ReloadConfig is defined in hot_reload.go.
-
-// InvalidateWorkflowCaches and InvalidateWorkflowCachesOnRuntime are defined in hot_reload.go.
-
 // shutdownDeps gracefully shuts down runtime resources in APIRuntime.
 //
 //nolint:unused // used by same-package tests
@@ -694,28 +686,9 @@ func shutdownDeps(rt *APIRuntime) {
 	rs.Shutdown()
 }
 
-// invalidateFactories is defined in hot_reload.go.
-
 // ---------------------------------------------------------------------------
 // Legacy compatibility — these package-level functions delegate to APIRuntime.
 // They exist so that callers that only have *APIDeps can still perform
 // lifecycle operations without constructing an APIRuntime explicitly.
 // New code in production paths should use *APIRuntime directly.
 // ---------------------------------------------------------------------------
-
-func setPosterHeaderTimeout(client *http.Client, idleTimeout time.Duration) {
-	if t, ok := client.Transport.(*http.Transport); ok && idleTimeout > 0 {
-		t.ResponseHeaderTimeout = idleTimeout
-		t.TLSHandshakeTimeout = idleTimeout
-		if t.DialContext != nil {
-			origDial := t.DialContext
-			t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				dialCtx, cancel := context.WithTimeout(ctx, idleTimeout)
-				defer cancel()
-				return origDial(dialCtx, network, addr)
-			}
-		} else {
-			t.DialContext = (&net.Dialer{Timeout: idleTimeout}).DialContext
-		}
-	}
-}

--- a/internal/api/core/runtime_manager.go
+++ b/internal/api/core/runtime_manager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"sync"
 	"time"
 
@@ -434,8 +436,10 @@ func (s *RuntimeSnapshot) PosterManager() poster.PosterManagerInterface {
 	}
 	r := s.rt
 	buildFromSnap := func() poster.PosterManagerInterface {
-		httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
-		return poster.NewPosterManager(r.deps.GetFs(), s.cfg.System.TempDir, httpClient)
+		httpClient := ssrf.NewSSRFSafeClient(0)
+		idleTimeout := time.Duration(s.cfg.Output.Download.DownloadTimeout) * time.Second
+		setPosterHeaderTimeout(httpClient, idleTimeout)
+		return poster.NewPosterManager(r.deps.GetFs(), s.cfg.System.TempDir, httpClient, idleTimeout)
 	}
 	rs := r.GetRuntime()
 	if rs == nil {
@@ -639,13 +643,17 @@ func (r *APIRuntime) GetPosterManager() poster.PosterManagerInterface {
 	rs := r.GetRuntime()
 	if rs == nil {
 		// Fallback: create a fresh instance if runtime state is not yet initialized.
-		httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
-		return poster.NewPosterManager(r.deps.GetFs(), cfg.System.TempDir, httpClient)
+		httpClient := ssrf.NewSSRFSafeClient(0)
+		idleTimeout := time.Duration(cfg.Output.Download.DownloadTimeout) * time.Second
+		setPosterHeaderTimeout(httpClient, idleTimeout)
+		return poster.NewPosterManager(r.deps.GetFs(), cfg.System.TempDir, httpClient, idleTimeout)
 	}
 
 	return rs.GetPosterManager(func() poster.PosterManagerInterface {
-		httpClient := ssrf.NewSSRFSafeClient(60 * time.Second)
-		return poster.NewPosterManager(r.deps.GetFs(), cfg.System.TempDir, httpClient)
+		httpClient := ssrf.NewSSRFSafeClient(0)
+		idleTimeout := time.Duration(cfg.Output.Download.DownloadTimeout) * time.Second
+		setPosterHeaderTimeout(httpClient, idleTimeout)
+		return poster.NewPosterManager(r.deps.GetFs(), cfg.System.TempDir, httpClient, idleTimeout)
 	})
 }
 
@@ -694,3 +702,20 @@ func shutdownDeps(rt *APIRuntime) {
 // lifecycle operations without constructing an APIRuntime explicitly.
 // New code in production paths should use *APIRuntime directly.
 // ---------------------------------------------------------------------------
+
+func setPosterHeaderTimeout(client *http.Client, idleTimeout time.Duration) {
+	if t, ok := client.Transport.(*http.Transport); ok && idleTimeout > 0 {
+		t.ResponseHeaderTimeout = idleTimeout
+		t.TLSHandshakeTimeout = idleTimeout
+		if t.DialContext != nil {
+			origDial := t.DialContext
+			t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				dialCtx, cancel := context.WithTimeout(ctx, idleTimeout)
+				defer cancel()
+				return origDial(dialCtx, network, addr)
+			}
+		} else {
+			t.DialContext = (&net.Dialer{Timeout: idleTimeout}).DialContext
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -311,7 +311,7 @@ type OutputDownloadConfig struct {
 	DownloadExtrafanart bool               `yaml:"download_extrafanart" json:"download_extrafanart"`
 	DownloadTrailer     bool               `yaml:"download_trailer" json:"download_trailer"`
 	DownloadActress     bool               `yaml:"download_actress" json:"download_actress"`
-	DownloadTimeout     int                `yaml:"download_timeout" json:"download_timeout"` // Timeout in seconds for HTTP downloads (default: 60)
+	DownloadTimeout     int                `yaml:"download_timeout" json:"download_timeout"` // Idle/stall timeout in seconds for media downloads. Aborts if no bytes received for this duration. 0 = no idle timeout (rely on worker context). Default: 120
 	DownloadProxy       models.ProxyConfig `yaml:"download_proxy" json:"download_proxy"`     // Separate proxy for downloads (optional)
 }
 

--- a/internal/config/config.yaml.example
+++ b/internal/config/config.yaml.example
@@ -473,7 +473,7 @@ output:
     download_extrafanart: true                  # Download screenshots to extrafanart folder
     download_trailer: true
     download_actress: true
-    download_timeout: 60
+    download_timeout: 120 # idle/stall timeout: abort if no bytes received for this duration (0 = no idle timeout)
     # Download proxy override (optional):
     # - If disabled, downloads use scrapers.proxy automatically when scraper proxy is enabled.
     # - Enable only when you need a separate proxy just for downloads.

--- a/internal/config/coverage_boost_test.go
+++ b/internal/config/coverage_boost_test.go
@@ -1374,3 +1374,12 @@ func TestValidate_ImageCacheMaxSizeNegative(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "image_cache_max_size_mb")
 }
+
+func TestValidateProxyProfileConfig_NegativeDownloadTimeout(t *testing.T) {
+	cfg := DefaultConfig(nil, nil)
+	cfg.Output.Download.DownloadTimeout = -1
+
+	err := validateProxyProfileConfig(cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "download_timeout must be >= 0")
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -271,7 +271,7 @@ func defaultOutputConfig() OutputConfig {
 			DownloadExtrafanart: true,
 			DownloadTrailer:     true,
 			DownloadActress:     true,
-			DownloadTimeout:     60, // 60 seconds default
+			DownloadTimeout:     120, // idle/stall timeout: abort if no bytes received for this duration (0 = no idle timeout)
 			DownloadProxy: models.ProxyConfig{
 				Enabled: false,
 			},

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -144,6 +144,9 @@ func validateProxyProfileConfig(c *Config) error {
 	}
 
 	// Validate output.download_proxy (not a scraper, special case)
+	if c.Output.Download.DownloadTimeout < 0 {
+		return fmt.Errorf("output.download_timeout must be >= 0 (0 = no idle timeout, rely on worker context)")
+	}
 	if err := validateProxyProfileRef("output.download_proxy", &c.Output.Download.DownloadProxy, profiles); err != nil {
 		return err
 	}

--- a/internal/downloader/coverage_final_test.go
+++ b/internal/downloader/coverage_final_test.go
@@ -1,0 +1,82 @@
+package downloader
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/spf13/afero"
+)
+
+func TestNewFallbackDownloadClient_WrapsDialContext(t *testing.T) {
+	client := newFallbackDownloadClient(15 * time.Second)
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if tr.DialContext == nil {
+		t.Error("DialContext should be wrapped")
+	}
+	if tr.ResponseHeaderTimeout != 15*time.Second {
+		t.Errorf("expected 15s, got %v", tr.ResponseHeaderTimeout)
+	}
+	if tr.TLSHandshakeTimeout != 15*time.Second {
+		t.Errorf("expected 15s, got %v", tr.TLSHandshakeTimeout)
+	}
+}
+
+func TestStallReader_WatchdogTimerStopFires(t *testing.T) {
+	body := newMockReadCloser(nil, 10*time.Millisecond)
+	r := NewStallReader(body, 50*time.Millisecond, context.Background())
+	buf := make([]byte, 10)
+	_, _ = r.Read(buf)
+	r.Disarm()
+	time.Sleep(100 * time.Millisecond)
+	if body.isClosed() {
+		t.Error("body should not be closed after Disarm")
+	}
+	r.Close()
+}
+
+func TestDownloadTrailer_RetryFailureResult(t *testing.T) {
+	server := new404Server()
+	defer server.Close()
+	d := NewDownloader(server.Client(), newMemFS(), &Config{
+		DownloadTrailer:   true,
+		MediaFormatConfig: organizerMediaFormatConfig(),
+	}, nil)
+	movie := &models.Movie{ID: "TEST-404", TrailerURL: server.URL + "/trailer.mp4"}
+	result, err := d.downloadTrailer(context.Background(), movie, "/tmp", nil)
+	if err == nil {
+		t.Error("expected error from 404")
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Type != MediaTypeTrailer {
+		t.Errorf("expected MediaTypeTrailer, got %v", result.Type)
+	}
+	if result.Error == nil {
+		t.Error("expected result.Error to be set")
+	}
+}
+
+func new404Server() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+func newMemFS() afero.Fs {
+	return afero.NewMemMapFs()
+}
+
+func organizerMediaFormatConfig() organizer.MediaFormatConfig {
+	return organizer.MediaFormatConfig{
+		TrailerFormat: "<ID>-trailer.mp4",
+	}
+}

--- a/internal/downloader/coverage_final_test.go
+++ b/internal/downloader/coverage_final_test.go
@@ -27,6 +27,8 @@ func TestNewFallbackDownloadClient_WrapsDialContext(t *testing.T) {
 	if tr.TLSHandshakeTimeout != 15*time.Second {
 		t.Errorf("expected 15s, got %v", tr.TLSHandshakeTimeout)
 	}
+	ctx := context.Background()
+	_, _ = tr.DialContext(ctx, "tcp", "localhost:1")
 }
 
 func TestStallReader_WatchdogTimerStopFires(t *testing.T) {

--- a/internal/downloader/coverage_final_test.go
+++ b/internal/downloader/coverage_final_test.go
@@ -27,7 +27,8 @@ func TestNewFallbackDownloadClient_WrapsDialContext(t *testing.T) {
 	if tr.TLSHandshakeTimeout != 15*time.Second {
 		t.Errorf("expected 15s, got %v", tr.TLSHandshakeTimeout)
 	}
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	_, _ = tr.DialContext(ctx, "tcp", "localhost:1")
 }
 

--- a/internal/downloader/coverage_gap_test.go
+++ b/internal/downloader/coverage_gap_test.go
@@ -1,0 +1,66 @@
+package downloader
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/httpclient"
+)
+
+func TestSetDownloadResponseHeaderTimeout_NilDialContext(t *testing.T) {
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	setDownloadResponseHeaderTimeout(client, 10*time.Second)
+	if transport.DialContext == nil {
+		t.Error("DialContext should be set when originally nil")
+	}
+	if transport.ResponseHeaderTimeout != 10*time.Second {
+		t.Errorf("expected ResponseHeaderTimeout=10s, got %v", transport.ResponseHeaderTimeout)
+	}
+}
+
+func TestNewFallbackDownloadClient_DialContext(t *testing.T) {
+	client := newFallbackDownloadClient(10 * time.Second)
+	t2, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if t2.DialContext == nil {
+		t.Error("DialContext should not be nil")
+	}
+	if t2.ResponseHeaderTimeout != 10*time.Second {
+		t.Errorf("expected ResponseHeaderTimeout=10s, got %v", t2.ResponseHeaderTimeout)
+	}
+}
+
+func TestStallReader_DisarmAlreadyClosed(t *testing.T) {
+	body := newMockReadCloser([]byte("x"), 10*time.Millisecond)
+	r := NewStallReader(body, 100*time.Millisecond, context.Background())
+	r.Disarm()
+	r.Disarm()
+	r.Close()
+}
+
+func TestStallReader_WatchdogTimerStop(t *testing.T) {
+	body := newMockReadCloser([]byte("data"), 50*time.Millisecond)
+	r := NewStallReader(body, 100*time.Millisecond, context.Background())
+	buf := make([]byte, 10)
+	_, _ = r.Read(buf)
+	r.Disarm()
+	time.Sleep(150 * time.Millisecond)
+	if body.isClosed() {
+		t.Error("body should not be closed after Disarm")
+	}
+	r.Close()
+}
+
+func TestAdaptiveDownloaderHTTPClient_DoFallback(t *testing.T) {
+	adaptive := &adaptiveDownloaderHTTPClient{
+		directClient: &http.Client{},
+		clients:      make(map[string]httpclient.HTTPClient),
+	}
+	req, _ := http.NewRequest("GET", "http://localhost:1", nil)
+	_, _ = adaptive.Do(req)
+}

--- a/internal/downloader/coverage_gap_test.go
+++ b/internal/downloader/coverage_gap_test.go
@@ -57,15 +57,17 @@ func TestStallReader_WatchdogTimerStop(t *testing.T) {
 }
 
 func TestStallReader_WatchdogTimerAlreadyFired(t *testing.T) {
-	body := newMockReadCloser(nil, time.Hour)
-	r := NewStallReader(body, 1*time.Millisecond, context.Background())
-	buf := make([]byte, 10)
-	go func() {
-		_, _ = r.Read(buf)
-	}()
-	time.Sleep(50 * time.Millisecond)
-	r.Disarm()
-	r.Close()
+	for i := 0; i < 500; i++ {
+		body := newMockReadCloser(nil, time.Hour)
+		r := NewStallReader(body, 1*time.Millisecond, context.Background())
+		buf := make([]byte, 10)
+		go func() {
+			_, _ = r.Read(buf)
+		}()
+		time.Sleep(1 * time.Millisecond)
+		r.Disarm()
+		r.Close()
+	}
 }
 
 func TestAdaptiveDownloaderHTTPClient_DoFallback(t *testing.T) {

--- a/internal/downloader/coverage_gap_test.go
+++ b/internal/downloader/coverage_gap_test.go
@@ -58,13 +58,13 @@ func TestStallReader_WatchdogTimerStop(t *testing.T) {
 
 func TestStallReader_WatchdogTimerAlreadyFired(t *testing.T) {
 	body := newMockReadCloser(nil, time.Hour)
-	r := NewStallReader(body, 50*time.Millisecond, context.Background())
+	r := NewStallReader(body, 1*time.Millisecond, context.Background())
 	buf := make([]byte, 10)
 	go func() {
-		time.Sleep(100 * time.Millisecond)
-		r.Disarm()
+		_, _ = r.Read(buf)
 	}()
-	_, _ = r.Read(buf)
+	time.Sleep(50 * time.Millisecond)
+	r.Disarm()
 	r.Close()
 }
 

--- a/internal/downloader/coverage_gap_test.go
+++ b/internal/downloader/coverage_gap_test.go
@@ -56,20 +56,6 @@ func TestStallReader_WatchdogTimerStop(t *testing.T) {
 	r.Close()
 }
 
-func TestStallReader_WatchdogTimerAlreadyFired(t *testing.T) {
-	for i := 0; i < 500; i++ {
-		body := newMockReadCloser(nil, time.Hour)
-		r := NewStallReader(body, 1*time.Millisecond, context.Background())
-		buf := make([]byte, 10)
-		go func() {
-			_, _ = r.Read(buf)
-		}()
-		time.Sleep(1 * time.Millisecond)
-		r.Disarm()
-		r.Close()
-	}
-}
-
 func TestAdaptiveDownloaderHTTPClient_DoFallback(t *testing.T) {
 	adaptive := &adaptiveDownloaderHTTPClient{
 		directClient: &http.Client{},

--- a/internal/downloader/coverage_gap_test.go
+++ b/internal/downloader/coverage_gap_test.go
@@ -56,6 +56,18 @@ func TestStallReader_WatchdogTimerStop(t *testing.T) {
 	r.Close()
 }
 
+func TestStallReader_WatchdogTimerAlreadyFired(t *testing.T) {
+	body := newMockReadCloser(nil, time.Hour)
+	r := NewStallReader(body, 50*time.Millisecond, context.Background())
+	buf := make([]byte, 10)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		r.Disarm()
+	}()
+	_, _ = r.Read(buf)
+	r.Close()
+}
+
 func TestAdaptiveDownloaderHTTPClient_DoFallback(t *testing.T) {
 	adaptive := &adaptiveDownloaderHTTPClient{
 		directClient: &http.Client{},

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -1120,14 +1120,22 @@ func TestDownloader_Download_Timeout(t *testing.T) {
 		t.Skip("Skipping timeout test in short mode")
 	}
 
-	// Create a server that delays response
+	// Create a server that sends headers then stalls mid-body — the stall
+	// watchdog should fire after DownloadTimeout seconds of no byte progress.
+	handlerDone := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(3 * time.Second)
 		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", "10000")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("data"))
+		_, _ = w.Write([]byte("partial"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		// Block until the test signals completion so server.Close() doesn't hang.
+		<-handlerDone
 	}))
 	defer server.Close()
+	defer close(handlerDone)
 
 	tmpDir := t.TempDir()
 	movie := createTestMovie()
@@ -1135,10 +1143,10 @@ func TestDownloader_Download_Timeout(t *testing.T) {
 
 	cfg := &Config{
 		DownloadCover:   true,
-		DownloadTimeout: 1, // 1 second timeout
+		DownloadTimeout: 1, // 1 second idle/stall timeout
 	}
 
-	// Create HTTP client with timeout for this test
+	// Create HTTP client — timeout=0 (stall watchdog governs body reads).
 	httpClient, err := NewHTTPClient(HTTPClientConfig{
 		Timeout: time.Duration(cfg.DownloadTimeout) * time.Second,
 	})
@@ -1148,13 +1156,30 @@ func TestDownloader_Download_Timeout(t *testing.T) {
 
 	downloader := NewDownloader(httpClient, afero.NewOsFs(), cfg, nil)
 
-	result, err := downloader.downloadCover(context.Background(), movie, tmpDir, nil)
+	// Use a context with a generous deadline so only the stall watchdog fires.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	result, err := downloader.downloadCover(ctx, movie, tmpDir, nil)
+	elapsed := time.Since(start)
+
 	if err == nil {
-		t.Error("Expected timeout error")
+		t.Error("Expected stall timeout error")
 	}
 
 	if result.Downloaded {
-		t.Error("Expected Downloaded to be false on timeout")
+		t.Error("Expected Downloaded to be false on stall timeout")
+	}
+
+	// The stall should fire within ~2x the idle timeout (1s), not the 10s
+	// context deadline.
+	if elapsed > 5*time.Second {
+		t.Errorf("Stall watchdog took too long: %v (expected ~1s idle timeout)", elapsed)
+	}
+
+	if !IsDownloadStalled(err) {
+		t.Errorf("Expected errDownloadStalled, got: %v", err)
 	}
 }
 

--- a/internal/downloader/http.go
+++ b/internal/downloader/http.go
@@ -113,6 +113,12 @@ func (d *Downloader) download(ctx context.Context, url, destPath string, mediaTy
 		result.Duration = time.Since(startTime)
 		return result, result.Error
 	}
+	idleTimeout := time.Duration(d.config.DownloadTimeout) * time.Second
+	var stallBody *StallReader
+	if idleTimeout > 0 {
+		stallBody = NewStallReader(resp.Body, idleTimeout, ctx)
+		resp.Body = stallBody
+	}
 	defer func() {
 		_ = httpclient.DrainAndClose(resp.Body)
 	}()
@@ -137,6 +143,10 @@ func (d *Downloader) download(ctx context.Context, url, destPath string, mediaTy
 		err = closeErr
 	}
 
+	if stallBody != nil && err == nil {
+		stallBody.Disarm()
+	}
+
 	if err != nil {
 		_ = d.fs.Remove(tempPath)
 		result.Error = fmt.Errorf("failed to write file: %w", err)
@@ -150,7 +160,7 @@ func (d *Downloader) download(ctx context.Context, url, destPath string, mediaTy
 	// --overwrite-existing-media, so refuse before any replacement.
 	if written == 0 {
 		_ = d.fs.Remove(tempPath)
-		result.Error = fmt.Errorf("downloaded 0 bytes for %s", url)
+		result.Error = fmt.Errorf("%w: downloaded 0 bytes for %s", errDownloadEmpty, url)
 		result.Duration = time.Since(startTime)
 		return result, result.Error
 	}
@@ -165,7 +175,7 @@ func (d *Downloader) download(ctx context.Context, url, destPath string, mediaTy
 	// "unspecified" for close-delimited responses, and -1 is chunked.
 	if resp.ContentLength > 0 && written != resp.ContentLength {
 		_ = d.fs.Remove(tempPath)
-		result.Error = fmt.Errorf("downloaded %d of %d bytes for %s (truncated)", written, resp.ContentLength, url)
+		result.Error = fmt.Errorf("%w: downloaded %d of %d bytes for %s (truncated)", errDownloadTruncated, written, resp.ContentLength, url)
 		result.Duration = time.Since(startTime)
 		return result, result.Error
 	}
@@ -397,6 +407,16 @@ func isRetryableError(err error) bool {
 		default:
 			return false
 		}
+	}
+
+	if errors.Is(err, errDownloadStalled) ||
+		errors.Is(err, errDownloadTruncated) ||
+		errors.Is(err, errDownloadEmpty) {
+		return true
+	}
+
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
 	}
 
 	var netErr net.Error

--- a/internal/downloader/media.go
+++ b/internal/downloader/media.go
@@ -260,7 +260,30 @@ func (d *Downloader) downloadTrailer(ctx context.Context, movie *models.Movie, d
 	tmplCtx := d.buildTemplateContext(movie, multipart)
 	destPath := d.pathResolver.ResolveTrailerPath(movie, true, tmplCtx, destDir)
 
-	return d.download(ctx, movie.TrailerURL, destPath, MediaTypeTrailer, overwriteExisting, dedup)
+	op := &retryableOperation{
+		initialDelay: 100 * time.Millisecond,
+		maxDelay:     10 * time.Second,
+	}
+
+	var lastResult *DownloadResult
+	retryErr := op.ExecuteWithRetry(ctx, func() error {
+		res, err := d.download(ctx, movie.TrailerURL, destPath, MediaTypeTrailer, overwriteExisting, dedup)
+		if err == nil {
+			lastResult = res
+		}
+		return err
+	}, 2, redactURL(movie.TrailerURL))
+
+	if retryErr != nil {
+		return &DownloadResult{
+			URL:       movie.TrailerURL,
+			LocalPath: destPath,
+			Type:      MediaTypeTrailer,
+			Error:     retryErr,
+		}, retryErr
+	}
+
+	return lastResult, nil
 }
 
 func (d *Downloader) downloadActressImages(ctx context.Context, movie *models.Movie, destDir string, options ...any) ([]DownloadResult, error) {

--- a/internal/downloader/proxy.go
+++ b/internal/downloader/proxy.go
@@ -237,9 +237,6 @@ func newFallbackDownloadClient(idleTimeout time.Duration) *http.Client {
 		base.ResponseHeaderTimeout = idleTimeout
 		base.TLSHandshakeTimeout = idleTimeout
 		origDial := base.DialContext
-		if origDial == nil {
-			origDial = (&net.Dialer{Timeout: idleTimeout}).DialContext
-		}
 		base.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 			dialCtx, cancel := context.WithTimeout(ctx, idleTimeout)
 			defer cancel()

--- a/internal/downloader/proxy.go
+++ b/internal/downloader/proxy.go
@@ -1,8 +1,10 @@
 package downloader
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -17,7 +19,7 @@ import (
 // NewHTTPClient creates an HTTP client for the downloader using pre-resolved configuration.
 // The bridge function resolves all proxy profiles so this function never imports internal/config.
 func NewHTTPClient(cfg HTTPClientConfig) (httpclient.HTTPClient, error) {
-	logging.Debugf("Downloader: HTTP client timeout=%s", timeout.FromDuration(cfg.Timeout, "config:downloader.timeout"))
+	logging.Debugf("Downloader: HTTP client idle/stall timeout=%s (client timeout disabled)", timeout.FromDuration(cfg.Timeout, "config:downloader.timeout"))
 	adaptiveClient := &adaptiveDownloaderHTTPClient{
 		timeout:        cfg.Timeout,
 		httpCfg:        cfg,
@@ -27,29 +29,26 @@ func NewHTTPClient(cfg HTTPClientConfig) (httpclient.HTTPClient, error) {
 
 	// Explicit download proxy override still takes precedence when configured.
 	if cfg.DownloadProxy != nil && cfg.DownloadProxy.URL != "" {
-		client, err := httpclient.NewHTTPClient(cfg.DownloadProxy, cfg.Timeout)
+		client, err := httpclient.NewHTTPClient(cfg.DownloadProxy, 0)
 		if err != nil {
 			logging.Errorf("Downloader: Failed to create download proxy client: %v, using adaptive routing", err)
 		} else {
+			setDownloadResponseHeaderTimeout(client, cfg.Timeout)
 			logging.Infof("Downloader: Using download proxy %s", httpclient.SanitizeProxyURL(cfg.DownloadProxy.URL))
 			adaptiveClient.forceClient = client
 			return adaptiveClient, nil
 		}
 	}
 
-	// Default direct client
-	directClient, err := httpclient.NewHTTPClient(nil, cfg.Timeout)
+	// Default direct client — timeout=0 (stall watchdog governs body reads;
+	// worker context governs overall budget). ResponseHeaderTimeout catches
+	// dead servers at the transport level.
+	directClient, err := httpclient.NewHTTPClient(nil, 0)
 	if err != nil {
-		logging.Errorf("Downloader: Failed to create direct HTTP client: %v, using standard http client", err)
-		directClient = &http.Client{
-			Timeout: cfg.Timeout,
-			Transport: &http.Transport{
-				MaxIdleConns:        10,
-				IdleConnTimeout:     30 * time.Second,
-				DisableCompression:  false,
-				MaxIdleConnsPerHost: 2,
-			},
-		}
+		logging.Errorf("Downloader: Failed to create direct HTTP client: %v, using fallback client", err)
+		directClient = newFallbackDownloadClient(cfg.Timeout)
+	} else {
+		setDownloadResponseHeaderTimeout(directClient, cfg.Timeout)
 	}
 	adaptiveClient.directClient = directClient
 
@@ -194,11 +193,62 @@ func (c *adaptiveDownloaderHTTPClient) getOrCreateProxyClient(proxyProfile *mode
 		return client, nil
 	}
 
-	client, err := httpclient.NewHTTPClient(proxyProfile, c.timeout)
+	client, err := httpclient.NewHTTPClient(proxyProfile, 0)
 	if err != nil {
 		return nil, err
 	}
+	setDownloadResponseHeaderTimeout(client, c.timeout)
 	c.clients[key] = client
 	logging.Infof("Downloader: Using scraper-level proxy for media host via %s", httpclient.SanitizeProxyURL(proxyProfile.URL))
 	return client, nil
+}
+
+func setDownloadResponseHeaderTimeout(client httpclient.HTTPClient, idleTimeout time.Duration) {
+	if dc, ok := unwrapClient(client); ok {
+		if t, ok := dc.Transport.(*http.Transport); ok {
+			if idleTimeout > 0 {
+				t.ResponseHeaderTimeout = idleTimeout
+				t.TLSHandshakeTimeout = idleTimeout
+				if t.DialContext != nil {
+					origDial := t.DialContext
+					t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+						dialCtx, cancel := context.WithTimeout(ctx, idleTimeout)
+						defer cancel()
+						return origDial(dialCtx, network, addr)
+					}
+				} else {
+					t.DialContext = (&net.Dialer{Timeout: idleTimeout}).DialContext
+				}
+			}
+		}
+	}
+}
+
+func unwrapClient(client httpclient.HTTPClient) (*http.Client, bool) {
+	if dc, ok := client.(*http.Client); ok {
+		return dc, true
+	}
+	return nil, false
+}
+
+func newFallbackDownloadClient(idleTimeout time.Duration) *http.Client {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	if idleTimeout > 0 {
+		base.ResponseHeaderTimeout = idleTimeout
+		base.TLSHandshakeTimeout = idleTimeout
+		if base.DialContext != nil {
+			origDial := base.DialContext
+			base.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				dialCtx, cancel := context.WithTimeout(ctx, idleTimeout)
+				defer cancel()
+				return origDial(dialCtx, network, addr)
+			}
+		} else {
+			base.DialContext = (&net.Dialer{Timeout: idleTimeout}).DialContext
+		}
+	}
+	base.Proxy = nil
+	return &http.Client{
+		Transport: base,
+	}
 }

--- a/internal/downloader/proxy.go
+++ b/internal/downloader/proxy.go
@@ -236,15 +236,14 @@ func newFallbackDownloadClient(idleTimeout time.Duration) *http.Client {
 	if idleTimeout > 0 {
 		base.ResponseHeaderTimeout = idleTimeout
 		base.TLSHandshakeTimeout = idleTimeout
-		if base.DialContext != nil {
-			origDial := base.DialContext
-			base.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				dialCtx, cancel := context.WithTimeout(ctx, idleTimeout)
-				defer cancel()
-				return origDial(dialCtx, network, addr)
-			}
-		} else {
-			base.DialContext = (&net.Dialer{Timeout: idleTimeout}).DialContext
+		origDial := base.DialContext
+		if origDial == nil {
+			origDial = (&net.Dialer{Timeout: idleTimeout}).DialContext
+		}
+		base.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			dialCtx, cancel := context.WithTimeout(ctx, idleTimeout)
+			defer cancel()
+			return origDial(dialCtx, network, addr)
 		}
 	}
 	base.Proxy = nil

--- a/internal/downloader/proxy.go
+++ b/internal/downloader/proxy.go
@@ -16,6 +16,8 @@ import (
 	"github.com/javinizer/javinizer-go/internal/timeout"
 )
 
+var newHTTPClientFunc = httpclient.NewHTTPClient
+
 // NewHTTPClient creates an HTTP client for the downloader using pre-resolved configuration.
 // The bridge function resolves all proxy profiles so this function never imports internal/config.
 func NewHTTPClient(cfg HTTPClientConfig) (httpclient.HTTPClient, error) {
@@ -29,7 +31,7 @@ func NewHTTPClient(cfg HTTPClientConfig) (httpclient.HTTPClient, error) {
 
 	// Explicit download proxy override still takes precedence when configured.
 	if cfg.DownloadProxy != nil && cfg.DownloadProxy.URL != "" {
-		client, err := httpclient.NewHTTPClient(cfg.DownloadProxy, 0)
+		client, err := newHTTPClientFunc(cfg.DownloadProxy, 0)
 		if err != nil {
 			logging.Errorf("Downloader: Failed to create download proxy client: %v, using adaptive routing", err)
 		} else {
@@ -43,7 +45,7 @@ func NewHTTPClient(cfg HTTPClientConfig) (httpclient.HTTPClient, error) {
 	// Default direct client — timeout=0 (stall watchdog governs body reads;
 	// worker context governs overall budget). ResponseHeaderTimeout catches
 	// dead servers at the transport level.
-	directClient, err := httpclient.NewHTTPClient(nil, 0)
+	directClient, err := newHTTPClientFunc(nil, 0)
 	if err != nil {
 		logging.Errorf("Downloader: Failed to create direct HTTP client: %v, using fallback client", err)
 		directClient = newFallbackDownloadClient(cfg.Timeout)

--- a/internal/downloader/proxy_coverage_test.go
+++ b/internal/downloader/proxy_coverage_test.go
@@ -1,8 +1,8 @@
 package downloader
 
 import (
+	"errors"
 	"fmt"
-	"github.com/javinizer/javinizer-go/internal/organizer"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/javinizer/javinizer-go/internal/httpclient"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
 	"github.com/javinizer/javinizer-go/internal/template"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -148,10 +149,8 @@ func TestResolveProfile_InheritsCredentialsFromGlobal(t *testing.T) {
 		},
 	}
 	result := c.resolveProfile("partial", &models.ProxyConfig{
-		Enabled: true,
-		Profiles: map[string]models.ProxyProfile{
-			"partial": {Username: "localuser"}, // URL and Password missing → inherit from global
-		},
+		Enabled:  true,
+		Profiles: map[string]models.ProxyProfile{"partial": {Username: "localuser"}},
 	})
 	require.NotNil(t, result)
 	assert.Equal(t, "http://global:8080", result.URL, "inherited URL from global")
@@ -245,7 +244,7 @@ func TestDo_ProxyClientCreationFails_FallsBackToDirect(t *testing.T) {
 		directClient: directClient,
 		httpCfg: HTTPClientConfig{
 			GlobalProxyConfig: &models.ProxyConfig{Enabled: true},
-			GlobalProxy:       &models.ProxyProfile{URL: "http://[::1]:%invalid"}, // invalid URL
+			GlobalProxy:       &models.ProxyProfile{URL: "http://[::1]:%invalid"},
 		},
 		proxyResolvers: []models.DownloadProxyResolver{
 			testDownloadProxyResolver{
@@ -283,6 +282,46 @@ func TestNewHTTPClient_DownloadProxyInvalidURL(t *testing.T) {
 	adaptive := client.(*adaptiveDownloaderHTTPClient)
 	assert.Nil(t, adaptive.forceClient, "invalid proxy URL should not set forceClient")
 	assert.NotNil(t, adaptive.directClient, "should fall back to direct client")
+}
+
+// --- NewHTTPClient: test-injectable error paths via newHTTPClientFunc ---
+
+func TestNewHTTPClient_FallbackOnDirectClientError(t *testing.T) {
+	origFunc := newHTTPClientFunc
+	newHTTPClientFunc = func(proxyProfile *models.ProxyProfile, timeout time.Duration) (*http.Client, error) {
+		return nil, errors.New("mock transport error")
+	}
+	t.Cleanup(func() { newHTTPClientFunc = origFunc })
+
+	cfg := HTTPClientConfig{Timeout: 5 * time.Second}
+	client, err := NewHTTPClient(cfg)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+}
+
+func TestNewHTTPClient_FallbackOnProxyClientError(t *testing.T) {
+	origFunc := newHTTPClientFunc
+	newHTTPClientFunc = func(proxyProfile *models.ProxyProfile, timeout time.Duration) (*http.Client, error) {
+		return nil, errors.New("mock proxy error")
+	}
+	t.Cleanup(func() { newHTTPClientFunc = origFunc })
+
+	proxyURL := "http://proxy.example.com:8080"
+	cfg := HTTPClientConfig{
+		Timeout:       5 * time.Second,
+		DownloadProxy: &models.ProxyProfile{URL: proxyURL},
+	}
+	client, err := NewHTTPClient(cfg)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
 }
 
 // --- generateActressFilename coverage ---

--- a/internal/downloader/stall_reader.go
+++ b/internal/downloader/stall_reader.go
@@ -1,0 +1,164 @@
+package downloader
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	neturl "net/url"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type downloadStalledError struct{}
+
+func (downloadStalledError) Error() string {
+	return "download stalled: no bytes received within idle timeout"
+}
+func (downloadStalledError) Timeout() bool   { return true }
+func (downloadStalledError) Temporary() bool { return true }
+
+var errDownloadStalled = downloadStalledError{}
+var _ net.Error = downloadStalledError{}
+
+// StallReader wraps an io.ReadCloser with a stall-based idle watchdog.
+type StallReader struct {
+	body         io.ReadCloser
+	idleTimeout  time.Duration
+	ctx          context.Context
+	stalled      atomic.Bool
+	timer        *time.Timer
+	watchdogOnce sync.Once
+	stop         chan struct{}
+	closeOnce    sync.Once
+}
+
+// NewStallReader wraps body with a stall watchdog. If idleTimeout <= 0, returns a no-op wrapper.
+func NewStallReader(body io.ReadCloser, idleTimeout time.Duration, ctx context.Context) *StallReader {
+	return &StallReader{
+		body:        body,
+		idleTimeout: idleTimeout,
+		ctx:         ctx,
+		stop:        make(chan struct{}),
+	}
+}
+
+func (r *StallReader) start() {
+	if r.idleTimeout <= 0 {
+		return
+	}
+	r.timer = time.NewTimer(r.idleTimeout)
+	go r.watchdog()
+}
+
+func (r *StallReader) watchdog() {
+	select {
+	case <-r.timer.C:
+		r.stalled.Store(true)
+		_ = r.body.Close()
+	case <-r.stop:
+		if !r.timer.Stop() {
+			select {
+			case <-r.timer.C:
+			default:
+			}
+		}
+	}
+}
+
+func (r *StallReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	r.watchdogOnce.Do(r.start)
+
+	if r.stalled.Load() {
+		return 0, errDownloadStalled
+	}
+
+	n, err := r.body.Read(p)
+
+	if n > 0 && r.timer != nil {
+		r.timer.Reset(r.idleTimeout)
+	}
+
+	if err != nil && r.stalled.Load() {
+		return n, errDownloadStalled
+	}
+
+	return n, err
+}
+
+// Disarm stops the stall watchdog without closing the underlying body.
+func (r *StallReader) Disarm() {
+	r.watchdogOnce.Do(func() {})
+	select {
+	case <-r.stop:
+	default:
+		close(r.stop)
+	}
+}
+
+// Close stops the watchdog and closes the underlying body.
+func (r *StallReader) Close() error {
+	r.watchdogOnce.Do(func() {})
+
+	var err error
+	r.closeOnce.Do(func() {
+		select {
+		case <-r.stop:
+		default:
+			close(r.stop)
+		}
+		err = r.body.Close()
+	})
+	return err
+}
+
+var _ io.ReadCloser = (*StallReader)(nil)
+
+// IsDownloadStalled returns true if the error is or wraps errDownloadStalled.
+func IsDownloadStalled(err error) bool {
+	return errors.Is(err, errDownloadStalled)
+}
+
+type downloadTruncatedError struct{}
+
+func (downloadTruncatedError) Error() string   { return "download truncated" }
+func (downloadTruncatedError) Timeout() bool   { return true }
+func (downloadTruncatedError) Temporary() bool { return true }
+
+var errDownloadTruncated = downloadTruncatedError{}
+var _ net.Error = downloadTruncatedError{}
+
+type downloadEmptyError struct{}
+
+func (downloadEmptyError) Error() string   { return "downloaded 0 bytes" }
+func (downloadEmptyError) Timeout() bool   { return true }
+func (downloadEmptyError) Temporary() bool { return true }
+
+var errDownloadEmpty = downloadEmptyError{}
+var _ net.Error = downloadEmptyError{}
+
+// IsDownloadTruncated returns true if the error is or wraps errDownloadTruncated.
+func IsDownloadTruncated(err error) bool {
+	return errors.Is(err, errDownloadTruncated)
+}
+
+// IsDownloadEmpty returns true if the error is or wraps errDownloadEmpty.
+func IsDownloadEmpty(err error) bool {
+	return errors.Is(err, errDownloadEmpty)
+}
+
+func redactURL(rawURL string) string {
+	parsed, err := neturl.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}

--- a/internal/downloader/stall_reader.go
+++ b/internal/downloader/stall_reader.go
@@ -58,12 +58,7 @@ func (r *StallReader) watchdog() {
 		r.stalled.Store(true)
 		_ = r.body.Close()
 	case <-r.stop:
-		if !r.timer.Stop() {
-			select {
-			case <-r.timer.C:
-			default:
-			}
-		}
+		r.timer.Stop()
 	}
 }
 

--- a/internal/downloader/stall_reader_coverage_test.go
+++ b/internal/downloader/stall_reader_coverage_test.go
@@ -1,0 +1,109 @@
+package downloader
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestDownloadTruncated_Temporary(t *testing.T) {
+	var e downloadTruncatedError
+	if !e.Temporary() {
+		t.Error("downloadTruncatedError.Temporary() should return true")
+	}
+}
+
+func TestDownloadEmpty_Temporary(t *testing.T) {
+	var e downloadEmptyError
+	if !e.Temporary() {
+		t.Error("downloadEmptyError.Temporary() should return true")
+	}
+}
+
+func TestIsDownloadTruncated_Wrapped(t *testing.T) {
+	wrapped := fmt.Errorf("%w: downloaded 5 of 10 bytes", errDownloadTruncated)
+	if !IsDownloadTruncated(wrapped) {
+		t.Error("wrapped truncation should be detected")
+	}
+	if IsDownloadTruncated(errDownloadStalled) {
+		t.Error("stalled error should not be detected as truncated")
+	}
+}
+
+func TestIsDownloadEmpty_Wrapped(t *testing.T) {
+	wrapped := fmt.Errorf("%w: downloaded 0 bytes", errDownloadEmpty)
+	if !IsDownloadEmpty(wrapped) {
+		t.Error("wrapped empty should be detected")
+	}
+	if IsDownloadEmpty(errDownloadStalled) {
+		t.Error("stalled error should not be detected as empty")
+	}
+}
+
+func TestRedactURL_WithQueryParams(t *testing.T) {
+	result := redactURL("https://example.com/path?token=secret&key=abc")
+	if result != "https://example.com/path" {
+		t.Errorf("expected redacted URL, got: %s", result)
+	}
+}
+
+func TestRedactURL_WithUserInfo(t *testing.T) {
+	result := redactURL("https://user:pass@example.com/path")
+	if result != "https://example.com/path" {
+		t.Errorf("expected redacted URL, got: %s", result)
+	}
+}
+
+func TestRedactURL_InvalidURL(t *testing.T) {
+	result := redactURL("://invalid")
+	if result != "://invalid" {
+		t.Errorf("expected original URL for invalid input, got: %s", result)
+	}
+}
+
+func TestNewFallbackDownloadClient_WithTimeout(t *testing.T) {
+	client := newFallbackDownloadClient(60 * time.Second)
+	if client.Timeout != 0 {
+		t.Errorf("expected Timeout=0, got %v", client.Timeout)
+	}
+	if client.Transport == nil {
+		t.Error("expected non-nil transport")
+	}
+}
+
+func TestNewFallbackDownloadClient_ZeroTimeout(t *testing.T) {
+	client := newFallbackDownloadClient(0)
+	if client.Timeout != 0 {
+		t.Errorf("expected Timeout=0, got %v", client.Timeout)
+	}
+}
+
+func TestUnwrapClient_DirectClient(t *testing.T) {
+	client := &http.Client{}
+	result, ok := unwrapClient(client)
+	if !ok || result != client {
+		t.Error("expected direct *http.Client to be unwrapped")
+	}
+}
+
+func TestUnwrapClient_NonHTTPClient(t *testing.T) {
+	client := &adaptiveDownloaderHTTPClient{}
+	_, ok := unwrapClient(client)
+	if ok {
+		t.Error("expected non-*http.Client to return false")
+	}
+}
+
+func TestSetDownloadResponseHeaderTimeout_NilTransport(t *testing.T) {
+	client := &http.Client{Transport: nil}
+	setDownloadResponseHeaderTimeout(client, 30*time.Second)
+}
+
+func TestIsRetryable_UnexpectedEOF(t *testing.T) {
+	wrapped := fmt.Errorf("failed to write file: %w", io.ErrUnexpectedEOF)
+	if !isRetryableError(wrapped) {
+		t.Error("io.ErrUnexpectedEOF should be retryable")
+	}
+}

--- a/internal/downloader/stall_reader_test.go
+++ b/internal/downloader/stall_reader_test.go
@@ -1,0 +1,317 @@
+package downloader
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type mockReadCloser struct {
+	data   []byte
+	pos    int
+	closed atomic.Bool
+	delay  time.Duration
+	done   chan struct{}
+}
+
+func newMockReadCloser(data []byte, delay time.Duration) *mockReadCloser {
+	return &mockReadCloser{data: data, delay: delay, done: make(chan struct{})}
+}
+
+func (m *mockReadCloser) Read(p []byte) (int, error) {
+	if m.closed.Load() {
+		return 0, io.ErrClosedPipe
+	}
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-m.done:
+			return 0, io.ErrClosedPipe
+		}
+	}
+	if m.closed.Load() {
+		return 0, io.ErrClosedPipe
+	}
+	if m.pos >= len(m.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, m.data[m.pos:])
+	m.pos += n
+	return n, nil
+}
+
+func (m *mockReadCloser) Close() error {
+	if m.closed.CompareAndSwap(false, true) {
+		close(m.done)
+	}
+	return nil
+}
+
+func (m *mockReadCloser) isClosed() bool {
+	return m.closed.Load()
+}
+
+func TestStallReader_SuccessfulReadsResetTimer(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 1000)
+	body := newMockReadCloser(data, 50*time.Millisecond)
+	ctx := context.Background()
+	r := NewStallReader(body, 200*time.Millisecond, ctx)
+
+	buf := make([]byte, 100)
+	totalRead := 0
+	for {
+		n, err := r.Read(buf)
+		totalRead += n
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if totalRead != 1000 {
+		t.Errorf("expected 1000 bytes, got %d", totalRead)
+	}
+	_ = r.Close()
+	if !body.isClosed() {
+		t.Error("underlying body not closed")
+	}
+}
+
+func TestStallReader_StalledBodyTriggersError(t *testing.T) {
+	body := newMockReadCloser(nil, time.Hour)
+	ctx := context.Background()
+	r := NewStallReader(body, 100*time.Millisecond, ctx)
+
+	buf := make([]byte, 100)
+	start := time.Now()
+	_, err := r.Read(buf)
+	elapsed := time.Since(start)
+
+	if !IsDownloadStalled(err) {
+		t.Errorf("expected errDownloadStalled, got: %v", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("stall took too long: %v", elapsed)
+	}
+	_ = r.Close()
+}
+
+func TestStallReader_IdleTimeoutZeroDisables(t *testing.T) {
+	body := newMockReadCloser([]byte("hello"), 0)
+	ctx := context.Background()
+	r := NewStallReader(body, 0, ctx)
+	buf := make([]byte, 10)
+	n, err := r.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("expected 5 bytes, got %d", n)
+	}
+	_ = r.Close()
+}
+
+func TestStallReader_WorkerContextCancellation(t *testing.T) {
+	body := newMockReadCloser(nil, time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	r := NewStallReader(body, 10*time.Second, ctx)
+	cancel()
+
+	buf := make([]byte, 100)
+	_, err := r.Read(buf)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+	if IsDownloadStalled(err) {
+		t.Error("should not be reported as stall")
+	}
+	_ = r.Close()
+}
+
+func TestStallReader_DisarmStopsWatchdog(t *testing.T) {
+	body := newMockReadCloser([]byte("data"), 50*time.Millisecond)
+	ctx := context.Background()
+	r := NewStallReader(body, 100*time.Millisecond, ctx)
+
+	buf := make([]byte, 10)
+	_, _ = r.Read(buf)
+	r.Disarm()
+	time.Sleep(200 * time.Millisecond)
+
+	if body.isClosed() {
+		t.Error("body was closed by watchdog after Disarm")
+	}
+	_ = r.Close()
+}
+
+func TestStallReader_ZeroByteReadDoesNotResetTimer(t *testing.T) {
+	body := newMockReadCloser([]byte("x"), 10*time.Millisecond)
+	ctx := context.Background()
+	r := NewStallReader(body, 500*time.Millisecond, ctx)
+	buf := make([]byte, 10)
+	_, err := r.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = r.Close()
+}
+
+type zeroByteReadCloser struct {
+	closed atomic.Bool
+	done   chan struct{}
+}
+
+func (z *zeroByteReadCloser) Read(p []byte) (int, error) {
+	if z.closed.Load() {
+		return 0, io.ErrClosedPipe
+	}
+	select {
+	case <-time.After(1 * time.Millisecond):
+		return 0, nil
+	case <-z.done:
+		return 0, io.ErrClosedPipe
+	}
+}
+
+func (z *zeroByteReadCloser) Close() error {
+	if z.closed.CompareAndSwap(false, true) {
+		close(z.done)
+	}
+	return nil
+}
+
+func TestStallReader_RepeatedZeroByteReadsTriggerStall(t *testing.T) {
+	body := &zeroByteReadCloser{done: make(chan struct{})}
+	ctx := context.Background()
+	r := NewStallReader(body, 100*time.Millisecond, ctx)
+
+	buf := make([]byte, 10)
+	start := time.Now()
+	var err error
+	for {
+		_, err = r.Read(buf)
+		if err != nil {
+			break
+		}
+	}
+	elapsed := time.Since(start)
+
+	if !IsDownloadStalled(err) {
+		t.Errorf("expected errDownloadStalled from repeated zero-byte reads, got: %v", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("stall took too long: %v", elapsed)
+	}
+	_ = r.Close()
+}
+
+func TestStallReader_CloseStopsGoroutine(t *testing.T) {
+	before := runtime.NumGoroutine()
+	body := newMockReadCloser([]byte("x"), 10*time.Millisecond)
+	ctx := context.Background()
+	r := NewStallReader(body, 100*time.Millisecond, ctx)
+
+	buf := make([]byte, 10)
+	_, _ = r.Read(buf)
+	_ = r.Close()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= before {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Errorf("goroutine leak: before=%d, after=%d", before, runtime.NumGoroutine())
+}
+
+func TestStallReader_DisarmThenClose(t *testing.T) {
+	body := newMockReadCloser([]byte("x"), 10*time.Millisecond)
+	ctx := context.Background()
+	r := NewStallReader(body, 100*time.Millisecond, ctx)
+
+	buf := make([]byte, 10)
+	_, _ = r.Read(buf)
+	r.Disarm()
+	_ = r.Close()
+
+	if !body.isClosed() {
+		t.Error("body should be closed after Close")
+	}
+}
+
+func TestDownloadStalled_ImplementsNetError(t *testing.T) {
+	var err net.Error
+	if !errors.As(downloadStalledError{}, &err) {
+		t.Error("errDownloadStalled does not satisfy net.Error")
+	}
+	if !err.Timeout() {
+		t.Error("errDownloadStalled.Timeout() should return true")
+	}
+	if !err.Temporary() {
+		t.Error("errDownloadStalled.Temporary() should return true")
+	}
+}
+
+func TestDownloadTruncated_ImplementsNetError(t *testing.T) {
+	var err net.Error
+	if !errors.As(downloadTruncatedError{}, &err) {
+		t.Error("errDownloadTruncated does not satisfy net.Error")
+	}
+	if !err.Timeout() {
+		t.Error("errDownloadTruncated.Timeout() should return true")
+	}
+}
+
+func TestDownloadEmpty_ImplementsNetError(t *testing.T) {
+	var err net.Error
+	if !errors.As(downloadEmptyError{}, &err) {
+		t.Error("errDownloadEmpty does not satisfy net.Error")
+	}
+	if !err.Timeout() {
+		t.Error("errDownloadEmpty.Timeout() should return true")
+	}
+}
+
+func TestIsRetryableError_StallError(t *testing.T) {
+	if !isRetryableError(errDownloadStalled) {
+		t.Error("errDownloadStalled should be retryable")
+	}
+}
+
+func TestIsRetryableError_TruncationError(t *testing.T) {
+	wrapped := fmt.Errorf("%w: downloaded 5 of 10 bytes", errDownloadTruncated)
+	if !isRetryableError(wrapped) {
+		t.Error("truncation error should be retryable")
+	}
+}
+
+func TestIsRetryableError_EmptyError(t *testing.T) {
+	wrapped := fmt.Errorf("%w: downloaded 0 bytes for http://example.com", errDownloadEmpty)
+	if !isRetryableError(wrapped) {
+		t.Error("empty download error should be retryable")
+	}
+}
+
+func TestIsRetryableError_NotFoundNotRetryable(t *testing.T) {
+	err := &statusError{statusCode: 404}
+	if isRetryableError(err) {
+		t.Error("404 should not be retryable")
+	}
+}
+
+func TestIsRetryableError_UnexpectedEOF(t *testing.T) {
+	wrapped := fmt.Errorf("failed to write file: %w", io.ErrUnexpectedEOF)
+	if !isRetryableError(wrapped) {
+		t.Error("io.ErrUnexpectedEOF should be retryable (truncation via early close)")
+	}
+}

--- a/internal/poster/generator_test.go
+++ b/internal/poster/generator_test.go
@@ -30,7 +30,7 @@ func TestScrapePosterGenerator_NilMovie(t *testing.T) {
 }
 
 func TestScrapePosterGenerator_NoPosterOrCoverURL(t *testing.T) {
-	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp", http.DefaultClient)
+	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp", http.DefaultClient, 0)
 	gen := NewScrapePosterGenerator(pm, "", "")
 	movie := &models.Movie{ID: "TEST-001"}
 	err := gen.GeneratePoster(context.Background(), "test-job", movie)
@@ -47,7 +47,7 @@ func TestScrapePosterGenerator_Success(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 	gen := NewScrapePosterGenerator(pm, "TestAgent", "")
 
 	movie := &models.Movie{ID: "TEST-001", Poster: models.PosterState{PosterURL: srv.URL + "/poster.jpg"}}
@@ -79,7 +79,7 @@ func TestScrapePosterGenerator_PreservesShouldCropPoster(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 	gen := NewScrapePosterGenerator(pm, "TestAgent", "")
 
 	// Simulate a cropping source (e.g. javbus/dmm): the aggregator has set
@@ -112,7 +112,7 @@ func TestScrapePosterGenerator_UsesCoverURLFallback(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 	gen := NewScrapePosterGenerator(pm, "", "")
 
 	movie := &models.Movie{ID: "TEST-002", Poster: models.PosterState{CoverURL: srv.URL + "/cover.jpg"}}
@@ -122,7 +122,7 @@ func TestScrapePosterGenerator_UsesCoverURLFallback(t *testing.T) {
 }
 
 func TestScrapePosterGenerator_DownloadError_Sanitized(t *testing.T) {
-	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp", &genFailingHTTPClient{})
+	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp", &genFailingHTTPClient{}, 0)
 	gen := NewScrapePosterGenerator(pm, "", "")
 
 	movie := &models.Movie{ID: "TEST-003", Poster: models.PosterState{PosterURL: "http://example.com/poster.jpg"}}
@@ -147,7 +147,7 @@ func TestScrapePosterGenerator_RefererPassthrough(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	// Test with explicit referer.
 	gen := NewScrapePosterGenerator(pm, "", "https://custom.referer.com/")
@@ -173,7 +173,7 @@ func TestScrapePosterGenerator_SSRFCheckPropagation(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 	gen := NewScrapePosterGenerator(pm, "", "").WithSSRFCheck(func(_ string) error { return nil })
 
 	movie := &models.Movie{ID: "TEST-004", Poster: models.PosterState{PosterURL: srv.URL + "/poster.jpg"}}

--- a/internal/poster/manager.go
+++ b/internal/poster/manager.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/javinizer/javinizer-go/internal/downloader"
 	httpclientiface "github.com/javinizer/javinizer-go/internal/httpclient"
 	"github.com/javinizer/javinizer-go/internal/imageutil"
 	"github.com/javinizer/javinizer-go/internal/logging"
@@ -76,22 +77,22 @@ type ssrfCheckFunc func(rawURL string) error
 // PosterManager implements PosterManagerInterface using an afero filesystem,
 // a temporary directory, and an HTTP client.
 type PosterManager struct {
-	fs         afero.Fs
-	tempDir    string
-	httpClient httpclientiface.HTTPClient
-	// ssrfCheck validates a URL for SSRF safety. Defaults to ssrf.CheckURL.
-	// Override via WithSSRFCheck for testing only.
-	ssrfCheck ssrfCheckFunc
+	fs          afero.Fs
+	tempDir     string
+	httpClient  httpclientiface.HTTPClient
+	idleTimeout time.Duration
+	ssrfCheck   ssrfCheckFunc
 }
 
 // NewPosterManager creates a PosterManager backed by the given filesystem,
 // temp directory root, and HTTP client.
-func NewPosterManager(fs afero.Fs, tempDir string, httpClient httpclientiface.HTTPClient) *PosterManager {
+func NewPosterManager(fs afero.Fs, tempDir string, httpClient httpclientiface.HTTPClient, idleTimeout time.Duration) *PosterManager {
 	return &PosterManager{
-		fs:         fs,
-		tempDir:    tempDir,
-		httpClient: httpClient,
-		ssrfCheck:  ssrf.CheckURL,
+		fs:          fs,
+		tempDir:     tempDir,
+		httpClient:  httpClient,
+		idleTimeout: idleTimeout,
+		ssrfCheck:   ssrf.CheckURL,
 	}
 }
 
@@ -231,6 +232,10 @@ func (pm *PosterManager) DownloadFromURL(ctx context.Context, jobID, posterID, r
 		return nil, fmt.Errorf("failed to download image: %w", err)
 	}
 	defer func() { _ = drainAndClose(resp.Body) }()
+
+	if pm.idleTimeout > 0 {
+		resp.Body = downloader.NewStallReader(resp.Body, pm.idleTimeout, ctx)
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("image download failed with status %d", resp.StatusCode)

--- a/internal/poster/manager_coverage_test.go
+++ b/internal/poster/manager_coverage_test.go
@@ -19,7 +19,7 @@ func TestDownloadFromURL_MkdirFailure(t *testing.T) {
 	// Use a read-only fs so MkdirAll fails
 	fs := afero.NewMemMapFs()
 	fs = afero.NewReadOnlyFs(fs)
-	pm := NewPosterManager(fs, "/tmp", http.DefaultClient).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", http.DefaultClient, 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", "http://example.com/img.jpg", "", "")
 	assert.Error(t, err)
@@ -149,7 +149,7 @@ func TestDownloadFromURL_RenamesTempFile(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	result, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")
 	require.NoError(t, err)

--- a/internal/poster/manager_miss2_test.go
+++ b/internal/poster/manager_miss2_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestMiss2_CropWithBounds_SourcePathTraversal(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", http.DefaultClient)
+	pm := NewPosterManager(fs, "/tmp", http.DefaultClient, 0)
 
 	// Create a poster file that exists but with a posterID that causes path traversal
 	posterID := "../../etc/passwd"
@@ -36,7 +36,7 @@ func TestMiss2_CropWithBounds_SourcePathTraversal(t *testing.T) {
 
 func TestMiss2_CropWithBounds_ValidPosterIDWithTraversal(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", http.DefaultClient)
+	pm := NewPosterManager(fs, "/tmp", http.DefaultClient, 0)
 
 	posterID := "valid-id"
 	posterDir := filepath.Join("/tmp", "posters", "job1")
@@ -53,7 +53,7 @@ func TestMiss2_CropWithBounds_ValidPosterIDWithTraversal(t *testing.T) {
 
 func TestMiss2_CropWithBounds_FallbackToNonFull(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", http.DefaultClient)
+	pm := NewPosterManager(fs, "/tmp", http.DefaultClient, 0)
 
 	posterID := "fallback-id"
 	posterDir := filepath.Join("/tmp", "posters", "job1")
@@ -86,7 +86,7 @@ func TestMiss2_DownloadFromURL_ImageTooLargeTruncation(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")
 	assert.Error(t, err)
@@ -101,7 +101,7 @@ func TestMiss2_DownloadFromURL_ImageTooLargeTruncation(t *testing.T) {
 
 func TestMiss2_DownloadFromURL_SSRFValidationFail(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", http.DefaultClient)
+	pm := NewPosterManager(fs, "/tmp", http.DefaultClient, 0)
 	// Default SSRF check should reject private IPs
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", "http://192.168.1.1/img.jpg", "", "")
 	assert.Error(t, err)
@@ -112,7 +112,7 @@ func TestMiss2_DownloadFromURL_SSRFValidationFail(t *testing.T) {
 
 func TestMiss2_DownloadFromURL_InvalidURL(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", http.DefaultClient).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", http.DefaultClient, 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", "://invalid-url", "", "")
 	assert.Error(t, err)
@@ -132,7 +132,7 @@ func TestMiss2_DownloadFromURL_CustomHeaders(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "CustomUA/1.0", "https://referer.example.com/")
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestMiss2_DownloadFromURL_CustomHeaders(t *testing.T) {
 
 func TestMiss2_DownloadFromURL_PathTraversalPosterID(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", http.DefaultClient).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", http.DefaultClient, 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	// A posterID with path separators should fail validation
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "../escape", "http://example.com/img.jpg", "", "")
@@ -241,7 +241,7 @@ func TestMiss2_DownloadFromURL_MkdirAllFailure(t *testing.T) {
 	// Read-only fs can't create directories
 	memFS := afero.NewMemMapFs()
 	readOnlyFS := afero.NewReadOnlyFs(memFS)
-	pm := NewPosterManager(readOnlyFS, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(readOnlyFS, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")
 	assert.Error(t, err)

--- a/internal/poster/manager_miss_test.go
+++ b/internal/poster/manager_miss_test.go
@@ -31,7 +31,7 @@ func TestDownloadFromURL_CloseErrorOnTempFile(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	result, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestDownloadFromURL_RenameFailure(t *testing.T) {
 
 	// Wrap with read-only to cause rename failure
 	readOnlyFS := afero.NewReadOnlyFs(memFS)
-	pm := NewPosterManager(readOnlyFS, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(readOnlyFS, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")
 	assert.Error(t, err)
@@ -94,7 +94,7 @@ func TestDownloadFromURL_CropFailsFallsBackToCopy(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	result, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")
 	// Even if crop fails, copyFile fallback should succeed
@@ -121,7 +121,7 @@ func TestDownloadFromURL_CropAndCopyBothFail(t *testing.T) {
 
 	// Use a custom fs that fails on Open (used by copyFile)
 	failOpenFS := &failOpenFs{Fs: memFS}
-	pm := NewPosterManager(failOpenFS, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(failOpenFS, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")
 	// Should fail because crop and copy both fail
@@ -147,7 +147,7 @@ func TestDownloadFromURL_CleanupOnFailure(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")
 	assert.Error(t, err)
@@ -215,7 +215,7 @@ func TestDownloadFromURL_AutoRefererFromURL(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")
 	require.NoError(t, err)
@@ -238,7 +238,7 @@ func TestDownloadFromURL_TempFileCreationFails(t *testing.T) {
 	// Read-only fs can't create temp files
 	memFS := afero.NewMemMapFs()
 	readOnlyFS := afero.NewReadOnlyFs(memFS)
-	pm := NewPosterManager(readOnlyFS, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(readOnlyFS, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")
 	assert.Error(t, err)
@@ -256,7 +256,7 @@ func TestDownloadFromURL_WideImageCrop(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	result, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")
 	require.NoError(t, err)
@@ -284,7 +284,7 @@ func TestDownloadFromURL_RemovesPreviousFullImage(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	// First download creates the full image
 	result1, err := pm.DownloadFromURL(context.Background(), "job1", "ABC-123", srv.URL+"/img.jpg", "", "")

--- a/internal/poster/manager_park_restore_test.go
+++ b/internal/poster/manager_park_restore_test.go
@@ -52,7 +52,7 @@ func TestDownloadFromURL_FailureRestoresParkedPair(t *testing.T) {
 	require.NoError(t, afero.WriteFile(base, dir+"/BAD-1-full.jpg", []byte("originalfull"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/BAD-1.jpg", []byte("originalcrop"), 0o644))
 	fs := createFailSuffixFS{Fs: base, suffix: "BAD-1.jpg"}
-	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "BAD-1", srv.URL+"/img.jpg", "", "")
 	require.Error(t, err)
@@ -94,7 +94,7 @@ func TestDownloadFromURL_ParkFailureAbortsClean(t *testing.T) {
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/BAD-2-full.jpg", []byte("originalfull"), 0o644))
 	fs := renameFailWhereFS{Fs: base, fail: func(_, n string) bool { return strings.HasSuffix(n, ".dlbak") }}
-	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "BAD-2", srv.URL+"/img.jpg", "", "")
 	require.ErrorContains(t, err, "failed to park previous full poster")
 	got, rerr := afero.ReadFile(base, dir+"/BAD-2-full.jpg")
@@ -119,7 +119,7 @@ func TestDownloadFromURL_FinalizeFailureRestoresPair(t *testing.T) {
 	fs := renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
 		return n == filepath.ToSlash(target) && !strings.HasSuffix(o, ".dlbak") // finalize (and restore) fail; park succeeds
 	}}
-	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "BAD-3", srv.URL+"/img.jpg", "", "")
 	require.ErrorContains(t, err, "failed to finalize image download")
 	got, rerr := afero.ReadFile(base, target)
@@ -141,7 +141,7 @@ func TestDownloadFromURL_CropParkFailureRestoresFull(t *testing.T) {
 	require.NoError(t, afero.WriteFile(base, dir+"/BAD-4-full.jpg", []byte("origfull"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/BAD-4.jpg", []byte("origcrop"), 0o644))
 	fs := renameFailWhereFS{Fs: base, fail: func(_, n string) bool { return strings.HasSuffix(n, "BAD-4.jpg.dlbak") }}
-	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "BAD-4", srv.URL+"/img.jpg", "", "")
 	require.ErrorContains(t, err, "failed to park previous cropped poster")
 	full, ferr := afero.ReadFile(base, dir+"/BAD-4-full.jpg")
@@ -170,7 +170,7 @@ func TestDownloadFromURL_CropParkFailureRestoreWarns(t *testing.T) {
 			(strings.HasSuffix(o, ".dlbak") && n == filepath.ToSlash(dir)+"/BAD-5-full.jpg")
 	}
 	fs := renameFailWhereFS{Fs: base, fail: wedged}
-	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "BAD-5", srv.URL+"/img.jpg", "", "")
 	require.ErrorContains(t, err, "failed to park previous cropped poster")
 	_, bakErr := base.Stat(dir + "/BAD-5-full.jpg.dlbak")
@@ -197,7 +197,7 @@ func TestDownloadFromURL_DeferRestoreWarns(t *testing.T) {
 			return strings.HasSuffix(o, ".dlbak") && (n == filepath.ToSlash(dir)+"/BAD-6-full.jpg" || n == filepath.ToSlash(dir)+"/BAD-6.jpg")
 		},
 	}
-	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 	_, err := pm.DownloadFromURL(context.Background(), "job2", "BAD-6", srv.URL+"/img.jpg", "", "")
 	require.Error(t, err)
 	for _, p := range []string{dir + "/BAD-6-full.jpg.dlbak", dir + "/BAD-6.jpg.dlbak"} {
@@ -239,7 +239,7 @@ func TestDownloadFromURL_SuccessDiscardsParkedPair(t *testing.T) {
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/GOOD-1-full.jpg", []byte("stalefull"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/GOOD-1.jpg", []byte("stalecrop"), 0o644))
-	pm := NewPosterManager(base, "/tmp/javinizer-test", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(base, "/tmp/javinizer-test", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	res, err := pm.DownloadFromURL(context.Background(), "job1", "GOOD-1", srv.URL+"/img.jpg", "", "")
 	require.NoError(t, err)
@@ -279,7 +279,7 @@ func TestDownloadFromURL_FullStatErrorRefusesDownload(t *testing.T) {
 	require.NoError(t, afero.WriteFile(base, dir+"/FULLST-1-full.jpg", []byte("originalfull"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/FULLST-1.jpg", []byte("originalcrop"), 0o644))
 	fs := statFailExactFS{Fs: base, path: dir + "/FULLST-1-full.jpg"}
-	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "FULLST-1", srv.URL+"/img.jpg", "", "")
 	require.ErrorContains(t, err, "failed to inspect previous full poster")
@@ -310,7 +310,7 @@ func TestDownloadFromURL_FinalizeFailureRestoreAlsoFails(t *testing.T) {
 	// Every rename landing ON the canonical full name fails: the finalize and
 	// the subsequent restore attempt alike.
 	fs := renameFailWhereFS{Fs: base, fail: func(_, n string) bool { return strings.HasSuffix(n, "/FIN-2-full.jpg") }}
-	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "FIN-2", srv.URL+"/img.jpg", "", "")
 	require.ErrorContains(t, err, "failed to finalize image download")
@@ -335,7 +335,7 @@ func TestDownloadFromURL_CropStatErrorRestoreAlsoFails(t *testing.T) {
 	require.NoError(t, afero.WriteFile(base, dir+"/CST-2.jpg", []byte("originalcrop"), 0o644))
 	inner := renameFailWhereFS{Fs: base, fail: func(o, _ string) bool { return strings.HasSuffix(o, ".dlbak") }}
 	fs := statFailExactFS{Fs: inner, path: dir + "/CST-2.jpg"}
-	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "CST-2", srv.URL+"/img.jpg", "", "")
 	require.ErrorContains(t, err, "failed to inspect previous cropped poster")
@@ -360,7 +360,7 @@ func TestDownloadFromURL_CropStatErrorRestoresFullLeg(t *testing.T) {
 	require.NoError(t, afero.WriteFile(base, dir+"/CROPST-1-full.jpg", []byte("originalfull"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/CROPST-1.jpg", []byte("originalcrop"), 0o644))
 	fs := statFailExactFS{Fs: base, path: dir + "/CROPST-1.jpg"}
-	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/tmp/javinizer-test", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	_, err := pm.DownloadFromURL(context.Background(), "job1", "CROPST-1", srv.URL+"/img.jpg", "", "")
 	require.ErrorContains(t, err, "failed to inspect previous cropped poster")

--- a/internal/poster/manager_seam_p2_test.go
+++ b/internal/poster/manager_seam_p2_test.go
@@ -34,7 +34,7 @@ func TestStagePosterDownload_WritesNothingCanonicalBeforePromote(t *testing.T) {
 	srv := stageImageServer(t)
 	base := afero.NewMemMapFs()
 	spy := &writeSpyFS{Fs: base, writes: map[string]int{}}
-	pm := NewPosterManager(spy, "/tmp/p2", srv.Client()).WithSSRFCheck(func(string) error { return nil })
+	pm := NewPosterManager(spy, "/tmp/p2", srv.Client(), 0).WithSSRFCheck(func(string) error { return nil })
 
 	staged, err := pm.StagePosterDownload(context.Background(), StagePosterRequest{
 		JobID: "job1", PosterID: "ST-P1", URL: srv.URL + "/img.jpg",
@@ -87,7 +87,7 @@ func TestPromoteStagedPoster_PartialFailureRestoresFirstLeg(t *testing.T) {
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-P2-full.jpg", []byte("old-full"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-P2.jpg", []byte("old-crop"), 0o644))
-	pm := NewPosterManager(base, "/tmp/p2", srv.Client()).WithSSRFCheck(func(string) error { return nil })
+	pm := NewPosterManager(base, "/tmp/p2", srv.Client(), 0).WithSSRFCheck(func(string) error { return nil })
 
 	// Stage via the public seam, then rehang on a rename-wedged fs.
 	staged, err := pm.StagePosterDownload(context.Background(), StagePosterRequest{
@@ -99,7 +99,7 @@ func TestPromoteStagedPoster_PartialFailureRestoresFirstLeg(t *testing.T) {
 	wedged := renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
 		return strings.Contains(o, ".stage-") && strings.HasSuffix(n, "/ST-P2.jpg")
 	}}
-	pmWedged := NewPosterManager(wedged, "/tmp/p2", nil)
+	pmWedged := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 
 	_, err2 := pmWedged.PromoteStagedPoster(staged)
 	require.ErrorContains(t, err2, "promote staged poster")
@@ -115,7 +115,7 @@ func TestPromoteStagedPoster_PartialFailureRestoresFirstLeg(t *testing.T) {
 func TestStagedPoster_DiscardAndNilSafety(t *testing.T) {
 	srv := stageImageServer(t)
 	base := afero.NewMemMapFs()
-	pm := NewPosterManager(base, "/tmp/p2", srv.Client()).WithSSRFCheck(func(string) error { return nil })
+	pm := NewPosterManager(base, "/tmp/p2", srv.Client(), 0).WithSSRFCheck(func(string) error { return nil })
 	staged, err := pm.StagePosterDownload(context.Background(), StagePosterRequest{
 		JobID: "job1", PosterID: "ST-P3", URL: srv.URL + "/img.jpg",
 	})
@@ -135,7 +135,7 @@ func TestStagedPoster_DiscardAndNilSafety(t *testing.T) {
 func TestScrapePosterGeneratorStageSplit(t *testing.T) {
 	srv := stageImageServer(t)
 	base := afero.NewMemMapFs()
-	pm := NewPosterManager(base, "/tmp/p2", srv.Client()).WithSSRFCheck(func(string) error { return nil })
+	pm := NewPosterManager(base, "/tmp/p2", srv.Client(), 0).WithSSRFCheck(func(string) error { return nil })
 	gen := NewScrapePosterGenerator(pm, "", "")
 
 	movie := &models.Movie{ID: "G-1", Poster: models.PosterState{CoverURL: srv.URL + "/cover.jpg"}}
@@ -160,7 +160,7 @@ func TestScrapePosterGeneratorStageSplit(t *testing.T) {
 
 func TestStagePosterDownload_ValidationAndDownloadErrors(t *testing.T) {
 	srv := stageImageServer(t)
-	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp/p2", srv.Client()).WithSSRFCheck(func(string) error { return nil })
+	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp/p2", srv.Client(), 0).WithSSRFCheck(func(string) error { return nil })
 	if _, err := pm.StagePosterDownload(context.Background(), StagePosterRequest{JobID: "../escape", PosterID: "X-1", URL: srv.URL}); err == nil {
 		t.Fatal("invalid jobID must fail")
 	}
@@ -191,7 +191,7 @@ func TestPromoteStagedPoster_StagingStatErrorAborts(t *testing.T) {
 	require.NoError(t, base.MkdirAll("/tmp/p2/posters/job1", 0o755))
 	require.NoError(t, afero.WriteFile(base, "/tmp/p2/posters/job1/ST-P4.stage-x.jpg", []byte("s"), 0o644))
 	wedged := statFailExactFS{Fs: base, path: "/tmp/p2/posters/job1/ST-P4.stage-x-full.jpg"}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P4.stage-x", "ST-P4", ""))
 	require.ErrorContains(t, err, "promote staging stat")
 }
@@ -205,7 +205,7 @@ func TestPromoteStagedPoster_CanonicalStatErrorAborts(t *testing.T) {
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-P5.stage-x.jpg", []byte("s-crop"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-P5-full.jpg", []byte("c"), 0o644))
 	wedged := statFailExactFS{Fs: base, path: dir + "/ST-P5-full.jpg"}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P5.stage-x", "ST-P5", ""))
 	require.ErrorContains(t, err, "promote canonical stat")
 	got, _ := afero.ReadFile(base, dir+"/ST-P5-full.jpg")
@@ -226,7 +226,7 @@ func TestPromoteStagedPoster_AsideFailureRestoresEarlierLegs(t *testing.T) {
 	wedged := renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
 		return strings.HasSuffix(n, ".bak") && strings.Contains(o, "ST-P6.jpg")
 	}}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P6.stage-x", "ST-P6", ""))
 	require.ErrorContains(t, err, "back up")
 	got, _ := afero.ReadFile(base, dir+"/ST-P6-full.jpg")
@@ -247,7 +247,7 @@ func TestPromoteStagedPoster_Phase2FailureWithoutBackup(t *testing.T) {
 	wedged := renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
 		return strings.Contains(o, ".stage-") && strings.HasSuffix(n, "/ST-P7.jpg")
 	}}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P7.stage-x", "ST-P7", ""))
 	require.ErrorContains(t, err, "promote staged poster")
 	_, ferr := base.Stat(dir + "/ST-P7-full.jpg")
@@ -270,7 +270,7 @@ func TestPromoteStagedPoster_RestoreFailureWarnsKeepsBackup(t *testing.T) {
 	wedged := renameFailWhereFS{Fs: base, fail: func(_, n string) bool {
 		return strings.HasSuffix(n, "/ST-P8-full.jpg")
 	}}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P8.stage-x", "ST-P8", ""))
 	require.ErrorContains(t, err, "promote staged poster")
 }
@@ -284,7 +284,7 @@ func TestPromoteStagedPoster_BackupSweepWarnIsNonFatal(t *testing.T) {
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-P9-stagez.jpg", []byte("s"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-P9.jpg", []byte("c"), 0o644))
 	wedged := removeFailWhereFS{Fs: base, fail: func(n string) bool { return strings.HasSuffix(n, ".bak") }}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 	res, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P9-stagez", "ST-P9", dir+"/ST-P9.jpg"))
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -306,7 +306,7 @@ func TestStagedPoster_DiscardRemoveFailureWarns(t *testing.T) {
 	dir := "/tmp/p2/posters/job1"
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-P10.stage-x.jpg", []byte("s"), 0o644))
-	pm := NewPosterManager(removeFailWhereFS{Fs: base, fail: func(string) bool { return true }}, "/tmp/p2", nil)
+	pm := NewPosterManager(removeFailWhereFS{Fs: base, fail: func(string) bool { return true }}, "/tmp/p2", nil, 0)
 	pm.DiscardStagedPoster(NewStagedPosterHandleForTest("job1", "ST-P10.stage-x", "ST-P10", "")) // warn-only, must not panic
 }
 
@@ -395,7 +395,7 @@ func TestPromoteStagedPoster_CanonicalStatWedgedRestoresAsidedLeg(t *testing.T) 
 	// The crop leg's canonical Stat fails transiently: the full leg has
 	// already been asided to .bak — the restore must put it back.
 	wedged := statFailExactFS{Fs: base, path: dir + "/PC-1.jpg"}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "PC-1.stage-x", "PC-1", ""))
 	require.ErrorContains(t, err, "promote canonical stat")
 
@@ -432,7 +432,7 @@ func TestPromoteStagedPoster_RestoreRenameWedgedKeepsBackup(t *testing.T) {
 		}
 		return strings.Contains(o, ".bak") && strings.HasSuffix(n, "/R-4-full.jpg")
 	}}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "R-4.stage-x", "R-4", ""))
 	require.ErrorContains(t, err, "promote staged poster")
 
@@ -468,7 +468,7 @@ func TestPromoteStagedPoster_IncompleteStageFails(t *testing.T) {
 	require.NoError(t, afero.WriteFile(base, dir+"/INC-1.stage-x.jpg", []byte("s-crop"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/INC-1-full.jpg", []byte("c-full"), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/INC-1.jpg", []byte("c-crop"), 0o644))
-	pm := NewPosterManager(base, "/tmp/p2", nil)
+	pm := NewPosterManager(base, "/tmp/p2", nil, 0)
 
 	_, err := pm.PromoteStagedPoster(NewStagedPosterHandleForTest("job1", "INC-1.stage-x", "INC-1", ""))
 	require.ErrorContains(t, err, "incomplete stage")

--- a/internal/poster/manager_stage_p2_test.go
+++ b/internal/poster/manager_stage_p2_test.go
@@ -56,7 +56,7 @@ func TestPosterManager_CropWithBounds_FailedInstallKeepsPreviousPreview(t *testi
 	base2 := &renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
 		return strings.Contains(o, ".tmp") && strings.HasSuffix(n, "/ST-1.jpg")
 	}}
-	pm := NewPosterManager(base2, "/tmp/p2", nil)
+	pm := NewPosterManager(base2, "/tmp/p2", nil, 0)
 
 	_, err := pm.CropWithBounds(context.Background(), "job1", "ST-1", 0, 0, 100, 150, 0)
 	require.Error(t, err, "install failure must surface")
@@ -85,7 +85,7 @@ func TestPosterManager_CropWithBounds_InstallWritesFinalPathOnlyViaRename(t *tes
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-2.jpg", []byte("old-preview-bytes"), 0o644))
 
 	spy := &writeSpyFS{Fs: base, writes: map[string]int{}}
-	pm := NewPosterManager(spy, "/tmp/p2", nil)
+	pm := NewPosterManager(spy, "/tmp/p2", nil, 0)
 
 	res, err := pm.CropWithBounds(context.Background(), "job1", "ST-2", 0, 0, 100, 150, 0)
 	require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestPosterManager_SnapshotRestore_RoundTrip(t *testing.T) {
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/SN-1-full.jpg", jpegBytes(200, 300), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/SN-1.jpg", []byte("crop-v1"), 0o644))
-	pm := NewPosterManager(base, "/tmp/p2", nil)
+	pm := NewPosterManager(base, "/tmp/p2", nil, 0)
 
 	snap, err := pm.SnapshotAssets("job1", "SN-1")
 	require.NoError(t, err)
@@ -134,7 +134,7 @@ func TestPosterManager_SnapshotRestore_RemovesCreatedAssets(t *testing.T) {
 	dir := "/tmp/p2/posters/job1"
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/SN-2-full.jpg", jpegBytes(200, 300), 0o644))
-	pm := NewPosterManager(base, "/tmp/p2", nil)
+	pm := NewPosterManager(base, "/tmp/p2", nil, 0)
 
 	snap, err := pm.SnapshotAssets("job1", "SN-2")
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestPosterManager_CropWithBounds_AsideFailureKeepsEverything(t *testing.T) 
 	wedged := openFileFailWhereFS{Fs: base, fail: func(n string, flag int) bool {
 		return strings.Contains(n, ".bak") && flag&os.O_CREATE != 0
 	}}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 
 	_, err := pm.CropWithBounds(context.Background(), "job1", "ST-3", 0, 0, 100, 150, 0)
 	require.ErrorContains(t, err, "back up previous preview")
@@ -230,7 +230,7 @@ func TestPosterManager_CropWithBounds_InstallFailureKeepsOld(t *testing.T) {
 	wedged := renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
 		return strings.Contains(o, ".tmp") && strings.HasSuffix(n, "/ST-4.jpg")
 	}}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 
 	_, err := pm.CropWithBounds(context.Background(), "job1", "ST-4", 0, 0, 100, 150, 0)
 	require.Error(t, err)
@@ -258,7 +258,7 @@ func TestPosterManager_CropWithBounds_BackupSweepWarnKeepsSuccess(t *testing.T) 
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-5-full.jpg", jpegBytes(200, 300), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-5.jpg", []byte("old-preview"), 0o644))
 	wedged := removeFailWhereFS{Fs: base, fail: func(n string) bool { return strings.HasSuffix(n, ".bak") }}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 
 	res, err := pm.CropWithBounds(context.Background(), "job1", "ST-5", 0, 0, 100, 150, 0)
 	require.NoError(t, err, "sweep wedge is warn-only")
@@ -274,7 +274,7 @@ func TestPosterManager_SnapshotAssets_ReadFaultSurfaces(t *testing.T) {
 	dir := "/tmp/p2/posters/job1"
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/SN-9-full.jpg", jpegBytes(200, 300), 0o644))
-	pm := NewPosterManager(openFailSuffixFS{Fs: base, suffix: "/SN-9-full.jpg"}, "/tmp/p2", nil)
+	pm := NewPosterManager(openFailSuffixFS{Fs: base, suffix: "/SN-9-full.jpg"}, "/tmp/p2", nil, 0)
 	_, err := pm.SnapshotAssets("job1", "SN-9")
 	require.ErrorContains(t, err, "snapshot assets")
 }
@@ -282,13 +282,13 @@ func TestPosterManager_SnapshotAssets_ReadFaultSurfaces(t *testing.T) {
 // Nil snapshot is a no-op; the crop-leg read fault also surfaces.
 func TestPosterManager_SnapshotRestore_EdgeArms(t *testing.T) {
 	base := afero.NewMemMapFs()
-	pm := NewPosterManager(base, "/tmp/p2", nil)
+	pm := NewPosterManager(base, "/tmp/p2", nil, 0)
 	require.NoError(t, pm.RestoreAssets(nil))
 
 	dir := "/tmp/p2/posters/job1"
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/SN-8.jpg", []byte("crop"), 0o644))
-	pm2 := NewPosterManager(openFailSuffixFS{Fs: base, suffix: "/SN-8.jpg"}, "/tmp/p2", nil)
+	pm2 := NewPosterManager(openFailSuffixFS{Fs: base, suffix: "/SN-8.jpg"}, "/tmp/p2", nil, 0)
 	_, err := pm2.SnapshotAssets("job1", "SN-8")
 	require.ErrorContains(t, err, "snapshot assets")
 }
@@ -301,20 +301,20 @@ func TestPosterManager_RestoreAssets_LegFailureArms(t *testing.T) {
 	dir := "/tmp/p2/posters/job1"
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/SN-3-full.jpg", jpegBytes(200, 300), 0o644))
-	pm := NewPosterManager(base, "/tmp/p2", nil)
+	pm := NewPosterManager(base, "/tmp/p2", nil, 0)
 	snap, err := pm.SnapshotAssets("job1", "SN-3")
 	require.NoError(t, err)
 	require.NoError(t, afero.WriteFile(base, dir+"/SN-3.jpg", jpegBytes(100, 150), 0o644))
 
 	wedged := removeFailWhereFS{Fs: base, fail: func(n string) bool { return strings.HasSuffix(n, "/SN-3.jpg") }}
-	pmWedged := NewPosterManager(wedged, "/tmp/p2", nil)
+	pmWedged := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 	require.ErrorContains(t, pmWedged.RestoreAssets(snap), "remove created leg")
 
 	// staged-write wedge when restoring an existing leg
 	base2 := afero.NewMemMapFs()
 	require.NoError(t, base2.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base2, dir+"/SN-4.jpg", []byte("v1"), 0o644))
-	pm2 := NewPosterManager(base2, "/tmp/p2", nil)
+	pm2 := NewPosterManager(base2, "/tmp/p2", nil, 0)
 	snap2, err := pm2.SnapshotAssets("job1", "SN-4")
 	require.NoError(t, err)
 	require.NoError(t, afero.WriteFile(base2, dir+"/SN-4.jpg", []byte("v2"), 0o644))
@@ -322,7 +322,7 @@ func TestPosterManager_RestoreAssets_LegFailureArms(t *testing.T) {
 	stageWedged := openFileFailWhereFS{Fs: base2, fail: func(n string, flag int) bool {
 		return strings.HasSuffix(n, ".tmp") && flag&os.O_CREATE != 0
 	}}
-	pm3 := NewPosterManager(stageWedged, "/tmp/p2", nil)
+	pm3 := NewPosterManager(stageWedged, "/tmp/p2", nil, 0)
 	require.ErrorContains(t, pm3.RestoreAssets(snap2), "stage leg")
 	got, rerr := afero.ReadFile(base2, dir+"/SN-4.jpg")
 	require.NoError(t, rerr)
@@ -330,7 +330,7 @@ func TestPosterManager_RestoreAssets_LegFailureArms(t *testing.T) {
 
 	// install wedge when restoring: error surfaces and no residue remains
 	installWedged := renameFailWhereFS{Fs: base2, fail: func(o, n string) bool { return strings.Contains(o, ".tmp") }}
-	pm4 := NewPosterManager(installWedged, "/tmp/p2", nil)
+	pm4 := NewPosterManager(installWedged, "/tmp/p2", nil, 0)
 	require.ErrorContains(t, pm4.RestoreAssets(snap2), "install leg")
 	entries, derr := afero.ReadDir(base2, dir)
 	require.NoError(t, derr)
@@ -341,7 +341,7 @@ func TestPosterManager_RestoreAssets_LegFailureArms(t *testing.T) {
 
 // Validation arms: a hostile jobID/posterID fails before any fs access.
 func TestPosterManager_SnapshotRestore_ValidationArms(t *testing.T) {
-	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp/p2", nil)
+	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp/p2", nil, 0)
 	if _, err := pm.SnapshotAssets("../escape", "V-1"); err == nil {
 		t.Fatal("invalid jobID must fail")
 	}
@@ -357,7 +357,7 @@ func TestPosterManager_RestoreAssets_FullLegFailureAbortsCropLeg(t *testing.T) {
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/SN-7-full.jpg", jpegBytes(200, 300), 0o644))
 	require.NoError(t, afero.WriteFile(base, dir+"/SN-7.jpg", []byte("crop-v1"), 0o644))
-	pm := NewPosterManager(base, "/tmp/p2", nil)
+	pm := NewPosterManager(base, "/tmp/p2", nil, 0)
 	snap, err := pm.SnapshotAssets("job1", "SN-7")
 	require.NoError(t, err)
 	require.NoError(t, afero.WriteFile(base, dir+"/SN-7.jpg", []byte("crop-v2"), 0o644))
@@ -366,7 +366,7 @@ func TestPosterManager_RestoreAssets_FullLegFailureAbortsCropLeg(t *testing.T) {
 	wedged := openFileFailWhereFS{Fs: base, fail: func(n string, flag int) bool {
 		return strings.Contains(n, "SN-7-full.jpg.") && strings.HasSuffix(n, ".tmp") && flag&os.O_CREATE != 0
 	}}
-	pmWedged := NewPosterManager(wedged, "/tmp/p2", nil)
+	pmWedged := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 	err2 := pmWedged.RestoreAssets(snap)
 	require.ErrorContains(t, err2, "stage leg")
 	got, rerr := afero.ReadFile(base, dir+"/SN-7.jpg")
@@ -381,7 +381,7 @@ func TestPosterManager_CropWithBounds_StagedCleanupWarnOnFailure(t *testing.T) {
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/ST-6-full.jpg", jpegBytes(200, 300), 0o644))
 	wedged := removeFailWhereFS{Fs: base, fail: func(n string) bool { return strings.HasSuffix(n, ".tmp") }}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 
 	// Out-of-range bounds: crop fails after the staged name is allocated.
 	_, err := pm.CropWithBounds(context.Background(), "job1", "ST-6", 0, 0, 99999, 99999, 0)
@@ -397,7 +397,7 @@ func TestInstallStagedPreview_StatWedgeFailsClosed(t *testing.T) {
 	require.NoError(t, base.MkdirAll(dir, 0o755))
 	require.NoError(t, afero.WriteFile(base, dir+"/FC-1.jpg", []byte("old-preview"), 0o644))
 	wedged := statFailExactFS{Fs: base, path: dir + "/FC-1.jpg"}
-	pm := NewPosterManager(wedged, "/tmp/p2", nil)
+	pm := NewPosterManager(wedged, "/tmp/p2", nil, 0)
 
 	staged := dir + "/FC-1.jpg.staged.tmp"
 	require.NoError(t, afero.WriteFile(base, staged, []byte("new-preview"), 0o644))
@@ -428,7 +428,7 @@ func TestInstallStagedPreview_NeverRemovesCanonical(t *testing.T) {
 	wedgeRemoveFinal := removeFailWhereFS{Fs: base, fail: func(n string) bool {
 		return strings.HasSuffix(n, "/NG-1.jpg")
 	}}
-	pm := NewPosterManager(wedgeRemoveFinal, "/tmp/p2", nil)
+	pm := NewPosterManager(wedgeRemoveFinal, "/tmp/p2", nil, 0)
 
 	err := pm.installStagedPreview(dir+"/NG-1.jpg", dir+"/NG-1.jpg.staged.tmp")
 	require.NoError(t, err, "no Remove(final) step exists at all — swap is rename-atomic")
@@ -447,7 +447,7 @@ func TestInstallStagedPreview_FailedInstallBackupSweepWarnOnly(t *testing.T) {
 	combo := removeFailWhereFS{Fs: renameFailWhereFS{Fs: base, fail: func(o, n string) bool {
 		return strings.Contains(o, ".tmp") && strings.HasSuffix(n, "/NG-2.jpg")
 	}}, fail: func(n string) bool { return strings.HasSuffix(n, ".bak") }}
-	pm := NewPosterManager(combo, "/tmp/p2", nil)
+	pm := NewPosterManager(combo, "/tmp/p2", nil, 0)
 
 	err := pm.installStagedPreview(dir+"/NG-2.jpg", dir+"/NG-2.jpg.staged.tmp")
 	require.ErrorContains(t, err, "failed to install staged preview")

--- a/internal/poster/manager_stall_coverage_test.go
+++ b/internal/poster/manager_stall_coverage_test.go
@@ -1,0 +1,32 @@
+package poster
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+)
+
+func TestDownloadFromURL_StallReaderWrapped(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("fake-image-data"))
+	}))
+	defer server.Close()
+
+	fs := afero.NewMemMapFs()
+	pm := NewPosterManager(fs, "/tmp", server.Client(), 100*time.Millisecond).
+		WithSSRFCheck(func(_ string) error { return nil })
+
+	result, err := pm.DownloadFromURL(context.Background(), "job1", "ST-STALL", server.URL+"/img.jpg", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}

--- a/internal/poster/manager_test.go
+++ b/internal/poster/manager_test.go
@@ -40,7 +40,7 @@ func createTestJPEG(fs afero.Fs, path string, width, height int) error {
 func newTestManager(httpClient httpclientiface.HTTPClient) *PosterManager {
 	fs := afero.NewMemMapFs()
 	tempDir := "/tmp/javinizer-test"
-	return NewPosterManager(fs, tempDir, httpClient)
+	return NewPosterManager(fs, tempDir, httpClient, 0)
 }
 
 // newTestManagerBypassSSRF creates a PosterManager that skips SSRF checks
@@ -454,7 +454,7 @@ func TestPosterManagerInterface_Satisfied(t *testing.T) {
 	// This test exists for documentation; the compile-time check is the
 	// var _ assignment in manager.go. We verify NewPosterManager returns a
 	// usable value.
-	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp", http.DefaultClient)
+	pm := NewPosterManager(afero.NewMemMapFs(), "/tmp", http.DefaultClient, 0)
 	assert.NotNil(t, pm)
 }
 
@@ -542,7 +542,7 @@ func TestDownloadFromURL_CreatesTempDir(t *testing.T) {
 
 	// Use a fresh fs so the temp dir doesn't exist yet.
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/fresh-tmp", srv.Client()).WithSSRFCheck(func(_ string) error { return nil })
+	pm := NewPosterManager(fs, "/fresh-tmp", srv.Client(), 0).WithSSRFCheck(func(_ string) error { return nil })
 
 	result, err := pm.DownloadFromURL(
 		context.Background(), "job1", "ABC-123",
@@ -566,7 +566,7 @@ func TestDownloadFromURL_CleansUpTempOnError(t *testing.T) {
 	defer srv.Close()
 
 	fs := afero.NewMemMapFs()
-	pm := NewPosterManager(fs, "/tmp", srv.Client())
+	pm := NewPosterManager(fs, "/tmp", srv.Client(), 0)
 
 	_, err := pm.DownloadFromURL(
 		context.Background(), "job1", "ABC-123",

--- a/internal/poster/uncovered_test.go
+++ b/internal/poster/uncovered_test.go
@@ -86,12 +86,12 @@ func TestMaxPosterSize_Uncovered(t *testing.T) {
 }
 
 func TestNewPosterManager_Uncovered(t *testing.T) {
-	pm := NewPosterManager(nil, "/tmp", nil)
+	pm := NewPosterManager(nil, "/tmp", nil, 0)
 	assert.NotNil(t, pm)
 }
 
 func TestPosterManager_WithSSRFCheck_Uncovered(t *testing.T) {
-	pm := NewPosterManager(nil, "/tmp", nil)
+	pm := NewPosterManager(nil, "/tmp", nil, 0)
 	pm2 := pm.WithSSRFCheck(func(rawURL string) error {
 		return nil
 	})

--- a/internal/workflow/factory.go
+++ b/internal/workflow/factory.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	httpclientiface "github.com/javinizer/javinizer-go/internal/httpclient"
+	httpclient "github.com/javinizer/javinizer-go/internal/httpclient"
 
 	"github.com/javinizer/javinizer-go/internal/aggregator"
 	"github.com/javinizer/javinizer-go/internal/config"
@@ -69,7 +69,7 @@ type workflowFactoryConfig struct {
 	NFOGenerator nfo.GeneratorInterface
 	NFOIface     nfo.NFOInterface // Composite passed to sub-orchestrators that narrow it: compare→NFOFieldMerger, preview→NFOFieldMerger, apply→NFOFileMerger, revertLog→NFOFieldMerger
 	Downloader   downloader.DownloaderInterface
-	HTTPClient   httpclientiface.HTTPClient
+	HTTPClient   httpclient.HTTPClient
 	PosterGen    poster.PosterGenerator
 	Scraper      scrape.ScraperInterface
 	Aggregator   aggregator.AggregatorInterface
@@ -169,9 +169,6 @@ func buildDownloadHTTPCfg(cfg *config.Config, downloadCfg *downloader.Config, sc
 	proxyResolvers := registry.CollectDownloadProxyResolvers(scrapeCfg.ScrapersPriority)
 
 	downloadTimeout := downloadCfg.DownloadTimeout
-	if downloadTimeout <= 0 {
-		downloadTimeout = 60
-	}
 	return downloader.HTTPClientConfig{
 		Timeout:           time.Duration(downloadTimeout) * time.Second,
 		DownloadProxy:     downloadProxyProfile,
@@ -192,7 +189,7 @@ func buildScanner(fs afero.Fs, snCfg *scanner.Config) scanner.ScannerInterface {
 // Per D-8: accepts ContentRepos + ReplacementRepos instead of the full Repositories
 // bag, making the dependency surface explicit — callers see exactly which domains
 // the scraper needs.
-func buildScraper(scrapeCfg *scrape.Config, aggCfg *aggregator.Config, translator scrape.Translator, registry ScraperResolver, httpClient httpclientiface.HTTPClient, fs afero.Fs, content database.ContentRepos, replacement database.ReplacementRepos) (scrape.ScraperInterface, aggregator.AggregatorInterface, error) {
+func buildScraper(scrapeCfg *scrape.Config, aggCfg *aggregator.Config, translator scrape.Translator, registry ScraperResolver, httpClient httpclient.HTTPClient, fs afero.Fs, content database.ContentRepos, replacement database.ReplacementRepos) (scrape.ScraperInterface, aggregator.AggregatorInterface, error) {
 	// MovieRepo is strictly required — it is accessed unconditionally during
 	// scraping and persistence. The other repos (ActressRepo, ActressAliasRepo,
 	// GenreReplacementRepo, WordReplacementRepo) are passed to the aggregator
@@ -268,7 +265,7 @@ func buildNFO(fs afero.Fs, nfoCfg *nfo.Config, engine *template.Engine) (nfo.Gen
 }
 
 // buildDownloader constructs the media downloader and its HTTP client.
-func buildDownloader(httpCfg downloader.HTTPClientConfig, fs afero.Fs, downloadCfg *downloader.Config, engine *template.Engine) (downloader.DownloaderInterface, httpclientiface.HTTPClient, error) {
+func buildDownloader(httpCfg downloader.HTTPClientConfig, fs afero.Fs, downloadCfg *downloader.Config, engine *template.Engine) (downloader.DownloaderInterface, httpclient.HTTPClient, error) {
 	httpClient, httpErr := downloader.NewHTTPClient(httpCfg)
 	if httpErr != nil {
 		return nil, nil, fmt.Errorf("buildDownloader: failed to create HTTP client: %w", httpErr)
@@ -277,8 +274,8 @@ func buildDownloader(httpCfg downloader.HTTPClientConfig, fs afero.Fs, downloadC
 }
 
 // buildPosterGenerator constructs the poster generator from its dependencies.
-func buildPosterGenerator(fs afero.Fs, scrapeCfg *scrape.Config, httpClient httpclientiface.HTTPClient) poster.PosterGenerator {
-	posterManager := poster.NewPosterManager(fs, scrapeCfg.TempDir, httpClient)
+func buildPosterGenerator(fs afero.Fs, scrapeCfg *scrape.Config, httpClient httpclient.HTTPClient, idleTimeout time.Duration) poster.PosterGenerator {
+	posterManager := poster.NewPosterManager(fs, scrapeCfg.TempDir, httpClient, idleTimeout)
 	return poster.NewScrapePosterGenerator(posterManager, scrapeCfg.UserAgent, scrapeCfg.Referer)
 }
 
@@ -363,7 +360,7 @@ func NewFactoryConfigFromRepos(cfg *config.Config, registry ScraperResolver, rep
 	if httpErr != nil {
 		return workflowFactoryConfig{}, httpErr
 	}
-	posterGen := buildPosterGenerator(fs, dcs.scrapeCfg, httpClient)
+	posterGen := buildPosterGenerator(fs, dcs.scrapeCfg, httpClient, time.Duration(dcs.downloadCfg.DownloadTimeout)*time.Second)
 
 	scraperObj, agg, scraperErr := buildScraper(dcs.scrapeCfg, dcs.aggCfg, dcs.translation, registry, httpClient, fs, repos.ContentRepos, repos.ReplacementRepos)
 	previewCfg, applyCfg := buildOrchestratorConfigs(cfg, dcs, fs, fileMatcher, sharedEngine)

--- a/internal/workflow/miss2_test.go
+++ b/internal/workflow/miss2_test.go
@@ -477,12 +477,12 @@ func TestBuildDownloadHTTPCfg_ZeroTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	downloadCfg := downloader.ConfigFromAppConfig(cfg, nfo.NFONameConfigFromAppConfig(cfg))
-	downloadCfg.DownloadTimeout = 0 // zero timeout should default to 60s
+	downloadCfg.DownloadTimeout = 0 // zero timeout = no idle timeout (not clamped)
 	scrapeCfg := scrape.ConfigFromAppConfig(cfg)
 	registry := scraperutil.NewScraperRegistry()
 
 	result := buildDownloadHTTPCfg(cfg, downloadCfg, scrapeCfg, registry)
-	assert.Equal(t, 60, int(result.Timeout.Seconds()), "zero timeout should default to 60s")
+	assert.Equal(t, 0, int(result.Timeout.Seconds()), "zero timeout should not be clamped to 60s")
 }
 
 // ---------------------------------------------------------------------------

--- a/web/frontend/messages/en-XA.json
+++ b/web/frontend/messages/en-XA.json
@@ -1411,7 +1411,7 @@
   "settings_output_download_extrafanart": "[ Döwñlöåd Ëxtråfåñårt ]",
   "settings_output_download_heading": "[ Döwñlöåd Öptíöñs ]",
   "settings_output_download_poster": "[ Döwñlöåd Pöstër ]",
-  "settings_output_download_timeout_desc": "[ Måxímüm tímë tö wåít för ímågë/vídëö döwñlöåds tö çömplëtë ]",
+  "settings_output_download_timeout_desc": "[ Ïðlë/ßtåll tëmpöråõüt: åbörtß å ðoŵñlöåð íf ño ßytëß årë nëcëíväð förr ðhíß ðüråtíöñ. 0 = ño íðlë tëmpöråõüt (rëlý oñ ẃörkërr çoñtëxt). Ðëfåült: 120 ]",
   "settings_output_download_timeout_label": "[ Döwñlöåd tímëöüt ]",
   "settings_output_download_trailer": "[ Döwñlöåd Tråílër ]",
   "settings_output_fanart_format_desc": "[ Ñåmíñg tëmplåtë för fåñårt/çövër ímågës ]",

--- a/web/frontend/messages/en.json
+++ b/web/frontend/messages/en.json
@@ -2069,7 +2069,7 @@
   "settings_output_download_extrafanart": "Download Extrafanart",
   "settings_output_download_heading": "Download Options",
   "settings_output_download_poster": "Download Poster",
-  "settings_output_download_timeout_desc": "Maximum time to wait for image/video downloads to complete",
+  "settings_output_download_timeout_desc": "Idle/stall timeout: aborts a download if no bytes are received for this duration. 0 = no idle timeout (rely on worker context). Default: 120",
   "settings_output_download_timeout_label": "Download timeout",
   "settings_output_download_trailer": "Download Trailer",
   "settings_output_fanart_format_desc": "Naming template for fanart/cover images",

--- a/web/frontend/messages/ja.json
+++ b/web/frontend/messages/ja.json
@@ -2071,7 +2071,7 @@
   "settings_output_download_extrafanart": "エクストラファンアートをダウンロード",
   "settings_output_download_heading": "ダウンロードオプション",
   "settings_output_download_poster": "ポスターをダウンロード",
-  "settings_output_download_timeout_desc": "画像/動画ダウンロード完了の最大待機時間",
+  "settings_output_download_timeout_desc": "アイドル/ストールタイムアウト: この時間内にバイトが受信されない場合、ダウンロードを中止します。0 = アイドルタイムアウトなし（ワーカーコンテキストに依存）。デフォルト: 120",
   "settings_output_download_timeout_label": "ダウンロードタイムアウト",
   "settings_output_download_trailer": "予告編をダウンロード",
   "settings_output_fanart_format_desc": "ファンアート/カバー画像用命名テンプレート",

--- a/web/frontend/messages/zh-Hans.json
+++ b/web/frontend/messages/zh-Hans.json
@@ -2071,7 +2071,7 @@
   "settings_output_download_extrafanart": "下载额外背景图",
   "settings_output_download_heading": "下载选项",
   "settings_output_download_poster": "下载海报",
-  "settings_output_download_timeout_desc": "等待图片/视频下载完成的最长时间",
+  "settings_output_download_timeout_desc": "空闲/停滞超时：如果在此期间内未收到字节，则中止下载。0 = 无空闲超时（依赖工作上下文）。默认值：120",
   "settings_output_download_timeout_label": "下载超时",
   "settings_output_download_trailer": "下载预告片",
   "settings_output_fanart_format_desc": "背景图/封面图片的命名模板",

--- a/web/frontend/messages/zh-Hant.json
+++ b/web/frontend/messages/zh-Hant.json
@@ -2071,7 +2071,7 @@
   "settings_output_download_extrafanart": "下載額外背景圖",
   "settings_output_download_heading": "下載選項",
   "settings_output_download_poster": "下載海報",
-  "settings_output_download_timeout_desc": "等待圖片/影片下載完成的最長時間",
+  "settings_output_download_timeout_desc": "空閒/停滯逾時：若在此期間內未收到位元組，則中止下載。0 = 無空閒逾時（依賴工作上下文）。預設值：120",
   "settings_output_download_timeout_label": "下載逾時",
   "settings_output_download_trailer": "下載預告片",
   "settings_output_fanart_format_desc": "背景圖/封面圖片的命名範本",

--- a/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
+++ b/web/frontend/src/lib/components/settings/sections/OutputSettingsSection.svelte
@@ -168,8 +168,8 @@
 		<FormNumberInput
 			label={m.settings_output_download_timeout_label()}
 			description={m.settings_output_download_timeout_desc()}
-			value={config.output.download_timeout ?? 60}
-			min={5}
+			value={config.output.download_timeout ?? 120}
+			min={0}
 			max={600}
 			unit="seconds"
 			onchange={(val) => {


### PR DESCRIPTION
## Summary

Trailer downloads fail with `context deadline exceeded (Client.Timeout or context cancellation while reading body)` because the downloader uses `http.Client.Timeout` (default 60s) as an absolute total deadline covering the entire HTTP exchange including body read via `io.Copy`. DMM trailers are large video files (10-600MB) served from throttled CDNs; 60s is insufficient. The user's `worker_timeout` (300-500s) is silently dominated by the 60s client wall - increasing it has no effect.

Reported in #214. Worked in v1.4.0 because the overwrite-existing-media flow (#177) now re-downloads trailers that v1.4.0 silently skipped when the file already existed.

## Changes

- **Remove `http.Client.Timeout`** from all downloader clients (set to 0)
- **Add `StallReader`**: wraps `resp.Body` with a stall watchdog that aborts only when no bytes are received for `download_timeout` seconds, permitting slow-but-active large downloads to proceed indefinitely
- **Set `ResponseHeaderTimeout`, `DialContext`, and `TLSHandshakeTimeout`** on downloader transports (downloader-side only, not shared `NewTransport`) to catch dead servers during connection setup
- **Route trailer downloads through `retryableOperation`** (2 retries, 100ms exponential backoff) with `errDownloadStalled`/`errDownloadTruncated`/`errDownloadEmpty` implementing `net.Error` for retry classification
- **Wrap `poster.Manager` response body** with `StallReader` (shared `httpClient`)
- **Add `io.ErrUnexpectedEOF`** as retryable (standard HTTP truncation case)
- **Reinterpret `download_timeout`** as idle/stall timeout (`0` = disabled)
- **Remove the `download_timeout <= 0 -> 60` clamp** in workflow factory
- **Increase default `download_timeout`** from 60 to 120
- **Add config validation** rejecting negative `download_timeout`
- **Update docs, swagger, config examples, and frontend i18n**

## Test plan

- [x] `go test -short ./...` - all pass
- [x] `go test -race ./internal/downloader/ ./internal/poster/ ./internal/workflow/ ./internal/api/core/` - all pass
- [x] `golangci-lint run ./...` - 0 issues
- [x] `go build ./...` - clean
- [x] `go vet ./...` - clean
- [x] `make coverage-check` - 92.11% (required 75%)
- [x] Frontend E2E tests - 146 passed
- [x] Frontend unit tests - 576 passed
- [x] `make swagger` - regenerated
- [x] `make i18n-check` - OK
- [x] Local codex review - 0 findings after 18 review rounds

Closes #214