### PR TITLE
feat: finish poster write hardening (phase 5)

### DIFF
--- a/internal/api/batch/apply_metadata_p5_test.go
+++ b/internal/api/batch/apply_metadata_p5_test.go
@@ -1,0 +1,31 @@
+package batch
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApply_MetadataEditDuringApply_StaysAccepted is the explicit D5
+// regression: apply owns the write-back merge, so review metadata edits remain
+// admitted while the apply phase marker is active.
+func TestApply_MetadataEditDuringApply_StaysAccepted(t *testing.T) {
+	_, job, router := newEditHardeningRouter(t, &config.Config{})
+	job.Controller().SetJobStatus(models.JobStatusRunning)
+	job.Lifecycle().SetCurrentPhase(string(worker.JobPhaseApply))
+
+	w := doJSON(t, router, http.MethodPatch,
+		fmt.Sprintf("/batch/%s/results/AAA-100", job.GetID()),
+		contracts.UpdateMovieRequest{Movie: &contracts.MovieView{ID: "AAA-100", Title: "edited during apply"}})
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	result, err := job.Results().GetMovieResult("/path/to/AAA-100.mp4")
+	require.NoError(t, err)
+	require.Equal(t, "edited during apply", result.Movie.Title)
+}

--- a/internal/api/core/bootstrap.go
+++ b/internal/api/core/bootstrap.go
@@ -62,6 +62,9 @@ func bootstrapAPIDeps(cfg *config.Config, configFile string, auth commandutil.Au
 	}); ok {
 		setter.SetOrganizedJobPruneHook(pruneSweeper.PruneOperationBackups)
 	}
+	// The API server starts this configured sweep at the server boundary via
+	// rt.StartStartupSweep after bootstrap returns, keeping reconciliation
+	// asynchronous while still covering the API startup crash window.
 	reverter := history.NewReverter(fs, repos.BatchFileOpRepo)
 
 	apiDeps := &APIDeps{

--- a/internal/api/core/bootstrap.go
+++ b/internal/api/core/bootstrap.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/javinizer/javinizer-go/internal/commandutil"
 	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/database"
 	"github.com/javinizer/javinizer-go/internal/eventlog"
 	"github.com/javinizer/javinizer-go/internal/history"
 	"github.com/javinizer/javinizer-go/internal/logging"
@@ -56,6 +57,10 @@ func bootstrapAPIDeps(cfg *config.Config, configFile string, auth commandutil.Au
 	fs := afero.NewOsFs()
 	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, sharedEngine, fs, worker.WithActressRepo(repos.ActressRepo), worker.WithHistoryRepo(repos.HistoryRepo), worker.WithEditTransactor(coreDeps.DB))
 	eventEmitter := eventlog.NewEmitter(repos.EventRepo)
+	pruneSweeper := history.NewReplacementSweeper(fs, repos.BatchFileOpRepo)
+	if setter, ok := repos.JobRepo.(database.OrganizedJobPruneHookSetter); ok {
+		setter.SetOrganizedJobPruneHook(pruneSweeper.PruneOperationBackups)
+	}
 	reverter := history.NewReverter(fs, repos.BatchFileOpRepo)
 
 	apiDeps := &APIDeps{

--- a/internal/api/core/bootstrap.go
+++ b/internal/api/core/bootstrap.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/javinizer/javinizer-go/internal/commandutil"
 	"github.com/javinizer/javinizer-go/internal/config"
-	"github.com/javinizer/javinizer-go/internal/database"
 	"github.com/javinizer/javinizer-go/internal/eventlog"
 	"github.com/javinizer/javinizer-go/internal/history"
 	"github.com/javinizer/javinizer-go/internal/logging"
@@ -58,7 +57,9 @@ func bootstrapAPIDeps(cfg *config.Config, configFile string, auth commandutil.Au
 	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, sharedEngine, fs, worker.WithActressRepo(repos.ActressRepo), worker.WithHistoryRepo(repos.HistoryRepo), worker.WithEditTransactor(coreDeps.DB))
 	eventEmitter := eventlog.NewEmitter(repos.EventRepo)
 	pruneSweeper := history.NewReplacementSweeper(fs, repos.BatchFileOpRepo)
-	if setter, ok := repos.JobRepo.(database.OrganizedJobPruneHookSetter); ok {
+	if setter, ok := repos.JobRepo.(interface {
+		SetOrganizedJobPruneHook(func(context.Context, []models.BatchFileOperation) error)
+	}); ok {
 		setter.SetOrganizedJobPruneHook(pruneSweeper.PruneOperationBackups)
 	}
 	reverter := history.NewReverter(fs, repos.BatchFileOpRepo)

--- a/internal/database/batch_file_operation_repo.go
+++ b/internal/database/batch_file_operation_repo.go
@@ -36,6 +36,9 @@ func NewBatchFileOperationRepository(db *DB) *BatchFileOperationRepository {
 
 // Create inserts a single batch file operation record.
 func (r *BatchFileOperationRepository) Create(ctx context.Context, op *models.BatchFileOperation) error {
+	if err := ensureJobWritable(r.GetDB().WithContext(ctx), op.BatchJobID); err != nil {
+		return wrapDBErr("create", fmt.Sprintf("batch file operation %d", op.ID), err)
+	}
 	return r.BaseRepository.Create(ctx, op)
 }
 
@@ -43,6 +46,9 @@ func (r *BatchFileOperationRepository) Create(ctx context.Context, op *models.Ba
 func (r *BatchFileOperationRepository) CreateBatch(ctx context.Context, ops []*models.BatchFileOperation) error {
 	return r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, op := range ops {
+			if err := ensureJobWritable(tx, op.BatchJobID); err != nil {
+				return err
+			}
 			if err := tx.Create(op).Error; err != nil {
 				return wrapDBErr("create", fmt.Sprintf("batch file operation %d", op.ID), err)
 			}
@@ -78,15 +84,24 @@ func (r *BatchFileOperationRepository) FindByBatchJobIDAndRevertStatus(ctx conte
 
 // UpdateRevertStatus sets the revert status of an operation, stamping reverted_at when the status is reverted.
 func (r *BatchFileOperationRepository) UpdateRevertStatus(ctx context.Context, id uint, status models.RevertStatusEnum) error {
+	now := time.Now().UTC()
 	updates := map[string]any{
 		"revert_status": status,
-		"updated_at":    time.Now().UTC(),
+		"updated_at":    now,
 	}
 	if status == models.RevertStatusReverted {
-		updates["reverted_at"] = time.Now().UTC()
+		updates["reverted_at"] = now
 	}
-	if err := r.GetDB().WithContext(ctx).Model(&models.BatchFileOperation{}).Where("id = ?", id).Updates(updates).Error; err != nil {
-		return wrapDBErr("update", fmt.Sprintf("batch file operation %d revert status", id), err)
+	db := r.GetDB().WithContext(ctx).Model(&models.BatchFileOperation{}).
+		Where("id = ? AND NOT EXISTS (SELECT 1 FROM jobs WHERE jobs.id = batch_file_operations.batch_job_id AND jobs.status = ?)", id, pruningJobStatus)
+	result := db.Updates(updates)
+	if result.Error != nil {
+		return wrapDBErr("update", fmt.Sprintf("batch file operation %d revert status", id), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		if err := ensureOperationWritable(r.GetDB().WithContext(ctx), id); err != nil {
+			return wrapDBErr("update", fmt.Sprintf("batch file operation %d revert status", id), err)
+		}
 	}
 	return nil
 }
@@ -165,6 +180,10 @@ func (r *BatchFileOperationRepository) UpdateJournalInTx(ctx context.Context, id
 		}
 	}()
 
+	if err := ensureOperationWritableConn(ctx, conn, id, true); err != nil {
+		return err
+	}
+
 	var raw sql.NullString
 	var status models.RevertStatusEnum
 	scanErr := conn.QueryRowContext(ctx,
@@ -209,6 +228,9 @@ func (r *BatchFileOperationRepository) UpdateJournalInTx(ctx context.Context, id
 // completion writes go through UpdateNonJournalFields (wave-10 codex
 // follow-up).
 func (r *BatchFileOperationRepository) Update(ctx context.Context, op *models.BatchFileOperation) error {
+	if err := ensureJobWritable(r.GetDB().WithContext(ctx), op.BatchJobID); err != nil {
+		return wrapDBErr("update", fmt.Sprintf("batch file operation %d", op.ID), err)
+	}
 	if err := r.GetDB().WithContext(ctx).Save(op).Error; err != nil {
 		return wrapDBErr("update", fmt.Sprintf("batch file operation %d", op.ID), err)
 	}
@@ -280,6 +302,9 @@ func (r *BatchFileOperationRepository) UpdateNonJournalFields(ctx context.Contex
 			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
 		}
 	}()
+	if err := ensureOperationWritableConn(ctx, conn, op.ID, false); err != nil {
+		return wrapDBErr("update non-journal fields", label, err)
+	}
 
 	now := time.Now().UTC()
 	// (a) Non-status columns unconditionally — the wave-10 Save-parity set.

--- a/internal/database/batch_file_operation_repo.go
+++ b/internal/database/batch_file_operation_repo.go
@@ -36,10 +36,16 @@ func NewBatchFileOperationRepository(db *DB) *BatchFileOperationRepository {
 
 // Create inserts a single batch file operation record.
 func (r *BatchFileOperationRepository) Create(ctx context.Context, op *models.BatchFileOperation) error {
-	if err := ensureJobWritable(r.GetDB().WithContext(ctx), op.BatchJobID); err != nil {
+	err := r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := ensureJobWritable(tx, op.BatchJobID); err != nil {
+			return err
+		}
+		return tx.Create(op).Error
+	})
+	if err != nil {
 		return wrapDBErr("create", fmt.Sprintf("batch file operation %d", op.ID), err)
 	}
-	return r.BaseRepository.Create(ctx, op)
+	return nil
 }
 
 // CreateBatch inserts multiple batch file operation records in a single transaction.
@@ -228,10 +234,13 @@ func (r *BatchFileOperationRepository) UpdateJournalInTx(ctx context.Context, id
 // completion writes go through UpdateNonJournalFields (wave-10 codex
 // follow-up).
 func (r *BatchFileOperationRepository) Update(ctx context.Context, op *models.BatchFileOperation) error {
-	if err := ensureJobWritable(r.GetDB().WithContext(ctx), op.BatchJobID); err != nil {
-		return wrapDBErr("update", fmt.Sprintf("batch file operation %d", op.ID), err)
-	}
-	if err := r.GetDB().WithContext(ctx).Save(op).Error; err != nil {
+	err := r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := ensureJobWritable(tx, op.BatchJobID); err != nil {
+			return err
+		}
+		return tx.Save(op).Error
+	})
+	if err != nil {
 		return wrapDBErr("update", fmt.Sprintf("batch file operation %d", op.ID), err)
 	}
 	return nil

--- a/internal/database/interfaces.go
+++ b/internal/database/interfaces.go
@@ -128,19 +128,6 @@ type MovieTagRepositoryInterface interface {
 // The canonical definition lives in models to avoid import cycles (scraperutil → database → config).
 type ContentIDMappingRepositoryInterface = models.ContentIDMappingRepositoryInterface
 
-// OrganizedJobPruneHook runs after DeleteOrganizedOlderThan commits its
-// job-row and operation-row deletions. It receives the deleted operation
-// snapshots so a filesystem owner can clean only backups that have no live
-// ledger references left.
-type OrganizedJobPruneHook func(context.Context, []models.BatchFileOperation) error
-
-// OrganizedJobPruneHookSetter is an optional capability of the concrete job
-// repository. It stays separate from JobRepositoryInterface so lightweight
-// repository test doubles do not need filesystem cleanup behavior.
-type OrganizedJobPruneHookSetter interface {
-	SetOrganizedJobPruneHook(OrganizedJobPruneHook)
-}
-
 // JobRepositoryInterface defines the contract for job database operations
 type JobRepositoryInterface interface {
 	Create(ctx context.Context, job *models.Job) error

--- a/internal/database/interfaces.go
+++ b/internal/database/interfaces.go
@@ -128,6 +128,19 @@ type MovieTagRepositoryInterface interface {
 // The canonical definition lives in models to avoid import cycles (scraperutil → database → config).
 type ContentIDMappingRepositoryInterface = models.ContentIDMappingRepositoryInterface
 
+// OrganizedJobPruneHook runs after DeleteOrganizedOlderThan commits its
+// job-row and operation-row deletions. It receives the deleted operation
+// snapshots so a filesystem owner can clean only backups that have no live
+// ledger references left.
+type OrganizedJobPruneHook func(context.Context, []models.BatchFileOperation) error
+
+// OrganizedJobPruneHookSetter is an optional capability of the concrete job
+// repository. It stays separate from JobRepositoryInterface so lightweight
+// repository test doubles do not need filesystem cleanup behavior.
+type OrganizedJobPruneHookSetter interface {
+	SetOrganizedJobPruneHook(OrganizedJobPruneHook)
+}
+
 // JobRepositoryInterface defines the contract for job database operations
 type JobRepositoryInterface interface {
 	Create(ctx context.Context, job *models.Job) error

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -61,11 +61,7 @@ func (r *JobRepository) Update(ctx context.Context, job *models.Job) error {
 	if job == nil {
 		return fmt.Errorf("update job: job must not be nil")
 	}
-	job.PruneVersion++
-	if err := r.GetDB().WithContext(ctx).Save(job).Error; err != nil {
-		return wrapDBErr("update", fmt.Sprintf("job %s", job.ID), err)
-	}
-	return nil
+	return r.saveVersioned(ctx, job, "update")
 }
 
 // Upsert inserts or replaces the given job record by primary key.
@@ -73,9 +69,32 @@ func (r *JobRepository) Upsert(ctx context.Context, job *models.Job) error {
 	if job == nil {
 		return fmt.Errorf("upsert job: job must not be nil")
 	}
-	job.PruneVersion++
-	if err := r.GetDB().WithContext(ctx).Save(job).Error; err != nil {
-		return wrapDBErr("upsert", fmt.Sprintf("job %s", job.ID), err)
+	return r.saveVersioned(ctx, job, "upsert")
+}
+
+// saveVersioned increments prune_version in the database before saving the
+// caller's fields. The first write acquires SQLite's writer lock, so stale
+// callers cannot reuse a version observed before a concurrent writer commit.
+func (r *JobRepository) saveVersioned(ctx context.Context, job *models.Job, operation string) error {
+	err := r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Model(&models.Job{}).Where("id = ?", job.ID).
+			UpdateColumn("prune_version", gorm.Expr("prune_version + 1"))
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			job.PruneVersion = 0
+			return tx.Create(job).Error
+		}
+		var version uint64
+		if err := tx.Model(&models.Job{}).Where("id = ?", job.ID).Pluck("prune_version", &version).Error; err != nil {
+			return err
+		}
+		job.PruneVersion = version
+		return tx.Save(job).Error
+	})
+	if err != nil {
+		return wrapDBErr(operation, fmt.Sprintf("job %s", job.ID), err)
 	}
 	return nil
 }
@@ -135,36 +154,63 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 		}
 	}
 
-	// Re-apply both job and operation UpdatedAt snapshots at deletion time.
-	// A concurrent revert/edit changes one of these versions and makes the
-	// eligible predicate empty, so cleanup never deletes a row it did not see.
-	jobPredicates := make([]string, 0, len(prunedJobs))
-	jobArgs := make([]any, 0, len(prunedJobs)*2)
-	for _, job := range prunedJobs {
-		jobPredicates = append(jobPredicates, "(id = ? AND prune_version = ?)")
-		jobArgs = append(jobArgs, job.ID, job.PruneVersion)
-	}
-	opPredicates := make([]string, 0, len(prunedOps))
-	opArgs := make([]any, 0, len(prunedOps)*2)
-	for _, op := range prunedOps {
-		opPredicates = append(opPredicates, "(id = ? AND updated_at = ?)")
-		opArgs = append(opArgs, op.ID, op.UpdatedAt)
-	}
 	return r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		jobWhere := "status = ? AND (" + strings.Join(jobPredicates, " OR ") + ")"
-		jobWhereArgs := append([]any{models.JobStatusOrganized}, jobArgs...)
-		eligibleJobs := tx.Model(&models.Job{}).Select("id").Where(jobWhere, jobWhereArgs...)
-		if len(opPredicates) > 0 {
-			opWhere := "(" + strings.Join(opPredicates, " OR ") + ") AND batch_job_id IN (?)"
-			if err := tx.Where(opWhere, append(opArgs, eligibleJobs)...).Delete(&models.BatchFileOperation{}).Error; err != nil {
-				return wrapDBErr("delete", "organized job operations", err)
+		for start := 0; start < len(prunedJobs); start += pruneDeleteBatchSize {
+			end := start + pruneDeleteBatchSize
+			if end > len(prunedJobs) {
+				end = len(prunedJobs)
 			}
-		}
-		if err := tx.Where("id IN (?) AND NOT EXISTS (SELECT 1 FROM batch_file_operations WHERE batch_job_id = jobs.id)", eligibleJobs).Delete(&models.Job{}).Error; err != nil {
-			return wrapDBErr("delete", "organized jobs", err)
+			jobChunk := prunedJobs[start:end]
+			jobIDs := make(map[string]struct{}, len(jobChunk))
+			for _, job := range jobChunk {
+				jobIDs[job.ID] = struct{}{}
+			}
+			opChunk := make([]models.BatchFileOperation, 0)
+			for _, op := range prunedOps {
+				if _, ok := jobIDs[op.BatchJobID]; ok {
+					opChunk = append(opChunk, op)
+				}
+			}
+			if err := deletePrunedJobChunk(tx, jobChunk, opChunk); err != nil {
+				return err
+			}
 		}
 		return nil
 	})
+}
+
+const pruneDeleteBatchSize = 200
+
+func deletePrunedJobChunk(tx *gorm.DB, jobs []models.Job, ops []models.BatchFileOperation) error {
+	jobPredicates := make([]string, 0, len(jobs))
+	jobArgs := make([]any, 0, len(jobs)*2)
+	for _, job := range jobs {
+		jobPredicates = append(jobPredicates, "(id = ? AND prune_version = ?)")
+		jobArgs = append(jobArgs, job.ID, job.PruneVersion)
+	}
+	jobWhere := "status = ? AND (" + strings.Join(jobPredicates, " OR ") + ")"
+	jobWhereArgs := append([]any{models.JobStatusOrganized}, jobArgs...)
+	eligibleJobs := tx.Model(&models.Job{}).Select("id").Where(jobWhere, jobWhereArgs...)
+	for start := 0; start < len(ops); start += pruneDeleteBatchSize {
+		end := start + pruneDeleteBatchSize
+		if end > len(ops) {
+			end = len(ops)
+		}
+		opPredicates := make([]string, 0, end-start)
+		opArgs := make([]any, 0, (end-start)*2)
+		for _, op := range ops[start:end] {
+			opPredicates = append(opPredicates, "(id = ? AND updated_at = ?)")
+			opArgs = append(opArgs, op.ID, op.UpdatedAt)
+		}
+		opWhere := "(" + strings.Join(opPredicates, " OR ") + ") AND batch_job_id IN (?)"
+		if err := tx.Where(opWhere, append(opArgs, eligibleJobs)...).Delete(&models.BatchFileOperation{}).Error; err != nil {
+			return wrapDBErr("delete", "organized job operations", err)
+		}
+	}
+	if err := tx.Where("id IN (?) AND NOT EXISTS (SELECT 1 FROM batch_file_operations WHERE batch_job_id = jobs.id)", eligibleJobs).Delete(&models.Job{}).Error; err != nil {
+		return wrapDBErr("delete", "organized jobs", err)
+	}
+	return nil
 }
 
 func hasReplacementLedger(ops []models.BatchFileOperation) bool {

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -58,6 +58,9 @@ func (r *JobRepository) Create(ctx context.Context, job *models.Job) error {
 
 // Update saves all fields of the given job record.
 func (r *JobRepository) Update(ctx context.Context, job *models.Job) error {
+	if job == nil {
+		return fmt.Errorf("update job: job must not be nil")
+	}
 	job.PruneVersion++
 	if err := r.GetDB().WithContext(ctx).Save(job).Error; err != nil {
 		return wrapDBErr("update", fmt.Sprintf("job %s", job.ID), err)
@@ -67,6 +70,9 @@ func (r *JobRepository) Update(ctx context.Context, job *models.Job) error {
 
 // Upsert inserts or replaces the given job record by primary key.
 func (r *JobRepository) Upsert(ctx context.Context, job *models.Job) error {
+	if job == nil {
+		return fmt.Errorf("upsert job: job must not be nil")
+	}
 	job.PruneVersion++
 	if err := r.GetDB().WithContext(ctx).Save(job).Error; err != nil {
 		return wrapDBErr("upsert", fmt.Sprintf("job %s", job.ID), err)
@@ -154,7 +160,7 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 				return wrapDBErr("delete", "organized job operations", err)
 			}
 		}
-		if err := tx.Where("id IN (?)", eligibleJobs).Delete(&models.Job{}).Error; err != nil {
+		if err := tx.Where("id IN (?) AND NOT EXISTS (SELECT 1 FROM batch_file_operations WHERE batch_job_id = jobs.id)", eligibleJobs).Delete(&models.Job{}).Error; err != nil {
 			return wrapDBErr("delete", "organized jobs", err)
 		}
 		return nil

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -58,6 +58,7 @@ func (r *JobRepository) Create(ctx context.Context, job *models.Job) error {
 
 // Update saves all fields of the given job record.
 func (r *JobRepository) Update(ctx context.Context, job *models.Job) error {
+	job.PruneVersion++
 	if err := r.GetDB().WithContext(ctx).Save(job).Error; err != nil {
 		return wrapDBErr("update", fmt.Sprintf("job %s", job.ID), err)
 	}
@@ -66,6 +67,7 @@ func (r *JobRepository) Update(ctx context.Context, job *models.Job) error {
 
 // Upsert inserts or replaces the given job record by primary key.
 func (r *JobRepository) Upsert(ctx context.Context, job *models.Job) error {
+	job.PruneVersion++
 	if err := r.GetDB().WithContext(ctx).Save(job).Error; err != nil {
 		return wrapDBErr("upsert", fmt.Sprintf("job %s", job.ID), err)
 	}
@@ -113,6 +115,9 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 	if err != nil {
 		return err
 	}
+	if len(prunedJobs) == 0 {
+		return nil
+	}
 
 	hook := r.organizedJobPruneHook()
 	if hasReplacementLedger(prunedOps) && hook == nil {
@@ -124,15 +129,32 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 		}
 	}
 
-	jobIDs := make([]string, 0, len(prunedJobs))
+	// Re-apply both job and operation UpdatedAt snapshots at deletion time.
+	// A concurrent revert/edit changes one of these versions and makes the
+	// eligible predicate empty, so cleanup never deletes a row it did not see.
+	jobPredicates := make([]string, 0, len(prunedJobs))
+	jobArgs := make([]any, 0, len(prunedJobs)*2)
 	for _, job := range prunedJobs {
-		jobIDs = append(jobIDs, job.ID)
+		jobPredicates = append(jobPredicates, "(id = ? AND prune_version = ?)")
+		jobArgs = append(jobArgs, job.ID, job.PruneVersion)
+	}
+	opPredicates := make([]string, 0, len(prunedOps))
+	opArgs := make([]any, 0, len(prunedOps)*2)
+	for _, op := range prunedOps {
+		opPredicates = append(opPredicates, "(id = ? AND updated_at = ?)")
+		opArgs = append(opArgs, op.ID, op.UpdatedAt)
 	}
 	return r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("batch_job_id IN ?", jobIDs).Delete(&models.BatchFileOperation{}).Error; err != nil {
-			return wrapDBErr("delete", "organized job operations", err)
+		jobWhere := "status = ? AND (" + strings.Join(jobPredicates, " OR ") + ")"
+		jobWhereArgs := append([]any{models.JobStatusOrganized}, jobArgs...)
+		eligibleJobs := tx.Model(&models.Job{}).Select("id").Where(jobWhere, jobWhereArgs...)
+		if len(opPredicates) > 0 {
+			opWhere := "(" + strings.Join(opPredicates, " OR ") + ") AND batch_job_id IN (?)"
+			if err := tx.Where(opWhere, append(opArgs, eligibleJobs)...).Delete(&models.BatchFileOperation{}).Error; err != nil {
+				return wrapDBErr("delete", "organized job operations", err)
+			}
 		}
-		if err := tx.Where("id IN ?", jobIDs).Delete(&models.Job{}).Error; err != nil {
+		if err := tx.Where("id IN (?)", eligibleJobs).Delete(&models.Job{}).Error; err != nil {
 			return wrapDBErr("delete", "organized jobs", err)
 		}
 		return nil
@@ -141,7 +163,11 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 
 func hasReplacementLedger(ops []models.BatchFileOperation) bool {
 	for _, op := range ops {
-		if strings.Contains(op.GeneratedFiles, `"replacements"`) {
+		if strings.TrimSpace(op.GeneratedFiles) == "" {
+			continue
+		}
+		gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+		if err != nil || len(gf.Replacements) > 0 {
 			return true
 		}
 	}

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/javinizer/javinizer-go/internal/models"
@@ -12,6 +13,9 @@ import (
 // JobRepository persists and queries Job records via GORM, composing BaseRepository for common operations.
 type JobRepository struct {
 	*BaseRepository[models.Job, string]
+
+	pruneMu   sync.RWMutex
+	pruneHook OrganizedJobPruneHook
 }
 
 // NewJobRepository constructs a JobRepository ordered by started_at then id for deterministic pagination.
@@ -29,6 +33,21 @@ func NewJobRepository(db *DB) *JobRepository {
 			WithNewEntity[models.Job, string](func() models.Job { return models.Job{} }),
 		),
 	}
+}
+
+// SetOrganizedJobPruneHook installs the post-commit cleanup invoked after
+// organized jobs and their operation rows are pruned. The hook is optional so
+// database-only callers can retain the repository's original behavior.
+func (r *JobRepository) SetOrganizedJobPruneHook(hook OrganizedJobPruneHook) {
+	r.pruneMu.Lock()
+	r.pruneHook = hook
+	r.pruneMu.Unlock()
+}
+
+func (r *JobRepository) organizedJobPruneHook() OrganizedJobPruneHook {
+	r.pruneMu.RLock()
+	defer r.pruneMu.RUnlock()
+	return r.pruneHook
 }
 
 // Create inserts a new job record, delegating to the base repository.
@@ -69,10 +88,14 @@ func (r *JobRepository) Delete(ctx context.Context, id string) error {
 
 // DeleteOrganizedOlderThan removes organized jobs whose organized_at predates the given date.
 func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.Time) error {
+	var prunedOps []models.BatchFileOperation
 	err := r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		oldJobs := tx.Model(&models.Job{}).
 			Select("id").
 			Where("status = ? AND organized_at < ?", models.JobStatusOrganized, date)
+		if err := tx.Where("batch_job_id IN (?)", oldJobs).Find(&prunedOps).Error; err != nil {
+			return wrapDBErr("find", "organized job operations", err)
+		}
 		if err := tx.Where("batch_job_id IN (?)", oldJobs).Delete(&models.BatchFileOperation{}).Error; err != nil {
 			return wrapDBErr("delete", "organized job operations", err)
 		}
@@ -81,5 +104,13 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 		}
 		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	if hook := r.organizedJobPruneHook(); hook != nil && len(prunedOps) > 0 {
+		if err := hook(ctx, prunedOps); err != nil {
+			return wrapDBErr("prune", "organized job backups", err)
+		}
+	}
+	return nil
 }

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -88,11 +89,15 @@ func (r *JobRepository) Delete(ctx context.Context, id string) error {
 
 // DeleteOrganizedOlderThan removes organized jobs whose organized_at predates the given date.
 func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.Time) error {
+	var prunedJobs []models.Job
 	var prunedOps []models.BatchFileOperation
 	err := r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		oldJobs := tx.Model(&models.Job{}).
 			Select("id").
 			Where("status = ? AND organized_at < ?", models.JobStatusOrganized, date)
+		if err := tx.Where("status = ? AND organized_at < ?", models.JobStatusOrganized, date).Find(&prunedJobs).Error; err != nil {
+			return wrapDBErr("find", "organized jobs", err)
+		}
 		if err := tx.Where("batch_job_id IN (?)", oldJobs).Find(&prunedOps).Error; err != nil {
 			return wrapDBErr("find", "organized job operations", err)
 		}
@@ -109,8 +114,31 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 	}
 	if hook := r.organizedJobPruneHook(); hook != nil && len(prunedOps) > 0 {
 		if err := hook(ctx, prunedOps); err != nil {
-			return wrapDBErr("prune", "organized job backups", err)
+			restoreErr := r.restorePrunedRows(ctx, prunedJobs, prunedOps)
+			return errors.Join(wrapDBErr("prune", "organized job backups", err), restoreErr)
 		}
 	}
 	return nil
+}
+
+// restorePrunedRows keeps the job and ledger snapshots durable when the
+// post-commit filesystem cleanup cannot start or complete. The caller can
+// retry pruning later without losing the backup ownership records.
+func (r *JobRepository) restorePrunedRows(ctx context.Context, jobs []models.Job, ops []models.BatchFileOperation) error {
+	if len(jobs) == 0 && len(ops) == 0 {
+		return nil
+	}
+	return r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for i := range jobs {
+			if err := tx.Create(&jobs[i]).Error; err != nil {
+				return wrapDBErr("restore", fmt.Sprintf("organized job %s", jobs[i].ID), err)
+			}
+		}
+		for i := range ops {
+			if err := tx.Create(&ops[i]).Error; err != nil {
+				return wrapDBErr("restore", fmt.Sprintf("organized job operation %d", ops[i].ID), err)
+			}
+		}
+		return nil
+	})
 }

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/javinizer/javinizer-go/internal/models"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // JobRepository persists and queries Job records via GORM, composing BaseRepository for common operations.
@@ -16,7 +17,7 @@ type JobRepository struct {
 	*BaseRepository[models.Job, string]
 
 	pruneMu   sync.RWMutex
-	pruneHook OrganizedJobPruneHook
+	pruneHook func(context.Context, []models.BatchFileOperation) error
 }
 
 // NewJobRepository constructs a JobRepository ordered by started_at then id for deterministic pagination.
@@ -39,13 +40,13 @@ func NewJobRepository(db *DB) *JobRepository {
 // SetOrganizedJobPruneHook installs the post-commit cleanup invoked after
 // organized jobs and their operation rows are pruned. The hook is optional so
 // database-only callers can retain the repository's original behavior.
-func (r *JobRepository) SetOrganizedJobPruneHook(hook OrganizedJobPruneHook) {
+func (r *JobRepository) SetOrganizedJobPruneHook(hook func(context.Context, []models.BatchFileOperation) error) {
 	r.pruneMu.Lock()
 	r.pruneHook = hook
 	r.pruneMu.Unlock()
 }
 
-func (r *JobRepository) organizedJobPruneHook() OrganizedJobPruneHook {
+func (r *JobRepository) organizedJobPruneHook() func(context.Context, []models.BatchFileOperation) error {
 	r.pruneMu.RLock()
 	defer r.pruneMu.RUnlock()
 	return r.pruneHook
@@ -114,11 +115,54 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 	}
 	if hook := r.organizedJobPruneHook(); hook != nil && len(prunedOps) > 0 {
 		if err := hook(ctx, prunedOps); err != nil {
-			restoreErr := r.restorePrunedRows(ctx, prunedJobs, prunedOps)
+			restoreOps := pruneOpsForRestore(prunedOps, err)
+			restoreCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			restoreErr := r.restorePrunedRows(restoreCtx, prunedJobs, restoreOps)
+			cancel()
 			return errors.Join(wrapDBErr("prune", "organized job backups", err), restoreErr)
 		}
 	}
 	return nil
+}
+
+// pruneOpsForRestore removes only entries that the cleanup hook confirms were
+// already consumed. This prevents a partial filesystem cleanup from restoring
+// a stale ledger reference to bytes that no longer exist.
+func pruneOpsForRestore(ops []models.BatchFileOperation, hookErr error) []models.BatchFileOperation {
+	type consumedProgress interface {
+		ConsumedBackups() map[uint]map[string]struct{}
+	}
+	var progress consumedProgress
+	if !errors.As(hookErr, &progress) {
+		return ops
+	}
+	consumed := progress.ConsumedBackups()
+	if len(consumed) == 0 {
+		return ops
+	}
+	restored := make([]models.BatchFileOperation, len(ops))
+	copy(restored, ops)
+	for i := range restored {
+		backups := consumed[restored[i].ID]
+		if len(backups) == 0 {
+			continue
+		}
+		gf, err := models.ParseGeneratedFiles(restored[i].GeneratedFiles)
+		if err != nil {
+			continue
+		}
+		kept := gf.Replacements[:0]
+		for _, entry := range gf.Replacements {
+			if _, removed := backups[entry.Backup]; !removed {
+				kept = append(kept, entry)
+			}
+		}
+		if len(kept) != len(gf.Replacements) {
+			gf.Replacements = kept
+			restored[i].GeneratedFiles = models.MarshalLedgerJSON(gf)
+		}
+	}
+	return restored
 }
 
 // restorePrunedRows keeps the job and ledger snapshots durable when the
@@ -130,12 +174,12 @@ func (r *JobRepository) restorePrunedRows(ctx context.Context, jobs []models.Job
 	}
 	return r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for i := range jobs {
-			if err := tx.Create(&jobs[i]).Error; err != nil {
+			if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&jobs[i]).Error; err != nil {
 				return wrapDBErr("restore", fmt.Sprintf("organized job %s", jobs[i].ID), err)
 			}
 		}
 		for i := range ops {
-			if err := tx.Create(&ops[i]).Error; err != nil {
+			if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&ops[i]).Error; err != nil {
 				return wrapDBErr("restore", fmt.Sprintf("organized job operation %d", ops[i].ID), err)
 			}
 		}

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -128,12 +128,20 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 		if len(prunedJobs) == 0 {
 			return nil
 		}
-		jobIDs := make([]string, 0, len(prunedJobs))
-		for _, job := range prunedJobs {
-			jobIDs = append(jobIDs, job.ID)
-		}
-		if err := tx.Where("batch_job_id IN ?", jobIDs).Find(&prunedOps).Error; err != nil {
-			return wrapDBErr("find", "organized job operations", err)
+		for start := 0; start < len(prunedJobs); start += pruneDeleteBatchSize {
+			end := start + pruneDeleteBatchSize
+			if end > len(prunedJobs) {
+				end = len(prunedJobs)
+			}
+			jobIDs := make([]string, 0, end-start)
+			for _, job := range prunedJobs[start:end] {
+				jobIDs = append(jobIDs, job.ID)
+			}
+			var chunk []models.BatchFileOperation
+			if err := tx.Where("batch_job_id IN ?", jobIDs).Find(&chunk).Error; err != nil {
+				return wrapDBErr("find", "organized job operations", err)
+			}
+			prunedOps = append(prunedOps, chunk...)
 		}
 		return nil
 	})
@@ -144,6 +152,7 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 		return nil
 	}
 
+	originalPrunedOps := append([]models.BatchFileOperation(nil), prunedOps...)
 	hook := r.organizedJobPruneHook()
 	if hasReplacementLedger(prunedOps) && hook == nil {
 		return fmt.Errorf("prune organized jobs: replacement cleanup hook is not configured")
@@ -151,6 +160,9 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 	if hook != nil && len(prunedOps) > 0 {
 		if err := hook(ctx, prunedOps); err != nil {
 			return wrapDBErr("prune", "organized job backups", err)
+		}
+		if err := r.refreshConsumedPrunedOps(ctx, originalPrunedOps, &prunedOps); err != nil {
+			return wrapDBErr("prune", "refresh consumed operation versions", err)
 		}
 	}
 
@@ -177,6 +189,41 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 		}
 		return nil
 	})
+}
+
+func (r *JobRepository) refreshConsumedPrunedOps(ctx context.Context, original []models.BatchFileOperation, current *[]models.BatchFileOperation) error {
+	if len(original) == 0 {
+		return nil
+	}
+	var live []models.BatchFileOperation
+	for start := 0; start < len(original); start += pruneDeleteBatchSize {
+		end := start + pruneDeleteBatchSize
+		if end > len(original) {
+			end = len(original)
+		}
+		ids := make([]uint, 0, end-start)
+		for _, op := range original[start:end] {
+			ids = append(ids, op.ID)
+		}
+		var chunk []models.BatchFileOperation
+		if err := r.GetDB().WithContext(ctx).Where("id IN ?", ids).Find(&chunk).Error; err != nil {
+			return err
+		}
+		live = append(live, chunk...)
+	}
+	byID := make(map[uint]models.BatchFileOperation, len(live))
+	for _, op := range live {
+		byID[op.ID] = op
+	}
+	for i := range *current {
+		if !hasReplacementLedger([]models.BatchFileOperation{original[i]}) {
+			continue
+		}
+		if liveOp, ok := byID[original[i].ID]; ok && !hasReplacementLedger([]models.BatchFileOperation{liveOp}) {
+			(*current)[i] = liveOp
+		}
+	}
+	return nil
 }
 
 const pruneDeleteBatchSize = 200

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/javinizer/javinizer-go/internal/models"
+	"gorm.io/gorm"
 )
 
 // JobRepository persists and queries Job records via GORM, composing BaseRepository for common operations.
@@ -68,8 +69,17 @@ func (r *JobRepository) Delete(ctx context.Context, id string) error {
 
 // DeleteOrganizedOlderThan removes organized jobs whose organized_at predates the given date.
 func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.Time) error {
-	if err := r.GetDB().WithContext(ctx).Where("status = ? AND organized_at < ?", models.JobStatusOrganized, date).Delete(&models.Job{}).Error; err != nil {
-		return wrapDBErr("delete", "organized jobs", err)
-	}
-	return nil
+	err := r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		oldJobs := tx.Model(&models.Job{}).
+			Select("id").
+			Where("status = ? AND organized_at < ?", models.JobStatusOrganized, date)
+		if err := tx.Where("batch_job_id IN (?)", oldJobs).Delete(&models.BatchFileOperation{}).Error; err != nil {
+			return wrapDBErr("delete", "organized job operations", err)
+		}
+		if err := tx.Where("status = ? AND organized_at < ?", models.JobStatusOrganized, date).Delete(&models.Job{}).Error; err != nil {
+			return wrapDBErr("delete", "organized jobs", err)
+		}
+		return nil
+	})
+	return err
 }

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -10,6 +11,23 @@ import (
 	"github.com/javinizer/javinizer-go/internal/models"
 	"gorm.io/gorm"
 )
+
+const pruningJobStatus models.JobStatus = "pruning"
+
+// ErrJobPruning reports that a mutation raced a durable organized-job prune claim.
+var ErrJobPruning = errors.New("organized job is being pruned")
+
+type pruneMaintenanceContextKey struct{}
+
+// WithPruneMaintenance authorizes the retention hook to mutate operation
+// journals while their owning jobs carry the durable pruning fence.
+func WithPruneMaintenance(ctx context.Context) context.Context {
+	return context.WithValue(ctx, pruneMaintenanceContextKey{}, true)
+}
+
+func pruneMaintenance(ctx context.Context) bool {
+	return ctx != nil && ctx.Value(pruneMaintenanceContextKey{}) == true
+}
 
 // JobRepository persists and queries Job records via GORM, composing BaseRepository for common operations.
 type JobRepository struct {
@@ -77,14 +95,22 @@ func (r *JobRepository) Upsert(ctx context.Context, job *models.Job) error {
 // callers cannot reuse a version observed before a concurrent writer commit.
 func (r *JobRepository) saveVersioned(ctx context.Context, job *models.Job, operation string) error {
 	err := r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		result := tx.Model(&models.Job{}).Where("id = ?", job.ID).
+		// The conditional increment is the first statement: either this writer
+		// wins the database writer lock before pruning claims the row, or the
+		// pruning fence is observed and the mutation is rejected.
+		result := tx.Model(&models.Job{}).Where("id = ? AND status <> ?", job.ID, pruningJobStatus).
 			UpdateColumn("prune_version", gorm.Expr("prune_version + 1"))
 		if result.Error != nil {
 			return result.Error
 		}
 		if result.RowsAffected == 0 {
-			job.PruneVersion = 0
-			return tx.Create(job).Error
+			var existing models.Job
+			statusResult := tx.Select("status").Where("id = ?", job.ID).First(&existing)
+			if errors.Is(statusResult.Error, gorm.ErrRecordNotFound) {
+				job.PruneVersion = 0
+				return tx.Create(job).Error
+			}
+			return ErrJobPruning
 		}
 		var version uint64
 		if err := tx.Model(&models.Job{}).Where("id = ?", job.ID).Pluck("prune_version", &version).Error; err != nil {
@@ -122,7 +148,15 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 	var prunedJobs []models.Job
 	var prunedOps []models.BatchFileOperation
 	err := r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("status = ? AND organized_at < ?", models.JobStatusOrganized, date).Find(&prunedJobs).Error; err != nil {
+		// Claim is the first write. A concurrent job/operation writer either
+		// commits before this fence and is included in the fresh snapshot, or
+		// observes pruningJobStatus and is rejected until cleanup finishes.
+		if err := tx.Model(&models.Job{}).
+			Where("status = ? AND organized_at < ?", models.JobStatusOrganized, date).
+			Update("status", pruningJobStatus).Error; err != nil {
+			return wrapDBErr("claim", "organized jobs for pruning", err)
+		}
+		if err := tx.Where("status = ? AND organized_at < ?", pruningJobStatus, date).Find(&prunedJobs).Error; err != nil {
 			return wrapDBErr("find", "organized jobs", err)
 		}
 		if len(prunedJobs) == 0 {
@@ -152,17 +186,13 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 		return nil
 	}
 
-	originalPrunedOps := append([]models.BatchFileOperation(nil), prunedOps...)
 	hook := r.organizedJobPruneHook()
 	if hasReplacementLedger(prunedOps) && hook == nil {
 		return fmt.Errorf("prune organized jobs: replacement cleanup hook is not configured")
 	}
 	if hook != nil && len(prunedOps) > 0 {
-		if err := hook(ctx, prunedOps); err != nil {
+		if err := hook(WithPruneMaintenance(ctx), prunedOps); err != nil {
 			return wrapDBErr("prune", "organized job backups", err)
-		}
-		if err := r.refreshConsumedPrunedOps(ctx, originalPrunedOps, &prunedOps); err != nil {
-			return wrapDBErr("prune", "refresh consumed operation versions", err)
 		}
 	}
 
@@ -173,17 +203,7 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 				end = len(prunedJobs)
 			}
 			jobChunk := prunedJobs[start:end]
-			jobIDs := make(map[string]struct{}, len(jobChunk))
-			for _, job := range jobChunk {
-				jobIDs[job.ID] = struct{}{}
-			}
-			opChunk := make([]models.BatchFileOperation, 0)
-			for _, op := range prunedOps {
-				if _, ok := jobIDs[op.BatchJobID]; ok {
-					opChunk = append(opChunk, op)
-				}
-			}
-			if err := deletePrunedJobChunk(tx, jobChunk, opChunk); err != nil {
+			if err := deletePrunedJobChunk(tx, jobChunk); err != nil {
 				return err
 			}
 		}
@@ -191,44 +211,9 @@ func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.
 	})
 }
 
-func (r *JobRepository) refreshConsumedPrunedOps(ctx context.Context, original []models.BatchFileOperation, current *[]models.BatchFileOperation) error {
-	if len(original) == 0 {
-		return nil
-	}
-	var live []models.BatchFileOperation
-	for start := 0; start < len(original); start += pruneDeleteBatchSize {
-		end := start + pruneDeleteBatchSize
-		if end > len(original) {
-			end = len(original)
-		}
-		ids := make([]uint, 0, end-start)
-		for _, op := range original[start:end] {
-			ids = append(ids, op.ID)
-		}
-		var chunk []models.BatchFileOperation
-		if err := r.GetDB().WithContext(ctx).Where("id IN ?", ids).Find(&chunk).Error; err != nil {
-			return err
-		}
-		live = append(live, chunk...)
-	}
-	byID := make(map[uint]models.BatchFileOperation, len(live))
-	for _, op := range live {
-		byID[op.ID] = op
-	}
-	for i := range *current {
-		if !hasReplacementLedger([]models.BatchFileOperation{original[i]}) {
-			continue
-		}
-		if liveOp, ok := byID[original[i].ID]; ok && !hasReplacementLedger([]models.BatchFileOperation{liveOp}) {
-			(*current)[i] = liveOp
-		}
-	}
-	return nil
-}
-
 const pruneDeleteBatchSize = 200
 
-func deletePrunedJobChunk(tx *gorm.DB, jobs []models.Job, ops []models.BatchFileOperation) error {
+func deletePrunedJobChunk(tx *gorm.DB, jobs []models.Job) error {
 	jobPredicates := make([]string, 0, len(jobs))
 	jobArgs := make([]any, 0, len(jobs)*2)
 	for _, job := range jobs {
@@ -236,23 +221,10 @@ func deletePrunedJobChunk(tx *gorm.DB, jobs []models.Job, ops []models.BatchFile
 		jobArgs = append(jobArgs, job.ID, job.PruneVersion)
 	}
 	jobWhere := "status = ? AND (" + strings.Join(jobPredicates, " OR ") + ")"
-	jobWhereArgs := append([]any{models.JobStatusOrganized}, jobArgs...)
+	jobWhereArgs := append([]any{pruningJobStatus}, jobArgs...)
 	eligibleJobs := tx.Model(&models.Job{}).Select("id").Where(jobWhere, jobWhereArgs...)
-	for start := 0; start < len(ops); start += pruneDeleteBatchSize {
-		end := start + pruneDeleteBatchSize
-		if end > len(ops) {
-			end = len(ops)
-		}
-		opPredicates := make([]string, 0, end-start)
-		opArgs := make([]any, 0, (end-start)*2)
-		for _, op := range ops[start:end] {
-			opPredicates = append(opPredicates, "(id = ? AND updated_at = ?)")
-			opArgs = append(opArgs, op.ID, op.UpdatedAt)
-		}
-		opWhere := "(" + strings.Join(opPredicates, " OR ") + ") AND batch_job_id IN (?)"
-		if err := tx.Where(opWhere, append(opArgs, eligibleJobs)...).Delete(&models.BatchFileOperation{}).Error; err != nil {
-			return wrapDBErr("delete", "organized job operations", err)
-		}
+	if err := tx.Where("batch_job_id IN (?)", eligibleJobs).Delete(&models.BatchFileOperation{}).Error; err != nil {
+		return wrapDBErr("delete", "organized job operations", err)
 	}
 	if err := tx.Where("id IN (?) AND NOT EXISTS (SELECT 1 FROM batch_file_operations WHERE batch_job_id = jobs.id)", eligibleJobs).Delete(&models.Job{}).Error; err != nil {
 		return wrapDBErr("delete", "organized jobs", err)

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -2,14 +2,13 @@ package database
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/javinizer/javinizer-go/internal/models"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 // JobRepository persists and queries Job records via GORM, composing BaseRepository for common operations.
@@ -89,100 +88,62 @@ func (r *JobRepository) Delete(ctx context.Context, id string) error {
 }
 
 // DeleteOrganizedOlderThan removes organized jobs whose organized_at predates the given date.
+// Filesystem-owned replacement backups are cleaned BEFORE the rows are deleted;
+// a crash during cleanup therefore leaves their ledger rows available to startup
+// reconciliation rather than creating an unowned backup.
 func (r *JobRepository) DeleteOrganizedOlderThan(ctx context.Context, date time.Time) error {
 	var prunedJobs []models.Job
 	var prunedOps []models.BatchFileOperation
 	err := r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		oldJobs := tx.Model(&models.Job{}).
-			Select("id").
-			Where("status = ? AND organized_at < ?", models.JobStatusOrganized, date)
 		if err := tx.Where("status = ? AND organized_at < ?", models.JobStatusOrganized, date).Find(&prunedJobs).Error; err != nil {
 			return wrapDBErr("find", "organized jobs", err)
 		}
-		if err := tx.Where("batch_job_id IN (?)", oldJobs).Find(&prunedOps).Error; err != nil {
+		if len(prunedJobs) == 0 {
+			return nil
+		}
+		jobIDs := make([]string, 0, len(prunedJobs))
+		for _, job := range prunedJobs {
+			jobIDs = append(jobIDs, job.ID)
+		}
+		if err := tx.Where("batch_job_id IN ?", jobIDs).Find(&prunedOps).Error; err != nil {
 			return wrapDBErr("find", "organized job operations", err)
-		}
-		if err := tx.Where("batch_job_id IN (?)", oldJobs).Delete(&models.BatchFileOperation{}).Error; err != nil {
-			return wrapDBErr("delete", "organized job operations", err)
-		}
-		if err := tx.Where("status = ? AND organized_at < ?", models.JobStatusOrganized, date).Delete(&models.Job{}).Error; err != nil {
-			return wrapDBErr("delete", "organized jobs", err)
 		}
 		return nil
 	})
 	if err != nil {
 		return err
 	}
-	if hook := r.organizedJobPruneHook(); hook != nil && len(prunedOps) > 0 {
+
+	hook := r.organizedJobPruneHook()
+	if hasReplacementLedger(prunedOps) && hook == nil {
+		return fmt.Errorf("prune organized jobs: replacement cleanup hook is not configured")
+	}
+	if hook != nil && len(prunedOps) > 0 {
 		if err := hook(ctx, prunedOps); err != nil {
-			restoreOps := pruneOpsForRestore(prunedOps, err)
-			restoreCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			restoreErr := r.restorePrunedRows(restoreCtx, prunedJobs, restoreOps)
-			cancel()
-			return errors.Join(wrapDBErr("prune", "organized job backups", err), restoreErr)
+			return wrapDBErr("prune", "organized job backups", err)
 		}
 	}
-	return nil
-}
 
-// pruneOpsForRestore removes only entries that the cleanup hook confirms were
-// already consumed. This prevents a partial filesystem cleanup from restoring
-// a stale ledger reference to bytes that no longer exist.
-func pruneOpsForRestore(ops []models.BatchFileOperation, hookErr error) []models.BatchFileOperation {
-	type consumedProgress interface {
-		ConsumedBackups() map[uint]map[string]struct{}
-	}
-	var progress consumedProgress
-	if !errors.As(hookErr, &progress) {
-		return ops
-	}
-	consumed := progress.ConsumedBackups()
-	if len(consumed) == 0 {
-		return ops
-	}
-	restored := make([]models.BatchFileOperation, len(ops))
-	copy(restored, ops)
-	for i := range restored {
-		backups := consumed[restored[i].ID]
-		if len(backups) == 0 {
-			continue
-		}
-		gf, err := models.ParseGeneratedFiles(restored[i].GeneratedFiles)
-		if err != nil {
-			continue
-		}
-		kept := gf.Replacements[:0]
-		for _, entry := range gf.Replacements {
-			if _, removed := backups[entry.Backup]; !removed {
-				kept = append(kept, entry)
-			}
-		}
-		if len(kept) != len(gf.Replacements) {
-			gf.Replacements = kept
-			restored[i].GeneratedFiles = models.MarshalLedgerJSON(gf)
-		}
-	}
-	return restored
-}
-
-// restorePrunedRows keeps the job and ledger snapshots durable when the
-// post-commit filesystem cleanup cannot start or complete. The caller can
-// retry pruning later without losing the backup ownership records.
-func (r *JobRepository) restorePrunedRows(ctx context.Context, jobs []models.Job, ops []models.BatchFileOperation) error {
-	if len(jobs) == 0 && len(ops) == 0 {
-		return nil
+	jobIDs := make([]string, 0, len(prunedJobs))
+	for _, job := range prunedJobs {
+		jobIDs = append(jobIDs, job.ID)
 	}
 	return r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		for i := range jobs {
-			if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&jobs[i]).Error; err != nil {
-				return wrapDBErr("restore", fmt.Sprintf("organized job %s", jobs[i].ID), err)
-			}
+		if err := tx.Where("batch_job_id IN ?", jobIDs).Delete(&models.BatchFileOperation{}).Error; err != nil {
+			return wrapDBErr("delete", "organized job operations", err)
 		}
-		for i := range ops {
-			if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&ops[i]).Error; err != nil {
-				return wrapDBErr("restore", fmt.Sprintf("organized job operation %d", ops[i].ID), err)
-			}
+		if err := tx.Where("id IN ?", jobIDs).Delete(&models.Job{}).Error; err != nil {
+			return wrapDBErr("delete", "organized jobs", err)
 		}
 		return nil
 	})
+}
+
+func hasReplacementLedger(ops []models.BatchFileOperation) bool {
+	for _, op := range ops {
+		if strings.Contains(op.GeneratedFiles, `"replacements"`) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -262,17 +262,28 @@ func TestPruneOpsForRestore_RemovesConsumedEntriesOnly(t *testing.T) {
 			{Destination: "/restore/a.jpg", Backup: "/restore/a.jpg.dlbak.a", Installed: true},
 			{Destination: "/restore/b.jpg", Backup: "/restore/b.jpg.dlbak.b", Installed: true},
 		}}),
+	}, {
+		ID: 78,
+		GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{
+			Destination: "/restore/c.jpg", Backup: "/restore/c.jpg.dlbak.c", Installed: true,
+		}}}),
 	}}
 	emptyProgress := &consumedPruneProgressTestError{consumed: map[uint]map[string]struct{}{}}
 	require.Equal(t, ops, pruneOpsForRestore(ops, emptyProgress))
 	hookErr := &consumedPruneProgressTestError{consumed: map[uint]map[string]struct{}{77: {"/restore/a.jpg.dlbak.a": {}}}}
 
 	restored := pruneOpsForRestore(ops, hookErr)
-	require.Len(t, restored, 1)
+	require.Len(t, restored, 2)
 	gf, err := models.ParseGeneratedFiles(restored[0].GeneratedFiles)
 	require.NoError(t, err)
 	require.Len(t, gf.Replacements, 1)
 	require.Equal(t, "/restore/b.jpg.dlbak.b", gf.Replacements[0].Backup)
+	gf, err = models.ParseGeneratedFiles(restored[1].GeneratedFiles)
+	require.NoError(t, err)
+	require.Len(t, gf.Replacements, 1)
+	require.Equal(t, "/restore/c.jpg.dlbak.c", gf.Replacements[0].Backup)
+	malformed := []models.BatchFileOperation{{ID: 77, GeneratedFiles: `{"replacements":`}}
+	require.Equal(t, malformed, pruneOpsForRestore(malformed, hookErr))
 }
 
 func TestJobRepository_DeleteOrganizedOlderThan_OperationLookupFailure(t *testing.T) {
@@ -301,6 +312,31 @@ func TestJobRepository_DeleteOrganizedOlderThan_OperationDeleteFailure(t *testin
 	err := repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "delete organized job operations")
+}
+
+func TestJobRepository_RestorePrunedRows_Empty(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	require.NoError(t, repo.restorePrunedRows(context.Background(), nil, nil))
+}
+
+func TestJobRepository_RestorePrunedRows_CreateFailures(t *testing.T) {
+	t.Run("job row", func(t *testing.T) {
+		db := newDatabaseTestDB(t)
+		repo := NewJobRepository(db)
+		require.NoError(t, db.DB.Exec(`CREATE TRIGGER fail_restore_job BEFORE INSERT ON jobs
+		 BEGIN SELECT RAISE(ABORT, 'forced restore job failure'); END;`).Error)
+		err := repo.restorePrunedRows(context.Background(), []models.Job{{ID: "restore-job-failure"}}, nil)
+		require.Error(t, err)
+	})
+	t.Run("operation row", func(t *testing.T) {
+		db := newDatabaseTestDB(t)
+		repo := NewJobRepository(db)
+		require.NoError(t, db.DB.Exec(`CREATE TRIGGER fail_restore_operation BEFORE INSERT ON batch_file_operations
+		 BEGIN SELECT RAISE(ABORT, 'forced restore operation failure'); END;`).Error)
+		err := repo.restorePrunedRows(context.Background(), nil, []models.BatchFileOperation{{ID: 88, BatchJobID: "restore-op-failure"}})
+		require.Error(t, err)
+	})
 }
 
 func ptrTime(t time.Time) *time.Time {

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -260,24 +260,6 @@ func TestJobRepository_DeleteOrganizedOlderThan_PruneHookRunsBeforeDelete(t *tes
 	require.Equal(t, op.GeneratedFiles, pruned[0].GeneratedFiles)
 }
 
-func TestJobRepository_DeleteOrganizedOlderThan_PruneHookRefreshFailureRetainsRows(t *testing.T) {
-	db := newDatabaseTestDB(t)
-	jobRepo := NewJobRepository(db)
-	opRepo := NewBatchFileOperationRepository(db)
-	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
-	job := &models.Job{ID: "organized-refresh-failure", Status: models.JobStatusOrganized, StartedAt: organizedAt, OrganizedAt: &organizedAt}
-	require.NoError(t, jobRepo.Create(context.Background(), job))
-	op := &models.BatchFileOperation{BatchJobID: job.ID, GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{Destination: "/refresh/dest", Backup: "/refresh/backup", Installed: true}}})}
-	require.NoError(t, opRepo.Create(context.Background(), op))
-	jobRepo.SetOrganizedJobPruneHook(func(context.Context, []models.BatchFileOperation) error {
-		return db.DB.Exec("DROP TABLE batch_file_operations").Error
-	})
-
-	err := jobRepo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "refresh consumed operation versions")
-}
-
 func TestJobRepository_DeleteOrganizedOlderThan_HookFailureRestoresRows(t *testing.T) {
 	db := newDatabaseTestDB(t)
 	jobRepo := NewJobRepository(db)
@@ -337,23 +319,6 @@ func TestJobRepository_DeleteOrganizedOlderThan_OperationDeleteFailure(t *testin
 	assert.Contains(t, err.Error(), "delete organized job operations")
 }
 
-func TestJobRepository_RefreshConsumedPrunedOps(t *testing.T) {
-	db := newDatabaseTestDB(t)
-	repo := NewJobRepository(db)
-	opRepo := NewBatchFileOperationRepository(db)
-	job := &models.Job{ID: "refresh-prune-job", Status: models.JobStatusOrganized, Files: "[]", StartedAt: time.Now().UTC(), OrganizedAt: ptrTime(time.Now().UTC().Add(-48 * time.Hour))}
-	require.NoError(t, repo.Create(context.Background(), job))
-	op := &models.BatchFileOperation{BatchJobID: job.ID, GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{Destination: "/refresh/dest", Backup: "/refresh/backup", Installed: true}}})}
-	require.NoError(t, opRepo.Create(context.Background(), op))
-	require.NoError(t, opRepo.UpdateJournalInTx(context.Background(), op.ID, func(current *models.BatchFileOperation) (models.GeneratedFilesJSON, bool, error) {
-		return models.GeneratedFilesJSON{}, true, nil
-	}))
-	current := []models.BatchFileOperation{*op}
-	require.NoError(t, repo.refreshConsumedPrunedOps(context.Background(), []models.BatchFileOperation{*op}, &current))
-	require.Equal(t, models.MarshalLedgerJSON(models.GeneratedFilesJSON{}), current[0].GeneratedFiles)
-	require.NoError(t, repo.refreshConsumedPrunedOps(context.Background(), nil, &current))
-}
-
 func TestJobRepository_DeleteOrganizedOlderThan_NoJobs(t *testing.T) {
 	db := newDatabaseTestDB(t)
 	require.NoError(t, NewJobRepository(db).DeleteOrganizedOlderThan(context.Background(), time.Now().UTC()))
@@ -393,19 +358,70 @@ func TestJobRepository_DeleteOrganizedOlderThan_VersionFenceKeepsConcurrentMutat
 		currentJob, err := repo.FindByID(ctx, job.ID)
 		require.NoError(t, err)
 		currentJob.Progress = 0.5
-		require.NoError(t, repo.Update(ctx, currentJob))
+		jobErr := repo.Update(ctx, currentJob)
+		require.ErrorIs(t, jobErr, ErrJobPruning)
 		currentOp, err := opRepo.FindByID(ctx, op.ID)
 		require.NoError(t, err)
 		currentOp.NewPath = "/fence/concurrent-dest"
-		return opRepo.Update(ctx, currentOp)
+		opErr := opRepo.Update(context.Background(), currentOp)
+		require.ErrorIs(t, opErr, ErrJobPruning)
+		createBatchErr := opRepo.CreateBatch(context.Background(), []*models.BatchFileOperation{{BatchJobID: job.ID, OriginalPath: "/fence/new", NewPath: "/fence/new-dest"}})
+		require.ErrorIs(t, createBatchErr, ErrJobPruning)
+		journalErr := opRepo.UpdateJournalInTx(context.Background(), op.ID, func(current *models.BatchFileOperation) (models.GeneratedFilesJSON, bool, error) {
+			return models.GeneratedFilesJSON{}, true, nil
+		})
+		require.ErrorIs(t, journalErr, ErrJobPruning)
+		revertErr := opRepo.UpdateRevertStatus(context.Background(), op.ID, models.RevertStatusReverted)
+		require.ErrorIs(t, revertErr, ErrJobPruning)
+		nonJournalErr := opRepo.UpdateNonJournalFields(context.Background(), currentOp)
+		require.ErrorIs(t, nonJournalErr, ErrJobPruning)
+		return errors.Join(jobErr, opErr, createBatchErr, journalErr, revertErr, nonJournalErr)
 	})
 
-	require.NoError(t, repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour)))
-	_, err := repo.FindByID(context.Background(), job.ID)
-	require.NoError(t, err, "a concurrently mutated job must not be deleted")
-	gotOp, err := opRepo.FindByID(context.Background(), op.ID)
-	require.NoError(t, err, "a concurrently mutated operation must not be deleted")
-	require.Equal(t, "/fence/concurrent-dest", gotOp.NewPath)
+	err := repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
+	require.ErrorIs(t, err, ErrJobPruning)
+	gotJob, findErr := repo.FindByID(context.Background(), job.ID)
+	require.NoError(t, findErr, "the fenced job must remain for retry")
+	require.Equal(t, pruningJobStatus, gotJob.Status)
+	gotOp, findErr := opRepo.FindByID(context.Background(), op.ID)
+	require.NoError(t, findErr, "the fenced operation must remain")
+	require.Equal(t, "/fence/dest", gotOp.NewPath)
+}
+
+func TestJobRepository_DeleteOrganizedOlderThan_ClaimedJobLookupFailure(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	require.NoError(t, repo.Create(context.Background(), &models.Job{ID: "organized-claim-query-failure", Status: models.JobStatusOrganized, StartedAt: organizedAt, OrganizedAt: &organizedAt}))
+	fired := false
+	const callbackName = "test:fail_prune_claim_query"
+	require.NoError(t, db.DB.Callback().Query().Before("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		if !fired && tx.Statement != nil && tx.Statement.Schema != nil && tx.Statement.Schema.Table == "jobs" {
+			fired = true
+			tx.AddError(errors.New("forced prune claim lookup failure"))
+		}
+	}))
+	t.Cleanup(func() { _ = db.DB.Callback().Query().Remove(callbackName) })
+
+	err := repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "find organized jobs")
+}
+
+func TestEnsureOperationWritable_PruneDiagnostics(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	opRepo := NewBatchFileOperationRepository(db)
+	job := &models.Job{ID: "operation-fence-diagnostic", Status: models.JobStatusOrganized, StartedAt: time.Now(), OrganizedAt: ptrTime(time.Now().Add(-48 * time.Hour))}
+	require.NoError(t, repo.Create(context.Background(), job))
+	op := &models.BatchFileOperation{BatchJobID: job.ID, OriginalPath: "/diag/src", NewPath: "/diag/dest"}
+	require.NoError(t, opRepo.Create(context.Background(), op))
+	require.NoError(t, db.DB.Exec("UPDATE jobs SET status = ? WHERE id = ?", pruningJobStatus, job.ID).Error)
+	require.ErrorIs(t, ensureOperationWritable(db.DB, op.ID), ErrJobPruning)
+	require.NoError(t, db.DB.Exec("UPDATE jobs SET status = ? WHERE id = ?", models.JobStatusOrganized, job.ID).Error)
+	require.NoError(t, ensureOperationWritable(db.DB, 99999))
+	require.NoError(t, db.DB.Exec("DROP TABLE batch_file_operations").Error)
+	require.Error(t, ensureOperationWritable(db.DB, op.ID))
 }
 
 func TestJobRepository_DeleteOrganizedOlderThan_BatchesLargeRetentionSet(t *testing.T) {

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -181,6 +181,41 @@ func TestJobRepository_DeleteOrganizedOlderThan_JobDeleteFailureRollsBack(t *tes
 	require.NoError(t, err, "transaction rolls the ops-first delete back")
 }
 
+func TestJobRepository_DeleteOrganizedOlderThan_PruneHookRunsAfterCommit(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	jobRepo := NewJobRepository(db)
+	opRepo := NewBatchFileOperationRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	job := &models.Job{
+		ID: "organized-prune-hook", Status: models.JobStatusOrganized,
+		StartedAt: organizedAt.Add(-time.Hour), OrganizedAt: &organizedAt,
+	}
+	require.NoError(t, jobRepo.Create(context.Background(), job))
+	op := &models.BatchFileOperation{
+		BatchJobID: job.ID, OriginalPath: "/hook/source.mp4", NewPath: "/hook/dest.mp4",
+		OperationType: models.OperationTypeUpdate,
+		GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{
+			Destination: "/hook/poster.jpg", Backup: "/hook/poster.jpg.dlbak.0123456789abcdef",
+		}}}),
+	}
+	require.NoError(t, opRepo.Create(context.Background(), op))
+
+	var pruned []models.BatchFileOperation
+	jobRepo.SetOrganizedJobPruneHook(func(_ context.Context, ops []models.BatchFileOperation) error {
+		pruned = append(pruned, ops...)
+		_, jobErr := jobRepo.FindByID(context.Background(), job.ID)
+		require.Error(t, jobErr, "job row must be gone before cleanup starts")
+		_, opErr := opRepo.FindByID(context.Background(), op.ID)
+		require.Error(t, opErr, "operation row must be gone before cleanup starts")
+		return nil
+	})
+
+	require.NoError(t, jobRepo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour)))
+	require.Len(t, pruned, 1)
+	require.Equal(t, op.ID, pruned[0].ID)
+	require.Equal(t, op.GeneratedFiles, pruned[0].GeneratedFiles)
+}
+
 func ptrTime(t time.Time) *time.Time {
 	return &t
 }

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -3,12 +3,14 @@ package database
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestJobRepository_UpdateUpsert_Nil(t *testing.T) {
@@ -16,6 +18,40 @@ func TestJobRepository_UpdateUpsert_Nil(t *testing.T) {
 	repo := NewJobRepository(db)
 	require.Error(t, repo.Update(context.Background(), nil))
 	require.Error(t, repo.Upsert(context.Background(), nil))
+}
+
+func TestJobRepository_UpsertVersioned_PluckFailure(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	job := &models.Job{ID: "versioned-pluck-failure", Status: models.JobStatusOrganized, Files: "[]", StartedAt: time.Now().UTC()}
+	require.NoError(t, repo.Create(context.Background(), job))
+	ctx, cancel := context.WithCancel(context.Background())
+	fired := false
+	const callbackName = "test:cancel_job_prune_pluck"
+	require.NoError(t, db.DB.Callback().Update().After("gorm:update").Register(callbackName, func(tx *gorm.DB) {
+		if !fired && tx.Statement != nil && tx.Statement.Schema != nil && tx.Statement.Schema.Table == "jobs" {
+			fired = true
+			cancel()
+		}
+	}))
+	defer func() { _ = db.DB.Callback().Update().Remove(callbackName) }()
+
+	loaded, err := repo.FindByID(context.Background(), job.ID)
+	require.NoError(t, err)
+	err = repo.Upsert(ctx, loaded)
+	require.Error(t, err)
+}
+
+func TestJobRepository_UpsertVersionedNewAndExisting(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	job := &models.Job{ID: "versioned-upsert", Status: models.JobStatusOrganized, Files: "[]", StartedAt: time.Now().UTC()}
+	require.NoError(t, repo.Upsert(context.Background(), job))
+	require.Zero(t, job.PruneVersion)
+	loaded, err := repo.FindByID(context.Background(), job.ID)
+	require.NoError(t, err)
+	require.NoError(t, repo.Upsert(context.Background(), loaded))
+	require.Equal(t, uint64(1), loaded.PruneVersion)
 }
 
 func TestJobRepository_Create(t *testing.T) {
@@ -335,6 +371,20 @@ func TestJobRepository_DeleteOrganizedOlderThan_VersionFenceKeepsConcurrentMutat
 	gotOp, err := opRepo.FindByID(context.Background(), op.ID)
 	require.NoError(t, err, "a concurrently mutated operation must not be deleted")
 	require.Equal(t, "/fence/concurrent-dest", gotOp.NewPath)
+}
+
+func TestJobRepository_DeleteOrganizedOlderThan_BatchesLargeRetentionSet(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	for i := 0; i < 401; i++ {
+		job := &models.Job{ID: fmt.Sprintf("organized-batch-%03d", i), Status: models.JobStatusOrganized, StartedAt: organizedAt, OrganizedAt: &organizedAt}
+		require.NoError(t, repo.Create(context.Background(), job))
+	}
+	require.NoError(t, repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour)))
+	jobs, err := repo.List(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, jobs)
 }
 
 func ptrTime(t time.Time) *time.Time {

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -365,6 +365,8 @@ func TestJobRepository_DeleteOrganizedOlderThan_VersionFenceKeepsConcurrentMutat
 		currentOp.NewPath = "/fence/concurrent-dest"
 		opErr := opRepo.Update(context.Background(), currentOp)
 		require.ErrorIs(t, opErr, ErrJobPruning)
+		createErr := opRepo.Create(context.Background(), &models.BatchFileOperation{BatchJobID: job.ID, OriginalPath: "/fence/create", NewPath: "/fence/create-dest"})
+		require.ErrorIs(t, createErr, ErrJobPruning)
 		createBatchErr := opRepo.CreateBatch(context.Background(), []*models.BatchFileOperation{{BatchJobID: job.ID, OriginalPath: "/fence/new", NewPath: "/fence/new-dest"}})
 		require.ErrorIs(t, createBatchErr, ErrJobPruning)
 		journalErr := opRepo.UpdateJournalInTx(context.Background(), op.ID, func(current *models.BatchFileOperation) (models.GeneratedFilesJSON, bool, error) {
@@ -375,7 +377,7 @@ func TestJobRepository_DeleteOrganizedOlderThan_VersionFenceKeepsConcurrentMutat
 		require.ErrorIs(t, revertErr, ErrJobPruning)
 		nonJournalErr := opRepo.UpdateNonJournalFields(context.Background(), currentOp)
 		require.ErrorIs(t, nonJournalErr, ErrJobPruning)
-		return errors.Join(jobErr, opErr, createBatchErr, journalErr, revertErr, nonJournalErr)
+		return errors.Join(jobErr, opErr, createErr, createBatchErr, journalErr, revertErr, nonJournalErr)
 	})
 
 	err := repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
@@ -422,6 +424,8 @@ func TestEnsureOperationWritable_PruneDiagnostics(t *testing.T) {
 	require.NoError(t, ensureOperationWritable(db.DB, 99999))
 	require.NoError(t, db.DB.Exec("DROP TABLE batch_file_operations").Error)
 	require.Error(t, ensureOperationWritable(db.DB, op.ID))
+	require.NoError(t, db.DB.Exec("DROP TABLE jobs").Error)
+	require.Error(t, ensureJobWritable(db.DB, job.ID))
 }
 
 func TestJobRepository_DeleteOrganizedOlderThan_BatchesLargeRetentionSet(t *testing.T) {

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -110,6 +110,77 @@ func TestJobRepository_DeleteOrganizedOlderThan(t *testing.T) {
 	assert.Equal(t, "organized-recent", list[0].ID)
 }
 
+func TestJobRepository_DeleteOrganizedOlderThan_PrunesOperationsBeforeJobs(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	jobRepo := NewJobRepository(db)
+	opRepo := NewBatchFileOperationRepository(db)
+	now := time.Now().UTC()
+	oldAt := now.Add(-48 * time.Hour)
+
+	oldJob := &models.Job{
+		ID: "organized-with-ledger-old", Status: models.JobStatusOrganized,
+		StartedAt: oldAt.Add(-time.Hour), OrganizedAt: &oldAt,
+	}
+	recentAt := now.Add(-12 * time.Hour)
+	recentJob := &models.Job{
+		ID: "organized-with-ledger-recent", Status: models.JobStatusOrganized,
+		StartedAt: recentAt.Add(-time.Hour), OrganizedAt: &recentAt,
+	}
+	require.NoError(t, jobRepo.Create(context.Background(), oldJob))
+	require.NoError(t, jobRepo.Create(context.Background(), recentJob))
+
+	oldOp := &models.BatchFileOperation{
+		BatchJobID: oldJob.ID, OriginalPath: "/old/source.mp4", NewPath: "/old/dest.mp4",
+		OperationType: models.OperationTypeMove,
+	}
+	recentOp := &models.BatchFileOperation{
+		BatchJobID: recentJob.ID, OriginalPath: "/recent/source.mp4", NewPath: "/recent/dest.mp4",
+		OperationType: models.OperationTypeMove,
+	}
+	require.NoError(t, opRepo.Create(context.Background(), oldOp))
+	require.NoError(t, opRepo.Create(context.Background(), recentOp))
+
+	require.NoError(t, jobRepo.DeleteOrganizedOlderThan(context.Background(), now.Add(-24*time.Hour)))
+	_, err := jobRepo.FindByID(context.Background(), oldJob.ID)
+	require.Error(t, err)
+	_, err = opRepo.FindByID(context.Background(), oldOp.ID)
+	require.Error(t, err, "operation rows must be pruned with the old job")
+	_, err = jobRepo.FindByID(context.Background(), recentJob.ID)
+	require.NoError(t, err)
+	_, err = opRepo.FindByID(context.Background(), recentOp.ID)
+	require.NoError(t, err, "recent job ledger must remain")
+}
+
+func TestJobRepository_DeleteOrganizedOlderThan_JobDeleteFailureRollsBack(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	jobRepo := NewJobRepository(db)
+	opRepo := NewBatchFileOperationRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	job := &models.Job{
+		ID: "organized-trigger-failure", Status: models.JobStatusOrganized,
+		StartedAt: organizedAt.Add(-time.Hour), OrganizedAt: &organizedAt,
+	}
+	require.NoError(t, jobRepo.Create(context.Background(), job))
+	op := &models.BatchFileOperation{
+		BatchJobID: job.ID, OriginalPath: "/trigger/source.mp4", NewPath: "/trigger/dest.mp4",
+		OperationType: models.OperationTypeMove,
+	}
+	require.NoError(t, opRepo.Create(context.Background(), op))
+	require.NoError(t, db.DB.Exec(
+		`CREATE TRIGGER fail_organized_job_delete BEFORE DELETE ON jobs
+		 WHEN OLD.id = 'organized-trigger-failure'
+		 BEGIN SELECT RAISE(ABORT, 'forced organized delete failure'); END;`,
+	).Error)
+
+	err := jobRepo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete organized jobs")
+	_, err = jobRepo.FindByID(context.Background(), job.ID)
+	require.NoError(t, err, "transaction rolls the job delete back")
+	_, err = opRepo.FindByID(context.Background(), op.ID)
+	require.NoError(t, err, "transaction rolls the ops-first delete back")
+}
+
 func ptrTime(t time.Time) *time.Time {
 	return &t
 }

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -214,6 +215,35 @@ func TestJobRepository_DeleteOrganizedOlderThan_PruneHookRunsAfterCommit(t *test
 	require.Len(t, pruned, 1)
 	require.Equal(t, op.ID, pruned[0].ID)
 	require.Equal(t, op.GeneratedFiles, pruned[0].GeneratedFiles)
+}
+
+func TestJobRepository_DeleteOrganizedOlderThan_HookFailureRestoresRows(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	jobRepo := NewJobRepository(db)
+	opRepo := NewBatchFileOperationRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	job := &models.Job{
+		ID: "organized-prune-hook-failure", Status: models.JobStatusOrganized,
+		StartedAt: organizedAt.Add(-time.Hour), OrganizedAt: &organizedAt,
+	}
+	require.NoError(t, jobRepo.Create(context.Background(), job))
+	op := &models.BatchFileOperation{
+		BatchJobID: job.ID, OriginalPath: "/hook-failure/source.mp4", NewPath: "/hook-failure/dest.mp4",
+		OperationType: models.OperationTypeUpdate,
+		GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{
+			Destination: "/hook-failure/poster.jpg", Backup: "/hook-failure/poster.jpg.dlbak.0123456789abcdef", Installed: true,
+		}}}),
+	}
+	require.NoError(t, opRepo.Create(context.Background(), op))
+	wantErr := errors.New("cleanup unavailable")
+	jobRepo.SetOrganizedJobPruneHook(func(context.Context, []models.BatchFileOperation) error { return wantErr })
+
+	err := jobRepo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
+	require.ErrorIs(t, err, wantErr)
+	_, err = jobRepo.FindByID(context.Background(), job.ID)
+	require.NoError(t, err, "failed cleanup must restore the job for retry")
+	_, err = opRepo.FindByID(context.Background(), op.ID)
+	require.NoError(t, err, "failed cleanup must restore the ledger ownership record")
 }
 
 func ptrTime(t time.Time) *time.Time {

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -182,7 +182,7 @@ func TestJobRepository_DeleteOrganizedOlderThan_JobDeleteFailureRollsBack(t *tes
 	require.NoError(t, err, "transaction rolls the ops-first delete back")
 }
 
-func TestJobRepository_DeleteOrganizedOlderThan_PruneHookRunsAfterCommit(t *testing.T) {
+func TestJobRepository_DeleteOrganizedOlderThan_PruneHookRunsBeforeDelete(t *testing.T) {
 	db := newDatabaseTestDB(t)
 	jobRepo := NewJobRepository(db)
 	opRepo := NewBatchFileOperationRepository(db)
@@ -205,9 +205,9 @@ func TestJobRepository_DeleteOrganizedOlderThan_PruneHookRunsAfterCommit(t *test
 	jobRepo.SetOrganizedJobPruneHook(func(_ context.Context, ops []models.BatchFileOperation) error {
 		pruned = append(pruned, ops...)
 		_, jobErr := jobRepo.FindByID(context.Background(), job.ID)
-		require.Error(t, jobErr, "job row must be gone before cleanup starts")
+		require.NoError(t, jobErr, "job row must remain while cleanup owns its ledger")
 		_, opErr := opRepo.FindByID(context.Background(), op.ID)
-		require.Error(t, opErr, "operation row must be gone before cleanup starts")
+		require.NoError(t, opErr, "operation row must remain while cleanup owns its ledger")
 		return nil
 	})
 
@@ -241,54 +241,16 @@ func TestJobRepository_DeleteOrganizedOlderThan_HookFailureRestoresRows(t *testi
 	err := jobRepo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
 	require.ErrorIs(t, err, wantErr)
 	_, err = jobRepo.FindByID(context.Background(), job.ID)
-	require.NoError(t, err, "failed cleanup must restore the job for retry")
+	require.NoError(t, err, "failed cleanup must retain the job for retry")
 	_, err = opRepo.FindByID(context.Background(), op.ID)
-	require.NoError(t, err, "failed cleanup must restore the ledger ownership record")
-}
-
-type consumedPruneProgressTestError struct {
-	consumed map[uint]map[string]struct{}
-}
-
-func (e *consumedPruneProgressTestError) Error() string { return "partial cleanup" }
-func (e *consumedPruneProgressTestError) ConsumedBackups() map[uint]map[string]struct{} {
-	return e.consumed
-}
-
-func TestPruneOpsForRestore_RemovesConsumedEntriesOnly(t *testing.T) {
-	ops := []models.BatchFileOperation{{
-		ID: 77,
-		GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{
-			{Destination: "/restore/a.jpg", Backup: "/restore/a.jpg.dlbak.a", Installed: true},
-			{Destination: "/restore/b.jpg", Backup: "/restore/b.jpg.dlbak.b", Installed: true},
-		}}),
-	}, {
-		ID: 78,
-		GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{
-			Destination: "/restore/c.jpg", Backup: "/restore/c.jpg.dlbak.c", Installed: true,
-		}}}),
-	}}
-	emptyProgress := &consumedPruneProgressTestError{consumed: map[uint]map[string]struct{}{}}
-	require.Equal(t, ops, pruneOpsForRestore(ops, emptyProgress))
-	hookErr := &consumedPruneProgressTestError{consumed: map[uint]map[string]struct{}{77: {"/restore/a.jpg.dlbak.a": {}}}}
-
-	restored := pruneOpsForRestore(ops, hookErr)
-	require.Len(t, restored, 2)
-	gf, err := models.ParseGeneratedFiles(restored[0].GeneratedFiles)
-	require.NoError(t, err)
-	require.Len(t, gf.Replacements, 1)
-	require.Equal(t, "/restore/b.jpg.dlbak.b", gf.Replacements[0].Backup)
-	gf, err = models.ParseGeneratedFiles(restored[1].GeneratedFiles)
-	require.NoError(t, err)
-	require.Len(t, gf.Replacements, 1)
-	require.Equal(t, "/restore/c.jpg.dlbak.c", gf.Replacements[0].Backup)
-	malformed := []models.BatchFileOperation{{ID: 77, GeneratedFiles: `{"replacements":`}}
-	require.Equal(t, malformed, pruneOpsForRestore(malformed, hookErr))
+	require.NoError(t, err, "failed cleanup must retain the ledger ownership record")
 }
 
 func TestJobRepository_DeleteOrganizedOlderThan_OperationLookupFailure(t *testing.T) {
 	db := newDatabaseTestDB(t)
 	repo := NewJobRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	require.NoError(t, repo.Create(context.Background(), &models.Job{ID: "organized-operation-lookup-failure", Status: models.JobStatusOrganized, StartedAt: organizedAt, OrganizedAt: &organizedAt}))
 	require.NoError(t, db.DB.Exec("DROP TABLE batch_file_operations").Error)
 
 	err := repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC())
@@ -314,29 +276,28 @@ func TestJobRepository_DeleteOrganizedOlderThan_OperationDeleteFailure(t *testin
 	assert.Contains(t, err.Error(), "delete organized job operations")
 }
 
-func TestJobRepository_RestorePrunedRows_Empty(t *testing.T) {
+func TestJobRepository_DeleteOrganizedOlderThan_NoJobs(t *testing.T) {
 	db := newDatabaseTestDB(t)
-	repo := NewJobRepository(db)
-	require.NoError(t, repo.restorePrunedRows(context.Background(), nil, nil))
+	require.NoError(t, NewJobRepository(db).DeleteOrganizedOlderThan(context.Background(), time.Now().UTC()))
 }
 
-func TestJobRepository_RestorePrunedRows_CreateFailures(t *testing.T) {
-	t.Run("job row", func(t *testing.T) {
-		db := newDatabaseTestDB(t)
-		repo := NewJobRepository(db)
-		require.NoError(t, db.DB.Exec(`CREATE TRIGGER fail_restore_job BEFORE INSERT ON jobs
-		 BEGIN SELECT RAISE(ABORT, 'forced restore job failure'); END;`).Error)
-		err := repo.restorePrunedRows(context.Background(), []models.Job{{ID: "restore-job-failure"}}, nil)
-		require.Error(t, err)
-	})
-	t.Run("operation row", func(t *testing.T) {
-		db := newDatabaseTestDB(t)
-		repo := NewJobRepository(db)
-		require.NoError(t, db.DB.Exec(`CREATE TRIGGER fail_restore_operation BEFORE INSERT ON batch_file_operations
-		 BEGIN SELECT RAISE(ABORT, 'forced restore operation failure'); END;`).Error)
-		err := repo.restorePrunedRows(context.Background(), nil, []models.BatchFileOperation{{ID: 88, BatchJobID: "restore-op-failure"}})
-		require.Error(t, err)
-	})
+func TestJobRepository_DeleteOrganizedOlderThan_ReplacementHookRequired(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	job := &models.Job{ID: "organized-hook-required", Status: models.JobStatusOrganized, StartedAt: organizedAt, OrganizedAt: &organizedAt}
+	require.NoError(t, repo.Create(context.Background(), job))
+	opRepo := NewBatchFileOperationRepository(db)
+	require.NoError(t, opRepo.Create(context.Background(), &models.BatchFileOperation{
+		BatchJobID: job.ID, OriginalPath: "/hook-required/source", NewPath: "/hook-required/dest",
+		GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{Destination: "/hook-required/dest", Backup: "/hook-required/dest.dlbak.a"}}}),
+	}))
+
+	err := repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cleanup hook is not configured")
+	_, err = repo.FindByID(context.Background(), job.ID)
+	require.NoError(t, err)
 }
 
 func ptrTime(t time.Time) *time.Time {

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -296,8 +296,38 @@ func TestJobRepository_DeleteOrganizedOlderThan_ReplacementHookRequired(t *testi
 	err := repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cleanup hook is not configured")
+	assert.True(t, hasReplacementLedger([]models.BatchFileOperation{{GeneratedFiles: `{"Replacements":[{"backup":"/x"}]}`}}))
+	assert.True(t, hasReplacementLedger([]models.BatchFileOperation{{GeneratedFiles: "not-json"}}))
 	_, err = repo.FindByID(context.Background(), job.ID)
 	require.NoError(t, err)
+}
+
+func TestJobRepository_DeleteOrganizedOlderThan_VersionFenceKeepsConcurrentMutation(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	opRepo := NewBatchFileOperationRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	job := &models.Job{ID: "organized-version-fence", Status: models.JobStatusOrganized, StartedAt: organizedAt, OrganizedAt: &organizedAt}
+	require.NoError(t, repo.Create(context.Background(), job))
+	op := &models.BatchFileOperation{BatchJobID: job.ID, OriginalPath: "/fence/source", NewPath: "/fence/dest", OperationType: models.OperationTypeMove}
+	require.NoError(t, opRepo.Create(context.Background(), op))
+	repo.SetOrganizedJobPruneHook(func(ctx context.Context, _ []models.BatchFileOperation) error {
+		currentJob, err := repo.FindByID(ctx, job.ID)
+		require.NoError(t, err)
+		currentJob.Progress = 0.5
+		require.NoError(t, repo.Update(ctx, currentJob))
+		currentOp, err := opRepo.FindByID(ctx, op.ID)
+		require.NoError(t, err)
+		currentOp.NewPath = "/fence/concurrent-dest"
+		return opRepo.Update(ctx, currentOp)
+	})
+
+	require.NoError(t, repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour)))
+	_, err := repo.FindByID(context.Background(), job.ID)
+	require.NoError(t, err, "a concurrently mutated job must not be deleted")
+	gotOp, err := opRepo.FindByID(context.Background(), op.ID)
+	require.NoError(t, err, "a concurrently mutated operation must not be deleted")
+	require.Equal(t, "/fence/concurrent-dest", gotOp.NewPath)
 }
 
 func ptrTime(t time.Time) *time.Time {

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestJobRepository_UpdateUpsert_Nil(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	require.Error(t, repo.Update(context.Background(), nil))
+	require.Error(t, repo.Upsert(context.Background(), nil))
+}
+
 func TestJobRepository_Create(t *testing.T) {
 	db := newDatabaseTestDB(t)
 	repo := NewJobRepository(db)

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -260,6 +260,24 @@ func TestJobRepository_DeleteOrganizedOlderThan_PruneHookRunsBeforeDelete(t *tes
 	require.Equal(t, op.GeneratedFiles, pruned[0].GeneratedFiles)
 }
 
+func TestJobRepository_DeleteOrganizedOlderThan_PruneHookRefreshFailureRetainsRows(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	jobRepo := NewJobRepository(db)
+	opRepo := NewBatchFileOperationRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	job := &models.Job{ID: "organized-refresh-failure", Status: models.JobStatusOrganized, StartedAt: organizedAt, OrganizedAt: &organizedAt}
+	require.NoError(t, jobRepo.Create(context.Background(), job))
+	op := &models.BatchFileOperation{BatchJobID: job.ID, GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{Destination: "/refresh/dest", Backup: "/refresh/backup", Installed: true}}})}
+	require.NoError(t, opRepo.Create(context.Background(), op))
+	jobRepo.SetOrganizedJobPruneHook(func(context.Context, []models.BatchFileOperation) error {
+		return db.DB.Exec("DROP TABLE batch_file_operations").Error
+	})
+
+	err := jobRepo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refresh consumed operation versions")
+}
+
 func TestJobRepository_DeleteOrganizedOlderThan_HookFailureRestoresRows(t *testing.T) {
 	db := newDatabaseTestDB(t)
 	jobRepo := NewJobRepository(db)
@@ -317,6 +335,23 @@ func TestJobRepository_DeleteOrganizedOlderThan_OperationDeleteFailure(t *testin
 	err := repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "delete organized job operations")
+}
+
+func TestJobRepository_RefreshConsumedPrunedOps(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	opRepo := NewBatchFileOperationRepository(db)
+	job := &models.Job{ID: "refresh-prune-job", Status: models.JobStatusOrganized, Files: "[]", StartedAt: time.Now().UTC(), OrganizedAt: ptrTime(time.Now().UTC().Add(-48 * time.Hour))}
+	require.NoError(t, repo.Create(context.Background(), job))
+	op := &models.BatchFileOperation{BatchJobID: job.ID, GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{Destination: "/refresh/dest", Backup: "/refresh/backup", Installed: true}}})}
+	require.NoError(t, opRepo.Create(context.Background(), op))
+	require.NoError(t, opRepo.UpdateJournalInTx(context.Background(), op.ID, func(current *models.BatchFileOperation) (models.GeneratedFilesJSON, bool, error) {
+		return models.GeneratedFilesJSON{}, true, nil
+	}))
+	current := []models.BatchFileOperation{*op}
+	require.NoError(t, repo.refreshConsumedPrunedOps(context.Background(), []models.BatchFileOperation{*op}, &current))
+	require.Equal(t, models.MarshalLedgerJSON(models.GeneratedFilesJSON{}), current[0].GeneratedFiles)
+	require.NoError(t, repo.refreshConsumedPrunedOps(context.Background(), nil, &current))
 }
 
 func TestJobRepository_DeleteOrganizedOlderThan_NoJobs(t *testing.T) {

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -246,6 +246,63 @@ func TestJobRepository_DeleteOrganizedOlderThan_HookFailureRestoresRows(t *testi
 	require.NoError(t, err, "failed cleanup must restore the ledger ownership record")
 }
 
+type consumedPruneProgressTestError struct {
+	consumed map[uint]map[string]struct{}
+}
+
+func (e *consumedPruneProgressTestError) Error() string { return "partial cleanup" }
+func (e *consumedPruneProgressTestError) ConsumedBackups() map[uint]map[string]struct{} {
+	return e.consumed
+}
+
+func TestPruneOpsForRestore_RemovesConsumedEntriesOnly(t *testing.T) {
+	ops := []models.BatchFileOperation{{
+		ID: 77,
+		GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{
+			{Destination: "/restore/a.jpg", Backup: "/restore/a.jpg.dlbak.a", Installed: true},
+			{Destination: "/restore/b.jpg", Backup: "/restore/b.jpg.dlbak.b", Installed: true},
+		}}),
+	}}
+	emptyProgress := &consumedPruneProgressTestError{consumed: map[uint]map[string]struct{}{}}
+	require.Equal(t, ops, pruneOpsForRestore(ops, emptyProgress))
+	hookErr := &consumedPruneProgressTestError{consumed: map[uint]map[string]struct{}{77: {"/restore/a.jpg.dlbak.a": {}}}}
+
+	restored := pruneOpsForRestore(ops, hookErr)
+	require.Len(t, restored, 1)
+	gf, err := models.ParseGeneratedFiles(restored[0].GeneratedFiles)
+	require.NoError(t, err)
+	require.Len(t, gf.Replacements, 1)
+	require.Equal(t, "/restore/b.jpg.dlbak.b", gf.Replacements[0].Backup)
+}
+
+func TestJobRepository_DeleteOrganizedOlderThan_OperationLookupFailure(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	require.NoError(t, db.DB.Exec("DROP TABLE batch_file_operations").Error)
+
+	err := repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "find organized job operations")
+}
+
+func TestJobRepository_DeleteOrganizedOlderThan_OperationDeleteFailure(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	job := &models.Job{ID: "organized-operation-delete-failure", Status: models.JobStatusOrganized, StartedAt: organizedAt, OrganizedAt: &organizedAt}
+	require.NoError(t, repo.Create(context.Background(), job))
+	opRepo := NewBatchFileOperationRepository(db)
+	require.NoError(t, opRepo.Create(context.Background(), &models.BatchFileOperation{BatchJobID: job.ID, OriginalPath: "/failure/source", NewPath: "/failure/dest", OperationType: models.OperationTypeMove}))
+	require.NoError(t, db.DB.Exec(
+		`CREATE TRIGGER fail_pruned_operation_delete BEFORE DELETE ON batch_file_operations
+		 BEGIN SELECT RAISE(ABORT, 'forced operation delete failure'); END;`,
+	).Error)
+
+	err := repo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete organized job operations")
+}
+
 func ptrTime(t time.Time) *time.Time {
 	return &t
 }

--- a/internal/database/migrations/000013_jobs_prune_version.sql
+++ b/internal/database/migrations/000013_jobs_prune_version.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE jobs ADD COLUMN prune_version INTEGER NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE jobs DROP COLUMN prune_version;
+-- +goose StatementEnd

--- a/internal/database/prune_fence.go
+++ b/internal/database/prune_fence.go
@@ -1,0 +1,76 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"gorm.io/gorm"
+)
+
+// ensureJobWritable rejects operation creation/mutation after retention has
+// claimed the owning organized job. The query and the later write are used by
+// callers whose write is already conditional or protected by BEGIN IMMEDIATE;
+// this helper also keeps the ordinary repository paths fail-closed.
+func ensureJobWritable(db *gorm.DB, jobID string) error {
+	if jobID == "" {
+		return nil
+	}
+	var row struct{ Status models.JobStatus }
+	result := db.Model(&models.Job{}).Select("status").Where("id = ?", jobID).First(&row)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil
+	}
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected > 0 && row.Status == pruningJobStatus {
+		return ErrJobPruning
+	}
+	return nil
+}
+
+// ensureOperationWritableConn is the transaction-local form used by the
+// BEGIN IMMEDIATE journal/non-journal writers. A claim that wins the writer
+// lock before this check is therefore observed before any operation mutation.
+func ensureOperationWritableConn(ctx context.Context, conn *sql.Conn, opID uint, allowMaintenance bool) error {
+	if allowMaintenance && pruneMaintenance(ctx) {
+		return nil
+	}
+	var status string
+	err := conn.QueryRowContext(ctx, `
+		SELECT jobs.status
+		FROM batch_file_operations AS ops
+		JOIN jobs ON jobs.id = ops.batch_job_id
+		WHERE ops.id = ?`, opID).Scan(&status)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return fmt.Errorf("check operation %d pruning fence: %w", opID, err)
+	}
+	if models.JobStatus(status) == pruningJobStatus {
+		return ErrJobPruning
+	}
+	return nil
+}
+
+// ensureOperationWritable is the repository-level operation-id form used by
+// status updates whose SQL statement reports zero affected rows. The status
+// lookup is only diagnostic after the conditional UPDATE; the UPDATE itself
+// is the race-free fence.
+func ensureOperationWritable(db *gorm.DB, opID uint) error {
+	var row struct {
+		Status models.JobStatus
+	}
+	result := db.Raw("SELECT jobs.status AS status FROM batch_file_operations AS ops JOIN jobs ON jobs.id = ops.batch_job_id WHERE ops.id = ?", opID).Scan(&row)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected > 0 && row.Status == pruningJobStatus {
+		return ErrJobPruning
+	}
+	return nil
+}

--- a/internal/history/replacement_backup_quarantine.go
+++ b/internal/history/replacement_backup_quarantine.go
@@ -512,21 +512,21 @@ func quarantineVerifiedBackup(fs afero.Fs, backup, phase string, handle afero.Fi
 		// nothing consumed, entry live, no move-back (nothing to move).
 		hold.moved = false
 		absoluteQuarantine, _ := filepath.Abs(quarantine)
-		return nil, fmt.Errorf("%w: %s (quarantine %s empty at the post-move re-verify)", errReplacementBackupQuarantineVanished, absoluteBackup, absoluteQuarantine)
+		return hold, fmt.Errorf("%w: %s (quarantine %s empty at the post-move re-verify)", errReplacementBackupQuarantineVanished, absoluteBackup, absoluteQuarantine)
 	case qerr != nil:
 		logging.Warnf("%s failed to re-verify quarantined backup %s (quarantine %s) before removal: %v — journal entry retained live", phase, absoluteBackup, quarantine, qerr)
-		return nil, hold.restoreOrJoin(qerr)
+		return hold, hold.restoreOrJoin(qerr)
 	}
 	if quarInfo == nil || quarInfo.Mode()&os.ModeSymlink != 0 || !quarInfo.Mode().IsRegular() {
-		return nil, hold.restoreOrJoin(refuseReplacementBackupRemoval(backup, phase, fmt.Sprintf("quarantined object at %s is not the verified regular file", quarantine)))
+		return hold, hold.restoreOrJoin(refuseReplacementBackupRemoval(backup, phase, fmt.Sprintf("quarantined object at %s is not the verified regular file", quarantine)))
 	}
 	if verDev, verIno, verOK := restoreSourceIdentity(verified); verOK {
 		if quarDev, quarIno, quarOK := restoreSourceIdentity(quarInfo); quarOK && (verDev != quarDev || verIno != quarIno) {
-			return nil, hold.restoreOrJoin(refuseReplacementBackupRemoval(backup, phase, fmt.Sprintf("quarantined object at %s is not the verified object (dev/inode mismatch) — foreign bytes preserved", quarantine)))
+			return hold, hold.restoreOrJoin(refuseReplacementBackupRemoval(backup, phase, fmt.Sprintf("quarantined object at %s is not the verified object (dev/inode mismatch) — foreign bytes preserved", quarantine)))
 		}
 	}
 	if quarInfo.Size() != verified.Size() || !quarInfo.ModTime().Equal(verified.ModTime()) {
-		return nil, hold.restoreOrJoin(refuseReplacementBackupRemoval(backup, phase, fmt.Sprintf("quarantined object at %s metadata differs from the verified object — foreign bytes preserved", quarantine)))
+		return hold, hold.restoreOrJoin(refuseReplacementBackupRemoval(backup, phase, fmt.Sprintf("quarantined object at %s metadata differs from the verified object — foreign bytes preserved", quarantine)))
 	}
 	hold.quar = quarInfo
 	return hold, nil

--- a/internal/history/replacement_backup_quarantine.go
+++ b/internal/history/replacement_backup_quarantine.go
@@ -56,6 +56,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/spf13/afero"
 
@@ -68,6 +70,17 @@ import (
 // ownership grammar (replacement_backup_name), so sweeps never arbitrate a
 // transient (or wedged) quarantine file as a set-aside.
 const backupQuarantineSuffix = ".dlq."
+
+var backupQuarantineNamePattern = regexp.MustCompile(`\.dlq\.[0-9a-f]{32}$`)
+
+func isReplacementBackupQuarantineName(name string) bool {
+	return backupQuarantineNamePattern.MatchString(name)
+}
+
+func originalReplacementBackupFromQuarantine(path string) string {
+	suffix := backupQuarantineNamePattern.FindString(path)
+	return strings.TrimSuffix(path, suffix)
+}
 
 // backupQuarantineClaimTries bounds the unpredictable-name draw loop; every
 // collision or racing claimant costs one draw.

--- a/internal/history/replacement_sweep_crash_p5_test.go
+++ b/internal/history/replacement_sweep_crash_p5_test.go
@@ -1,0 +1,65 @@
+package history
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSweep_ReconcilesIntentBeforeMoveCrash covers both pre-install crash
+// states: an intent with no backup only remains journaled for retry, while an
+// uninstalled intent with its backup restores the missing destination.
+func TestSweep_ReconcilesIntentBeforeMoveCrash(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("intent without backup only cleans stage state", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		repo := newP3OpRepo()
+		dest := "/out/INTENT-NOBACK/poster.jpg"
+		backup := dest + ".dlbak." + p3HexA
+		require.NoError(t, fs.MkdirAll("/out/INTENT-NOBACK", 0o755))
+		op := journalRow(t, repo, "job-intent-noback", "INTENT-NOBACK", dest, backup, 1, models.RevertStatusApplied)
+
+		restored := NewReplacementSweeper(fs, repo).restoreAndConsume(ctx, op, backup, dest, sweepSlash(backup), nil)
+		require.False(t, restored)
+		_, err := fs.Stat(dest)
+		require.ErrorIs(t, err, os.ErrNotExist)
+		_, err = fs.Stat(backup)
+		require.ErrorIs(t, err, os.ErrNotExist)
+		row, err := repo.FindByID(ctx, op.ID)
+		require.NoError(t, err)
+		gf, err := models.ParseGeneratedFiles(row.GeneratedFiles)
+		require.NoError(t, err)
+		require.Len(t, gf.Replacements, 1, "missing backup keeps intent for a later retry")
+	})
+
+	t.Run("backup without completed install restores destination", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		repo := newP3OpRepo()
+		dir := "/out/INTENT-RESTORE"
+		dest := dir + "/poster.jpg"
+		backup := dest + ".dlbak." + p3HexB
+		require.NoError(t, fs.MkdirAll(dir, 0o755))
+		writeSweepFile(t, fs, backup, "pre-crash", time.Hour)
+		op := journalRow(t, repo, "job-intent-restore", "INTENT-RESTORE", dest, backup, 1, models.RevertStatusApplied)
+
+		healed, err := NewReplacementSweeper(fs, repo).Sweep(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, healed)
+		data, err := afero.ReadFile(fs, dest)
+		require.NoError(t, err)
+		require.Equal(t, "pre-crash", string(data))
+		_, err = fs.Stat(backup)
+		require.ErrorIs(t, err, os.ErrNotExist)
+		row, err := repo.FindByID(ctx, op.ID)
+		require.NoError(t, err)
+		gf, err := models.ParseGeneratedFiles(row.GeneratedFiles)
+		require.NoError(t, err)
+		require.Empty(t, gf.Replacements)
+	})
+}

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -707,10 +707,14 @@ func (s *ReplacementSweeper) markPruneCleanupPending(opID uint, entry models.Rep
 // quarantine object and marks cleanup pending so a later retry never treats a
 // missing original name as already consumed.
 func (s *ReplacementSweeper) persistPruneQuarantine(opID uint, original models.ReplacementEntry, quarantine string) error {
-	ctx, cancel := context.WithTimeout(database.WithPruneMaintenance(context.Background()), 30*time.Second)
-	defer cancel()
 	release := fsutil.SharedJournalLocks().Acquire(strconv.Itoa(int(opID)))
 	defer release()
+	return s.persistPruneQuarantineLocked(opID, original, quarantine)
+}
+
+func (s *ReplacementSweeper) persistPruneQuarantineLocked(opID uint, original models.ReplacementEntry, quarantine string) error {
+	ctx, cancel := context.WithTimeout(database.WithPruneMaintenance(context.Background()), 30*time.Second)
+	defer cancel()
 	err := s.repo.UpdateJournalInTx(ctx, opID, func(current *models.BatchFileOperation) (models.GeneratedFilesJSON, bool, error) {
 		gf, err := models.ParseGeneratedFiles(current.GeneratedFiles)
 		if err != nil {
@@ -2070,7 +2074,7 @@ func (s *ReplacementSweeper) retryPendingRemovalClaimed(ctx context.Context, row
 		hold, rmErr = quarantineReplacementBackupForRemoval(s.fs, backup, "replacement sweep", &durableEntry, backupInfo)
 	}
 	if rmErr != nil && effectiveKind == models.RestorePendingKindPrune && hold != nil && hold.moved {
-		_ = s.persistPruneQuarantine(rowID, durableEntry, hold.quarantine)
+		_ = s.persistPruneQuarantineLocked(rowID, durableEntry, hold.quarantine)
 	}
 	if rmErr == nil && effectiveKind != models.RestorePendingKindPrune {
 		if _, derr := lstatRestoreSource(s.fs, dest); derr != nil {

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -543,7 +543,7 @@ pruneEntries:
 		}
 	}
 	if len(errs) == 0 {
-		return nil
+		return s.retractConsumedEntries(context.Background(), consumed, candidateIDs)
 	}
 	retractCtx := ctx
 	if retractCtx.Err() != nil {
@@ -658,6 +658,9 @@ func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, opID uint
 	if claim != nil && claim.abandonIfRevoked("prune backup quarantine", entry.Backup, entry.Destination) {
 		return false, fsutil.ErrReplacementBusy
 	}
+	if err := s.markPruneCleanupPending(opID, entry); err != nil {
+		return false, err
+	}
 	hold, err := quarantineReplacementBackupForPrune(s.fs, entry.Backup, "organized-job prune", &entry, nil)
 	if err != nil {
 		if hold != nil && hold.moved {
@@ -690,6 +693,14 @@ func (s *ReplacementSweeper) joinPruneRestoreFailure(opID uint, entry models.Rep
 		return errors.Join(cause, restoreErr, s.persistPruneQuarantine(opID, entry, hold.quarantine))
 	}
 	return cause
+}
+
+// markPruneCleanupPending durably records the two-phase cleanup intent
+// before any backup bytes move. A crash leaves a retryable pending entry.
+func (s *ReplacementSweeper) markPruneCleanupPending(opID uint, entry models.ReplacementEntry) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return markReplacementEntryRestorePendingKind(ctx, s.repo, opID, sweepSlash(entry.Backup), models.RestorePendingKindClean)
 }
 
 // markPruneRearmRefused records that the original backup name is no longer

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -184,6 +184,25 @@ func quarantineReplacementBackupForRemoval(fs afero.Fs, backup, phase string, en
 		return &replacementBackupQuarantine{fs: fs, backup: backup, phase: phase, unlinked: true}, nil
 	}
 	defer func() { _ = handle.Close() }()
+	hold, err := quarantineVerifiedBackup(fs, backup, phase, handle, verified)
+	if err != nil {
+		return nil, err
+	}
+	return hold, nil
+}
+
+// quarantineReplacementBackupForPrune preserves a partially moved quarantine
+// hold for the prune path; generic sweep callers retain their established
+// nil-hold error contract.
+func quarantineReplacementBackupForPrune(fs afero.Fs, backup, phase string, entry *models.ReplacementEntry, copiedFrom os.FileInfo) (*replacementBackupQuarantine, error) {
+	handle, verified, err := openVerifiedReplacementBackup(fs, backup, phase, entry, copiedFrom)
+	if err != nil {
+		return nil, err
+	}
+	if handle == nil {
+		return &replacementBackupQuarantine{fs: fs, backup: backup, phase: phase, unlinked: true}, nil
+	}
+	defer func() { _ = handle.Close() }()
 	return quarantineVerifiedBackup(fs, backup, phase, handle, verified)
 }
 
@@ -526,7 +545,11 @@ pruneEntries:
 	if len(errs) == 0 {
 		return nil
 	}
-	if err := s.retractConsumedEntries(consumed, candidateIDs); err != nil {
+	retractCtx := ctx
+	if retractCtx.Err() != nil {
+		retractCtx = context.Background()
+	}
+	if err := s.retractConsumedEntries(retractCtx, consumed, candidateIDs); err != nil {
 		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
@@ -535,7 +558,7 @@ pruneEntries:
 // retractConsumedEntries removes already-consumed backup entries from every
 // candidate row, including another row that shared the same backup spelling.
 // The journal RMW is durable and serialized with ordinary journal writers.
-func (s *ReplacementSweeper) retractConsumedEntries(consumed map[uint]map[string]struct{}, candidateIDs map[uint]struct{}) error {
+func (s *ReplacementSweeper) retractConsumedEntries(parentCtx context.Context, consumed map[uint]map[string]struct{}, candidateIDs map[uint]struct{}) error {
 	if len(consumed) == 0 || len(candidateIDs) == 0 {
 		return nil
 	}
@@ -545,11 +568,18 @@ func (s *ReplacementSweeper) retractConsumedEntries(consumed map[uint]map[string
 			want[sweepSlash(backup)] = struct{}{}
 		}
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
 	defer cancel()
 	var errs []error
 	for opID := range candidateIDs {
-		release := fsutil.SharedJournalLocks().Acquire(strconv.Itoa(int(opID)))
+		release, lockErr := acquireJournalLockWithin(ctx, strconv.Itoa(int(opID)))
+		if lockErr != nil {
+			errs = append(errs, fmt.Errorf("retract consumed entries lock for operation %d: %w", opID, lockErr))
+			continue
+		}
 		err := s.repo.UpdateJournalInTx(ctx, opID, func(current *models.BatchFileOperation) (models.GeneratedFilesJSON, bool, error) {
 			gf, err := models.ParseGeneratedFiles(current.GeneratedFiles)
 			if err != nil {
@@ -576,6 +606,21 @@ func (s *ReplacementSweeper) retractConsumedEntries(consumed map[uint]map[string
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// acquireJournalLockWithin bounds the wait for the process-local journal lock.
+// If the context expires, the eventual acquirer releases immediately without
+// touching the row.
+func acquireJournalLockWithin(ctx context.Context, key string) (func(), error) {
+	result := make(chan func(), 1)
+	go func() { result <- fsutil.SharedJournalLocks().Acquire(key) }()
+	select {
+	case release := <-result:
+		return release, nil
+	case <-ctx.Done():
+		go func() { (<-result)() }()
+		return nil, ctx.Err()
+	}
 }
 
 // pruneOperationBackup rechecks all live ledger rows while the destination
@@ -613,8 +658,11 @@ func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, opID uint
 	if claim != nil && claim.abandonIfRevoked("prune backup quarantine", entry.Backup, entry.Destination) {
 		return false, fsutil.ErrReplacementBusy
 	}
-	hold, err := quarantineReplacementBackupForRemoval(s.fs, entry.Backup, "organized-job prune", &entry, nil)
+	hold, err := quarantineReplacementBackupForPrune(s.fs, entry.Backup, "organized-job prune", &entry, nil)
 	if err != nil {
+		if hold != nil && hold.moved {
+			return false, errors.Join(err, s.persistPruneQuarantine(opID, entry, hold.quarantine))
+		}
 		return false, errors.Join(err, s.markPruneRearmRefused(opID, entry))
 	}
 	if hold == nil || hold.unlinked {
@@ -624,7 +672,7 @@ func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, opID uint
 		return false, s.joinPruneRestoreFailure(opID, entry, hold, err)
 	}
 	if claim != nil && claim.abandonIfRevoked("prune backup unlink", entry.Backup, entry.Destination) {
-		return false, s.joinPruneRestoreFailure(opID, entry, hold, fsutil.ErrReplacementBusy)
+		return false, errors.Join(fsutil.ErrReplacementBusy, s.persistPruneQuarantine(opID, entry, hold.quarantine))
 	}
 	if err := hold.removeVerified(); err != nil {
 		if hold.moved {

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -438,11 +438,35 @@ func NewReplacementSweeper(fs afero.Fs, repo database.BatchFileOperationReposito
 	return &ReplacementSweeper{fs: fs, repo: repo, pendingRemovals: map[string]string{}}
 }
 
+// PruneOperationBackupsError reports a cleanup failure together with the
+// replacement entries already consumed before the failure. The database layer
+// uses that progress to restore only still-live ledger entries.
+type PruneOperationBackupsError struct {
+	err      error
+	consumed map[uint]map[string]struct{}
+}
+
+func (e *PruneOperationBackupsError) Error() string { return e.err.Error() }
+func (e *PruneOperationBackupsError) Unwrap() error { return e.err }
+
+// ConsumedBackups returns operation ID → raw backup spelling for entries that
+// were already absent or successfully removed before another entry failed.
+func (e *PruneOperationBackupsError) ConsumedBackups() map[uint]map[string]struct{} {
+	out := make(map[uint]map[string]struct{}, len(e.consumed))
+	for opID, backups := range e.consumed {
+		out[opID] = make(map[string]struct{}, len(backups))
+		for backup := range backups {
+			out[opID][backup] = struct{}{}
+		}
+	}
+	return out
+}
+
 // PruneOperationBackups removes replacement backups belonging to operation rows
 // that have just been pruned. The database deletion is already committed when
-// this hook runs; each destination is then locked and the live ledger is
-// re-read before an identity-bound unlink, so a concurrently appended row
-// keeps its shared backup alive.
+// this hook runs; each destination claims the cross-process busy marker, then
+// takes the process-local lock and re-reads the live ledger before an
+// identity-bound unlink.
 func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []models.BatchFileOperation) error {
 	if len(ops) == 0 {
 		return nil
@@ -452,6 +476,13 @@ func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []mo
 	}
 
 	var errs []error
+	consumed := make(map[uint]map[string]struct{})
+	markConsumed := func(opID uint, backup string) {
+		if consumed[opID] == nil {
+			consumed[opID] = make(map[string]struct{})
+		}
+		consumed[opID][backup] = struct{}{}
+	}
 	for i := range ops {
 		gf, err := models.ParseGeneratedFiles(ops[i].GeneratedFiles)
 		if err != nil {
@@ -469,49 +500,83 @@ func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []mo
 				continue
 			}
 			if err := ctx.Err(); err != nil {
-				return errors.Join(append(errs, err)...)
+				errs = append(errs, err)
+				return &PruneOperationBackupsError{err: errors.Join(errs...), consumed: consumed}
 			}
 
+			busyRelease, busyToken, busyErr := acquireReplacementBusyExFn(s.fs, entry.Destination)
+			if busyErr != nil {
+				errs = append(errs, fmt.Errorf("claim destination %s: %w", entry.Destination, busyErr))
+				continue
+			}
+			if busyRelease == nil || busyToken == "" {
+				if busyRelease != nil {
+					busyRelease()
+				}
+				errs = append(errs, fmt.Errorf("claim destination %s: busy-marker provenance unavailable", entry.Destination))
+				continue
+			}
+			if err := ctx.Err(); err != nil {
+				busyRelease()
+				errs = append(errs, err)
+				return &PruneOperationBackupsError{err: errors.Join(errs...), consumed: consumed}
+			}
 			release := fsutil.SharedDestLocks().Acquire(entry.Destination)
-			err := s.pruneOperationBackup(ctx, entry)
+			wasConsumed, pruneErr := s.pruneOperationBackup(ctx, entry)
 			release()
-			if err != nil {
-				errs = append(errs, fmt.Errorf("operation %d backup %s: %w", ops[i].ID, entry.Backup, err))
+			busyRelease()
+			if wasConsumed {
+				markConsumed(ops[i].ID, entry.Backup)
+			}
+			if pruneErr != nil {
+				errs = append(errs, fmt.Errorf("operation %d backup %s: %w", ops[i].ID, entry.Backup, pruneErr))
 			}
 		}
 	}
-	return errors.Join(errs...)
+	if len(errs) == 0 {
+		return nil
+	}
+	return &PruneOperationBackupsError{err: errors.Join(errs...), consumed: consumed}
 }
 
 // pruneOperationBackup rechecks all live ledger rows while the destination
-// lock is held. A shared backup name is retained if any row still references
+// locks are held. A shared backup name is retained if any row still references
 // it; otherwise the normal identity-bound quarantine/unlink path consumes it.
-func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, entry models.ReplacementEntry) error {
+func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, entry models.ReplacementEntry) (bool, error) {
 	rows, err := s.repo.FindOperationsWithLedger(ctx)
 	if err != nil {
-		return fmt.Errorf("read live ledger: %w", err)
+		return false, fmt.Errorf("read live ledger: %w", err)
 	}
 	want := sweepSlash(entry.Backup)
 	for i := range rows {
 		gf, parseErr := models.ParseGeneratedFiles(rows[i].GeneratedFiles)
 		if parseErr != nil {
-			return fmt.Errorf("cannot prove backup %s is unreferenced by operation %d: %w", entry.Backup, rows[i].ID, parseErr)
+			return false, fmt.Errorf("cannot prove backup %s is unreferenced by operation %d: %w", entry.Backup, rows[i].ID, parseErr)
 		}
 		for _, live := range gf.Replacements {
 			if sweepSlash(live.Backup) == want {
-				return nil
+				return false, nil
 			}
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
 	hold, err := quarantineReplacementBackupForRemoval(s.fs, entry.Backup, "organized-job prune", &entry, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if hold == nil || hold.unlinked {
-		return nil
+		return true, nil
 	}
-	return hold.removeVerified()
+	if err := ctx.Err(); err != nil {
+		return false, errors.Join(err, hold.restore())
+	}
+	if err := hold.removeVerified(); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // rememberPendingRemoval records the in-process cleanup authorization with

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -464,6 +464,10 @@ func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []mo
 				errs = append(errs, fmt.Errorf("operation %d has an incomplete replacement entry", ops[i].ID))
 				continue
 			}
+			if !entry.Installed || entry.PendingKind() == models.RestorePendingKindRearmRefused {
+				logging.Warnf("organized-job prune retained backup %s for operation %d: install is unconfirmed or backup ownership is refused", entry.Backup, ops[i].ID)
+				continue
+			}
 			if err := ctx.Err(); err != nil {
 				return errors.Join(append(errs, err)...)
 			}

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -543,12 +543,11 @@ pruneEntries:
 		}
 	}
 	retractCtx := ctx
+	if retractCtx.Err() != nil {
+		retractCtx = context.WithoutCancel(retractCtx)
+	}
 	if len(errs) == 0 {
 		return s.retractConsumedEntries(retractCtx, consumed, candidateIDs)
-	}
-
-	if retractCtx.Err() != nil {
-		retractCtx = context.Background()
 	}
 	if err := s.retractConsumedEntries(retractCtx, consumed, candidateIDs); err != nil {
 		errs = append(errs, err)
@@ -2063,7 +2062,16 @@ func (s *ReplacementSweeper) retryPendingRemovalClaimed(ctx context.Context, row
 	if claim.abandonIfRevoked("clean pending backup quarantine removal", backup, dest) {
 		return false
 	}
-	hold, rmErr := quarantineReplacementBackupForRemoval(s.fs, backup, "replacement sweep", &durableEntry, backupInfo)
+	var hold *replacementBackupQuarantine
+	var rmErr error
+	if effectiveKind == models.RestorePendingKindPrune {
+		hold, rmErr = quarantineReplacementBackupForPrune(s.fs, backup, "replacement sweep", &durableEntry, backupInfo)
+	} else {
+		hold, rmErr = quarantineReplacementBackupForRemoval(s.fs, backup, "replacement sweep", &durableEntry, backupInfo)
+	}
+	if rmErr != nil && effectiveKind == models.RestorePendingKindPrune && hold != nil && hold.moved {
+		_ = s.persistPruneQuarantine(rowID, durableEntry, hold.quarantine)
+	}
 	if rmErr == nil && effectiveKind != models.RestorePendingKindPrune {
 		if _, derr := lstatRestoreSource(s.fs, dest); derr != nil {
 			if rerr := hold.restore(); rerr != nil {
@@ -2093,6 +2101,8 @@ func (s *ReplacementSweeper) retryPendingRemovalClaimed(ctx context.Context, row
 			s.rememberPendingRemoval(backupSlash)
 			return false
 		}
+	}
+	if rmErr == nil {
 		rmErr = hold.removeVerified()
 	}
 	if rmErr != nil {

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -1056,6 +1056,9 @@ func (s *ReplacementSweeper) Sweep(ctx context.Context) (int, error) {
 		if _, ok := idx.journaled[entry.backupSlash]; !ok {
 			continue
 		}
+		if err := ctx.Err(); err != nil {
+			return healed, err
+		}
 		healed += s.consumePrunePending(ctx, idx, entry)
 	}
 	return healed, nil

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -462,6 +462,7 @@ func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []mo
 		}
 		consumed[opID][backup] = struct{}{}
 	}
+pruneEntries:
 	for i := range ops {
 		gf, err := models.ParseGeneratedFiles(ops[i].GeneratedFiles)
 		if err != nil {
@@ -474,13 +475,17 @@ func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []mo
 				errs = append(errs, fmt.Errorf("operation %d has an incomplete replacement entry", ops[i].ID))
 				continue
 			}
-			if !entry.Installed || entry.PendingKind() == models.RestorePendingKindRearmRefused {
-				logging.Warnf("organized-job prune retained backup %s for operation %d: install is unconfirmed or backup ownership is refused", entry.Backup, ops[i].ID)
+			if !entry.Installed {
+				errs = append(errs, fmt.Errorf("operation %d backup %s: install is unconfirmed", ops[i].ID, entry.Backup))
+				continue
+			}
+			if entry.PendingKind() == models.RestorePendingKindRearmRefused {
+				errs = append(errs, fmt.Errorf("operation %d backup %s: ownership is rearm-refused", ops[i].ID, entry.Backup))
 				continue
 			}
 			if err := ctx.Err(); err != nil {
 				errs = append(errs, err)
-				return errors.Join(errs...)
+				break pruneEntries
 			}
 
 			busyRelease, busyToken, busyErr := acquireReplacementBusyExFn(s.fs, entry.Destination)
@@ -610,10 +615,10 @@ func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, opID uint
 	}
 	hold, err := quarantineReplacementBackupForRemoval(s.fs, entry.Backup, "organized-job prune", &entry, nil)
 	if err != nil {
-		return false, err
+		return false, errors.Join(err, s.markPruneRearmRefused(opID, entry))
 	}
 	if hold == nil || hold.unlinked {
-		return true, nil
+		return false, errors.Join(fmt.Errorf("backup %s is absent during prune", entry.Backup), s.markPruneRearmRefused(opID, entry))
 	}
 	if err := ctx.Err(); err != nil {
 		return false, s.joinPruneRestoreFailure(opID, entry, hold, err)
@@ -637,6 +642,14 @@ func (s *ReplacementSweeper) joinPruneRestoreFailure(opID uint, entry models.Rep
 		return errors.Join(cause, restoreErr, s.persistPruneQuarantine(opID, entry, hold.quarantine))
 	}
 	return cause
+}
+
+// markPruneRearmRefused records that the original backup name is no longer
+// safe to path-operate during a later cleanup retry.
+func (s *ReplacementSweeper) markPruneRearmRefused(opID uint, entry models.ReplacementEntry) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return markReplacementEntryRestorePendingKind(ctx, s.repo, opID, sweepSlash(entry.Backup), models.RestorePendingKindRearmRefused)
 }
 
 // persistPruneQuarantine moves the durable ledger pointer to the recoverable

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/javinizer/javinizer-go/internal/database"
 	"github.com/javinizer/javinizer-go/internal/fsutil"
@@ -438,35 +439,9 @@ func NewReplacementSweeper(fs afero.Fs, repo database.BatchFileOperationReposito
 	return &ReplacementSweeper{fs: fs, repo: repo, pendingRemovals: map[string]string{}}
 }
 
-// PruneOperationBackupsError reports a cleanup failure together with the
-// replacement entries already consumed before the failure. The database layer
-// uses that progress to restore only still-live ledger entries.
-type PruneOperationBackupsError struct {
-	err      error
-	consumed map[uint]map[string]struct{}
-}
-
-func (e *PruneOperationBackupsError) Error() string { return e.err.Error() }
-func (e *PruneOperationBackupsError) Unwrap() error { return e.err }
-
-// ConsumedBackups returns operation ID → raw backup spelling for entries that
-// were already absent or successfully removed before another entry failed.
-func (e *PruneOperationBackupsError) ConsumedBackups() map[uint]map[string]struct{} {
-	out := make(map[uint]map[string]struct{}, len(e.consumed))
-	for opID, backups := range e.consumed {
-		out[opID] = make(map[string]struct{}, len(backups))
-		for backup := range backups {
-			out[opID][backup] = struct{}{}
-		}
-	}
-	return out
-}
-
 // PruneOperationBackups removes replacement backups belonging to operation rows
-// that have just been pruned. The database deletion is already committed when
-// this hook runs; each destination claims the cross-process busy marker, then
-// takes the process-local lock and re-reads the live ledger before an
-// identity-bound unlink.
+// that are about to be pruned. The caller keeps those rows live until this hook
+// succeeds, so a crash or failed cleanup leaves durable ledger ownership.
 func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []models.BatchFileOperation) error {
 	if len(ops) == 0 {
 		return nil
@@ -475,6 +450,10 @@ func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []mo
 		return fmt.Errorf("prune operation backups: sweeper is not configured")
 	}
 
+	candidateIDs := make(map[uint]struct{}, len(ops))
+	for _, op := range ops {
+		candidateIDs[op.ID] = struct{}{}
+	}
 	var errs []error
 	consumed := make(map[uint]map[string]struct{})
 	markConsumed := func(opID uint, backup string) {
@@ -501,7 +480,7 @@ func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []mo
 			}
 			if err := ctx.Err(); err != nil {
 				errs = append(errs, err)
-				return &PruneOperationBackupsError{err: errors.Join(errs...), consumed: consumed}
+				return errors.Join(errs...)
 			}
 
 			busyRelease, busyToken, busyErr := acquireReplacementBusyExFn(s.fs, entry.Destination)
@@ -519,10 +498,10 @@ func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []mo
 			if err := ctx.Err(); err != nil {
 				busyRelease()
 				errs = append(errs, err)
-				return &PruneOperationBackupsError{err: errors.Join(errs...), consumed: consumed}
+				return errors.Join(errs...)
 			}
 			release := fsutil.SharedDestLocks().Acquire(entry.Destination)
-			wasConsumed, pruneErr := s.pruneOperationBackup(ctx, entry)
+			wasConsumed, pruneErr := s.pruneOperationBackup(ctx, entry, candidateIDs)
 			release()
 			busyRelease()
 			if wasConsumed {
@@ -536,19 +515,71 @@ func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []mo
 	if len(errs) == 0 {
 		return nil
 	}
-	return &PruneOperationBackupsError{err: errors.Join(errs...), consumed: consumed}
+	if err := s.retractConsumedEntries(consumed, candidateIDs); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// retractConsumedEntries removes already-consumed backup entries from every
+// candidate row, including another row that shared the same backup spelling.
+// The journal RMW is durable and serialized with ordinary journal writers.
+func (s *ReplacementSweeper) retractConsumedEntries(consumed map[uint]map[string]struct{}, candidateIDs map[uint]struct{}) error {
+	if len(consumed) == 0 || len(candidateIDs) == 0 {
+		return nil
+	}
+	want := make(map[string]struct{})
+	for _, backups := range consumed {
+		for backup := range backups {
+			want[sweepSlash(backup)] = struct{}{}
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var errs []error
+	for opID := range candidateIDs {
+		release := fsutil.SharedJournalLocks().Acquire(strconv.Itoa(int(opID)))
+		err := s.repo.UpdateJournalInTx(ctx, opID, func(current *models.BatchFileOperation) (models.GeneratedFilesJSON, bool, error) {
+			gf, err := models.ParseGeneratedFiles(current.GeneratedFiles)
+			if err != nil {
+				return models.GeneratedFilesJSON{}, false, err
+			}
+			kept := gf.Replacements[:0]
+			for _, entry := range gf.Replacements {
+				if _, remove := want[sweepSlash(entry.Backup)]; !remove {
+					kept = append(kept, entry)
+				}
+			}
+			if len(kept) == len(gf.Replacements) {
+				return gf, false, nil
+			}
+			gf.Replacements = kept
+			return gf, true, nil
+		})
+		release()
+		if errors.Is(err, database.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			errs = append(errs, fmt.Errorf("retract consumed entries for operation %d: %w", opID, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // pruneOperationBackup rechecks all live ledger rows while the destination
-// locks are held. A shared backup name is retained if any row still references
-// it; otherwise the normal identity-bound quarantine/unlink path consumes it.
-func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, entry models.ReplacementEntry) (bool, error) {
+// locks are held. Candidate rows are ignored because they are the rows this
+// pre-delete cleanup is about to retire; any other row keeps the backup alive.
+func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, entry models.ReplacementEntry, candidateIDs map[uint]struct{}) (bool, error) {
 	rows, err := s.repo.FindOperationsWithLedger(ctx)
 	if err != nil {
 		return false, fmt.Errorf("read live ledger: %w", err)
 	}
 	want := sweepSlash(entry.Backup)
 	for i := range rows {
+		if _, candidate := candidateIDs[rows[i].ID]; candidate {
+			continue
+		}
 		gf, parseErr := models.ParseGeneratedFiles(rows[i].GeneratedFiles)
 		if parseErr != nil {
 			return false, fmt.Errorf("cannot prove backup %s is unreferenced by operation %d: %w", entry.Backup, rows[i].ID, parseErr)

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -495,14 +495,20 @@ func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []mo
 				errs = append(errs, fmt.Errorf("claim destination %s: busy-marker provenance unavailable", entry.Destination))
 				continue
 			}
-			if err := ctx.Err(); err != nil {
+			claim, untrack := recordSweepBusyClaim(ctx, s.fs, entry.Destination, busyToken, busyRelease)
+			rawRelease := fsutil.SharedDestLocks().Acquire(entry.Destination)
+			if !claim.bindDestLock(rawRelease) {
+				rawRelease()
+				untrack()
+				claim.releaseAdmit()
 				busyRelease()
-				errs = append(errs, err)
-				return errors.Join(errs...)
+				errs = append(errs, fmt.Errorf("claim destination %s was revoked before cleanup", entry.Destination))
+				continue
 			}
-			release := fsutil.SharedDestLocks().Acquire(entry.Destination)
-			wasConsumed, pruneErr := s.pruneOperationBackup(ctx, entry, candidateIDs)
-			release()
+			wasConsumed, pruneErr := s.pruneOperationBackup(ctx, ops[i].ID, entry, candidateIDs, claim)
+			claim.releaseAdmit()
+			claim.releaseDestLock()
+			untrack()
 			busyRelease()
 			if wasConsumed {
 				markConsumed(ops[i].ID, entry.Backup)
@@ -570,7 +576,12 @@ func (s *ReplacementSweeper) retractConsumedEntries(consumed map[uint]map[string
 // pruneOperationBackup rechecks all live ledger rows while the destination
 // locks are held. Candidate rows are ignored because they are the rows this
 // pre-delete cleanup is about to retire; any other row keeps the backup alive.
-func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, entry models.ReplacementEntry, candidateIDs map[uint]struct{}) (bool, error) {
+func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, opID uint, entry models.ReplacementEntry, candidateIDs map[uint]struct{}, claim *sweepBusyMarkerClaim) (bool, error) {
+	defer func() {
+		if claim != nil {
+			claim.releaseAdmit()
+		}
+	}()
 	rows, err := s.repo.FindOperationsWithLedger(ctx)
 	if err != nil {
 		return false, fmt.Errorf("read live ledger: %w", err)
@@ -594,6 +605,9 @@ func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, entry mod
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
+	if claim != nil && claim.abandonIfRevoked("prune backup quarantine", entry.Backup, entry.Destination) {
+		return false, fsutil.ErrReplacementBusy
+	}
 	hold, err := quarantineReplacementBackupForRemoval(s.fs, entry.Backup, "organized-job prune", &entry, nil)
 	if err != nil {
 		return false, err
@@ -602,12 +616,53 @@ func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, entry mod
 		return true, nil
 	}
 	if err := ctx.Err(); err != nil {
-		return false, errors.Join(err, hold.restore())
+		return false, s.joinPruneRestoreFailure(opID, entry, hold, err)
+	}
+	if claim != nil && claim.abandonIfRevoked("prune backup unlink", entry.Backup, entry.Destination) {
+		return false, s.joinPruneRestoreFailure(opID, entry, hold, fsutil.ErrReplacementBusy)
 	}
 	if err := hold.removeVerified(); err != nil {
+		if hold.moved {
+			return false, errors.Join(err, s.persistPruneQuarantine(opID, entry, hold.quarantine))
+		}
 		return false, err
 	}
 	return true, nil
+}
+
+// joinPruneRestoreFailure retains a durable ledger pointer to the quarantine
+// name when compensation cannot restore the original backup name.
+func (s *ReplacementSweeper) joinPruneRestoreFailure(opID uint, entry models.ReplacementEntry, hold *replacementBackupQuarantine, cause error) error {
+	if restoreErr := hold.restore(); restoreErr != nil {
+		return errors.Join(cause, restoreErr, s.persistPruneQuarantine(opID, entry, hold.quarantine))
+	}
+	return cause
+}
+
+// persistPruneQuarantine moves the durable ledger pointer to the recoverable
+// quarantine object and marks cleanup pending so a later retry never treats a
+// missing original name as already consumed.
+func (s *ReplacementSweeper) persistPruneQuarantine(opID uint, original models.ReplacementEntry, quarantine string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	release := fsutil.SharedJournalLocks().Acquire(strconv.Itoa(int(opID)))
+	defer release()
+	err := s.repo.UpdateJournalInTx(ctx, opID, func(current *models.BatchFileOperation) (models.GeneratedFilesJSON, bool, error) {
+		gf, err := models.ParseGeneratedFiles(current.GeneratedFiles)
+		if err != nil {
+			return models.GeneratedFilesJSON{}, false, err
+		}
+		for i := range gf.Replacements {
+			if sweepSlash(gf.Replacements[i].Backup) != sweepSlash(original.Backup) || sweepSlash(gf.Replacements[i].Destination) != sweepSlash(original.Destination) {
+				continue
+			}
+			gf.Replacements[i].Backup = quarantine
+			gf.Replacements[i].SetRestorePending(models.RestorePendingKindClean)
+			return gf, true, nil
+		}
+		return gf, false, nil
+	})
+	return err
 }
 
 // rememberPendingRemoval records the in-process cleanup authorization with

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -438,6 +438,78 @@ func NewReplacementSweeper(fs afero.Fs, repo database.BatchFileOperationReposito
 	return &ReplacementSweeper{fs: fs, repo: repo, pendingRemovals: map[string]string{}}
 }
 
+// PruneOperationBackups removes replacement backups belonging to operation rows
+// that have just been pruned. The database deletion is already committed when
+// this hook runs; each destination is then locked and the live ledger is
+// re-read before an identity-bound unlink, so a concurrently appended row
+// keeps its shared backup alive.
+func (s *ReplacementSweeper) PruneOperationBackups(ctx context.Context, ops []models.BatchFileOperation) error {
+	if len(ops) == 0 {
+		return nil
+	}
+	if s == nil || s.fs == nil || s.repo == nil {
+		return fmt.Errorf("prune operation backups: sweeper is not configured")
+	}
+
+	var errs []error
+	for i := range ops {
+		gf, err := models.ParseGeneratedFiles(ops[i].GeneratedFiles)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("operation %d ledger parse: %w", ops[i].ID, err))
+			continue
+		}
+		for j := range gf.Replacements {
+			entry := gf.Replacements[j]
+			if strings.TrimSpace(entry.Backup) == "" || strings.TrimSpace(entry.Destination) == "" {
+				errs = append(errs, fmt.Errorf("operation %d has an incomplete replacement entry", ops[i].ID))
+				continue
+			}
+			if err := ctx.Err(); err != nil {
+				return errors.Join(append(errs, err)...)
+			}
+
+			release := fsutil.SharedDestLocks().Acquire(entry.Destination)
+			err := s.pruneOperationBackup(ctx, entry)
+			release()
+			if err != nil {
+				errs = append(errs, fmt.Errorf("operation %d backup %s: %w", ops[i].ID, entry.Backup, err))
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// pruneOperationBackup rechecks all live ledger rows while the destination
+// lock is held. A shared backup name is retained if any row still references
+// it; otherwise the normal identity-bound quarantine/unlink path consumes it.
+func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, entry models.ReplacementEntry) error {
+	rows, err := s.repo.FindOperationsWithLedger(ctx)
+	if err != nil {
+		return fmt.Errorf("read live ledger: %w", err)
+	}
+	want := sweepSlash(entry.Backup)
+	for i := range rows {
+		gf, parseErr := models.ParseGeneratedFiles(rows[i].GeneratedFiles)
+		if parseErr != nil {
+			return fmt.Errorf("cannot prove backup %s is unreferenced by operation %d: %w", entry.Backup, rows[i].ID, parseErr)
+		}
+		for _, live := range gf.Replacements {
+			if sweepSlash(live.Backup) == want {
+				return nil
+			}
+		}
+	}
+
+	hold, err := quarantineReplacementBackupForRemoval(s.fs, entry.Backup, "organized-job prune", &entry, nil)
+	if err != nil {
+		return err
+	}
+	if hold == nil || hold.unlinked {
+		return nil
+	}
+	return hold.removeVerified()
+}
+
 // rememberPendingRemoval records the in-process cleanup authorization with
 // the legacy CLEAN kind (the backup name still holds the operation's own
 // bytes — e.g. its removal just failed).

--- a/internal/history/replacement_sweep_p3.go
+++ b/internal/history/replacement_sweep_p3.go
@@ -542,10 +542,11 @@ pruneEntries:
 			}
 		}
 	}
-	if len(errs) == 0 {
-		return s.retractConsumedEntries(context.Background(), consumed, candidateIDs)
-	}
 	retractCtx := ctx
+	if len(errs) == 0 {
+		return s.retractConsumedEntries(retractCtx, consumed, candidateIDs)
+	}
+
 	if retractCtx.Err() != nil {
 		retractCtx = context.Background()
 	}
@@ -666,10 +667,10 @@ func (s *ReplacementSweeper) pruneOperationBackup(ctx context.Context, opID uint
 		if hold != nil && hold.moved {
 			return false, errors.Join(err, s.persistPruneQuarantine(opID, entry, hold.quarantine))
 		}
-		return false, errors.Join(err, s.markPruneRearmRefused(opID, entry))
+		return false, err
 	}
 	if hold == nil || hold.unlinked {
-		return false, errors.Join(fmt.Errorf("backup %s is absent during prune", entry.Backup), s.markPruneRearmRefused(opID, entry))
+		return false, fmt.Errorf("backup %s is absent during prune", entry.Backup)
 	}
 	if err := ctx.Err(); err != nil {
 		return false, s.joinPruneRestoreFailure(opID, entry, hold, err)
@@ -698,24 +699,16 @@ func (s *ReplacementSweeper) joinPruneRestoreFailure(opID uint, entry models.Rep
 // markPruneCleanupPending durably records the two-phase cleanup intent
 // before any backup bytes move. A crash leaves a retryable pending entry.
 func (s *ReplacementSweeper) markPruneCleanupPending(opID uint, entry models.ReplacementEntry) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(database.WithPruneMaintenance(context.Background()), 30*time.Second)
 	defer cancel()
-	return markReplacementEntryRestorePendingKind(ctx, s.repo, opID, sweepSlash(entry.Backup), models.RestorePendingKindClean)
-}
-
-// markPruneRearmRefused records that the original backup name is no longer
-// safe to path-operate during a later cleanup retry.
-func (s *ReplacementSweeper) markPruneRearmRefused(opID uint, entry models.ReplacementEntry) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	return markReplacementEntryRestorePendingKind(ctx, s.repo, opID, sweepSlash(entry.Backup), models.RestorePendingKindRearmRefused)
+	return markReplacementEntryRestorePendingKind(ctx, s.repo, opID, sweepSlash(entry.Backup), models.RestorePendingKindPrune)
 }
 
 // persistPruneQuarantine moves the durable ledger pointer to the recoverable
 // quarantine object and marks cleanup pending so a later retry never treats a
 // missing original name as already consumed.
 func (s *ReplacementSweeper) persistPruneQuarantine(opID uint, original models.ReplacementEntry, quarantine string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(database.WithPruneMaintenance(context.Background()), 30*time.Second)
 	defer cancel()
 	release := fsutil.SharedJournalLocks().Acquire(strconv.Itoa(int(opID)))
 	defer release()
@@ -729,7 +722,7 @@ func (s *ReplacementSweeper) persistPruneQuarantine(opID uint, original models.R
 				continue
 			}
 			gf.Replacements[i].Backup = quarantine
-			gf.Replacements[i].SetRestorePending(models.RestorePendingKindClean)
+			gf.Replacements[i].SetRestorePending(models.RestorePendingKindPrune)
 			return gf, true, nil
 		}
 		return gf, false, nil
@@ -818,7 +811,8 @@ type replacementLedgerIndex struct {
 	// LIVE ledger may authorize (the orphan posture retains + warns instead).
 	journaled       map[string]*models.BatchFileOperation // backup path → owning row
 	dirs            map[string]bool                       // directories holding journaled destinations
-	refusedPendings []rearmRefusedLedgerEntry             // wave-29: ledger-only rearm-refused pendings
+	refusedPendings []rearmRefusedLedgerEntry
+	prunePendings   []prunePendingLedgerEntry // wave-29: ledger-only rearm-refused pendings
 }
 
 // rearmRefusedLedgerEntry is one journaled restore-pending entry of the
@@ -832,6 +826,18 @@ type rearmRefusedLedgerEntry struct {
 	backup      string // recorded spelling — never a path-operation target here
 	dest        string // recorded spelling of the certified destination
 	backupSlash string // probe-aware journal key
+}
+
+// prunePendingLedgerEntry is a durable retention intent that may need a
+// ledger-only retry after the process crashed between backup quarantine and
+// journal consumption. backup is the current filesystem path to clean;
+// journalBackup is the spelling stored in the ledger.
+type prunePendingLedgerEntry struct {
+	rowID         uint
+	backup        string
+	journalBackup string
+	dest          string
+	backupSlash   string
 }
 
 func (s *ReplacementSweeper) index(ctx context.Context) (*replacementLedgerIndex, error) {
@@ -860,7 +866,13 @@ func (s *ReplacementSweeper) index(ctx context.Context) (*replacementLedgerIndex
 			continue
 		}
 		for _, rep := range gf.Replacements {
-			idx.journaled[sweepSlash(rep.Backup)] = row
+			backupSlash := sweepSlash(rep.Backup)
+			idx.journaled[backupSlash] = row
+			if rep.RestorePending && rep.PendingKind() == models.RestorePendingKindPrune {
+				idx.prunePendings = append(idx.prunePendings, prunePendingLedgerEntry{
+					rowID: row.ID, backup: rep.Backup, journalBackup: rep.Backup, dest: rep.Destination, backupSlash: backupSlash,
+				})
+			}
 			// Dirs are FS ENUMERATION paths — keep their recorded case (the
 			// probe-aware key is only a comparison form).
 			idx.dirs[filepath.ToSlash(filepath.Clean(filepath.Dir(rep.Destination)))] = true
@@ -897,6 +909,74 @@ func (s *ReplacementSweeper) index(ctx context.Context) (*replacementLedgerIndex
 		}
 	}
 	return idx, nil
+}
+
+// consumePrunePending retries one durable retention intent under the same
+// destination/busy-marker claim discipline as ordinary sweep legs. Prune
+// cleanup is intentionally allowed to consume journal-only when its backup
+// path is already absent: that absence means unlink completed before the
+// process crashed, not that destination bytes were restored.
+func (s *ReplacementSweeper) consumePrunePending(ctx context.Context, idx *replacementLedgerIndex, entry prunePendingLedgerEntry) int {
+	busyRelease, busyToken, busyErr := acquireReplacementBusyExFn(s.fs, entry.dest)
+	if errors.Is(busyErr, fsutil.ErrReplacementBusy) {
+		return 0
+	}
+	if busyErr != nil || busyToken == "" {
+		if busyErr == nil {
+			busyRelease()
+		}
+		return 0
+	}
+	defer busyRelease()
+	claim, untrack := recordSweepBusyClaim(ctx, s.fs, entry.dest, busyToken, busyRelease)
+	defer untrack()
+	defer claim.releaseAdmit()
+	rawDestRelease := fsutil.SharedDestLocks().Acquire(entry.dest)
+	if !claim.bindDestLock(rawDestRelease) {
+		rawDestRelease()
+		claim.abandonIfRevoked("destination lock acquisition", entry.backup, entry.dest)
+		return 0
+	}
+	defer claim.releaseDestLock()
+	if s.retryPendingRemovalClaimed(database.WithPruneMaintenance(ctx), entry.rowID, entry.backup, entry.dest, entry.backupSlash, claim) {
+		delete(idx.journaled, entry.backupSlash)
+		return 1
+	}
+	return 0
+}
+
+// sweepPruneQuarantine routes a .dlq object back to the prune intent that
+// owns its original .dlbak name. This closes the crash window between the
+// verified quarantine move and persistence of the new ledger pointer.
+func (s *ReplacementSweeper) sweepPruneQuarantine(ctx context.Context, idx *replacementLedgerIndex, dirSlash string, e os.FileInfo) int {
+	quarantine := filepath.FromSlash(dirSlash + "/" + e.Name())
+	original := originalReplacementBackupFromQuarantine(quarantine)
+	journalBackup := original
+	owner, ok := idx.journaled[sweepSlash(journalBackup)]
+	if !ok {
+		journalBackup = quarantine
+		owner, ok = idx.journaled[sweepSlash(journalBackup)]
+	}
+	if !ok || journalEntryPendingKind(owner, sweepSlash(journalBackup)) != models.RestorePendingKindPrune {
+		return 0
+	}
+	return s.consumePrunePending(ctx, idx, prunePendingLedgerEntry{
+		rowID: owner.ID, backup: quarantine, journalBackup: journalBackup,
+		dest: journalEntryDestination(owner, sweepSlash(journalBackup)), backupSlash: sweepSlash(journalBackup),
+	})
+}
+
+func journalEntryDestination(row *models.BatchFileOperation, backupSlash string) string {
+	gf, err := models.ParseGeneratedFiles(row.GeneratedFiles)
+	if err != nil {
+		return ""
+	}
+	for _, rep := range gf.Replacements {
+		if sweepSlash(rep.Backup) == backupSlash {
+			return rep.Destination
+		}
+	}
+	return ""
 }
 
 // Sweep runs a full startup sweep: every directory that holds a journaled
@@ -956,11 +1036,24 @@ func (s *ReplacementSweeper) Sweep(ctx context.Context) (int, error) {
 			return healed, err
 		}
 		for _, e := range entries {
-			if e.IsDir() || !IsReplacementBackupName(e.Name()) {
+			if e.IsDir() {
 				continue
 			}
-			healed += s.sweepOne(ctx, idx, dir, e)
+			switch {
+			case IsReplacementBackupName(e.Name()):
+				healed += s.sweepOne(ctx, idx, dir, e)
+			case isReplacementBackupQuarantineName(e.Name()):
+				healed += s.sweepPruneQuarantine(ctx, idx, dir, e)
+			}
 		}
+	}
+	// A prune intent whose original name is absent and whose quarantine move
+	// was not visible to the directory scan still converges journal-only.
+	for _, entry := range idx.prunePendings {
+		if _, ok := idx.journaled[entry.backupSlash]; !ok {
+			continue
+		}
+		healed += s.consumePrunePending(ctx, idx, entry)
 	}
 	return healed, nil
 }
@@ -1308,7 +1401,11 @@ func (s *ReplacementSweeper) restoreAndConsume(ctx context.Context, row *models.
 				return false
 			}
 		}
-		return s.retryPendingRemovalClaimed(ctx, row.ID, backup, dest, backupSlash, claim)
+		retryCtx := ctx
+		if journalEntryPendingKind(row, backupSlash) == models.RestorePendingKindPrune {
+			retryCtx = database.WithPruneMaintenance(ctx)
+		}
+		return s.retryPendingRemovalClaimed(retryCtx, row.ID, backup, dest, backupSlash, claim)
 	} else if !errors.Is(lstatErr, afero.ErrFileNotFound) {
 		logging.Warnf("replacement sweep %s: destination indeterminate (%v) — kept", backup, lstatErr)
 		return false
@@ -1887,9 +1984,35 @@ func (s *ReplacementSweeper) retryPendingRemovalClaimed(ctx context.Context, row
 	// rearm-refused memory DOMINATES — a refused re-arm this process watched
 	// is fresher ownership evidence than the committed (clean) posture.
 	effectiveKind := durableKind
-	if fallbackKind, ok := s.pendingRemovalKind(backupSlash); ok && fallbackKind == models.RestorePendingKindRearmRefused {
-		effectiveKind = models.RestorePendingKindRearmRefused
+	if fallbackKind, ok := s.pendingRemovalKind(backupSlash); ok && (fallbackKind == models.RestorePendingKindRearmRefused || fallbackKind == models.RestorePendingKindPrune) {
+		effectiveKind = fallbackKind
 	}
+	if effectiveKind == models.RestorePendingKindPrune {
+		// A prune intent deliberately removes the old bytes while the
+		// organized destination remains in place. If the process crashed after
+		// unlink but before journal consumption, the absent path is evidence of
+		// completed prune cleanup, so consume journal-only; never re-arm from
+		// the organized destination.
+		if _, backupErr := lstatRestoreSource(s.fs, backup); errors.Is(backupErr, afero.ErrFileNotFound) {
+			if claim.abandonIfRevoked("prune pending journal consumption", backup, dest) {
+				return false
+			}
+			consumeCtx := database.WithPruneMaintenance(ctx)
+			uErr := s.repo.UpdateJournalInTx(consumeCtx, rowID, func(current *models.BatchFileOperation) (models.GeneratedFilesJSON, bool, error) {
+				return consumeSweepJournalEntry(current, backupSlash)
+			})
+			if uErr == nil {
+				s.forgetPendingRemoval(backupSlash)
+				return true
+			}
+			s.rememberPendingRemovalKind(backupSlash, models.RestorePendingKindPrune)
+			logging.Warnf("replacement sweep %s: prune-pending journal consumption failed after the backup was already absent: %v", backup, uErr)
+			return false
+		} else if backupErr != nil {
+			return false
+		}
+	}
+
 	if effectiveKind == models.RestorePendingKindRearmRefused {
 		// Rearm-refused pending (wave-19): destination bytes were certified in
 		// place when the marker was set and the backup name is unowned — skip
@@ -1941,7 +2064,7 @@ func (s *ReplacementSweeper) retryPendingRemovalClaimed(ctx context.Context, row
 		return false
 	}
 	hold, rmErr := quarantineReplacementBackupForRemoval(s.fs, backup, "replacement sweep", &durableEntry, backupInfo)
-	if rmErr == nil {
+	if rmErr == nil && effectiveKind != models.RestorePendingKindPrune {
 		if _, derr := lstatRestoreSource(s.fs, dest); derr != nil {
 			if rerr := hold.restore(); rerr != nil {
 				// Wave-36 (codex local review round 6, PR#215 finding F3): the
@@ -1987,14 +2110,18 @@ func (s *ReplacementSweeper) retryPendingRemovalClaimed(ctx context.Context, row
 		// rearm-refused (journal-only) kind — durable and in-process alike —
 		// or the clean-kind retry would wait forever on a file that can
 		// never reappear.
-		if errors.Is(rmErr, errReplacementBackupQuarantineVanished) {
+		if errors.Is(rmErr, errReplacementBackupQuarantineVanished) && effectiveKind != models.RestorePendingKindPrune {
 			s.rememberPendingRemovalKind(backupSlash, models.RestorePendingKindRearmRefused)
 			if markErr := s.persistRestorePendingMarkerKind(ctx, rowID, backupSlash, models.RestorePendingKindRearmRefused); markErr != nil {
 				logging.Warnf("replacement sweep %s: vanished-quarantine removal could not persist the rearm-refused upgrade (%v after %v) — entry stays clean-pending for later arbitration", backup, markErr, rmErr)
 			}
 			return false
 		}
-		s.rememberPendingRemoval(backupSlash)
+		if effectiveKind == models.RestorePendingKindPrune {
+			s.rememberPendingRemovalKind(backupSlash, models.RestorePendingKindPrune)
+		} else {
+			s.rememberPendingRemoval(backupSlash)
+		}
 		return false
 	}
 	// Wave-52 (round 7, finding F1, stage d): the consumption update — a
@@ -2005,7 +2132,11 @@ func (s *ReplacementSweeper) retryPendingRemovalClaimed(ctx context.Context, row
 	if claim.abandonIfRevoked("clean pending journal consumption", backup, dest) {
 		return false
 	}
-	uErr := s.repo.UpdateJournalInTx(ctx, rowID, func(current *models.BatchFileOperation) (models.GeneratedFilesJSON, bool, error) {
+	consumeCtx := ctx
+	if effectiveKind == models.RestorePendingKindPrune {
+		consumeCtx = database.WithPruneMaintenance(ctx)
+	}
+	uErr := s.repo.UpdateJournalInTx(consumeCtx, rowID, func(current *models.BatchFileOperation) (models.GeneratedFilesJSON, bool, error) {
 		return consumeSweepJournalEntry(current, backupSlash)
 	})
 	if uErr != nil {
@@ -2015,6 +2146,14 @@ func (s *ReplacementSweeper) retryPendingRemovalClaimed(ctx context.Context, row
 		// point), and the clean-kind retry tolerates the absent name — the
 		// resting shape needs nothing else.
 		if claim.abandonIfRevoked("clean pending consumption compensation (re-arm)", backup, dest) {
+			return false
+		}
+		if effectiveKind == models.RestorePendingKindPrune {
+			s.rememberPendingRemovalKind(backupSlash, models.RestorePendingKindPrune)
+			if markErr := s.persistRestorePendingMarkerKind(database.WithPruneMaintenance(ctx), rowID, backupSlash, models.RestorePendingKindPrune); markErr != nil {
+				logging.Warnf("replacement sweep %s: prune-pending consumption failed (%v) and marker persistence failed (%v)", backup, uErr, markErr)
+			}
+			logging.Warnf("replacement sweep %s: prune-pending consumption failed: %v — backup cleanup will retry without re-arming from organized bytes", backup, uErr)
 			return false
 		}
 		fallbackKind := models.RestorePendingKindClean

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -1067,6 +1067,29 @@ func TestReplacementSweeper_PrunePendingAbsentConsumptionFailureKeepsIntent(t *t
 	require.False(t, NewReplacementSweeper(base, repo).retryPendingRemoval(context.Background(), op.ID, backup, dest, sweepSlash(backup)))
 }
 
+func TestReplacementSweeper_PrunePendingPersistsPartialQuarantine(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dest := "/out/PRUNE-PENDING-DLQ/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, base.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, afero.WriteFile(base, dest, []byte("organized"), 0o644))
+	require.NoError(t, afero.WriteFile(base, backup, []byte("old"), 0o644))
+	repo := newP3OpRepo()
+	op := installedPruneCandidate(t, repo, "job-prune-dlq", "PRUNE-PENDING-DLQ", dest, backup)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	require.True(t, gf.Replacements[0].SetRestorePending(models.RestorePendingKindPrune))
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+	fs := &cancelOnPruneQuarantineFs{Fs: base, cancel: func() {}, plantPath: backup, plantBytes: []byte("foreign"), postMoveErr: errors.New("prune retry post-move wedge")}
+	require.False(t, NewReplacementSweeper(fs, repo).retryPendingRemoval(context.Background(), op.ID, backup, dest, sweepSlash(backup)))
+	row, err := repo.FindByID(context.Background(), op.ID)
+	require.NoError(t, err)
+	got, err := models.ParseGeneratedFiles(row.GeneratedFiles)
+	require.NoError(t, err)
+	require.Contains(t, got.Replacements[0].Backup, backupQuarantineSuffix)
+}
+
 func TestReplacementSweeper_PrunePendingIndeterminateBackupKeepsIntent(t *testing.T) {
 	base := afero.NewMemMapFs()
 	dest := "/out/PRUNE-PENDING-IND/poster.jpg"

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -260,7 +260,7 @@ func TestReplacementSweeper_PruneOperationBackups_RemovesOnlyUnreferenced(t *tes
 		delete(repo.ops, op.ID)
 
 		err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
-		require.NoError(t, err)
+		require.Contains(t, err.Error(), "install is unconfirmed")
 		exists, statErr := afero.Exists(fs, backup)
 		require.NoError(t, statErr)
 		require.True(t, exists, "an unconfirmed install must retain recoverable bytes")
@@ -279,7 +279,7 @@ func TestReplacementSweeper_PruneOperationBackups_RemovesOnlyUnreferenced(t *tes
 		delete(repo.ops, op.ID)
 
 		err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
-		require.NoError(t, err)
+		require.Contains(t, err.Error(), "ownership is rearm-refused")
 		got, readErr := afero.ReadFile(fs, backup)
 		require.NoError(t, readErr)
 		require.Equal(t, "foreign", string(got))
@@ -496,7 +496,7 @@ func TestReplacementSweeper_PruneOperationBackups_ErrorBranches(t *testing.T) {
 		repo := newP3OpRepo()
 		op := installedPruneCandidate(t, repo, "job-absent", "PRUNE-ABSENT", "/out/PRUNE-ABSENT/poster.jpg", "/out/PRUNE-ABSENT/poster.jpg.dlbak."+p3HexA)
 		err := NewReplacementSweeper(afero.NewMemMapFs(), repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
-		require.NoError(t, err)
+		require.Contains(t, err.Error(), "is absent during prune")
 	})
 
 	t.Run("unlink failure retains backup", func(t *testing.T) {

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -656,6 +656,7 @@ func TestReplacementSweeper_PruneOperationBackups_PersistsPartialPostMoveHold(t 
 	gf, parseErr := models.ParseGeneratedFiles(row.GeneratedFiles)
 	require.NoError(t, parseErr)
 	require.True(t, gf.Replacements[0].RestorePending)
+	require.Equal(t, models.RestorePendingKindPrune, gf.Replacements[0].PendingKind())
 	require.Contains(t, gf.Replacements[0].Backup, backupQuarantineSuffix)
 }
 
@@ -682,6 +683,7 @@ func TestReplacementSweeper_PruneOperationBackups_RevokedAfterQuarantinePersists
 	gf, parseErr := models.ParseGeneratedFiles(row.GeneratedFiles)
 	require.NoError(t, parseErr)
 	require.True(t, gf.Replacements[0].RestorePending)
+	require.Equal(t, models.RestorePendingKindPrune, gf.Replacements[0].PendingKind())
 	require.Contains(t, gf.Replacements[0].Backup, backupQuarantineSuffix)
 }
 
@@ -710,6 +712,7 @@ func TestReplacementSweeper_PruneOperationBackups_PersistsQuarantineAfterRestore
 	require.NoError(t, parseErr)
 	require.Len(t, gf.Replacements, 1)
 	require.True(t, gf.Replacements[0].RestorePending)
+	require.Equal(t, models.RestorePendingKindPrune, gf.Replacements[0].PendingKind())
 	require.Contains(t, gf.Replacements[0].Backup, backupQuarantineSuffix)
 	foreign, readErr := afero.ReadFile(fs, backup)
 	require.NoError(t, readErr)
@@ -813,6 +816,7 @@ func TestReplacementSweeper_PruneOperationBackups_PersistsAfterUnlinkRestoreFail
 	gf, parseErr := models.ParseGeneratedFiles(row.GeneratedFiles)
 	require.NoError(t, parseErr)
 	require.True(t, gf.Replacements[0].RestorePending)
+	require.Equal(t, models.RestorePendingKindPrune, gf.Replacements[0].PendingKind())
 	require.Contains(t, gf.Replacements[0].Backup, backupQuarantineSuffix)
 }
 
@@ -877,6 +881,243 @@ func (r *retractErrorRepo) UpdateJournalInTx(ctx context.Context, id uint, fn da
 		return r.err
 	}
 	return r.p3OpRepo.UpdateJournalInTx(ctx, id, fn)
+}
+
+func TestReplacementSweeper_PrunePendingRetryConsumesWithoutRestore(t *testing.T) {
+	base := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	dest := "/out/PRUNE-PENDING-RETRY/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, base.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, afero.WriteFile(base, dest, []byte("organized"), 0o644))
+	require.NoError(t, afero.WriteFile(base, backup, []byte("old"), 0o644))
+	op := installedPruneCandidate(t, repo, "job-prune-pending-retry", "PRUNE-PENDING-RETRY", dest, backup)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	require.True(t, gf.Replacements[0].SetRestorePending(models.RestorePendingKindPrune))
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+
+	healed, err := NewReplacementSweeper(base, repo).Sweep(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, healed)
+	exists, statErr := afero.Exists(base, backup)
+	require.NoError(t, statErr)
+	require.False(t, exists)
+	require.Equal(t, "organized", string(mustRead2(t, base, dest)))
+	require.Empty(t, requireLedgerReplacements(t, repo, op.ID))
+}
+
+func TestReplacementSweeper_PrunePendingRetryConsumesAbsentBackup(t *testing.T) {
+	base := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	dest := "/out/PRUNE-PENDING-ABSENT/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, base.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, afero.WriteFile(base, dest, []byte("organized"), 0o644))
+	op := installedPruneCandidate(t, repo, "job-prune-pending-absent", "PRUNE-PENDING-ABSENT", dest, backup)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	require.True(t, gf.Replacements[0].SetRestorePending(models.RestorePendingKindPrune))
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+
+	healed, err := NewReplacementSweeper(base, repo).Sweep(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, healed)
+	require.Empty(t, requireLedgerReplacements(t, repo, op.ID))
+}
+
+func TestReplacementSweeper_SweepRecoversPruneQuarantine(t *testing.T) {
+	base := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	dest := "/out/PRUNE-QUAR-CRASH/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	quarantine := backup + backupQuarantineSuffix + "0123456789abcdef0123456789abcdef"
+	require.NoError(t, base.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, afero.WriteFile(base, dest, []byte("organized"), 0o644))
+	require.NoError(t, afero.WriteFile(base, quarantine, []byte("old"), 0o644))
+	op := installedPruneCandidate(t, repo, "job-prune-quar-crash", "PRUNE-QUAR-CRASH", dest, backup)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	require.True(t, gf.Replacements[0].SetRestorePending(models.RestorePendingKindPrune))
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+
+	healed, err := NewReplacementSweeper(base, repo).Sweep(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, healed)
+	exists, statErr := afero.Exists(base, quarantine)
+	require.NoError(t, statErr)
+	require.False(t, exists)
+	require.Empty(t, requireLedgerReplacements(t, repo, op.ID))
+}
+
+func TestReplacementSweeper_ConsumePrunePendingClaimBranches(t *testing.T) {
+	base := afero.NewMemMapFs()
+	idx := &replacementLedgerIndex{journaled: map[string]*models.BatchFileOperation{}}
+	entry := prunePendingLedgerEntry{dest: "/out/PRUNE-CLAIM/poster.jpg", backup: "/out/PRUNE-CLAIM/poster.jpg.dlbak." + p3HexA}
+	prev := acquireReplacementBusyExFn
+	t.Cleanup(func() { acquireReplacementBusyExFn = prev })
+
+	acquireReplacementBusyExFn = func(afero.Fs, string) (func(), string, error) {
+		return nil, "", fsutil.ErrReplacementBusy
+	}
+	require.Zero(t, NewReplacementSweeper(base, newP3OpRepo()).consumePrunePending(context.Background(), idx, entry))
+	acquireReplacementBusyExFn = func(afero.Fs, string) (func(), string, error) {
+		return nil, "", errors.New("busy lookup failed")
+	}
+	require.Zero(t, NewReplacementSweeper(base, newP3OpRepo()).consumePrunePending(context.Background(), idx, entry))
+	released := false
+	acquireReplacementBusyExFn = func(afero.Fs, string) (func(), string, error) {
+		return func() { released = true }, "", nil
+	}
+	require.Zero(t, NewReplacementSweeper(base, newP3OpRepo()).consumePrunePending(context.Background(), idx, entry))
+	require.True(t, released)
+	acquireReplacementBusyExFn = func(afero.Fs, string) (func(), string, error) { return func() {}, "token", nil }
+	require.Zero(t, NewReplacementSweeper(base, newP3OpRepo()).consumePrunePending(context.Background(), idx, entry))
+}
+
+func TestReplacementSweeper_ConsumePrunePendingBindRevoked(t *testing.T) {
+	base := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	dest := "/out/PRUNE-CLAIM-REVOKE/poster.jpg"
+	entry := prunePendingLedgerEntry{rowID: 1, dest: dest, backup: dest + ".dlbak." + p3HexA, backupSlash: sweepSlash(dest + ".dlbak." + p3HexA)}
+	prev := acquireReplacementBusyExFn
+	acquireReplacementBusyExFn = func(afero.Fs, string) (func(), string, error) { return func() {}, "token", nil }
+	t.Cleanup(func() { acquireReplacementBusyExFn = prev })
+	lockRelease := fsutil.SharedDestLocks().Acquire(dest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan int, 1)
+	go func() {
+		result <- NewReplacementSweeper(base, repo).consumePrunePending(ctx, &replacementLedgerIndex{journaled: map[string]*models.BatchFileOperation{}}, entry)
+	}()
+	cancel()
+	require.Eventually(t, func() bool { return reclaimAbandonedSweepBusyMarker(dest) }, time.Second, time.Millisecond)
+	lockRelease()
+	require.Zero(t, <-result)
+}
+
+func TestReplacementSweeper_JournalEntryDestinationBranches(t *testing.T) {
+	require.Empty(t, journalEntryDestination(&models.BatchFileOperation{GeneratedFiles: `{"replacements":broken`}, "/x"))
+	require.Empty(t, journalEntryDestination(&models.BatchFileOperation{GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{Backup: "/other"}}})}, "/missing"))
+}
+
+func TestReplacementSweeper_PrunePendingRemovalFailureKeepsIntent(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dest := "/out/PRUNE-PENDING-REMOVE/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, base.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, afero.WriteFile(base, dest, []byte("organized"), 0o644))
+	require.NoError(t, afero.WriteFile(base, backup, []byte("old"), 0o644))
+	repo := newP3OpRepo()
+	op := installedPruneCandidate(t, repo, "job-prune-remove-failure", "PRUNE-PENDING-REMOVE", dest, backup)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	require.True(t, gf.Replacements[0].SetRestorePending(models.RestorePendingKindPrune))
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+	fs := &w8RemoveFs{Fs: base, victim: backup, err: errors.New("prune unlink wedged"), fail: true}
+	require.False(t, NewReplacementSweeper(fs, repo).retryPendingRemoval(context.Background(), op.ID, backup, dest, sweepSlash(backup)))
+	row, err := repo.FindByID(context.Background(), op.ID)
+	require.NoError(t, err)
+	got, err := models.ParseGeneratedFiles(row.GeneratedFiles)
+	require.NoError(t, err)
+	require.Equal(t, models.RestorePendingKindPrune, got.Replacements[0].PendingKind())
+}
+
+func TestReplacementSweeper_PrunePendingConsumptionFailureKeepsIntent(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dest := "/out/PRUNE-PENDING-CONSUME/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, base.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, afero.WriteFile(base, dest, []byte("organized"), 0o644))
+	require.NoError(t, afero.WriteFile(base, backup, []byte("old"), 0o644))
+	baseRepo := newP3OpRepo()
+	op := installedPruneCandidate(t, baseRepo, "job-prune-consume-failure", "PRUNE-PENDING-CONSUME", dest, backup)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	require.True(t, gf.Replacements[0].SetRestorePending(models.RestorePendingKindPrune))
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, baseRepo.Update(context.Background(), op))
+	repo := &w18TxFailRepo{p3OpRepo: baseRepo, fail: map[int]error{2: errors.New("prune consume wedged"), 3: errors.New("prune marker persist wedged")}}
+	require.False(t, NewReplacementSweeper(base, repo).retryPendingRemoval(context.Background(), op.ID, backup, dest, sweepSlash(backup)))
+	row, err := baseRepo.FindByID(context.Background(), op.ID)
+	require.NoError(t, err)
+	got, err := models.ParseGeneratedFiles(row.GeneratedFiles)
+	require.NoError(t, err)
+	require.Equal(t, models.RestorePendingKindPrune, got.Replacements[0].PendingKind())
+}
+
+func TestReplacementSweeper_PrunePendingAbsentConsumptionFailureKeepsIntent(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dest := "/out/PRUNE-PENDING-ABSENT-FAIL/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, base.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, afero.WriteFile(base, dest, []byte("organized"), 0o644))
+	baseRepo := newP3OpRepo()
+	op := installedPruneCandidate(t, baseRepo, "job-prune-absent-failure", "PRUNE-PENDING-ABSENT-FAIL", dest, backup)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	require.True(t, gf.Replacements[0].SetRestorePending(models.RestorePendingKindPrune))
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, baseRepo.Update(context.Background(), op))
+	repo := &w18TxFailRepo{p3OpRepo: baseRepo, fail: map[int]error{2: errors.New("prune absent consume wedged")}}
+	require.False(t, NewReplacementSweeper(base, repo).retryPendingRemoval(context.Background(), op.ID, backup, dest, sweepSlash(backup)))
+}
+
+func TestReplacementSweeper_PrunePendingIndeterminateBackupKeepsIntent(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dest := "/out/PRUNE-PENDING-IND/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, base.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, afero.WriteFile(base, dest, []byte("organized"), 0o644))
+	baseRepo := newP3OpRepo()
+	op := installedPruneCandidate(t, baseRepo, "job-prune-indeterminate", "PRUNE-PENDING-IND", dest, backup)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	require.True(t, gf.Replacements[0].SetRestorePending(models.RestorePendingKindPrune))
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, baseRepo.Update(context.Background(), op))
+	fs := &indeterminateStatFs{Fs: base, failPath: backup}
+	require.False(t, NewReplacementSweeper(fs, baseRepo).retryPendingRemoval(context.Background(), op.ID, backup, dest, sweepSlash(backup)))
+}
+
+func TestReplacementSweeper_PrunePendingAbsentRevocationKeepsIntent(t *testing.T) {
+	base := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	dest := "/out/PRUNE-PENDING-REVOKE/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, base.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, afero.WriteFile(base, dest, []byte("organized"), 0o644))
+	op := installedPruneCandidate(t, repo, "job-prune-revoke", "PRUNE-PENDING-REVOKE", dest, backup)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	require.True(t, gf.Replacements[0].SetRestorePending(models.RestorePendingKindPrune))
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+	claim, _, reclaim := w52LiveClaim(t, filepath.ToSlash(dest))
+	fs := &w52LstatStageFs{Fs: base, match: filepath.ToSlash(backup), stage: reclaim}
+	require.False(t, NewReplacementSweeper(fs, repo).retryPendingRemovalClaimed(context.Background(), op.ID, backup, dest, sweepSlash(backup), claim))
+}
+
+func TestReverter_PrunePendingIsNotRestoreComplete(t *testing.T) {
+	base := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	dest := "/out/PRUNE-REVERT/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, base.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, afero.WriteFile(base, dest, []byte("organized"), 0o644))
+	require.NoError(t, afero.WriteFile(base, backup, []byte("old"), 0o644))
+	op := installedPruneCandidate(t, repo, "job-prune-revert", "PRUNE-REVERT", dest, backup)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	require.True(t, gf.Replacements[0].SetRestorePending(models.RestorePendingKindPrune))
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+	_, err = NewReverter(base, repo).restoreReplacementJournal(context.Background(), op)
+	require.Contains(t, err.Error(), "prune-pending")
 }
 
 func TestReplacementSweeper_PruneOperationBackups_RetractionFailureSurfaces(t *testing.T) {

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -438,6 +438,22 @@ func (r *cancelPruneLedgerRepo) FindOperationsWithLedger(ctx context.Context) ([
 	return rows, err
 }
 
+type revokeOnLedgerRepo struct {
+	*p3OpRepo
+	dest string
+}
+
+func (r *revokeOnLedgerRepo) FindOperationsWithLedger(ctx context.Context) ([]models.BatchFileOperation, error) {
+	rows, err := r.p3OpRepo.FindOperationsWithLedger(ctx)
+	key := sweepBusyClaims.resolver.Key(r.dest)
+	sweepBusyClaims.mu.Lock()
+	if claim := sweepBusyClaims.byDest[key]; claim != nil {
+		claim.revoke()
+	}
+	sweepBusyClaims.mu.Unlock()
+	return rows, err
+}
+
 func installedPruneCandidate(t *testing.T, repo *p3OpRepo, jobID, movieID, dest, backup string) *models.BatchFileOperation {
 	t.Helper()
 	op := journalRow(t, repo, jobID, movieID, dest, backup, 1, models.RevertStatusApplied)
@@ -502,14 +518,21 @@ func TestReplacementSweeper_PruneOperationBackups_ErrorBranches(t *testing.T) {
 
 type cancelOnPruneQuarantineFs struct {
 	afero.Fs
-	cancel context.CancelFunc
-	fired  bool
+	cancel     context.CancelFunc
+	fired      bool
+	plantPath  string
+	plantBytes []byte
 }
 
 func (f *cancelOnPruneQuarantineFs) Rename(oldname, newname string) error {
 	err := f.Fs.Rename(oldname, newname)
-	if err == nil && !f.fired && strings.Contains(newname, backupQuarantineSuffix) {
+	if err == nil && !f.fired && strings.Contains(newname, backupQuarantineSuffix) && !strings.Contains(oldname, backupQuarantineSuffix) {
 		f.fired = true
+		if f.plantPath != "" {
+			if werr := afero.WriteFile(f.Fs, f.plantPath, f.plantBytes, 0o644); werr != nil {
+				return werr
+			}
+		}
 		f.cancel()
 	}
 	return err
@@ -548,6 +571,37 @@ func TestReplacementSweeper_PruneOperationBackups_CancellationAfterQuarantine(t 
 	exists, statErr := afero.Exists(fs, backup)
 	require.NoError(t, statErr)
 	require.True(t, exists, "cancellation after quarantine must restore the backup name")
+}
+
+func TestReplacementSweeper_PruneOperationBackups_PersistsQuarantineAfterRestoreRefusal(t *testing.T) {
+	base := afero.NewMemMapFs()
+	ctx, cancel := context.WithCancel(context.Background())
+	dest := "/out/PRUNE-QUAR-PERSIST/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	fs := &cancelOnPruneQuarantineFs{Fs: base, cancel: cancel, plantPath: backup, plantBytes: []byte("foreign")}
+	require.NoError(t, fs.MkdirAll("/out/PRUNE-QUAR-PERSIST", 0o755))
+	require.NoError(t, afero.WriteFile(fs, dest, []byte("current"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, backup, []byte("old"), 0o644))
+	repo := newP3OpRepo()
+	op := journalRow(t, repo, "job-quar-persist", "PRUNE-QUAR-PERSIST", dest, backup, 1, models.RevertStatusApplied)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	gf.Replacements[0].Installed = true
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+
+	err = NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
+	require.ErrorIs(t, err, context.Canceled)
+	row, findErr := repo.FindByID(context.Background(), op.ID)
+	require.NoError(t, findErr)
+	gf, parseErr := models.ParseGeneratedFiles(row.GeneratedFiles)
+	require.NoError(t, parseErr)
+	require.Len(t, gf.Replacements, 1)
+	require.True(t, gf.Replacements[0].RestorePending)
+	require.Contains(t, gf.Replacements[0].Backup, backupQuarantineSuffix)
+	foreign, readErr := afero.ReadFile(fs, backup)
+	require.NoError(t, readErr)
+	require.Equal(t, "foreign", string(foreign))
 }
 
 func TestReplacementSweeper_RetractConsumedEntries_Branches(t *testing.T) {
@@ -622,6 +676,82 @@ func TestReplacementSweeper_PruneOperationBackups_RetractionFailureSurfaces(t *t
 
 	err := NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
 	require.Contains(t, err.Error(), "retract consumed entries")
+}
+
+func TestJobRepository_PruneHookFilesystemIntegration(t *testing.T) {
+	db, err := database.New(&database.Config{Type: "sqlite", DSN: ":memory:", LogLevel: "silent"})
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.RunMigrationsOnStartup(context.Background()))
+	repos := db.Repositories()
+	setter, ok := repos.JobRepo.(interface {
+		SetOrganizedJobPruneHook(func(context.Context, []models.BatchFileOperation) error)
+	})
+	require.True(t, ok)
+	fs := afero.NewMemMapFs()
+	sweeper := NewReplacementSweeper(fs, repos.BatchFileOpRepo)
+	setter.SetOrganizedJobPruneHook(sweeper.PruneOperationBackups)
+
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	job := &models.Job{ID: "integration-prune-job", Status: models.JobStatusOrganized, StartedAt: organizedAt, OrganizedAt: &organizedAt}
+	require.NoError(t, repos.JobRepo.Create(context.Background(), job))
+	dest := "/out/INTEGRATION/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, fs.MkdirAll("/out/INTEGRATION", 0o755))
+	require.NoError(t, afero.WriteFile(fs, dest, []byte("current"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, backup, []byte("old"), 0o644))
+	raw := models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{Destination: dest, Backup: backup, Installed: true}}})
+	op := &models.BatchFileOperation{BatchJobID: job.ID, OriginalPath: "/src/integration.mkv", NewPath: dest, OperationType: models.OperationTypeUpdate, GeneratedFiles: raw}
+	require.NoError(t, repos.BatchFileOpRepo.Create(context.Background(), op))
+
+	require.NoError(t, repos.JobRepo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour)))
+	_, err = repos.JobRepo.FindByID(context.Background(), job.ID)
+	require.Error(t, err)
+	_, err = repos.BatchFileOpRepo.FindByID(context.Background(), op.ID)
+	require.Error(t, err)
+	exists, statErr := afero.Exists(fs, backup)
+	require.NoError(t, statErr)
+	require.False(t, exists, "the real repository hook must consume the final unreferenced backup")
+}
+
+func TestReplacementSweeper_PruneOperationBackups_RevokedBeforeQuarantine(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	base := newP3OpRepo()
+	dest := "/out/PRUNE-REVOKE/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	op := installedPruneCandidate(t, base, "job-revoke", "PRUNE-REVOKE", dest, backup)
+	repo := &revokeOnLedgerRepo{p3OpRepo: base, dest: dest}
+
+	err := NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+	require.ErrorIs(t, err, fsutil.ErrReplacementBusy)
+}
+
+func TestReplacementSweeper_PruneOperationBackups_RevokedBeforeBind(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	dest := "/out/PRUNE-REVOKE-BIND/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	op := installedPruneCandidate(t, repo, "job-revoke-bind", "PRUNE-REVOKE-BIND", dest, backup)
+	acquired := make(chan struct{})
+	prev := acquireReplacementBusyExFn
+	acquireReplacementBusyExFn = func(_ afero.Fs, _ string) (func(), string, error) {
+		close(acquired)
+		return func() {}, "token", nil
+	}
+	t.Cleanup(func() { acquireReplacementBusyExFn = prev })
+	lockRelease := fsutil.SharedDestLocks().Acquire(dest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
+	}()
+	<-acquired
+	cancel()
+	require.Eventually(t, func() bool { return reclaimAbandonedSweepBusyMarker(dest) }, time.Second, time.Millisecond)
+	lockRelease()
+	err := <-errCh
+	require.Contains(t, err.Error(), "revoked")
 }
 
 func mustRead2(t *testing.T, fs afero.Fs, path string) []byte {

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -3,7 +3,10 @@ package history
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -412,6 +415,138 @@ func TestReplacementSweeper_PruneOperationBackups_CancellationAfterBusyClaim(t *
 
 	err = NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+type pruneLedgerErrorRepo struct {
+	*p3OpRepo
+	err error
+}
+
+func (r *pruneLedgerErrorRepo) FindOperationsWithLedger(context.Context) ([]models.BatchFileOperation, error) {
+	return nil, r.err
+}
+
+type cancelPruneLedgerRepo struct {
+	*p3OpRepo
+	cancel context.CancelFunc
+}
+
+func (r *cancelPruneLedgerRepo) FindOperationsWithLedger(ctx context.Context) ([]models.BatchFileOperation, error) {
+	rows, err := r.p3OpRepo.FindOperationsWithLedger(ctx)
+	r.cancel()
+	return rows, err
+}
+
+func installedPruneCandidate(t *testing.T, repo *p3OpRepo, jobID, movieID, dest, backup string) *models.BatchFileOperation {
+	t.Helper()
+	op := journalRow(t, repo, jobID, movieID, dest, backup, 1, models.RevertStatusApplied)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	gf.Replacements[0].Installed = true
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+	delete(repo.ops, op.ID)
+	return op
+}
+
+func TestReplacementSweeper_PruneOperationBackups_ErrorBranches(t *testing.T) {
+	t.Run("live ledger read failure", func(t *testing.T) {
+		base := newP3OpRepo()
+		op := installedPruneCandidate(t, base, "job-read-failure", "PRUNE-READ", "/out/PRUNE-READ/poster.jpg", "/out/PRUNE-READ/poster.jpg.dlbak."+p3HexA)
+		repo := &pruneLedgerErrorRepo{p3OpRepo: base, err: errors.New("ledger read failed")}
+		err := NewReplacementSweeper(afero.NewMemMapFs(), repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+		require.Contains(t, err.Error(), "ledger read failed")
+	})
+
+	t.Run("malformed live ledger", func(t *testing.T) {
+		repo := newP3OpRepo()
+		op := installedPruneCandidate(t, repo, "job-malformed", "PRUNE-MALFORMED", "/out/PRUNE-MALFORMED/poster.jpg", "/out/PRUNE-MALFORMED/poster.jpg.dlbak."+p3HexA)
+		require.NoError(t, repo.Create(context.Background(), &models.BatchFileOperation{GeneratedFiles: `{"replacements":broken`}))
+		err := NewReplacementSweeper(afero.NewMemMapFs(), repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+		require.Contains(t, err.Error(), "cannot prove backup")
+	})
+
+	t.Run("cancellation before quarantine", func(t *testing.T) {
+		base := newP3OpRepo()
+		op := installedPruneCandidate(t, base, "job-cancel-prune", "PRUNE-CANCEL-LEDGER", "/out/PRUNE-CANCEL-LEDGER/poster.jpg", "/out/PRUNE-CANCEL-LEDGER/poster.jpg.dlbak."+p3HexA)
+		ctx, cancel := context.WithCancel(context.Background())
+		repo := &cancelPruneLedgerRepo{p3OpRepo: base, cancel: cancel}
+		err := NewReplacementSweeper(afero.NewMemMapFs(), repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("absent backup is already consumed", func(t *testing.T) {
+		repo := newP3OpRepo()
+		op := installedPruneCandidate(t, repo, "job-absent", "PRUNE-ABSENT", "/out/PRUNE-ABSENT/poster.jpg", "/out/PRUNE-ABSENT/poster.jpg.dlbak."+p3HexA)
+		err := NewReplacementSweeper(afero.NewMemMapFs(), repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+		require.NoError(t, err)
+	})
+
+	t.Run("unlink failure retains backup", func(t *testing.T) {
+		inner := afero.NewMemMapFs()
+		backup := "/out/PRUNE-UNLINK/poster.jpg.dlbak." + p3HexA
+		fs := &removeFailFs{Fs: inner, victim: backup}
+		require.NoError(t, fs.MkdirAll("/out/PRUNE-UNLINK", 0o755))
+		require.NoError(t, afero.WriteFile(fs, "/out/PRUNE-UNLINK/poster.jpg", []byte("current"), 0o644))
+		require.NoError(t, afero.WriteFile(fs, backup, []byte("old"), 0o644))
+		repo := newP3OpRepo()
+		op := installedPruneCandidate(t, repo, "job-unlink", "PRUNE-UNLINK", "/out/PRUNE-UNLINK/poster.jpg", backup)
+		err := NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+		require.Error(t, err)
+		exists, statErr := afero.Exists(fs, backup)
+		require.NoError(t, statErr)
+		require.True(t, exists)
+	})
+}
+
+type cancelOnPruneQuarantineFs struct {
+	afero.Fs
+	cancel context.CancelFunc
+	fired  bool
+}
+
+func (f *cancelOnPruneQuarantineFs) Rename(oldname, newname string) error {
+	err := f.Fs.Rename(oldname, newname)
+	if err == nil && !f.fired && strings.Contains(newname, backupQuarantineSuffix) {
+		f.fired = true
+		f.cancel()
+	}
+	return err
+}
+
+func TestReplacementSweeper_PruneOperationBackups_QuarantineFailure(t *testing.T) {
+	fs := afero.NewOsFs()
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "poster.jpg")
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, afero.WriteFile(fs, dest, []byte("current"), 0o644))
+	require.NoError(t, os.Symlink(filepath.Join(dir, "missing"), backup))
+	repo := newP3OpRepo()
+	op := installedPruneCandidate(t, repo, "job-symlink", "PRUNE-SYMLINK", dest, backup)
+
+	err := NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+	require.Contains(t, err.Error(), "symlink")
+	_, statErr := os.Lstat(backup)
+	require.NoError(t, statErr, "a symlink occupant must remain untouched")
+}
+
+func TestReplacementSweeper_PruneOperationBackups_CancellationAfterQuarantine(t *testing.T) {
+	base := afero.NewMemMapFs()
+	ctx, cancel := context.WithCancel(context.Background())
+	fs := &cancelOnPruneQuarantineFs{Fs: base, cancel: cancel}
+	dest := "/out/PRUNE-CANCEL-QUAR/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, fs.MkdirAll("/out/PRUNE-CANCEL-QUAR", 0o755))
+	require.NoError(t, afero.WriteFile(fs, dest, []byte("current"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, backup, []byte("old"), 0o644))
+	repo := newP3OpRepo()
+	op := installedPruneCandidate(t, repo, "job-cancel-quar", "PRUNE-CANCEL-QUAR", dest, backup)
+
+	err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
+	require.ErrorIs(t, err, context.Canceled)
+	exists, statErr := afero.Exists(fs, backup)
+	require.NoError(t, statErr)
+	require.True(t, exists, "cancellation after quarantine must restore the backup name")
 }
 
 func mustRead2(t *testing.T, fs afero.Fs, path string) []byte {

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -187,6 +187,48 @@ func TestSweep_RootsAndMarkers(t *testing.T) {
 	})
 }
 
+func TestReplacementSweeper_PruneOperationBackups_RemovesOnlyUnreferenced(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("removed operation releases its backup", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		repo := newP3OpRepo()
+		dest := "/out/PRUNE/poster.jpg"
+		backup := dest + ".dlbak." + p3HexA
+		require.NoError(t, fs.MkdirAll("/out/PRUNE", 0o755))
+		writeSweepFile(t, fs, dest, "current", time.Hour)
+		writeSweepFile(t, fs, backup, "old", time.Hour)
+		op := journalRow(t, repo, "job-pruned", "PRUNE-001", dest, backup, 1, models.RevertStatusApplied)
+		delete(repo.ops, op.ID)
+
+		err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
+		require.NoError(t, err)
+		exists, statErr := afero.Exists(fs, backup)
+		require.NoError(t, statErr)
+		require.False(t, exists, "an unreferenced pruned backup must be consumed")
+		require.Equal(t, "current", string(mustRead2(t, fs, dest)))
+	})
+
+	t.Run("shared backup remains owned", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		repo := newP3OpRepo()
+		dest := "/out/PRUNE-SHARED/poster.jpg"
+		backup := dest + ".dlbak." + p3HexB
+		require.NoError(t, fs.MkdirAll("/out/PRUNE-SHARED", 0o755))
+		writeSweepFile(t, fs, dest, "current", time.Hour)
+		writeSweepFile(t, fs, backup, "old", time.Hour)
+		pruned := journalRow(t, repo, "job-pruned", "PRUNE-002", dest, backup, 1, models.RevertStatusApplied)
+		journalRow(t, repo, "job-live", "PRUNE-003", dest, backup, 2, models.RevertStatusApplied)
+		delete(repo.ops, pruned.ID)
+
+		err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*pruned})
+		require.NoError(t, err)
+		exists, statErr := afero.Exists(fs, backup)
+		require.NoError(t, statErr)
+		require.True(t, exists, "a backup with a remaining ledger reference must stay")
+	})
+}
+
 func mustRead2(t *testing.T, fs afero.Fs, path string) []byte {
 	t.Helper()
 	data, err := afero.ReadFile(fs, path)

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -217,7 +217,6 @@ func TestReplacementSweeper_PruneOperationBackups_RemovesOnlyUnreferenced(t *tes
 		writeSweepFile(t, fs, backup, "old", time.Hour)
 		op := journalRow(t, repo, "job-pruned", "PRUNE-001", dest, backup, 1, models.RevertStatusApplied)
 		markInstalled(t, repo, op, "")
-		delete(repo.ops, op.ID)
 
 		err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
 		require.NoError(t, err)
@@ -239,7 +238,6 @@ func TestReplacementSweeper_PruneOperationBackups_RemovesOnlyUnreferenced(t *tes
 		markInstalled(t, repo, pruned, "")
 		live := journalRow(t, repo, "job-live", "PRUNE-003", dest, backup, 2, models.RevertStatusApplied)
 		markInstalled(t, repo, live, "")
-		delete(repo.ops, pruned.ID)
 
 		err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*pruned})
 		require.NoError(t, err)
@@ -284,6 +282,24 @@ func TestReplacementSweeper_PruneOperationBackups_RemovesOnlyUnreferenced(t *tes
 		require.NoError(t, readErr)
 		require.Equal(t, "foreign", string(got))
 	})
+}
+
+func TestReplacementSweeper_PruneOperationBackups_PendingMarkerFailureBlocksCleanup(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	dest := "/out/PRUNE-PENDING-FAIL/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, fs.MkdirAll("/out/PRUNE-PENDING-FAIL", 0o755))
+	require.NoError(t, afero.WriteFile(fs, dest, []byte("current"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, backup, []byte("old"), 0o644))
+	op := installedPruneCandidate(t, repo, "job-pending-fail", "PRUNE-PENDING-FAIL", dest, backup)
+	delete(repo.ops, op.ID)
+
+	err := NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+	require.Contains(t, err.Error(), "owner row")
+	exists, statErr := afero.Exists(fs, backup)
+	require.NoError(t, statErr)
+	require.True(t, exists)
 }
 
 func TestReplacementSweeper_PruneOperationBackups_BusyMarkerRetainsBackup(t *testing.T) {
@@ -462,7 +478,6 @@ func installedPruneCandidate(t *testing.T, repo *p3OpRepo, jobID, movieID, dest,
 	gf.Replacements[0].Installed = true
 	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
 	require.NoError(t, repo.Update(context.Background(), op))
-	delete(repo.ops, op.ID)
 	return op
 }
 
@@ -852,11 +867,16 @@ func TestReplacementSweeper_RetractConsumedEntries_Branches(t *testing.T) {
 
 type retractErrorRepo struct {
 	*p3OpRepo
-	err error
+	err   error
+	calls int
 }
 
-func (r *retractErrorRepo) UpdateJournalInTx(context.Context, uint, database.JournalUpdateFn) error {
-	return r.err
+func (r *retractErrorRepo) UpdateJournalInTx(ctx context.Context, id uint, fn database.JournalUpdateFn) error {
+	r.calls++
+	if r.calls > 1 {
+		return r.err
+	}
+	return r.p3OpRepo.UpdateJournalInTx(ctx, id, fn)
 }
 
 func TestReplacementSweeper_PruneOperationBackups_RetractionFailureSurfaces(t *testing.T) {

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -1090,6 +1090,54 @@ func TestReplacementSweeper_PrunePendingPersistsPartialQuarantine(t *testing.T) 
 	require.Contains(t, got.Replacements[0].Backup, backupQuarantineSuffix)
 }
 
+// cancelSweepReadDirErrorFs cancels after the ledger index is built, then
+// makes the directory scan fail. That leaves the final prune-pending loop as
+// the next cancellation observation point.
+type cancelSweepReadDirErrorFs struct {
+	afero.Fs
+	dir    string
+	cancel context.CancelFunc
+	fired  bool
+}
+
+func (f *cancelSweepReadDirErrorFs) Open(name string) (afero.File, error) {
+	if !f.fired && filepath.Clean(name) == filepath.Clean(f.dir) {
+		f.fired = true
+		f.cancel()
+		return nil, errors.New("directory scan canceled")
+	}
+	return f.Fs.Open(name)
+}
+
+func TestReplacementSweeper_Sweep_PrunePendingCancellationBeforeRetry(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dir := "/out/PRUNE-PENDING-CANCEL"
+	dest := dir + "/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, base.MkdirAll(dir, 0o755))
+	require.NoError(t, afero.WriteFile(base, dest, []byte("organized"), 0o644))
+	repo := newP3OpRepo()
+	op := installedPruneCandidate(t, repo, "job-prune-cancel", "PRUNE-PENDING-CANCEL", dest, backup)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	require.True(t, gf.Replacements[0].SetRestorePending(models.RestorePendingKindPrune))
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	fs := &cancelSweepReadDirErrorFs{Fs: base, dir: dir, cancel: cancel}
+	healed, err := NewReplacementSweeper(fs, repo).Sweep(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, healed)
+
+	row, findErr := repo.FindByID(context.Background(), op.ID)
+	require.NoError(t, findErr)
+	got, parseErr := models.ParseGeneratedFiles(row.GeneratedFiles)
+	require.NoError(t, parseErr)
+	require.True(t, got.Replacements[0].RestorePending, "cancellation must not consume the pending prune intent")
+	require.Equal(t, models.RestorePendingKindPrune, got.Replacements[0].PendingKind())
+}
+
 func TestReplacementSweeper_PrunePendingIndeterminateBackupKeepsIntent(t *testing.T) {
 	base := afero.NewMemMapFs()
 	dest := "/out/PRUNE-PENDING-IND/poster.jpg"

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/javinizer/javinizer-go/internal/fsutil"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -279,6 +280,138 @@ func TestReplacementSweeper_PruneOperationBackups_RemovesOnlyUnreferenced(t *tes
 		require.NoError(t, readErr)
 		require.Equal(t, "foreign", string(got))
 	})
+}
+
+func TestReplacementSweeper_PruneOperationBackups_BusyMarkerRetainsBackup(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	dest := "/out/PRUNE-BUSY/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	require.NoError(t, fs.MkdirAll("/out/PRUNE-BUSY", 0o755))
+	writeSweepFile(t, fs, dest, "current", time.Hour)
+	writeSweepFile(t, fs, backup, "old", time.Hour)
+	op := journalRow(t, repo, "job-pruned", "PRUNE-BUSY", dest, backup, 1, models.RevertStatusApplied)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	gf.Replacements[0].Installed = true
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+	delete(repo.ops, op.ID)
+
+	prev := acquireReplacementBusyExFn
+	acquireReplacementBusyExFn = func(afero.Fs, string) (func(), string, error) {
+		return nil, "", fsutil.ErrReplacementBusy
+	}
+	t.Cleanup(func() { acquireReplacementBusyExFn = prev })
+
+	err = NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+	require.ErrorIs(t, err, fsutil.ErrReplacementBusy)
+	exists, statErr := afero.Exists(fs, backup)
+	require.NoError(t, statErr)
+	require.True(t, exists, "a busy destination must retain its backup")
+}
+
+func TestReplacementSweeper_PruneOperationBackups_ReportsConsumedProgress(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	destA := "/out/PRUNE-PARTIAL/a.jpg"
+	backupA := destA + ".dlbak." + p3HexA
+	destB := "/out/PRUNE-PARTIAL/b.jpg"
+	backupB := destB + ".dlbak." + p3HexB
+	require.NoError(t, fs.MkdirAll("/out/PRUNE-PARTIAL", 0o755))
+	writeSweepFile(t, fs, destA, "current-a", time.Hour)
+	writeSweepFile(t, fs, backupA, "old-a", time.Hour)
+	writeSweepFile(t, fs, destB, "current-b", time.Hour)
+	writeSweepFile(t, fs, backupB, "old-b", time.Hour)
+	raw := models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{
+		{Destination: destA, Backup: backupA, DestSeq: 1, Installed: true},
+		{Destination: destB, Backup: backupB, DestSeq: 2, Installed: true},
+	}})
+	op := &models.BatchFileOperation{BatchJobID: "job-partial", MovieID: "PRUNE-PARTIAL", GeneratedFiles: raw, RevertStatus: models.RevertStatusApplied}
+	require.NoError(t, repo.Create(context.Background(), op))
+	delete(repo.ops, op.ID)
+
+	prev := acquireReplacementBusyExFn
+	acquireReplacementBusyExFn = func(fsys afero.Fs, dest string) (func(), string, error) {
+		if dest == destB {
+			return nil, "", fsutil.ErrReplacementBusy
+		}
+		return fsutil.AcquireReplacementBusyEx(fsys, dest)
+	}
+	t.Cleanup(func() { acquireReplacementBusyExFn = prev })
+
+	err := NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+	var pruneErr *PruneOperationBackupsError
+	require.ErrorAs(t, err, &pruneErr)
+	require.NotEmpty(t, pruneErr.Error())
+	consumed := pruneErr.ConsumedBackups()
+	require.Contains(t, consumed[op.ID], backupA)
+	require.NotContains(t, consumed[op.ID], backupB)
+	existsA, statErr := afero.Exists(fs, backupA)
+	require.NoError(t, statErr)
+	require.False(t, existsA)
+	existsB, statErr := afero.Exists(fs, backupB)
+	require.NoError(t, statErr)
+	require.True(t, existsB)
+}
+
+func TestReplacementSweeper_PruneOperationBackups_EarlyBranches(t *testing.T) {
+	repo := newP3OpRepo()
+	validRaw := models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{
+		Destination: "/out/EARLY/poster.jpg", Backup: "/out/EARLY/poster.jpg.dlbak." + p3HexA, Installed: true,
+	}}})
+	valid := models.BatchFileOperation{ID: 1, GeneratedFiles: validRaw}
+
+	require.NoError(t, NewReplacementSweeper(afero.NewMemMapFs(), repo).PruneOperationBackups(context.Background(), nil))
+	var nilSweeper *ReplacementSweeper
+	require.Error(t, nilSweeper.PruneOperationBackups(context.Background(), []models.BatchFileOperation{valid}))
+	require.Error(t, (&ReplacementSweeper{}).PruneOperationBackups(context.Background(), []models.BatchFileOperation{valid}))
+	require.Error(t, NewReplacementSweeper(afero.NewMemMapFs(), repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{{ID: 2, GeneratedFiles: `{"replacements":`}}))
+	incomplete := models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{Destination: "/out/EARLY/poster.jpg", Installed: true}}})
+	require.Error(t, NewReplacementSweeper(afero.NewMemMapFs(), repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{{ID: 3, GeneratedFiles: incomplete}}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.Error(t, NewReplacementSweeper(afero.NewMemMapFs(), repo).PruneOperationBackups(ctx, []models.BatchFileOperation{valid}))
+}
+
+func TestReplacementSweeper_PruneOperationBackups_BusyTokenUnavailable(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	op := journalRow(t, repo, "job-token", "PRUNE-TOKEN", "/out/PRUNE-TOKEN/poster.jpg", "/out/PRUNE-TOKEN/poster.jpg.dlbak."+p3HexA, 1, models.RevertStatusApplied)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	gf.Replacements[0].Installed = true
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+	delete(repo.ops, op.ID)
+	swapBusyAcquireProvenanceUnavailable(t)
+
+	err = NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+	require.Contains(t, err.Error(), "provenance unavailable")
+}
+
+func TestReplacementSweeper_PruneOperationBackups_CancellationAfterBusyClaim(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	repo := newP3OpRepo()
+	op := journalRow(t, repo, "job-cancel", "PRUNE-CANCEL", "/out/PRUNE-CANCEL/poster.jpg", "/out/PRUNE-CANCEL/poster.jpg.dlbak."+p3HexA, 1, models.RevertStatusApplied)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	gf.Replacements[0].Installed = true
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+	delete(repo.ops, op.ID)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	prev := acquireReplacementBusyExFn
+	acquireReplacementBusyExFn = func(_ afero.Fs, _ string) (func(), string, error) {
+		cancel()
+		return func() {}, "token", nil
+	}
+	t.Cleanup(func() { acquireReplacementBusyExFn = prev })
+
+	err = NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func mustRead2(t *testing.T, fs afero.Fs, path string) []byte {

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -190,6 +190,18 @@ func TestSweep_RootsAndMarkers(t *testing.T) {
 func TestReplacementSweeper_PruneOperationBackups_RemovesOnlyUnreferenced(t *testing.T) {
 	ctx := context.Background()
 
+	markInstalled := func(t *testing.T, repo *p3OpRepo, op *models.BatchFileOperation, pendingKind string) {
+		t.Helper()
+		gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+		require.NoError(t, err)
+		gf.Replacements[0].Installed = true
+		if pendingKind != "" {
+			gf.Replacements[0].SetRestorePending(pendingKind)
+		}
+		op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+		require.NoError(t, repo.Update(context.Background(), op))
+	}
+
 	t.Run("removed operation releases its backup", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		repo := newP3OpRepo()
@@ -199,6 +211,7 @@ func TestReplacementSweeper_PruneOperationBackups_RemovesOnlyUnreferenced(t *tes
 		writeSweepFile(t, fs, dest, "current", time.Hour)
 		writeSweepFile(t, fs, backup, "old", time.Hour)
 		op := journalRow(t, repo, "job-pruned", "PRUNE-001", dest, backup, 1, models.RevertStatusApplied)
+		markInstalled(t, repo, op, "")
 		delete(repo.ops, op.ID)
 
 		err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
@@ -218,7 +231,9 @@ func TestReplacementSweeper_PruneOperationBackups_RemovesOnlyUnreferenced(t *tes
 		writeSweepFile(t, fs, dest, "current", time.Hour)
 		writeSweepFile(t, fs, backup, "old", time.Hour)
 		pruned := journalRow(t, repo, "job-pruned", "PRUNE-002", dest, backup, 1, models.RevertStatusApplied)
-		journalRow(t, repo, "job-live", "PRUNE-003", dest, backup, 2, models.RevertStatusApplied)
+		markInstalled(t, repo, pruned, "")
+		live := journalRow(t, repo, "job-live", "PRUNE-003", dest, backup, 2, models.RevertStatusApplied)
+		markInstalled(t, repo, live, "")
 		delete(repo.ops, pruned.ID)
 
 		err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*pruned})
@@ -226,6 +241,43 @@ func TestReplacementSweeper_PruneOperationBackups_RemovesOnlyUnreferenced(t *tes
 		exists, statErr := afero.Exists(fs, backup)
 		require.NoError(t, statErr)
 		require.True(t, exists, "a backup with a remaining ledger reference must stay")
+	})
+
+	t.Run("unconfirmed install retains the backup", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		repo := newP3OpRepo()
+		dest := "/out/PRUNE-UNCONFIRMED/poster.jpg"
+		backup := dest + ".dlbak." + p3HexC
+		require.NoError(t, fs.MkdirAll("/out/PRUNE-UNCONFIRMED", 0o755))
+		writeSweepFile(t, fs, dest, "current", time.Hour)
+		writeSweepFile(t, fs, backup, "old", time.Hour)
+		op := journalRow(t, repo, "job-pruned", "PRUNE-004", dest, backup, 1, models.RevertStatusApplied)
+		delete(repo.ops, op.ID)
+
+		err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
+		require.NoError(t, err)
+		exists, statErr := afero.Exists(fs, backup)
+		require.NoError(t, statErr)
+		require.True(t, exists, "an unconfirmed install must retain recoverable bytes")
+	})
+
+	t.Run("rearm-refused ownership retains the occupant", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		repo := newP3OpRepo()
+		dest := "/out/PRUNE-REFUSED/poster.jpg"
+		backup := dest + ".dlbak." + p3HexA
+		require.NoError(t, fs.MkdirAll("/out/PRUNE-REFUSED", 0o755))
+		writeSweepFile(t, fs, dest, "current", time.Hour)
+		writeSweepFile(t, fs, backup, "foreign", time.Hour)
+		op := journalRow(t, repo, "job-pruned", "PRUNE-005", dest, backup, 1, models.RevertStatusApplied)
+		markInstalled(t, repo, op, models.RestorePendingKindRearmRefused)
+		delete(repo.ops, op.ID)
+
+		err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
+		require.NoError(t, err)
+		got, readErr := afero.ReadFile(fs, backup)
+		require.NoError(t, readErr)
+		require.Equal(t, "foreign", string(got))
 	})
 }
 

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/javinizer/javinizer-go/internal/database"
 	"github.com/javinizer/javinizer-go/internal/fsutil"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/spf13/afero"
@@ -332,7 +333,6 @@ func TestReplacementSweeper_PruneOperationBackups_ReportsConsumedProgress(t *tes
 	}})
 	op := &models.BatchFileOperation{BatchJobID: "job-partial", MovieID: "PRUNE-PARTIAL", GeneratedFiles: raw, RevertStatus: models.RevertStatusApplied}
 	require.NoError(t, repo.Create(context.Background(), op))
-	delete(repo.ops, op.ID)
 
 	prev := acquireReplacementBusyExFn
 	acquireReplacementBusyExFn = func(fsys afero.Fs, dest string) (func(), string, error) {
@@ -344,12 +344,13 @@ func TestReplacementSweeper_PruneOperationBackups_ReportsConsumedProgress(t *tes
 	t.Cleanup(func() { acquireReplacementBusyExFn = prev })
 
 	err := NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
-	var pruneErr *PruneOperationBackupsError
-	require.ErrorAs(t, err, &pruneErr)
-	require.NotEmpty(t, pruneErr.Error())
-	consumed := pruneErr.ConsumedBackups()
-	require.Contains(t, consumed[op.ID], backupA)
-	require.NotContains(t, consumed[op.ID], backupB)
+	require.ErrorIs(t, err, fsutil.ErrReplacementBusy)
+	row, findErr := repo.FindByID(context.Background(), op.ID)
+	require.NoError(t, findErr)
+	gf, parseErr := models.ParseGeneratedFiles(row.GeneratedFiles)
+	require.NoError(t, parseErr)
+	require.Len(t, gf.Replacements, 1)
+	require.Equal(t, backupB, gf.Replacements[0].Backup, "partial cleanup retracts the consumed shared ledger entry")
 	existsA, statErr := afero.Exists(fs, backupA)
 	require.NoError(t, statErr)
 	require.False(t, existsA)
@@ -547,6 +548,80 @@ func TestReplacementSweeper_PruneOperationBackups_CancellationAfterQuarantine(t 
 	exists, statErr := afero.Exists(fs, backup)
 	require.NoError(t, statErr)
 	require.True(t, exists, "cancellation after quarantine must restore the backup name")
+}
+
+func TestReplacementSweeper_RetractConsumedEntries_Branches(t *testing.T) {
+	repo := newP3OpRepo()
+	destA := "/out/RETRACT/a.jpg"
+	backupA := destA + ".dlbak." + p3HexA
+	destB := "/out/RETRACT/b.jpg"
+	backupB := destB + ".dlbak." + p3HexB
+	opA := &models.BatchFileOperation{BatchJobID: "retract-a", GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{
+		{Destination: destA, Backup: backupA, Installed: true},
+		{Destination: destB, Backup: backupB, Installed: true},
+	}})}
+	opB := &models.BatchFileOperation{BatchJobID: "retract-b", GeneratedFiles: models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{{
+		Destination: "/out/RETRACT/c.jpg", Backup: "/out/RETRACT/c.jpg.dlbak." + p3HexC, Installed: true,
+	}}})}
+	bad := &models.BatchFileOperation{BatchJobID: "retract-bad", GeneratedFiles: `{"replacements":broken`}
+	require.NoError(t, repo.Create(context.Background(), opA))
+	require.NoError(t, repo.Create(context.Background(), opB))
+	require.NoError(t, repo.Create(context.Background(), bad))
+	sweeper := NewReplacementSweeper(afero.NewMemMapFs(), repo)
+	require.NoError(t, sweeper.retractConsumedEntries(nil, map[uint]struct{}{opA.ID: {}}))
+
+	err := sweeper.retractConsumedEntries(
+		map[uint]map[string]struct{}{opA.ID: {backupA: {}}},
+		map[uint]struct{}{opA.ID: {}, opB.ID: {}, bad.ID: {}, 999: {}},
+	)
+	require.Error(t, err)
+	row, findErr := repo.FindByID(context.Background(), opA.ID)
+	require.NoError(t, findErr)
+	gf, parseErr := models.ParseGeneratedFiles(row.GeneratedFiles)
+	require.NoError(t, parseErr)
+	require.Len(t, gf.Replacements, 1)
+	require.Equal(t, backupB, gf.Replacements[0].Backup)
+}
+
+type retractErrorRepo struct {
+	*p3OpRepo
+	err error
+}
+
+func (r *retractErrorRepo) UpdateJournalInTx(context.Context, uint, database.JournalUpdateFn) error {
+	return r.err
+}
+
+func TestReplacementSweeper_PruneOperationBackups_RetractionFailureSurfaces(t *testing.T) {
+	base := newP3OpRepo()
+	destA := "/out/RETRACT-FAIL/a.jpg"
+	backupA := destA + ".dlbak." + p3HexA
+	destB := "/out/RETRACT-FAIL/b.jpg"
+	backupB := destB + ".dlbak." + p3HexB
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/out/RETRACT-FAIL", 0o755))
+	writeSweepFile(t, fs, destA, "current-a", time.Hour)
+	writeSweepFile(t, fs, backupA, "old-a", time.Hour)
+	writeSweepFile(t, fs, destB, "current-b", time.Hour)
+	writeSweepFile(t, fs, backupB, "old-b", time.Hour)
+	raw := models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{
+		{Destination: destA, Backup: backupA, Installed: true},
+		{Destination: destB, Backup: backupB, Installed: true},
+	}})
+	op := &models.BatchFileOperation{BatchJobID: "retract-failure", GeneratedFiles: raw, RevertStatus: models.RevertStatusApplied}
+	require.NoError(t, base.Create(context.Background(), op))
+	repo := &retractErrorRepo{p3OpRepo: base, err: errors.New("journal retraction failed")}
+	prev := acquireReplacementBusyExFn
+	acquireReplacementBusyExFn = func(fsys afero.Fs, dest string) (func(), string, error) {
+		if dest == destB {
+			return nil, "", fsutil.ErrReplacementBusy
+		}
+		return fsutil.AcquireReplacementBusyEx(fsys, dest)
+	}
+	t.Cleanup(func() { acquireReplacementBusyExFn = prev })
+
+	err := NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+	require.Contains(t, err.Error(), "retract consumed entries")
 }
 
 func mustRead2(t *testing.T, fs afero.Fs, path string) []byte {

--- a/internal/history/replacement_sweep_p3_test.go
+++ b/internal/history/replacement_sweep_p3_test.go
@@ -516,18 +516,52 @@ func TestReplacementSweeper_PruneOperationBackups_ErrorBranches(t *testing.T) {
 	})
 }
 
+type cancelOnPruneRemoveFs struct {
+	afero.Fs
+	cancel context.CancelFunc
+	fired  bool
+}
+
+func (f *cancelOnPruneRemoveFs) Remove(name string) error {
+	var size int64
+	if strings.Contains(name, backupQuarantineSuffix) {
+		if info, statErr := f.Fs.Stat(name); statErr == nil {
+			size = info.Size()
+		}
+	}
+	err := f.Fs.Remove(name)
+	if err == nil && !f.fired && size > 0 {
+		f.fired = true
+		f.cancel()
+	}
+	return err
+}
+
 type cancelOnPruneQuarantineFs struct {
 	afero.Fs
-	cancel     context.CancelFunc
-	fired      bool
-	plantPath  string
-	plantBytes []byte
+	cancel      context.CancelFunc
+	fired       bool
+	plantPath   string
+	plantBytes  []byte
+	postMoveErr error
+	quarName    string
+	revokeDest  string
+	revoke      bool
 }
 
 func (f *cancelOnPruneQuarantineFs) Rename(oldname, newname string) error {
 	err := f.Fs.Rename(oldname, newname)
 	if err == nil && !f.fired && strings.Contains(newname, backupQuarantineSuffix) && !strings.Contains(oldname, backupQuarantineSuffix) {
 		f.fired = true
+		f.quarName = newname
+		if f.revoke {
+			key := sweepBusyClaims.resolver.Key(f.revokeDest)
+			sweepBusyClaims.mu.Lock()
+			if claim := sweepBusyClaims.byDest[key]; claim != nil {
+				claim.revoke()
+			}
+			sweepBusyClaims.mu.Unlock()
+		}
 		if f.plantPath != "" {
 			if werr := afero.WriteFile(f.Fs, f.plantPath, f.plantBytes, 0o644); werr != nil {
 				return werr
@@ -536,6 +570,17 @@ func (f *cancelOnPruneQuarantineFs) Rename(oldname, newname string) error {
 		f.cancel()
 	}
 	return err
+}
+
+func (f *cancelOnPruneQuarantineFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	if f.postMoveErr != nil && f.fired && name == f.quarName {
+		return nil, false, f.postMoveErr
+	}
+	if ls, ok := f.Fs.(afero.Lstater); ok {
+		return ls.LstatIfPossible(name)
+	}
+	info, err := f.Fs.Stat(name)
+	return info, false, err
 }
 
 func TestReplacementSweeper_PruneOperationBackups_QuarantineFailure(t *testing.T) {
@@ -573,6 +618,58 @@ func TestReplacementSweeper_PruneOperationBackups_CancellationAfterQuarantine(t 
 	require.True(t, exists, "cancellation after quarantine must restore the backup name")
 }
 
+func TestReplacementSweeper_PruneOperationBackups_PersistsPartialPostMoveHold(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dest := "/out/PRUNE-QUAR-VERIFY/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	fs := &cancelOnPruneQuarantineFs{Fs: base, cancel: func() {}, plantPath: backup, plantBytes: []byte("foreign"), postMoveErr: errors.New("post-move verification failed")}
+	require.NoError(t, fs.MkdirAll("/out/PRUNE-QUAR-VERIFY", 0o755))
+	require.NoError(t, afero.WriteFile(fs, dest, []byte("current"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, backup, []byte("old"), 0o644))
+	repo := newP3OpRepo()
+	op := journalRow(t, repo, "job-quar-verify", "PRUNE-QUAR-VERIFY", dest, backup, 1, models.RevertStatusApplied)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	gf.Replacements[0].Installed = true
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+
+	err = NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+	require.Contains(t, err.Error(), "post-move verification failed")
+	row, findErr := repo.FindByID(context.Background(), op.ID)
+	require.NoError(t, findErr)
+	gf, parseErr := models.ParseGeneratedFiles(row.GeneratedFiles)
+	require.NoError(t, parseErr)
+	require.True(t, gf.Replacements[0].RestorePending)
+	require.Contains(t, gf.Replacements[0].Backup, backupQuarantineSuffix)
+}
+
+func TestReplacementSweeper_PruneOperationBackups_RevokedAfterQuarantinePersistsPointer(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dest := "/out/PRUNE-REVOKE-UNLINK/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	fs := &cancelOnPruneQuarantineFs{Fs: base, cancel: func() {}, revoke: true, revokeDest: dest}
+	require.NoError(t, fs.MkdirAll("/out/PRUNE-REVOKE-UNLINK", 0o755))
+	require.NoError(t, afero.WriteFile(fs, dest, []byte("current"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, backup, []byte("old"), 0o644))
+	repo := newP3OpRepo()
+	op := journalRow(t, repo, "job-revoke-unlink", "PRUNE-REVOKE-UNLINK", dest, backup, 1, models.RevertStatusApplied)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	gf.Replacements[0].Installed = true
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+
+	err = NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+	require.ErrorIs(t, err, fsutil.ErrReplacementBusy)
+	row, findErr := repo.FindByID(context.Background(), op.ID)
+	require.NoError(t, findErr)
+	gf, parseErr := models.ParseGeneratedFiles(row.GeneratedFiles)
+	require.NoError(t, parseErr)
+	require.True(t, gf.Replacements[0].RestorePending)
+	require.Contains(t, gf.Replacements[0].Backup, backupQuarantineSuffix)
+}
+
 func TestReplacementSweeper_PruneOperationBackups_PersistsQuarantineAfterRestoreRefusal(t *testing.T) {
 	base := afero.NewMemMapFs()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -604,6 +701,121 @@ func TestReplacementSweeper_PruneOperationBackups_PersistsQuarantineAfterRestore
 	require.Equal(t, "foreign", string(foreign))
 }
 
+func TestReplacementSweeper_PruneOperationBackups_CancellationRetractsPriorConsumption(t *testing.T) {
+	base := afero.NewMemMapFs()
+	ctx, cancel := context.WithCancel(context.Background())
+	fs := &cancelOnPruneRemoveFs{Fs: base, cancel: cancel}
+	jobID := "job-cancel-retract"
+	destA := "/out/PRUNE-CANCEL-RETRACT/a.jpg"
+	backupA := destA + ".dlbak." + p3HexA
+	destB := "/out/PRUNE-CANCEL-RETRACT/b.jpg"
+	backupB := destB + ".dlbak." + p3HexB
+	require.NoError(t, fs.MkdirAll("/out/PRUNE-CANCEL-RETRACT", 0o755))
+	for _, item := range []struct{ path, data string }{{destA, "current-a"}, {backupA, "old-a"}, {destB, "current-b"}, {backupB, "old-b"}} {
+		require.NoError(t, afero.WriteFile(fs, item.path, []byte(item.data), 0o644))
+	}
+	raw := models.MarshalLedgerJSON(models.GeneratedFilesJSON{Replacements: []models.ReplacementEntry{
+		{Destination: destA, Backup: backupA, Installed: true},
+		{Destination: destB, Backup: backupB, Installed: true},
+	}})
+	repo := newP3OpRepo()
+	op := &models.BatchFileOperation{BatchJobID: jobID, GeneratedFiles: raw, RevertStatus: models.RevertStatusApplied}
+	require.NoError(t, repo.Create(context.Background(), op))
+
+	err := NewReplacementSweeper(fs, repo).PruneOperationBackups(ctx, []models.BatchFileOperation{*op})
+	require.ErrorIs(t, err, context.Canceled)
+	row, findErr := repo.FindByID(context.Background(), op.ID)
+	require.NoError(t, findErr)
+	gf, parseErr := models.ParseGeneratedFiles(row.GeneratedFiles)
+	require.NoError(t, parseErr)
+	require.Len(t, gf.Replacements, 1)
+	require.Equal(t, backupB, gf.Replacements[0].Backup)
+}
+
+func TestRetractConsumedEntries_LockCancellationSurfaces(t *testing.T) {
+	key := "0"
+	hold := fsutil.SharedJournalLocks().Acquire(key)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	sweeper := NewReplacementSweeper(afero.NewMemMapFs(), newP3OpRepo())
+	err := sweeper.retractConsumedEntries(ctx, map[uint]map[string]struct{}{0: {"/x": {}}}, map[uint]struct{}{0: {}})
+	require.ErrorIs(t, err, context.Canceled)
+	hold()
+	probe := fsutil.SharedJournalLocks().Acquire(key)
+	probe()
+}
+
+func TestAcquireJournalLockWithin_BoundsCanceledWait(t *testing.T) {
+	key := "prune-lock-cancel"
+	hold := fsutil.SharedJournalLocks().Acquire(key)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := acquireJournalLockWithin(ctx, key)
+	require.ErrorIs(t, err, context.Canceled)
+	hold()
+	probe := fsutil.SharedJournalLocks().Acquire(key)
+	probe()
+}
+
+type pruneRemovePlantFs struct {
+	*removeFailFs
+	plantPath  string
+	plantBytes []byte
+	fired      bool
+}
+
+func (f *pruneRemovePlantFs) Rename(oldname, newname string) error {
+	err := f.removeFailFs.Fs.Rename(oldname, newname)
+	if err == nil && !f.fired && strings.Contains(newname, backupQuarantineSuffix) && !strings.Contains(oldname, backupQuarantineSuffix) {
+		f.fired = true
+		if werr := afero.WriteFile(f.removeFailFs.Fs, f.plantPath, f.plantBytes, 0o644); werr != nil {
+			return werr
+		}
+	}
+	return err
+}
+
+func TestReplacementSweeper_PruneOperationBackups_PersistsAfterUnlinkRestoreFailure(t *testing.T) {
+	base := afero.NewMemMapFs()
+	dest := "/out/PRUNE-UNLINK-RESTORE/poster.jpg"
+	backup := dest + ".dlbak." + p3HexA
+	fs := &pruneRemovePlantFs{removeFailFs: &removeFailFs{Fs: base, victim: backup}, plantPath: backup, plantBytes: []byte("foreign")}
+	require.NoError(t, fs.MkdirAll("/out/PRUNE-UNLINK-RESTORE", 0o755))
+	require.NoError(t, afero.WriteFile(fs, dest, []byte("current"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, backup, []byte("old"), 0o644))
+	repo := newP3OpRepo()
+	op := journalRow(t, repo, "job-unlink-restore", "PRUNE-UNLINK-RESTORE", dest, backup, 1, models.RevertStatusApplied)
+	gf, err := models.ParseGeneratedFiles(op.GeneratedFiles)
+	require.NoError(t, err)
+	gf.Replacements[0].Installed = true
+	op.GeneratedFiles = models.MarshalLedgerJSON(gf)
+	require.NoError(t, repo.Update(context.Background(), op))
+
+	err = NewReplacementSweeper(fs, repo).PruneOperationBackups(context.Background(), []models.BatchFileOperation{*op})
+	require.Contains(t, err.Error(), "journaled name")
+	row, findErr := repo.FindByID(context.Background(), op.ID)
+	require.NoError(t, findErr)
+	gf, parseErr := models.ParseGeneratedFiles(row.GeneratedFiles)
+	require.NoError(t, parseErr)
+	require.True(t, gf.Replacements[0].RestorePending)
+	require.Contains(t, gf.Replacements[0].Backup, backupQuarantineSuffix)
+}
+
+func TestPersistPruneQuarantine_LedgerBranches(t *testing.T) {
+	repo := newP3OpRepo()
+	bad := &models.BatchFileOperation{GeneratedFiles: `{"replacements":broken`}
+	require.NoError(t, repo.Create(context.Background(), bad))
+	sweeper := NewReplacementSweeper(afero.NewMemMapFs(), repo)
+	entry := models.ReplacementEntry{Destination: "/out/persist/dest", Backup: "/out/persist/backup"}
+	require.Error(t, sweeper.persistPruneQuarantine(bad.ID, entry, "/out/persist/backup.dlq.token"))
+
+	good := journalRow(t, repo, "job-persist-no-match", "PRUNE-PERSIST-NOMATCH", "/out/persist/other", "/out/persist/other.dlbak."+p3HexA, 1, models.RevertStatusApplied)
+	require.NoError(t, sweeper.persistPruneQuarantine(good.ID, entry, "/out/persist/backup.dlq.token"))
+	row, findErr := repo.FindByID(context.Background(), good.ID)
+	require.NoError(t, findErr)
+	require.Equal(t, good.GeneratedFiles, row.GeneratedFiles)
+}
+
 func TestReplacementSweeper_RetractConsumedEntries_Branches(t *testing.T) {
 	repo := newP3OpRepo()
 	destA := "/out/RETRACT/a.jpg"
@@ -622,9 +834,10 @@ func TestReplacementSweeper_RetractConsumedEntries_Branches(t *testing.T) {
 	require.NoError(t, repo.Create(context.Background(), opB))
 	require.NoError(t, repo.Create(context.Background(), bad))
 	sweeper := NewReplacementSweeper(afero.NewMemMapFs(), repo)
-	require.NoError(t, sweeper.retractConsumedEntries(nil, map[uint]struct{}{opA.ID: {}}))
+	require.NoError(t, sweeper.retractConsumedEntries(nil, map[uint]map[string]struct{}{opA.ID: {"/unmatched": {}}}, map[uint]struct{}{opA.ID: {}}))
 
 	err := sweeper.retractConsumedEntries(
+		context.Background(),
 		map[uint]map[string]struct{}{opA.ID: {backupA: {}}},
 		map[uint]struct{}{opA.ID: {}, opB.ID: {}, bad.ID: {}, 999: {}},
 	)

--- a/internal/history/reverter_replacements_p3.go
+++ b/internal/history/reverter_replacements_p3.go
@@ -326,6 +326,10 @@ func (r *Reverter) restoreReplacementJournal(ctx context.Context, op *models.Bat
 				// name (a refusal left it foreign or absent), so any facts verdict
 				// against that name measures foreign bytes. Legacy-unstamped
 				// entries keep the same presence posture (documented residual).
+				if restorePending && pendingKind == models.RestorePendingKindPrune {
+					return fmt.Errorf("journaled prune-pending entry for destination %s is owned by retention cleanup", dest)
+				}
+
 				if restorePending && pendingKind == models.RestorePendingKindRearmRefused {
 					if destLstatErr != nil {
 						return fmt.Errorf("journaled rearm-refused pending entry for destination %s cannot be consumed: destination unreadable: %w", dest, destLstatErr)

--- a/internal/models/job.go
+++ b/internal/models/job.go
@@ -40,6 +40,7 @@ func (s JobStatus) Value() (driver.Value, error) { return StringEnumValue(string
 // Job represents a background processing job persisted in the database.
 type Job struct {
 	ID                    string                      `json:"id" gorm:"primaryKey"`
+	PruneVersion          uint64                      `json:"-" gorm:"not null;default:0"`
 	Status                JobStatus                   `json:"status" gorm:"index"`
 	TotalFiles            int                         `json:"total_files"`
 	Completed             int                         `json:"completed"`

--- a/internal/models/revert_types.go
+++ b/internal/models/revert_types.go
@@ -95,8 +95,8 @@ func (e ReplacementEntry) BackupFactsStamped() bool { return e.BackupModUnix != 
 
 // Restore-pending kinds carried by ReplacementEntry.RestorePendingKind. The
 // persistence contract keeps the clean kind UNWRITTEN ("") so wave-19 blobs
-// for the legacy path stay byte-identical to their wave-18 form; only the
-// rearm-refused kind ever materializes in JSON.
+// for the legacy path stay byte-identical to their wave-18 form; explicit
+// rearm-refused and prune intents materialize in JSON.
 const (
 	// RestorePendingKindClean certifies the destination bytes are in place
 	// while the journal-owned backup still holds this operation's own bytes,
@@ -110,6 +110,10 @@ const (
 	// pending retry consumes the journal entry without any backup-path
 	// operation.
 	RestorePendingKindRearmRefused = "rearm_refused"
+	// RestorePendingKindPrune records that the destination still contains the
+	// organized bytes and the backup is being removed because its operation is
+	// fenced for retention. It must never use restore-completion semantics.
+	RestorePendingKindPrune = "prune"
 )
 
 // PendingKind normalizes the entry's restore-pending kind. A non-pending
@@ -124,6 +128,8 @@ func (e ReplacementEntry) PendingKind() string {
 	switch e.RestorePendingKind {
 	case "", RestorePendingKindClean:
 		return RestorePendingKindClean
+	case RestorePendingKindPrune:
+		return RestorePendingKindPrune
 	default:
 		return RestorePendingKindRearmRefused
 	}
@@ -137,6 +143,16 @@ func (e ReplacementEntry) PendingKind() string {
 func (e *ReplacementEntry) SetRestorePending(kind string) bool {
 	if e.RestorePending {
 		if e.PendingKind() == kind {
+			return false
+		}
+		if kind == RestorePendingKindPrune {
+			if e.PendingKind() != RestorePendingKindClean {
+				return false
+			}
+			e.RestorePendingKind = RestorePendingKindPrune
+			return true
+		}
+		if e.PendingKind() == RestorePendingKindPrune {
 			return false
 		}
 		if kind != RestorePendingKindRearmRefused {

--- a/internal/models/revert_types_pending_kind_w19_test.go
+++ b/internal/models/revert_types_pending_kind_w19_test.go
@@ -23,6 +23,7 @@ func TestReplacementEntryPendingKindW19_NormalizationTable(t *testing.T) {
 		{"legacy pending (empty kind) defaults to clean", ReplacementEntry{RestorePending: true}, RestorePendingKindClean},
 		{"explicit clean stays clean", ReplacementEntry{RestorePending: true, RestorePendingKind: RestorePendingKindClean}, RestorePendingKindClean},
 		{"rearm-refused round-trips", ReplacementEntry{RestorePending: true, RestorePendingKind: RestorePendingKindRearmRefused}, RestorePendingKindRearmRefused},
+		{"prune round-trips", ReplacementEntry{RestorePending: true, RestorePendingKind: RestorePendingKindPrune}, RestorePendingKindPrune},
 		{
 			"unknown kinds conservatively read as rearm-refused",
 			ReplacementEntry{RestorePending: true, RestorePendingKind: "future-kind-from-a-newer-build"},
@@ -43,6 +44,20 @@ func TestReplacementEntrySetRestorePendingW19_MergeDiscipline(t *testing.T) {
 		require.True(t, e.RestorePending)
 		require.Equal(t, "", e.RestorePendingKind, "the clean kind stays unwritten (omitempty) for legacy blob parity")
 		require.Equal(t, RestorePendingKindClean, e.PendingKind())
+	})
+
+	t.Run("prune mark writes an explicit kind", func(t *testing.T) {
+		e := ReplacementEntry{}
+		require.True(t, e.SetRestorePending(RestorePendingKindPrune))
+		require.Equal(t, RestorePendingKindPrune, e.RestorePendingKind)
+		require.False(t, e.SetRestorePending(RestorePendingKindClean), "prune intent must not downgrade to restore-clean")
+
+		clean := ReplacementEntry{RestorePending: true}
+		require.True(t, clean.SetRestorePending(RestorePendingKindPrune), "prune cleanup upgrades a legacy clean marker")
+		require.Equal(t, RestorePendingKindPrune, clean.PendingKind())
+
+		refused := ReplacementEntry{RestorePending: true, RestorePendingKind: RestorePendingKindRearmRefused}
+		require.False(t, refused.SetRestorePending(RestorePendingKindPrune), "prune cannot reclaim a name already proven unowned")
 	})
 
 	t.Run("rearm-refused mark on a non-pending entry writes the kind", func(t *testing.T) {
@@ -86,6 +101,16 @@ func TestReplacementEntryPendingKindW19_PayloadShape(t *testing.T) {
 			"a pre-wave-19 pending entry carries no kind and defaults to clean")
 		require.Equal(t, legacy, MarshalLedgerJSON(gf),
 			"clean-kind entries never materialize the kind field — wave-18 blob parity")
+	})
+
+	t.Run("prune blob shape", func(t *testing.T) {
+		e := ReplacementEntry{Destination: "/d/poster.jpg", Backup: "/d/poster.jpg.dlbak.0123456789abcdef", DestSeq: 1}
+		require.True(t, e.SetRestorePending(RestorePendingKindPrune))
+		blob := MarshalLedgerJSON(GeneratedFilesJSON{Replacements: []ReplacementEntry{e}})
+		require.Contains(t, blob, `"restore_pending_kind":"prune"`)
+		parsed, err := ParseGeneratedFiles(blob)
+		require.NoError(t, err)
+		require.Equal(t, RestorePendingKindPrune, parsed.Replacements[0].PendingKind())
 	})
 
 	t.Run("rearm-refused blob shape", func(t *testing.T) {

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -372,7 +372,7 @@ func interpretApplyResult(
 				current.Error = errMsg
 				current.StartedAt = startTime
 				current.EndedAt = &now
-				return current, mergeWriteBackProvenance(nil, prov), nil
+				return current, mergeWriteBackProvenance(inputs.Provenance[filePath], prov), nil
 			})
 			if errUp != nil {
 				inputs.Updater.UpdateFileResult(filePath, &resultstore.MovieResult{
@@ -446,7 +446,7 @@ func interpretApplyResult(
 						return current, prov, nil
 					}
 					current.Movie = mergeLiveReviewEdits(movie, result.Movie, current.Movie)
-					return current, mergeWriteBackProvenance(nil, prov), nil
+					return current, mergeWriteBackProvenance(inputs.Provenance[filePath], prov), nil
 				})
 				if err2 != nil {
 					logging.Warnf("Failed to update movie result for %s after apply: %v", filePath, err2)
@@ -526,6 +526,7 @@ func applyFile(
 		// would then show the file as single-part.
 		fmi:              fileResult.FileMatchInfo,
 		movie:            fileResult.Movie,
+		provenance:       inputs.Provenance[filePath],
 		updater:          inputs.Updater,
 		broadcast:        broadcastFailure(inputs.Broadcaster, inputs.JobID, movie.ID, jobEventPhaseApply, "Apply"),
 		startTime:        startTime,

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -375,14 +375,14 @@ func interpretApplyResult(
 				return current, mergeWriteBackProvenance(inputs.Provenance[filePath], prov), nil
 			})
 			if errUp != nil {
-				inputs.Updater.UpdateFileResult(filePath, &resultstore.MovieResult{
+				upsertWriteBackResultWithProvenance(inputs.Updater, filePath, &resultstore.MovieResult{
 					FileMatchInfo: afc.Match,
 					Movie:         movie,
 					Status:        fileStatus,
 					Error:         errMsg,
 					StartedAt:     startTime,
 					EndedAt:       &now,
-				})
+				}, inputs.Provenance[filePath])
 			}
 		}
 

--- a/internal/worker/apply_writeback_merge.go
+++ b/internal/worker/apply_writeback_merge.go
@@ -148,6 +148,22 @@ func mergeWriteBackProvenance(frozen, live *resultstore.ProvenanceData) *results
 	return out
 }
 
+// upsertWriteBackResultWithProvenance keeps missing-row fallbacks atomic when
+// the concrete result store supports the lock-held upsert seam. Test doubles
+// that only implement the older interface retain the safe two-call fallback.
+func upsertWriteBackResultWithProvenance(updater resultstore.ResultUpdater, filePath string, result *resultstore.MovieResult, prov *resultstore.ProvenanceData) {
+	if atomic, ok := updater.(interface {
+		UpsertFileResultWithProvenance(string, *resultstore.MovieResult, *resultstore.ProvenanceData)
+	}); ok {
+		atomic.UpsertFileResultWithProvenance(filePath, result, prov)
+		return
+	}
+	updater.UpdateFileResult(filePath, result)
+	if prov != nil {
+		updater.SetProvenance(filePath, prov)
+	}
+}
+
 func mergeSourceMap(frozen, live map[string]string) map[string]string {
 	if len(frozen) == 0 && len(live) == 0 {
 		return nil

--- a/internal/worker/apply_writeback_merge.go
+++ b/internal/worker/apply_writeback_merge.go
@@ -125,10 +125,11 @@ func mergeLiveReviewEdits(baseline, phaseOut, live *models.Movie) *models.Movie 
 
 // mergeWriteBackProvenance merges per-file provenance for a write-back commit
 // (D5): live (phase-time edited) attribution wins the keys it covers; the
-// phase-frozen snapshot fills keys the user never touched. ScraperResults are
-// not merged here — their resolution is the envelope-wide rule (a rescrape
-// committed after phase start wins the live set outright, else the frozen
-// snapshot is kept), handled by the caller that owns both snapshots.
+// phase-frozen snapshot fills keys the user never touched. Raw ScraperResults
+// are one global set rather than per-key data: when a live set exists and
+// differs, it represents a post-phase rescrape and wins as a whole; otherwise
+// the frozen set is retained. Every returned slice/map is detached from the
+// result store so the atomic updater can publish it safely.
 func mergeWriteBackProvenance(frozen, live *resultstore.ProvenanceData) *resultstore.ProvenanceData {
 	switch {
 	case frozen == nil && live == nil:
@@ -141,6 +142,9 @@ func mergeWriteBackProvenance(frozen, live *resultstore.ProvenanceData) *results
 	out := frozen.Clone()
 	out.FieldSources = mergeSourceMap(frozen.FieldSources, live.FieldSources)
 	out.ActressSources = mergeSourceMap(frozen.ActressSources, live.ActressSources)
+	if live.ScraperResults != nil && !reflect.DeepEqual(frozen.ScraperResults, live.ScraperResults) {
+		out.ScraperResults = live.Clone().ScraperResults
+	}
 	return out
 }
 

--- a/internal/worker/apply_writeback_provenance_p5_test.go
+++ b/internal/worker/apply_writeback_provenance_p5_test.go
@@ -86,3 +86,36 @@ func TestApplyWriteBack_FrozenProvenanceSurvivesAllPaths(t *testing.T) {
 		assertFrozenApplyProvenance(t, store)
 	})
 }
+
+func TestApplyWriteBack_MissingRowFallbackPreservesProvenance(t *testing.T) {
+	store := resultstore.New(1, []string{"/f/p5.mp4"})
+	movie := &models.Movie{ID: "P5-MISSING", Title: "phase title"}
+	frozen := frozenApplyProvenance()
+	frozen.FieldSources["title"] = "user"
+	inputs := minimalApplyInputs(t, store, false)
+	inputs.Provenance = map[string]*resultstore.ProvenanceData{"/f/p5.mp4": frozen}
+
+	outcome := interpretApplyResult("/f/p5.mp4", movie, time.Now(), 0, inputs, ApplyPhaseConfig{}, context.Background(),
+		&ApplyFileContext{FilePath: "/f/p5.mp4", Match: models.FileMatchInfo{Path: "/f/p5.mp4", MovieID: movie.ID}}, nil, errors.New("apply failed before result creation"))
+	require.True(t, outcome.Failed)
+	assertFrozenApplyProvenance(t, store)
+}
+
+func TestRecovery_MissingRowFallbackPreservesProvenance(t *testing.T) {
+	store := resultstore.New(1, []string{"/f/p5.mp4"})
+	movie := &models.Movie{ID: "P5-RECOVERY-MISSING", Title: "phase title"}
+	frozen := frozenApplyProvenance()
+	frozen.FieldSources["title"] = "user"
+	outcome := &applyFileOutcome{}
+	rc := recoveryContext{
+		filePath: "/f/p5.mp4", fmi: models.FileMatchInfo{Path: "/f/p5.mp4", MovieID: movie.ID},
+		movie: movie, provenance: frozen, updater: store,
+	}
+	func() {
+		defer withFileRecovery(rc, outcome)()
+		panic("apply panic before result creation")
+	}()
+
+	require.True(t, outcome.Panic)
+	assertFrozenApplyProvenance(t, store)
+}

--- a/internal/worker/apply_writeback_provenance_p5_test.go
+++ b/internal/worker/apply_writeback_provenance_p5_test.go
@@ -119,3 +119,8 @@ func TestRecovery_MissingRowFallbackPreservesProvenance(t *testing.T) {
 	require.True(t, outcome.Panic)
 	assertFrozenApplyProvenance(t, store)
 }
+
+func TestUpsertWriteBackResultWithProvenance_LegacyUpdaterFallback(t *testing.T) {
+	legacy := &callbackOnlyUpdater{inner: resultstore.New(1, []string{"/f/legacy.mp4"})}
+	upsertWriteBackResultWithProvenance(legacy, "/f/legacy.mp4", &resultstore.MovieResult{Status: models.JobStatusFailed}, frozenApplyProvenance())
+}

--- a/internal/worker/apply_writeback_provenance_p5_test.go
+++ b/internal/worker/apply_writeback_provenance_p5_test.go
@@ -1,0 +1,88 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func frozenApplyProvenance() *resultstore.ProvenanceData {
+	return &resultstore.ProvenanceData{
+		FieldSources:   map[string]string{"title": "scraper", "director": "scraper"},
+		ScraperResults: []*models.ScraperResult{{Source: "dmm", Title: "phase source"}},
+	}
+}
+
+func seedApplyProvenanceStore(t *testing.T) (resultstore.Store, *models.Movie, *resultstore.ProvenanceData) {
+	t.Helper()
+	store := resultstore.New(1, []string{"/f/p5.mp4"})
+	movie := &models.Movie{ID: "P5-001", Title: "phase title", Director: "phase director"}
+	store.UpdateFileResult("/f/p5.mp4", &resultstore.MovieResult{
+		ResultID: "res-p5", Revision: 1, Status: models.JobStatusRunning,
+		FileMatchInfo: models.FileMatchInfo{Path: "/f/p5.mp4", MovieID: movie.ID},
+		Movie:         movie.Clone(),
+	})
+	frozen := frozenApplyProvenance()
+	store.SetProvenance("/f/p5.mp4", &resultstore.ProvenanceData{
+		FieldSources:   map[string]string{"title": "user"},
+		ScraperResults: frozen.ScraperResults,
+	})
+	return store, movie, frozen
+}
+
+func assertFrozenApplyProvenance(t *testing.T, store resultstore.Store) {
+	t.Helper()
+	got := store.GetProvenance("/f/p5.mp4")
+	require.NotNil(t, got)
+	assert.Equal(t, map[string]string{"title": "user", "director": "scraper"}, got.FieldSources)
+	require.Len(t, got.ScraperResults, 1)
+	assert.Equal(t, "dmm", got.ScraperResults[0].Source)
+}
+
+// TestApplyWriteBack_FrozenProvenanceSurvivesAllPaths verifies that apply
+// success, failure, and panic recovery all preserve untouched frozen
+// attribution while retaining live per-key edits and the global raw set.
+func TestApplyWriteBack_FrozenProvenanceSurvivesAllPaths(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		store, movie, frozen := seedApplyProvenanceStore(t)
+		inputs := minimalApplyInputs(t, store, false)
+		inputs.Provenance = map[string]*resultstore.ProvenanceData{"/f/p5.mp4": frozen}
+		outcome := interpretApplyResult("/f/p5.mp4", movie, time.Now(), 0, inputs, ApplyPhaseConfig{}, context.Background(),
+			&ApplyFileContext{FilePath: "/f/p5.mp4", Match: models.FileMatchInfo{Path: "/f/p5.mp4", MovieID: movie.ID}},
+			&workflow.ApplyResult{Movie: &models.Movie{ID: movie.ID, Title: "apply title"}}, nil)
+		require.True(t, outcome.Success)
+		assertFrozenApplyProvenance(t, store)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		store, movie, frozen := seedApplyProvenanceStore(t)
+		inputs := minimalApplyInputs(t, store, false)
+		inputs.Provenance = map[string]*resultstore.ProvenanceData{"/f/p5.mp4": frozen}
+		outcome := interpretApplyResult("/f/p5.mp4", movie, time.Now(), 0, inputs, ApplyPhaseConfig{}, context.Background(),
+			&ApplyFileContext{FilePath: "/f/p5.mp4", Match: models.FileMatchInfo{Path: "/f/p5.mp4", MovieID: movie.ID}}, nil, errors.New("apply failed"))
+		require.True(t, outcome.Failed)
+		assertFrozenApplyProvenance(t, store)
+	})
+
+	t.Run("panic recovery", func(t *testing.T) {
+		store, movie, frozen := seedApplyProvenanceStore(t)
+		outcome := &applyFileOutcome{}
+		rc := recoveryContext{
+			filePath: "/f/p5.mp4", fmi: models.FileMatchInfo{Path: "/f/p5.mp4", MovieID: movie.ID},
+			movie: movie, provenance: frozen, updater: store,
+		}
+		func() {
+			defer withFileRecovery(rc, outcome)()
+			panic("apply panic")
+		}()
+		require.True(t, outcome.Panic)
+		assertFrozenApplyProvenance(t, store)
+	})
+}

--- a/internal/worker/batch_job.go
+++ b/internal/worker/batch_job.go
@@ -111,7 +111,8 @@ type BatchJob struct {
 	results   resultstore.Store `json:"-"` // Result state: Results map, progress counters, files (sole result-state seam)
 
 	// Retained on BatchJob (not mutex-protected state groups)
-	StartedAt time.Time `json:"started_at"`
+	StartedAt    time.Time `json:"started_at"`
+	pruneVersion uint64
 
 	// Configuration — set from ApplyPhaseConfig at StartApply or from DB during reconstruction.
 	// External callers cannot mutate these; configuration flows through StartApply(ctx, ApplyPhaseConfig).
@@ -255,9 +256,10 @@ func (job *BatchJob) attachLifecycleCallback() {
 type batchJobSnapshot struct {
 	batchJobBase
 
-	results     map[string]*resultstore.MovieResult
-	provenance  map[string]*resultstore.ProvenanceData
-	resultIndex map[string]string // ResultID → FilePath
+	pruneVersion uint64
+	results      map[string]*resultstore.MovieResult
+	provenance   map[string]*resultstore.ProvenanceData
+	resultIndex  map[string]string // ResultID → FilePath
 }
 
 // snapshotFull reads result state via Store.SnapshotForStatus() (self-locking)
@@ -283,6 +285,7 @@ func (job *BatchJob) snapshotFull() batchJobSnapshot {
 	defer job.mu.RUnlock()
 
 	return batchJobSnapshot{
+		pruneVersion: job.pruneVersion,
 		batchJobBase: batchJobBase{
 			ID:                    job.ID,
 			Status:                lcSnap.Status,

--- a/internal/worker/edit_lock_cores_p5_test.go
+++ b/internal/worker/edit_lock_cores_p5_test.go
@@ -1,0 +1,38 @@
+package worker
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithMovieEditLock_CallbackSeesOnlyCores pins the callback method set:
+// it can compose lock-free cores, but cannot recursively acquire the public
+// editor wrapper while the family key is held.
+func TestWithMovieEditLock_CallbackSeesOnlyCores(t *testing.T) {
+	store := NewInMemoryJobStore()
+	job := seedOneMovie(t, store, "/v/cores.mp4", "CORES-001")
+
+	var exported []string
+	err := job.posterEditor.WithMovieEditLock("CORES-001", func(ops *LockedMovieOps) error {
+		typ := reflect.TypeOf(ops)
+		for i := 0; i < typ.NumMethod(); i++ {
+			method := typ.Method(i)
+			if method.PkgPath == "" { // exported method
+				exported = append(exported, method.Name)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		"ApplyFieldOverride",
+		"ApplyFieldOverrideWithRevisions",
+		"ExcludeFamily",
+		"MovieID",
+		"UpdateMovieFamily",
+		"UpdatePosterCrop",
+		"UpdatePosterFromURL",
+	}, exported)
+}

--- a/internal/worker/job_controller.go
+++ b/internal/worker/job_controller.go
@@ -497,7 +497,6 @@ func (c *jobController) buildRescrapeInputs(wf workflow.WorkflowInterface, batch
 	tempDir := c.job.cfg.tempDir
 	histRepo := c.job.deps.HistoryRepo
 	c.job.mu.RUnlock()
-	snap := c.job.results.SnapshotData()
 
 	return rescrapePhaseInputs{
 		JobID:       c.job.ID,
@@ -505,8 +504,6 @@ func (c *jobController) buildRescrapeInputs(wf workflow.WorkflowInterface, batch
 		WF:          wf,
 		PosterGen:   pg,
 		HistoryRepo: histRepo,
-		Results:     snap.Results,
-		Provenance:  snap.Provenance,
 		// Commit leg wraps through the family lock (codex r20): the scrape's network section stays unlocked; CommitResult serializes with concurrent family edits on the process-wide registry.
 		ResultMap: &familyKeyedResultMap{
 			ResultMapAccessor: c.job.results,

--- a/internal/worker/job_controller.go
+++ b/internal/worker/job_controller.go
@@ -474,6 +474,7 @@ func (c *jobController) buildApplyInputs(wf workflow.WorkflowInterface, batchCfg
 		NFOEnabled:       batchCfg.NFOEnabled,
 		WF:               wf,
 		Results:          snap.Results,
+		Provenance:       snap.Provenance,
 		Excluded:         snap.Excluded,
 		Destination:      cfg.Destination,
 		Update:           upd,
@@ -496,6 +497,7 @@ func (c *jobController) buildRescrapeInputs(wf workflow.WorkflowInterface, batch
 	tempDir := c.job.cfg.tempDir
 	histRepo := c.job.deps.HistoryRepo
 	c.job.mu.RUnlock()
+	snap := c.job.results.SnapshotData()
 
 	return rescrapePhaseInputs{
 		JobID:       c.job.ID,
@@ -503,6 +505,8 @@ func (c *jobController) buildRescrapeInputs(wf workflow.WorkflowInterface, batch
 		WF:          wf,
 		PosterGen:   pg,
 		HistoryRepo: histRepo,
+		Results:     snap.Results,
+		Provenance:  snap.Provenance,
 		// Commit leg wraps through the family lock (codex r20): the scrape's network section stays unlocked; CommitResult serializes with concurrent family edits on the process-wide registry.
 		ResultMap: &familyKeyedResultMap{
 			ResultMapAccessor: c.job.results,

--- a/internal/worker/job_persistencer.go
+++ b/internal/worker/job_persistencer.go
@@ -127,6 +127,9 @@ func persistToDatabase(jobRepo database.JobRepositoryInterface, job *BatchJob) e
 		job.controller.SetPersistError(persistMsg)
 		return fmt.Errorf("persist job %s: %w", job.ID.String(), err)
 	}
+	job.mu.Lock()
+	job.pruneVersion = dbJob.PruneVersion
+	job.mu.Unlock()
 	job.controller.SetPersistError("")
 	return nil
 }

--- a/internal/worker/job_store_persist.go
+++ b/internal/worker/job_store_persist.go
@@ -86,8 +86,9 @@ func (s *JobStore) reconstructBatchJob(dbJob *models.Job) *BatchJob {
 	)
 
 	batchJob := &BatchJob{
-		ID:        jobID,
-		StartedAt: snapshot.StartedAt,
+		ID:           jobID,
+		pruneVersion: snapshot.PruneVersion,
+		StartedAt:    snapshot.StartedAt,
 		lifecycle: &JobLifecycle{
 			Status:      snapshot.Status,
 			CompletedAt: snapshot.CompletedAt,
@@ -277,6 +278,7 @@ func s_candidateEnvelope(job *BatchJob, overrides map[string]*resultstore.MovieR
 
 	persistSnapshot := jobpersist.Snapshot{
 		ID:                    snapshot.ID.String(),
+		PruneVersion:          snapshot.pruneVersion,
 		Status:                snapshot.Status,
 		TotalFiles:            snapshot.TotalFiles,
 		Completed:             snapshot.Completed,

--- a/internal/worker/job_store_persist_parallel_p5_test.go
+++ b/internal/worker/job_store_persist_parallel_p5_test.go
@@ -1,0 +1,79 @@
+package worker
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/stretchr/testify/require"
+)
+
+type parallelPersistRepo struct {
+	mockJobRepoForPersist
+	armed   atomic.Bool
+	entered chan struct{}
+	release <-chan struct{}
+}
+
+func (r *parallelPersistRepo) Upsert(_ context.Context, _ *models.Job) error {
+	if r.armed.Load() && r.armed.CompareAndSwap(true, false) {
+		close(r.entered)
+		<-r.release
+	}
+	return nil
+}
+
+// TestJobStorePersist_MutationWorkStaysParallel stalls one envelope upsert.
+// The other movie's in-memory mutation must publish before the first upsert is
+// released; only the shared marshal+upsert section is serialized.
+func TestJobStorePersist_MutationWorkStaysParallel(t *testing.T) {
+	release := make(chan struct{})
+	repo := &parallelPersistRepo{entered: make(chan struct{}), release: release}
+	store := NewJobStore(repo, nil, nil, "", nil, nil)
+	job := store.CreateJobBatch([]string{"/v/a.mp4", "/v/b.mp4"})
+	job.results.UpdateFileResult("/v/a.mp4", &resultstore.MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: "/v/a.mp4", MovieID: "A-1"},
+		Status:        models.JobStatusCompleted,
+		Movie:         &models.Movie{ID: "A-1", Title: "a"},
+	})
+	job.results.UpdateFileResult("/v/b.mp4", &resultstore.MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: "/v/b.mp4", MovieID: "B-1"},
+		Status:        models.JobStatusCompleted,
+		Movie:         &models.Movie{ID: "B-1", Title: "b"},
+	})
+	job.Controller().SetJobStatus(models.JobStatusCompleted)
+	repo.armed.Store(true)
+
+	errs := make(chan error, 2)
+	go func() {
+		errs <- job.posterEditor.UpdateMovieFamily(context.Background(), "A-1", "", &models.Movie{ID: "A-1", Title: "a-edit"}, FamilySaveOptions{})
+	}()
+	select {
+	case <-repo.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first persist did not reach the stalled upsert")
+	}
+
+	go func() {
+		errs <- job.posterEditor.UpdateMovieFamily(context.Background(), "B-1", "", &models.Movie{ID: "B-1", Title: "b-edit"}, FamilySaveOptions{})
+	}()
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	for {
+		result, err := job.results.GetMovieResult("/v/b.mp4")
+		if err == nil && result != nil && result.Movie != nil && result.Movie.Title == "b-edit" {
+			break
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("second movie mutation stayed blocked behind the first envelope upsert")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	close(release)
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+}

--- a/internal/worker/jobpersist/codec.go
+++ b/internal/worker/jobpersist/codec.go
@@ -29,6 +29,7 @@ type JobResultsEnvelope struct {
 // IsDeleted, ResultIndex) that are not persisted in the database.
 type Snapshot struct {
 	ID                    string
+	PruneVersion          uint64
 	Status                models.JobStatus
 	TotalFiles            int
 	Completed             int
@@ -102,6 +103,7 @@ func Encode(snapshot Snapshot) (*models.Job, error) {
 
 	return &models.Job{
 		ID:                    snapshot.ID,
+		PruneVersion:          snapshot.PruneVersion,
 		Status:                snapshot.Status,
 		TotalFiles:            snapshot.TotalFiles,
 		Completed:             snapshot.Completed,
@@ -134,6 +136,7 @@ func Decode(dbJob *models.Job) (Snapshot, []error) {
 
 	snapshot := Snapshot{
 		ID:                    dbJob.ID,
+		PruneVersion:          dbJob.PruneVersion,
 		Status:                dbJob.Status,
 		TotalFiles:            dbJob.TotalFiles,
 		Completed:             dbJob.Completed,

--- a/internal/worker/jobpersist/codec_test.go
+++ b/internal/worker/jobpersist/codec_test.go
@@ -20,6 +20,7 @@ func TestEncodeDecode_RoundTrip(t *testing.T) {
 
 	original := Snapshot{
 		ID:                    "round-trip-job",
+		PruneVersion:          7,
 		Status:                models.JobStatusCompleted,
 		TotalFiles:            3,
 		Completed:             2,
@@ -48,6 +49,7 @@ func TestEncodeDecode_RoundTrip(t *testing.T) {
 	assert.Empty(t, errs, "round-trip should produce no decode errors")
 
 	assert.Equal(t, original.ID, decoded.ID)
+	assert.Equal(t, original.PruneVersion, decoded.PruneVersion)
 	assert.Equal(t, original.Status, decoded.Status)
 	assert.Equal(t, original.TotalFiles, decoded.TotalFiles)
 	assert.Equal(t, original.Completed, decoded.Completed)

--- a/internal/worker/phase_interfaces.go
+++ b/internal/worker/phase_interfaces.go
@@ -182,13 +182,8 @@ type rescrapePhaseInputs struct {
 	// For ScrapeSingle — no job state access needed
 	// For CompleteRescrape — needs result map access + metadata
 	ResultMap resultstore.ResultMapAccessor
-	// Frozen phase-entry clones are retained for closeout arbitration and
-	// provenance-preserving write-backs. Rescrape commits still use ResultMap
-	// for their keyed live CAS; these snapshots make the phase boundary explicit.
-	Results    map[string]*resultstore.MovieResult
-	Provenance map[string]*resultstore.ProvenanceData
-	Lifecycle  PhaseLifecycle
-	persister  persister
+	Lifecycle PhaseLifecycle
+	persister persister
 
 	// additional dependencies for full rescrape sequence
 	HistoryRepo database.HistoryRepositoryInterface

--- a/internal/worker/phase_interfaces.go
+++ b/internal/worker/phase_interfaces.go
@@ -147,6 +147,7 @@ type applyPhaseInputs struct {
 
 	// Current state snapshot (frozen at construction, not live)
 	Results     map[string]*resultstore.MovieResult
+	Provenance  map[string]*resultstore.ProvenanceData
 	Excluded    map[string]bool
 	Destination string
 	Update      bool // Update mode (in-place, no file organization)
@@ -181,8 +182,13 @@ type rescrapePhaseInputs struct {
 	// For ScrapeSingle — no job state access needed
 	// For CompleteRescrape — needs result map access + metadata
 	ResultMap resultstore.ResultMapAccessor
-	Lifecycle PhaseLifecycle
-	persister persister
+	// Frozen phase-entry clones are retained for closeout arbitration and
+	// provenance-preserving write-backs. Rescrape commits still use ResultMap
+	// for their keyed live CAS; these snapshots make the phase boundary explicit.
+	Results    map[string]*resultstore.MovieResult
+	Provenance map[string]*resultstore.ProvenanceData
+	Lifecycle  PhaseLifecycle
+	persister  persister
 
 	// additional dependencies for full rescrape sequence
 	HistoryRepo database.HistoryRepositoryInterface

--- a/internal/worker/recovery.go
+++ b/internal/worker/recovery.go
@@ -26,6 +26,7 @@ type recoveryContext struct {
 	fmi        models.FileMatchInfo
 	editLockFn func(movieIDs ...string) func() // optional: serializes write-back with review edits (codex r11; variadic per codex r42 total-order rule)
 	movie      *models.Movie                   // optional: prior scrape-phase Movie to preserve on apply panic (mirrors fix in interpretApplyResult's err branch)
+	provenance *resultstore.ProvenanceData     // frozen phase-entry attribution for apply write-back
 	// promoteWitnessFn reports an unresolved .promote- witness for the family
 	// (codex P2: panics never funnel through the interpret failure branch —
 	// this recovery write-back is the ONLY panic publication, so it must
@@ -109,7 +110,7 @@ func withFileRecovery(rc recoveryContext, outcome recoverableOutcome) func() {
 						current.StartedAt = rc.startTime
 						current.EndedAt = &now
 					}
-					return current, mergeWriteBackProvenance(nil, prov), nil
+					return current, mergeWriteBackProvenance(rc.provenance, prov), nil
 				})
 				if errUp != nil {
 					mr := &resultstore.MovieResult{

--- a/internal/worker/recovery.go
+++ b/internal/worker/recovery.go
@@ -125,7 +125,7 @@ func withFileRecovery(rc recoveryContext, outcome recoverableOutcome) func() {
 						mr.StartedAt = rc.startTime
 						mr.EndedAt = &now
 					}
-					rc.updater.UpdateFileResult(rc.filePath, mr)
+					upsertWriteBackResultWithProvenance(rc.updater, rc.filePath, mr, rc.provenance)
 				}
 			}
 

--- a/internal/worker/resultstore/atomic_provenance_p2_test.go
+++ b/internal/worker/resultstore/atomic_provenance_p2_test.go
@@ -176,3 +176,14 @@ func TestAtomicUpdateFileResultWithProvenance_IdentitySkipPublishesNothing(t *te
 	require.NoError(t, err)
 	assert.Equal(t, uint64(5), state.Results["/f/skip.mp4"].Revision, "mutations still advance the revision")
 }
+
+func TestUpsertFileResultWithProvenance_InitializesNilMap(t *testing.T) {
+	tracker := New(1, []string{"/f/upsert.mp4"}).(*ResultTracker)
+	tracker.Provenance = nil
+	prov := &ProvenanceData{FieldSources: map[string]string{"title": "frozen"}}
+	tracker.UpsertFileResultWithProvenance("/f/upsert.mp4", &MovieResult{Status: models.JobStatusFailed}, prov)
+
+	got := tracker.Provenance["/f/upsert.mp4"]
+	require.NotNil(t, got)
+	assert.Equal(t, "frozen", got.FieldSources["title"])
+}

--- a/internal/worker/resultstore/result_updater.go
+++ b/internal/worker/resultstore/result_updater.go
@@ -22,6 +22,25 @@ type resultUpdater struct {
 func (ru *resultUpdater) UpdateFileResult(filePath string, result *MovieResult) {
 	ru.mu.Lock()
 	defer ru.mu.Unlock()
+	ru.updateFileResultLocked(filePath, result)
+}
+
+// UpsertFileResultWithProvenance publishes a result and its provenance under
+// one lock acquisition. It is the missing-row fallback for callers whose
+// normal atomic read-modify-write requires an existing result.
+func (ru *resultUpdater) UpsertFileResultWithProvenance(filePath string, result *MovieResult, prov *ProvenanceData) {
+	ru.mu.Lock()
+	defer ru.mu.Unlock()
+	ru.updateFileResultLocked(filePath, result)
+	if prov != nil {
+		if ru.Provenance == nil {
+			ru.Provenance = make(map[string]*ProvenanceData)
+		}
+		ru.Provenance[filePath] = prov.Clone()
+	}
+}
+
+func (ru *resultUpdater) updateFileResultLocked(filePath string, result *MovieResult) {
 	existing := ru.Results[filePath]
 	stateReindexFilePathLocked(ru.resultTrackerState, filePath, existing, result)
 	if existing != nil {
@@ -55,7 +74,7 @@ func (ru *resultUpdater) UpdateFileResult(filePath string, result *MovieResult) 
 	// For excluded files the Completed/Failed counters are deliberately not
 	// touched above, so the counter-based helper would compute progress from
 	// stale counters and could regress after a late terminal update. Trigger a
-	// full recalculation instead, which iterates actual results and skips
+	// full recalculation instead, which iterates the Results map and skips
 	// excluded paths. Non-excluded updates keep the fast counter path.
 	if ru.Excluded[filePath] {
 		stateRecalculateProgress(ru.resultTrackerState)

--- a/internal/worker/writeback_provenance_p2_test.go
+++ b/internal/worker/writeback_provenance_p2_test.go
@@ -39,6 +39,29 @@ func TestApplyWriteBack_MergesEditableSet_AdditionalFields(t *testing.T) {
 		assert.Equal(t, map[string]string{"A-ONE": "user"}, got.ActressSources)
 	})
 
+	t.Run("scraper_results_resolve_as_one_global_set", func(t *testing.T) {
+		frozen := &resultstore.ProvenanceData{
+			FieldSources:   map[string]string{"director": "scraper"},
+			ScraperResults: []*models.ScraperResult{{Source: "dmm", Title: "old"}},
+		}
+		liveSame := &resultstore.ProvenanceData{
+			FieldSources:   map[string]string{"title": "user"},
+			ScraperResults: []*models.ScraperResult{{Source: "dmm", Title: "old"}},
+		}
+		kept := mergeWriteBackProvenance(frozen, liveSame)
+		require.Len(t, kept.ScraperResults, 1)
+		assert.Equal(t, "old", kept.ScraperResults[0].Title, "unchanged raw set falls back to frozen")
+		assert.Equal(t, map[string]string{"director": "scraper", "title": "user"}, kept.FieldSources)
+
+		liveRescrape := &resultstore.ProvenanceData{
+			FieldSources:   map[string]string{"title": "rescrape"},
+			ScraperResults: []*models.ScraperResult{{Source: "r18dev", Title: "new"}},
+		}
+		updated := mergeWriteBackProvenance(frozen, liveRescrape)
+		require.Len(t, updated.ScraperResults, 1)
+		assert.Equal(t, "r18dev", updated.ScraperResults[0].Source, "changed live raw set wins globally")
+	})
+
 	t.Run("provenance_empty_maps_collapse_to_nil", func(t *testing.T) {
 		got := mergeWriteBackProvenance(&resultstore.ProvenanceData{}, &resultstore.ProvenanceData{})
 		require.NotNil(t, got)

--- a/internal/workflow/apply_begin_p5_test.go
+++ b/internal/workflow/apply_begin_p5_test.go
@@ -1,0 +1,44 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+type beginGuardOrganizer struct {
+	calls int
+}
+
+func (o *beginGuardOrganizer) Organize(_ context.Context, _ organizer.OrganizeCmd) (*organizer.OrganizeResult, error) {
+	o.calls++
+	return &organizer.OrganizeResult{NewPath: "/dest/movie.mp4"}, nil
+}
+
+// TestApply_BeginFailureFailsDestructiveStep proves a failed ledger Begin is a
+// hard precondition: no organize/download/NFO step may run without a durable
+// inverse for destructive work.
+func TestApply_BeginFailureFailsDestructiveStep(t *testing.T) {
+	org := &beginGuardOrganizer{}
+	impl := &applyOrchImpl{
+		fs:        afero.NewMemMapFs(),
+		organizer: org,
+		revertLog: &stubRevertLog{beginErr: errTestBegin},
+	}
+
+	result, err := impl.Execute(context.Background(), ApplyCmd{
+		Movie:    &models.Movie{ID: "BEGIN-FAIL-001"},
+		Match:    models.FileMatchInfo{Path: "/source/BEGIN-FAIL-001.mp4", MovieID: "BEGIN-FAIL-001"},
+		DestPath: "/dest",
+		Organize: OrganizeOptions{MoveFiles: true},
+	})
+
+	require.ErrorIs(t, err, errTestBegin)
+	require.NotNil(t, result)
+	require.Equal(t, "revert_begin", result.FailedStep)
+	require.Equal(t, 0, org.calls, "no destructive step may run after Begin fails")
+}

--- a/internal/workflow/apply_orchestrator.go
+++ b/internal/workflow/apply_orchestrator.go
@@ -121,7 +121,14 @@ func (o *applyOrchImpl) Execute(ctx context.Context, cmd ApplyCmd) (*ApplyResult
 	}
 
 	// Step 0: Begin revert log BEFORE any filesystem mutation.
-	opID := o.beginRevertLog(ctx, cmd)
+	opID, beginErr := o.beginRevertLog(ctx, cmd)
+	if beginErr != nil {
+		return &ApplyResult{
+			Movie:       cmd.Movie,
+			OperationID: opID,
+			FailedStep:  "revert_begin",
+		}, beginErr
+	}
 
 	movie := cmd.Movie
 	targetDir := cmd.DestPath
@@ -515,23 +522,27 @@ func replacementRecorder(rl RevertLog) downloader.ReplacementRecorder {
 	return rl
 }
 
-// Returns empty OperationID if revertLog is nil or Begin fails.
-func (o *applyOrchImpl) beginRevertLog(ctx context.Context, cmd ApplyCmd) OperationID {
+// Returns an empty OperationID with no error when revert logging is disabled.
+// A configured logger's failed Begin is fatal for destructive apply work: no
+// filesystem step may run without a committed inverse in the ledger.
+func (o *applyOrchImpl) beginRevertLog(ctx context.Context, cmd ApplyCmd) (OperationID, error) {
 	if o.revertLog == nil {
-		return ""
+		return "", nil
 	}
 	opID, beginErr := o.revertLog.Begin(ctx, cmd)
 	if beginErr != nil {
 		if cmd.DryRun {
+			// Dry-run performs no destructive filesystem work, so a ledger is
+			// not required to preview the pipeline.
 			resolveLogger(o.logger).Warnf("[workflow] RevertLog.Begin failed for %s: %v", cmd.Movie.ID, beginErr)
-		} else {
-			resolveLogger(o.logger).Errorf("[workflow] RevertLog.Begin failed for %s: %v — proceeding without revert safety", cmd.Movie.ID, beginErr)
+			return opID, nil
 		}
-		return opID // may be partial — still return it
+		resolveLogger(o.logger).Errorf("[workflow] RevertLog.Begin failed for %s: %v — aborting before destructive steps", cmd.Movie.ID, beginErr)
+		return opID, fmt.Errorf("revert log begin failed: %w", beginErr)
 	}
 	// snapshot is optional enrichment — failure doesn't block Apply.
 	o.revertLog.CaptureSnapshot(ctx, opID, cmd)
-	return opID
+	return opID, nil
 }
 
 // noOpApplyOrchestrator returns an error — Apply is not configured for ScrapeOnly workflows.

--- a/internal/workflow/apply_orchestrator_coverage_test.go
+++ b/internal/workflow/apply_orchestrator_coverage_test.go
@@ -959,14 +959,15 @@ func TestApplyOrchImpl_Execute_RevertLogBeginError(t *testing.T) {
 		nfo:       &applyStubNFO{},
 		revertLog: rl,
 	}
-	// Should not panic when Begin fails
+	// A failed Begin is a hard precondition for a non-dry-run apply.
 	result, err := impl.Execute(context.Background(), ApplyCmd{
 		Movie:    &models.Movie{ID: "TEST-001", Title: "Test"},
 		Match:    defaultMatch(),
 		Organize: OrganizeOptions{Skip: true},
 	})
-	assert.NoError(t, err)
+	assert.Error(t, err)
 	require.NotNil(t, result)
+	assert.Equal(t, "revert_begin", result.FailedStep)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/workflow/apply_orchestrator_helpers_test.go
+++ b/internal/workflow/apply_orchestrator_helpers_test.go
@@ -27,15 +27,17 @@ func TestCompleteRevertLog_EmptyOpID_DoesNothing(t *testing.T) {
 func TestBeginRevertLog_NilRevertLog_ReturnsEmpty(t *testing.T) {
 	o := &applyOrchImpl{revertLog: nil}
 	cmd := ApplyCmd{Movie: &models.Movie{ID: "TEST-001"}}
-	opID := o.beginRevertLog(context.Background(), cmd)
+	opID, err := o.beginRevertLog(context.Background(), cmd)
+	assert.NoError(t, err)
 	assert.Equal(t, "", opID)
 }
 
-func TestBeginRevertLog_BeginFails_ReturnsEmptyAndLogs(t *testing.T) {
+func TestBeginRevertLog_BeginFails_ReturnsErrorAndLogs(t *testing.T) {
 	mock := &stubRevertLog{beginErr: errTestBegin}
 	o := &applyOrchImpl{revertLog: mock}
 	cmd := ApplyCmd{Movie: &models.Movie{ID: "TEST-001"}}
-	opID := o.beginRevertLog(context.Background(), cmd)
+	opID, err := o.beginRevertLog(context.Background(), cmd)
+	assert.ErrorIs(t, err, errTestBegin)
 	assert.Equal(t, "", opID)
 	assert.Equal(t, 1, mock.beginCalls, "Begin should be called once")
 }


### PR DESCRIPTION
## Summary

Completes Phase 5 of `poster-write-hardening`.

- Makes organized-job operation-ledger pruning ops-first and transactional, with failures rolling back safely.
- Makes apply `Begin` fail closed when a durable revert log cannot be created.
- Preserves frozen scraped provenance while merging explicitly changed live values, including global scraper results.
- Hardens apply ownership/recovery, write-back persistence, phase contracts, and parallel job-store persistence.
- Adds regression coverage for crash recovery, write-back provenance, edit-lock cores, metadata apply, persistence, and Begin behavior.

## Validation

- Pre-commit checks passed: formatting, golangci-lint, go vet, short tests, build, and Swagger validation.
- `make coverage` passed.
- Strict patch coverage: **100%** (38/38 changed production lines).
- `openspec validate poster-write-hardening` passed.
