### PR TITLE
fix(organize): refuse silent overwrite of same-named multipart destinations

### DIFF
--- a/internal/api/batch/apply_config_builder.go
+++ b/internal/api/batch/apply_config_builder.go
@@ -87,7 +87,7 @@ func resolveOrganizeApplyConfig(
 		workflow.OrganizeOptions{
 			MoveFiles:       !req.CopyOnly,
 			LinkMode:        resolved.LinkMode,
-			ForceUpdate:     true,
+			ForceUpdate:     false,
 			ForceRenameFile: forceRenameFile,
 			Skip:            !effectiveMode.RequiresOrganize(),
 		},

--- a/internal/api/batch/organize_overwrite_default_test.go
+++ b/internal/api/batch/organize_overwrite_default_test.go
@@ -1,0 +1,21 @@
+package batch
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression: web/API organize jobs must NOT default to authorized overwrites
+// (ForceUpdate). The pre-fix default silently replaced existing destination files.
+func TestResolveOrganizeApplyConfig_ForceUpdateDefaultsFalse(t *testing.T) {
+	rt := core.NewAPIRuntime(nil)
+	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
+	cfg, err := resolveOrganizeApplyConfig(core.NewSnapshotForTesting(rt, core.APIConfig{}), factory, &stubControlledJob{}, contracts.OrganizeRequest{OperationMode: "in-place"})
+	require.NoError(t, err)
+	assert.False(t, cfg.OrganizeOptions.ForceUpdate, "organize jobs must not authorize overwrite by default")
+}

--- a/internal/organizer/organize_conflict_copy_inplace_test.go
+++ b/internal/organizer/organize_conflict_copy_inplace_test.go
@@ -1,0 +1,91 @@
+package organizer
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/matcher"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/testutil"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Unauthorized copy (MoveFiles=false) against a late-created destination conflicts
+// instead of overwriting.
+func TestOrganize_Copy_LateConflictRefused(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true, OperationMode: operationmode.OperationModeOrganize}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	movie := testutil.NewMovieBuilder().WithID("IPX-321").Build()
+	match := models.FileMatchInfo{Path: "/src/IPX-321.mp4", Name: "IPX-321.mp4", Extension: ".mp4", MovieID: "IPX-321"}
+
+	strategy := org.strategyFromType(strategyOrganize)
+	plan, err := strategy.Plan(match, movie, "/dest", false)
+	require.NoError(t, err)
+	plan.moveFiles = false
+	plan.LinkMode = LinkModeNone
+
+	require.NoError(t, afero.WriteFile(fs, "/src/IPX-321.mp4", []byte("incoming"), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/dest/IPX-321/IPX-321.mp4", []byte("existing"), 0644))
+
+	result, err := strategy.Execute(plan)
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, result.Error.Error(), "refusing to overwrite")
+
+	data, _ := afero.ReadFile(fs, "/dest/IPX-321/IPX-321.mp4")
+	assert.Equal(t, []byte("existing"), data)
+}
+
+// In-place-norenamefolder: a late-created different destination conflicts instead of
+// being replaced by the rename.
+func TestInPlaceNoRenameFolder_LateConflictRefused(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true, OperationMode: operationmode.OperationModeInPlaceNoRenameFolder}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	movie := testutil.NewMovieBuilder().WithID("IPX-777").Build()
+	require.NoError(t, afero.WriteFile(fs, "/lib/IPX-777-odd.mp4", []byte("mine"), 0644))
+
+	strategy := org.strategyFromType(strategyInPlaceNoRenameFolder)
+	match := models.FileMatchInfo{Path: "/lib/IPX-777-odd.mp4", Name: "IPX-777-odd.mp4", Extension: ".mp4", MovieID: "IPX-777"}
+	plan, err := strategy.Plan(match, movie, "/lib", false)
+	require.NoError(t, err)
+
+	require.NoError(t, afero.WriteFile(fs, "/lib/IPX-777.mp4", []byte("exists"), 0644))
+
+	result, err := strategy.Execute(plan)
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, result.Error.Error(), "refusing to overwrite")
+	data, _ := afero.ReadFile(fs, "/lib/IPX-777.mp4")
+	assert.Equal(t, []byte("exists"), data)
+}
+
+// In-place strategy's move-to-organize-folder (non-InPlace) branch also refuses late conflicts.
+func TestInPlaceStrategy_FileBranch_LateConflictRefused(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &Config{OperationMode: operationmode.OperationModeOrganize, FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}
+	m, _ := matcher.NewMatcher(&matcher.Config{})
+	strategy := newInPlaceStrategy(fs, cfg, m, nil)
+
+	require.NoError(t, afero.WriteFile(fs, "/source/folder/ABC-888.mp4", []byte("mine"), 0644))
+	plan := &OrganizePlan{
+		SourcePath: "/source/folder/ABC-888.mp4",
+		TargetDir:  "/dest/ABC-888",
+		TargetFile: "ABC-888.mp4",
+		TargetPath: "/dest/ABC-888/ABC-888.mp4",
+		WillMove:   true,
+		InPlace:    false,
+	}
+
+	require.NoError(t, afero.WriteFile(fs, "/dest/ABC-888/ABC-888.mp4", []byte("exists"), 0644))
+
+	result, err := strategy.Execute(plan)
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, result.Error.Error(), "refusing to overwrite")
+	data, _ := afero.ReadFile(fs, "/dest/ABC-888/ABC-888.mp4")
+	assert.Equal(t, []byte("exists"), data)
+}

--- a/internal/organizer/organize_conflict_execute_test.go
+++ b/internal/organizer/organize_conflict_execute_test.go
@@ -1,0 +1,111 @@
+package organizer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/testutil"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Concurrent workers racing to one destination: exactly one wins, losers get conflict
+// errors, and the existing content is never silently replaced.
+func TestOrganizeStrategy_Execute_ConcurrentSameDestination_ExactlyOneWins(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	movie := testutil.NewMovieBuilder().WithID("IPX-123").Build()
+
+	const workers = 10
+	var okCount, failCount int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start // release all workers at once for the same destination
+			src := fmt.Sprintf("/incoming/IPX-123-%02d.mp4", i)
+			if err := afero.WriteFile(fs, src, []byte(fmt.Sprintf("part-%d", i)), 0644); err != nil {
+				t.Errorf("write: %v", err)
+				return
+			}
+			match := models.FileMatchInfo{Path: src, Name: filepath.Base(src), Extension: ".mp4", MovieID: "IPX-123"}
+			_, err := org.Organize(context.Background(), OrganizeCmd{
+				Match: match, Movie: movie, DestDir: "/sorted", MoveFiles: true,
+			})
+			if err != nil {
+				atomic.AddInt64(&failCount, 1)
+			} else {
+				atomic.AddInt64(&okCount, 1)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int64(1), atomic.LoadInt64(&okCount))
+	assert.Equal(t, int64(workers-1), atomic.LoadInt64(&failCount))
+
+	entries, err := afero.ReadDir(fs, "/sorted/IPX-123")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	data, err := afero.ReadFile(fs, "/sorted/IPX-123/IPX-123.mp4")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "part-")
+}
+
+// Same-inode aliasing must keep working: a destination that is a hardlink alias of the
+// source is an idempotent no-op, not a conflict.
+func TestOrganizeStrategy_Execute_SameInodeDestination_NoConflict(t *testing.T) {
+	if _, err := os.Stat("/tmp"); err != nil {
+		t.Skip("os fs unavailable")
+	}
+	// MemMapFs cannot create hardlinks; use the real filesystem.
+	fs := afero.NewOsFs()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "IPX-999-a.mp4")
+	aliasDir := filepath.Join(dir, "out", "IPX-999")
+	require.NoError(t, os.MkdirAll(aliasDir, 0755))
+	require.NoError(t, os.WriteFile(src, []byte("shared-bytes"), 0644))
+	require.NoError(t, os.Link(src, filepath.Join(aliasDir, "IPX-999.mp4")))
+
+	cfg := &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	movie := testutil.NewMovieBuilder().WithID("IPX-999").Build()
+	match := models.FileMatchInfo{Path: src, Name: "IPX-999-a.mp4", Extension: ".mp4", MovieID: "IPX-999"}
+
+	result, err := org.Organize(context.Background(), OrganizeCmd{
+		Match: match, Movie: movie, DestDir: filepath.Join(dir, "out"), MoveFiles: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Moved)
+
+	data, err := os.ReadFile(filepath.Join(aliasDir, "IPX-999.mp4"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("shared-bytes"), data)
+
+	// Idempotent same-inode move must NOT consume the source path entry.
+	srcData, err := os.ReadFile(src)
+	require.NoError(t, err, "source alias must be preserved on same-inode no-op")
+	assert.Equal(t, []byte("shared-bytes"), srcData)
+}

--- a/internal/organizer/organize_conflict_fsedge_test.go
+++ b/internal/organizer/organize_conflict_fsedge_test.go
@@ -1,0 +1,180 @@
+package organizer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/testutil"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// OS-level: a dangling destination symlink is an existing entry — unauthorized moves
+// conflict rather than replacing it.
+func TestOrganize_DanglingSymlink_Conflicts(t *testing.T) {
+	fs := afero.NewOsFs()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "IPX-123.mp4")
+	dst := filepath.Join(dir, "out", "IPX-123", "IPX-123.mp4")
+	require.NoError(t, os.WriteFile(src, []byte("mine"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0755))
+	require.NoError(t, os.Symlink(filepath.Join(dir, "does-not-exist.mp4"), dst))
+
+	cfg := &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true, OperationMode: operationmode.OperationModeOrganize}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	movie := testutil.NewMovieBuilder().WithID("IPX-123").Build()
+	match := models.FileMatchInfo{Path: src, Name: "IPX-123.mp4", Extension: ".mp4", MovieID: "IPX-123"}
+
+	result, err := org.Organize(context.Background(), OrganizeCmd{
+		Match: match, Movie: movie, DestDir: filepath.Join(dir, "out"), MoveFiles: true,
+	})
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, result.Error.Error(), "refusing to overwrite")
+
+	// The symlink entry remains; source is intact.
+	info, err := os.Lstat(dst)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink)
+	srcData, _ := os.ReadFile(src)
+	assert.Equal(t, []byte("mine"), srcData)
+}
+
+// Two in-place operations from different old directories converging on one target dir:
+// exactly one renames, the other fails without disturbing contents.
+func TestInPlaceStrategy_SiblingCollision_NeverIllegalClobber(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &Config{OperationMode: operationmode.OperationModeInPlace, FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}
+	strategy := newInPlaceStrategy(fs, cfg, nil, nil)
+
+	require.NoError(t, afero.WriteFile(fs, "/a/old/ABC-555.mp4", []byte("a-content"), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/b/old/ABC-555.mp4", []byte("b-content"), 0644))
+
+	mk := func(old string) *OrganizePlan {
+		return &OrganizePlan{
+			SourcePath: old + "/ABC-555.mp4",
+			TargetDir:  "/a/new",
+			TargetFile: "ABC-555.mp4",
+			TargetPath: "/a/new/ABC-555.mp4",
+			WillMove:   true,
+			InPlace:    true,
+			OldDir:     old,
+			Match:      models.FileMatchInfo{Path: old + "/ABC-555.mp4", Name: "ABC-555.mp4"},
+		}
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	var mu sync.Mutex
+	var r1, r2 *OrganizeResult
+	var err1, err2 error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		r, err := strategy.Execute(mk("/a/old"))
+		mu.Lock()
+		r1, err1 = r, err
+		mu.Unlock()
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		r, err := strategy.Execute(mk("/b/old"))
+		mu.Lock()
+		r2, err2 = r, err
+		mu.Unlock()
+	}()
+	close(start)
+	wg.Wait()
+
+	succeeded, failed := 0, 0
+	for _, okres := range []bool{err1 == nil && r1 != nil && r1.Moved, err2 == nil && r2 != nil && r2.Moved} {
+		if okres {
+			succeeded++
+		} else {
+			failed++
+		}
+	}
+	assert.Equal(t, 1, succeeded, "exactly one dir rename succeeds")
+	assert.Equal(t, 1, failed, "the other refuses")
+
+	data, err := afero.ReadFile(fs, "/a/new/ABC-555.mp4")
+	require.NoError(t, err)
+	assert.Contains(t, [][]byte{[]byte("a-content"), []byte("b-content")}, data, "winner content intact")
+	// The loser source must still be in place where it began (whichever it was)
+	if err1 == nil && r1 != nil && r1.Moved {
+		loser, err := afero.ReadFile(fs, "/b/old/ABC-555.mp4")
+		require.NoError(t, err, "loser source preserved in its original directory")
+		assert.Equal(t, loser, []byte("b-content"))
+	} else {
+		loser, err := afero.ReadFile(fs, "/a/old/ABC-555.mp4")
+		require.NoError(t, err, "loser source preserved in its original directory")
+		assert.Equal(t, loser, []byte("a-content"))
+	}
+}
+
+// renameHookFs injects a rival destination write immediately after a specific rename
+// completes — deterministically reproducing the interleaving the up-front TargetPath
+// lock guards against (a writer placing a different file at the inner target between
+// the directory rename and the inner file step).
+type renameHookFs struct {
+	afero.Fs
+	onAfterRename func(oldPath, newPath string)
+}
+
+func (f *renameHookFs) Rename(oldPath, newPath string) error {
+	err := f.Fs.Rename(oldPath, newPath)
+	if err == nil && f.onAfterRename != nil {
+		f.onAfterRename(oldPath, newPath)
+	}
+	return err
+}
+
+func TestInPlaceStrategy_RivalWrittenMidSequence_NeverClobbered(t *testing.T) {
+	base := afero.NewMemMapFs()
+	hook := &renameHookFs{Fs: base}
+	cfg := &Config{OperationMode: operationmode.OperationModeInPlace, FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}
+	strategy := newInPlaceStrategy(hook, cfg, nil, nil)
+
+	require.NoError(t, afero.WriteFile(base, "/old/ABC-777.mp4", []byte("mine"), 0644))
+	plan := &OrganizePlan{
+		SourcePath: "/old/ABC-777.mp4",
+		TargetDir:  "/new",
+		TargetFile: "ABC-777-renamed.mp4",
+		TargetPath: "/new/ABC-777-renamed.mp4",
+		WillMove:   true,
+		InPlace:    true,
+		OldDir:     "/old",
+		Match:      models.FileMatchInfo{Path: "/old/ABC-777.mp4", Name: "ABC-777.mp4"},
+	}
+	hook.onAfterRename = func(_, newPath string) {
+		if newPath == "/new" {
+			_ = afero.WriteFile(base, "/new/ABC-777-renamed.mp4", []byte("rival"), 0644)
+		}
+	}
+
+	result, err := strategy.Execute(plan)
+	require.Error(t, err, "rival at the inner destination must force refusal")
+	require.NotNil(t, result)
+	assert.False(t, result.Moved)
+
+	// The rival's bytes must survive untouched wherever they ended up — before the fix
+	// the inner rename could overwrite them outright. Both outcomes (rollback dragged the
+	// entry back under /old, or it never left /new) are acceptable; a clobber is not.
+	rival, rerr := afero.ReadFile(base, "/old/ABC-777-renamed.mp4")
+	if rerr != nil {
+		rival, rerr = afero.ReadFile(base, "/new/ABC-777-renamed.mp4")
+	}
+	require.NoError(t, rerr)
+	assert.Equal(t, []byte("rival"), rival, "rival content must never be overwritten")
+	src, serr := afero.ReadFile(base, "/old/ABC-777.mp4")
+	require.NoError(t, serr, "rollback must restore the source to its old directory")
+	assert.Equal(t, []byte("mine"), src)
+}

--- a/internal/organizer/organize_conflict_guards_test.go
+++ b/internal/organizer/organize_conflict_guards_test.go
@@ -1,0 +1,107 @@
+package organizer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/testutil"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Subtitle destinations are race-safe: a subtitle created between check and move is
+// preserved and the incoming one is skipped.
+func TestOrganize_Subtitle_LateExistingSkipped(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &Config{
+		FolderFormat:       "<ID>",
+		FileFormat:         "<ID>",
+		RenameFile:         true,
+		MoveSubtitles:      true,
+		SubtitleExtensions: []string{".srt"},
+		OperationMode:      operationmode.OperationModeOrganize,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	movie := testutil.NewMovieBuilder().WithID("IPX-535").Build()
+
+	require.NoError(t, org.fs.MkdirAll("/src", 0755))
+	require.NoError(t, afero.WriteFile(fs, "/src/IPX-535.mp4", []byte("video"), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/src/IPX-535.srt", []byte("subtitle-mine"), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/dest/IPX-535/IPX-535.srt", []byte("subtitle-existing"), 0644))
+
+	match := models.FileMatchInfo{Path: "/src/IPX-535.mp4", Name: "IPX-535.mp4", Extension: ".mp4", MovieID: "IPX-535"}
+	result, err := org.Organize(context.Background(), OrganizeCmd{
+		Match: match, Movie: movie, DestDir: "/dest", MoveFiles: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Subtitles, 1)
+	assert.True(t, result.Subtitles[0].Skipped, "existing subtitle must be skipped")
+	data, _ := afero.ReadFile(fs, "/dest/IPX-535/IPX-535.srt")
+	assert.Equal(t, []byte("subtitle-existing"), data, "existing subtitle preserved")
+}
+
+func TestLockRegistry_BoundedUnderChurn(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				dst := fmt.Sprintf("/dst-%d", j%25)
+				_ = withDestFileLock(dst, func() error { return nil })
+			}
+		}(i)
+	}
+	wg.Wait()
+	operationLocks.mu.Lock()
+	size := len(operationLocks.items)
+	operationLocks.mu.Unlock()
+	assert.Equal(t, 0, size, "unused entries must be evicted when last waiter releases")
+}
+
+// Verifies a lock mutually excludes simultaneous waiters: the in-flight counter must
+// never exceed 1 across all queued critical sections — an unlocked or mis-keyed
+// implementation fails this even while still running every callback.
+func TestLockRegistry_WaiterQueuedSerialized(t *testing.T) {
+	var inFlight atomic.Int32
+	var maxSeen atomic.Int32
+	executed := make(chan int, 4)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 1; i <= 4; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			<-start
+			_ = withDestFileLock("/x-child", func() error {
+				cur := inFlight.Add(1)
+				for {
+					m := maxSeen.Load()
+					if cur <= m || maxSeen.CompareAndSwap(m, cur) {
+						break
+					}
+				}
+				time.Sleep(time.Millisecond)
+				inFlight.Add(-1)
+				executed <- n
+				return nil
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(executed)
+	assert.Equal(t, int32(1), maxSeen.Load(), "critical sections under one key must never overlap")
+	count := 0
+	for range executed {
+		count++
+	}
+	assert.Equal(t, 4, count, "every queued waiter must be served exactly once")
+}

--- a/internal/organizer/organize_conflict_guards_test.go
+++ b/internal/organizer/organize_conflict_guards_test.go
@@ -105,3 +105,85 @@ func TestLockRegistry_WaiterQueuedSerialized(t *testing.T) {
 	}
 	assert.Equal(t, 4, count, "every queued waiter must be served exactly once")
 }
+
+// Exclusive directory locks exclude concurrent shared child writes and vice versa:
+// a rename-in-progress must never drag a freshly landed file away (and a landed file
+// must never be followed by a rollback into the wrong directory).
+func TestDirOperationLocks_ExclusiveExcludesShared(t *testing.T) {
+	held := make(chan struct{})
+	release := make(chan struct{})
+	exclusiveDone := make(chan struct{})
+	go func() {
+		defer close(exclusiveDone)
+		_ = withDestDirExclusiveLock("/target-dir", func() error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held
+
+	sharedEntered := make(chan struct{})
+	go func() {
+		defer close(sharedEntered)
+		_ = withDestDirSharedLock("/target-dir", func() error { return nil })
+	}()
+
+	select {
+	case <-sharedEntered:
+		t.Fatal("shared child lock entered while the exclusive directory rename was held")
+	case <-time.After(100 * time.Millisecond): // scheduling grace; blocking is the assertion
+	}
+	close(release)
+	<-exclusiveDone
+	select {
+	case <-sharedEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shared child lock never entered after the exclusive holder released")
+	}
+}
+
+func TestDirOperationLocks_SharedChildrenRunInParallel(t *testing.T) {
+	var inFlight atomic.Int32
+	var maxSeen atomic.Int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = withDestDirSharedLock("/target-dir", func() error {
+				cur := inFlight.Add(1)
+				for {
+					m := maxSeen.Load()
+					if cur <= m || maxSeen.CompareAndSwap(m, cur) {
+						break
+					}
+				}
+				time.Sleep(2 * time.Millisecond)
+				inFlight.Add(-1)
+				return nil
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+	assert.Greater(t, maxSeen.Load(), int32(1), "shared directory locks must permit concurrent child writes (batch copy throughput)")
+}
+
+func TestDirOperationLocks_EvictsIdleEntries(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			_ = withDestDirSharedLock(fmt.Sprintf("/evictable-%d", n), func() error { return nil })
+		}(i)
+	}
+	wg.Wait()
+	dirOperationLocks.mu.Lock()
+	size := len(dirOperationLocks.items)
+	dirOperationLocks.mu.Unlock()
+	assert.Equal(t, 0, size, "directory lock entries must be evicted when unused")
+}

--- a/internal/organizer/organize_conflict_regression_test.go
+++ b/internal/organizer/organize_conflict_regression_test.go
@@ -1,0 +1,206 @@
+package organizer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/testutil"
+	"github.com/spf13/afero"
+	"sync"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression: undetected multipart siblings collapsed to one destination and were
+// silently overwritten when batch organize hardcoded ForceUpdate. Defaults must refuse
+// to clobber; explicit force restores legacy replace behavior.
+func TestOrganize_UndetectedMultipartSiblings_NeverOverwriteByDefault(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID><IF:MULTIPART>-pt<PART></IF>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	movie := testutil.NewMovieBuilder().WithID("IPX-535").Build()
+
+	successes, failures := 0, 0
+	for i := 1; i <= 7; i++ {
+		src := fmt.Sprintf("/incoming/IPX-535-x%d.mp4", i)
+		require.NoError(t, afero.WriteFile(fs, src, []byte(fmt.Sprintf("part-%d", i)), 0644))
+		match := models.FileMatchInfo{
+			Path: src, Name: fmt.Sprintf("IPX-535-x%d.mp4", i), Extension: ".mp4",
+			MovieID: "IPX-535",
+		}
+		_, err := org.Organize(context.Background(), OrganizeCmd{
+			Match: match, Movie: movie, DestDir: "/sorted", MoveFiles: true,
+		})
+		if err != nil {
+			failures++
+		} else {
+			successes++
+		}
+	}
+
+	assert.Equal(t, 1, successes, "exactly one part may occupy the shared destination")
+	assert.Equal(t, 6, failures, "all other parts must fail with conflicts")
+
+	entries, err := afero.ReadDir(fs, "/sorted/IPX-535")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	srcEntries, err := afero.ReadDir(fs, "/incoming")
+	require.NoError(t, err)
+	assert.Len(t, srcEntries, 6, "conflicted sources must be preserved in place")
+}
+
+// The execute-time guard closes the plan→execute race: a destination created between
+// planning and moving must conflict even if plan-time checks passed.
+func TestOrganizeStrategy_Execute_RefusesLateConflictWithoutAuthorization(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	movie := testutil.NewMovieBuilder().WithID("IPX-123").Build()
+	match := models.FileMatchInfo{Path: "/source/IPX-123.mp4", Name: "IPX-123.mp4", Extension: ".mp4", MovieID: "IPX-123"}
+	require.NoError(t, afero.WriteFile(fs, match.Path, []byte("incoming"), 0644))
+
+	strategy := org.strategyFromType(strategyOrganize)
+	plan, err := strategy.Plan(match, movie, "/dest", false)
+	require.NoError(t, err)
+
+	require.NoError(t, afero.WriteFile(fs, "/dest/IPX-123/IPX-123.mp4", []byte("simultaneous-writer"), 0644))
+
+	result, err := strategy.Execute(plan)
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, result.Error.Error(), "refusing to overwrite")
+
+	content, err := afero.ReadFile(fs, "/dest/IPX-123/IPX-123.mp4")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("simultaneous-writer"), content, "existing destination must not be replaced")
+
+	sourceContent, err := afero.ReadFile(fs, "/source/IPX-123.mp4")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("incoming"), sourceContent, "source must remain in place")
+}
+
+// Explicit authorization restores legacy replace behavior.
+func TestOrganizeStrategy_Execute_AuthorizedOverwriteReplaces(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	movie := testutil.NewMovieBuilder().WithID("IPX-123").Build()
+	match := models.FileMatchInfo{Path: "/source/IPX-123.mp4", Name: "IPX-123.mp4", Extension: ".mp4", MovieID: "IPX-123"}
+	require.NoError(t, afero.WriteFile(fs, match.Path, []byte("incoming"), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/dest/IPX-123/IPX-123.mp4", []byte("previous"), 0644))
+
+	result, err := org.Organize(context.Background(), OrganizeCmd{
+		Match: match, Movie: movie, DestDir: "/dest", MoveFiles: true, ForceUpdate: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Moved)
+
+	content, err := afero.ReadFile(fs, "/dest/IPX-123/IPX-123.mp4")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("incoming"), content)
+}
+
+// Concurrent plans-then-executes: every part plans FIRST (all plan-time checks pass —
+// the destination is unused at plan time), then all executions race onto the shared
+// destination. Exactly one may win; all losing sources must survive untouched.
+func TestOrganize_UndetectedMultipartSiblings_ConcurrentPlansSerialize(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID><IF:MULTIPART>-pt<PART></IF>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	movie := testutil.NewMovieBuilder().WithID("IPX-535").Build()
+	strategy := org.strategyFromType(strategyOrganize)
+
+	const parts = 7
+	plans := make([]*OrganizePlan, parts)
+	for i := 1; i <= parts; i++ {
+		src := fmt.Sprintf("/incoming/IPX-535-x%d.mp4", i)
+		require.NoError(t, afero.WriteFile(fs, src, []byte(fmt.Sprintf("part-%d", i)), 0644))
+		match := models.FileMatchInfo{
+			Path: src, Name: fmt.Sprintf("IPX-535-x%d.mp4", i), Extension: ".mp4",
+			MovieID: "IPX-535",
+		}
+		p, err := strategy.Plan(match, movie, "/sorted", false)
+		require.NoError(t, err)
+		plans[i-1] = p
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([]*OrganizeResult, parts)
+	errs := make([]error, parts)
+	for i := 0; i < parts; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx], errs[idx] = strategy.Execute(plans[idx])
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	moved := 0
+	for i := range errs {
+		if errs[i] == nil && results[i] != nil && results[i].Moved {
+			moved++
+		}
+	}
+	assert.Equal(t, 1, moved, "exactly one racing part may occupy the shared destination")
+
+	// Exactly one winner occupies the destination, and its bytes must be one of the
+	// seven part payloads — assert unconditionally so an unreadable or wrong-content
+	// destination fails loudly instead of skipping the anti-clobber check.
+	winnerDest, derr := afero.ReadFile(fs, "/sorted/IPX-535/IPX-535.mp4")
+	require.NoError(t, derr, "shared destination must exist and be readable after one winner moves in")
+	winnerIdx := -1
+	for i := 1; i <= parts; i++ {
+		if string(winnerDest) == fmt.Sprintf("part-%d", i) {
+			winnerIdx = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, winnerIdx, "destination bytes must be exactly one part's payload — any mixture or foreign bytes means a clobber")
+
+	// All six losing parts still live under /incoming with their original bytes.
+	preserved := 0
+	for i := 1; i <= parts; i++ {
+		if i == winnerIdx {
+			continue
+		}
+		data, err := afero.ReadFile(fs, fmt.Sprintf("/incoming/IPX-535-x%d.mp4", i))
+		if err == nil && string(data) == fmt.Sprintf("part-%d", i) {
+			preserved++
+		}
+	}
+	assert.Equal(t, parts-1, preserved, "all losing parts must remain at their source paths with original bytes")
+
+	entries, err := afero.ReadDir(fs, "/sorted/IPX-535")
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "shared destination holds exactly one file")
+	assert.Equal(t, "IPX-535.mp4", entries[0].Name())
+}

--- a/internal/organizer/organize_pathclass_coverage_test.go
+++ b/internal/organizer/organize_pathclass_coverage_test.go
@@ -1,0 +1,572 @@
+package organizer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/testutil"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// forceStatFallbackFs wraps an fs so Lstater reports didLstat=false — exercising the
+// Stat-following fallback legs (readlink probes) even when the inner fs supports links.
+type forceStatFallbackFs struct{ afero.Fs }
+
+func (f forceStatFallbackFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	info, err := f.Fs.Stat(name)
+	return info, false, err
+}
+
+func (f forceStatFallbackFs) ReadlinkIfPossible(name string) (string, error) {
+	if lr, ok := f.Fs.(afero.LinkReader); ok {
+		return lr.ReadlinkIfPossible(name)
+	}
+	return "", os.ErrNotExist
+}
+
+// plainStatFs hides Lstater entirely, so callers take the plain-Stat legs.
+type plainStatFs struct{ afero.Fs }
+
+func (f plainStatFs) ReadlinkIfPossible(name string) (string, error) {
+	if lr, ok := f.Fs.(afero.LinkReader); ok {
+		return lr.ReadlinkIfPossible(name)
+	}
+	return "", os.ErrNotExist
+}
+
+// failStatPathsFs injects errors for chosen cleaned paths on both Stat and Lstat legs.
+type failStatPathsFs struct {
+	afero.Fs
+	fail map[string]error
+}
+
+func (f failStatPathsFs) Stat(name string) (os.FileInfo, error) {
+	if err, ok := f.fail[filepath.Clean(name)]; ok {
+		return nil, err
+	}
+	return f.Fs.Stat(name)
+}
+
+func (f failStatPathsFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	if err, ok := f.fail[filepath.Clean(name)]; ok {
+		return nil, true, err
+	}
+	if lst, ok := f.Fs.(afero.Lstater); ok {
+		info, did, err := lst.LstatIfPossible(name)
+		return info, did, err
+	}
+	info, err := f.Fs.Stat(name)
+	return info, false, err
+}
+
+func (f failStatPathsFs) ReadlinkIfPossible(name string) (string, error) {
+	if lr, ok := f.Fs.(afero.LinkReader); ok {
+		return lr.ReadlinkIfPossible(name)
+	}
+	return "", os.ErrNotExist
+}
+
+// statCountFs fails the Nth Stat of a target path — used to reach the defensive
+// second-stat failure branch after an initial stat succeeded.
+type statCountFs struct {
+	afero.Fs
+	target string
+	failOn int
+	n      int
+}
+
+func (f *statCountFs) Stat(name string) (os.FileInfo, error) {
+	if filepath.Clean(name) == f.target {
+		f.n++
+		if f.n == f.failOn {
+			return nil, errors.New("injected transient stat failure")
+		}
+	}
+	return f.Fs.Stat(name)
+}
+
+// renamePolicyFs can fail renames selectively and run a hook after specific renames.
+type renamePolicyFs struct {
+	afero.Fs
+	failPair func(oldPath, newPath string) bool
+	after    func(oldPath, newPath string)
+}
+
+func (f *renamePolicyFs) Rename(oldPath, newPath string) error {
+	if f.failPair != nil && f.failPair(oldPath, newPath) {
+		return errors.New("injected rename failure")
+	}
+	err := f.Fs.Rename(oldPath, newPath)
+	if err == nil && f.after != nil {
+		f.after(oldPath, newPath)
+	}
+	return err
+}
+
+// failRemovePathFs fails Remove for one cleaned path.
+type failRemovePathFs struct {
+	afero.Fs
+	target string
+}
+
+func (f failRemovePathFs) Remove(name string) error {
+	if filepath.Clean(name) == f.target {
+		return errors.New("injected remove failure")
+	}
+	return f.Fs.Remove(name)
+}
+
+// errLinker fails selected link operations.
+type errLinker struct {
+	hardErr error
+	softErr error
+	copyErr error
+}
+
+func (l errLinker) hardlink(_, _ string) error             { return l.hardErr }
+func (l errLinker) symlink(_, _ string) error              { return l.softErr }
+func (l errLinker) copyFile(_ afero.Fs, _, _ string) error { return l.copyErr }
+
+// --- refuseExistingDestination: dangling-symlink probe under Stat fallback -----------
+
+func TestRefuseExistingDestination_DanglingSymlinkProbe_StatFallbackLegs(t *testing.T) {
+	dir := t.TempDir()
+	base := afero.NewOsFs()
+	src := filepath.Join(dir, "src.mp4")
+	dst := filepath.Join(dir, "dst.mp4")
+	require.NoError(t, os.WriteFile(src, []byte("mine"), 0644))
+	require.NoError(t, os.Symlink(filepath.Join(dir, "gone.mp4"), dst)) // dangling
+
+	for name, fs := range map[string]afero.Fs{
+		"forced didLstat=false": forceStatFallbackFs{base},
+		"no Lstater at all":     plainStatFs{base},
+	} {
+		t.Run(name, func(t *testing.T) {
+			identical, sameIn, err := refuseExistingDestination(fs, src, dst)
+			require.Error(t, err, "dangling symlink must refuse overwrite on Stat-fallback filesystems")
+			assert.Contains(t, err.Error(), "refusing to overwrite")
+			assert.False(t, identical)
+			assert.False(t, sameIn)
+		})
+	}
+}
+
+// --- pathExistsBestEffort: every leg -------------------------------------------------
+
+func TestPathExistsBestEffort_Legs(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.txt"), []byte("x"), 0644))
+	require.NoError(t, os.Symlink(filepath.Join(dir, "gone.txt"), filepath.Join(dir, "dangling.txt")))
+
+	mem := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(mem, "/present.txt", []byte("x"), 0644))
+
+	permErr := errors.New("permission denied")
+
+	t.Run("lstater hit", func(t *testing.T) {
+		ok, err := pathExistsBestEffort(mem, "/present.txt")
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+	t.Run("lstater miss with didLstat=false falls through to readlink probe", func(t *testing.T) {
+		ok, err := pathExistsBestEffort(mem, "/absent.txt")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+	t.Run("lstater miss with true didLstat is authoritative", func(t *testing.T) {
+		ok, err := pathExistsBestEffort(afero.NewOsFs(), filepath.Join(dir, "never.txt"))
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+	t.Run("lstater non-NotExist error surfaces", func(t *testing.T) {
+		bad := failStatPathsFs{Fs: mem, fail: map[string]error{"/boom.txt": permErr}}
+		ok, err := pathExistsBestEffort(bad, "/boom.txt")
+		require.ErrorIs(t, err, permErr)
+		assert.False(t, ok)
+	})
+	t.Run("didLstat=false dangling found via readlink", func(t *testing.T) {
+		ok, err := pathExistsBestEffort(forceStatFallbackFs{afero.NewOsFs()}, filepath.Join(dir, "dangling.txt"))
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+	t.Run("plain stat hit", func(t *testing.T) {
+		ok, err := pathExistsBestEffort(plainStatFs{afero.NewOsFs()}, filepath.Join(dir, "real.txt"))
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+	t.Run("plain stat non-NotExist error surfaces", func(t *testing.T) {
+		bad := plainStatFs{failStatPathsFs{Fs: mem, fail: map[string]error{"/boom.txt": permErr}}}
+		ok, err := pathExistsBestEffort(bad, "/boom.txt")
+		require.ErrorIs(t, err, permErr)
+		assert.False(t, ok)
+	})
+	t.Run("plain stat miss found via readlink", func(t *testing.T) {
+		ok, err := pathExistsBestEffort(plainStatFs{afero.NewOsFs()}, filepath.Join(dir, "dangling.txt"))
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+}
+
+// --- no-rename-folder in-place: lexical self is a no-op -------------------------------
+
+func TestInPlaceNoRenameFolderStrategy_LexicalSelf_NoClobber(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &Config{OperationMode: operationmode.OperationModeInPlace, FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}
+	strategy := newInPlaceNoRenameFolderStrategy(fs, cfg, nil, nil)
+	require.NoError(t, afero.WriteFile(fs, "/dir/ABC-9.mp4", []byte("stay"), 0644))
+
+	plan := &OrganizePlan{
+		SourcePath: "/dir/ABC-9.mp4",
+		TargetDir:  "/dir",
+		TargetFile: "ABC-9.mp4",
+		TargetPath: "/dir/ABC-9.mp4",
+		WillMove:   true,
+		Match:      models.FileMatchInfo{Path: "/dir/ABC-9.mp4", Name: "ABC-9.mp4"},
+	}
+	result, err := strategy.Execute(plan)
+	require.NoError(t, err, "lexically identical source and target must be a no-op, not a conflict")
+	require.NotNil(t, result)
+	data, _ := afero.ReadFile(fs, "/dir/ABC-9.mp4")
+	assert.Equal(t, []byte("stay"), data)
+}
+
+// --- in-place TargetDir classification legs -------------------------------------------
+
+func mkInPlacePlan(oldDir, targetDir string) *OrganizePlan {
+	return &OrganizePlan{
+		SourcePath: oldDir + "/v.mp4",
+		TargetDir:  targetDir,
+		TargetFile: "v.mp4",
+		TargetPath: targetDir + "/v.mp4",
+		WillMove:   true,
+		InPlace:    true,
+		OldDir:     oldDir,
+		Match:      models.FileMatchInfo{Path: oldDir + "/v.mp4", Name: "v.mp4"},
+	}
+}
+
+func TestInPlaceStrategy_TargetDirIsSymlink_Refused(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on windows CI")
+	}
+	dir := t.TempDir()
+	base := afero.NewOsFs()
+	realDir := filepath.Join(dir, "real")
+	oldDir := filepath.Join(dir, "old")
+	require.NoError(t, os.MkdirAll(realDir, 0755))
+	require.NoError(t, os.MkdirAll(oldDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(oldDir, "v.mp4"), []byte("v"), 0644))
+
+	symlinkDir := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink(realDir, symlinkDir))
+	danglingDir := filepath.Join(dir, "dangling")
+	require.NoError(t, os.Symlink(filepath.Join(dir, "gone"), danglingDir))
+
+	cfg := &Config{OperationMode: operationmode.OperationModeInPlace, FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}
+
+	t.Run("lstater leg", func(t *testing.T) {
+		strategy := newInPlaceStrategy(base, cfg, nil, nil)
+		_, err := strategy.Execute(mkInPlacePlan(oldDir, symlinkDir))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target directory is a symlink")
+	})
+	t.Run("didLstat=false success leg", func(t *testing.T) {
+		strategy := newInPlaceStrategy(forceStatFallbackFs{base}, cfg, nil, nil)
+		_, err := strategy.Execute(mkInPlacePlan(oldDir, symlinkDir))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target directory is a symlink")
+	})
+	t.Run("didLstat=false dangling leg", func(t *testing.T) {
+		strategy := newInPlaceStrategy(forceStatFallbackFs{base}, cfg, nil, nil)
+		_, err := strategy.Execute(mkInPlacePlan(oldDir, danglingDir))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target directory is a symlink")
+	})
+	t.Run("plain stat symlink leg", func(t *testing.T) {
+		strategy := newInPlaceStrategy(plainStatFs{base}, cfg, nil, nil)
+		_, err := strategy.Execute(mkInPlacePlan(oldDir, symlinkDir))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target directory is a symlink")
+	})
+	t.Run("plain stat dangling leg", func(t *testing.T) {
+		strategy := newInPlaceStrategy(plainStatFs{base}, cfg, nil, nil)
+		_, err := strategy.Execute(mkInPlacePlan(oldDir, danglingDir))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target directory is a symlink")
+	})
+	t.Run("plain stat real dir leg sets dirExists", func(t *testing.T) {
+		strategy := newInPlaceStrategy(plainStatFs{base}, cfg, nil, nil)
+		_, err := strategy.Execute(mkInPlacePlan(oldDir, realDir))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target directory already exists")
+	})
+}
+
+func TestInPlaceStrategy_TargetDirCheckErrors_Surface(t *testing.T) {
+	cfg := &Config{OperationMode: operationmode.OperationModeInPlace, FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}
+	permErr := errors.New("permission denied")
+
+	t.Run("lstater non-NotExist error", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/old/v.mp4", []byte("v"), 0644))
+		bad := failStatPathsFs{Fs: fs, fail: map[string]error{"/new": permErr}}
+		strategy := newInPlaceStrategy(bad, cfg, nil, nil)
+		_, err := strategy.Execute(mkInPlacePlan("/old", "/new"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check target directory")
+	})
+	t.Run("plain stat non-NotExist error", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/old/v.mp4", []byte("v"), 0644))
+		bad := plainStatFs{failStatPathsFs{Fs: fs, fail: map[string]error{"/new": permErr}}}
+		strategy := newInPlaceStrategy(bad, cfg, nil, nil)
+		_, err := strategy.Execute(mkInPlacePlan("/old", "/new"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check target directory")
+	})
+	t.Run("second stat of old dir failure is defensive but surfaces", func(t *testing.T) {
+		fs := &statCountFs{Fs: afero.NewMemMapFs(), target: "/old", failOn: 2}
+		require.NoError(t, afero.WriteFile(fs, "/old/v.mp4", []byte("v"), 0644))
+		require.NoError(t, fs.MkdirAll("/new", 0755))
+		strategy := newInPlaceStrategy(fs, cfg, nil, nil)
+		_, err := strategy.Execute(mkInPlacePlan("/old", "/new"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target directory already exists")
+	})
+}
+
+// --- in-place rollback legs -----------------------------------------------------------
+
+func TestInPlaceStrategy_RollbackAlsoFails_RefusalStillReturned(t *testing.T) {
+	base := afero.NewMemMapFs()
+	cfg := &Config{OperationMode: operationmode.OperationModeInPlace, FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}
+	hook := &renamePolicyFs{Fs: base}
+	strategy := newInPlaceStrategy(hook, cfg, nil, nil)
+	require.NoError(t, afero.WriteFile(base, "/old/ABC-777.mp4", []byte("mine"), 0644))
+
+	plan := mkInPlacePlan("/old", "/new")
+	plan.SourcePath = "/old/ABC-777.mp4"
+	plan.TargetFile = "ABC-777-renamed.mp4"
+	plan.TargetPath = "/new/ABC-777-renamed.mp4"
+	plan.Match = models.FileMatchInfo{Path: "/old/ABC-777.mp4", Name: "ABC-777.mp4"}
+
+	hook.after = func(_, newPath string) {
+		if newPath == "/new" {
+			_ = afero.WriteFile(base, "/new/ABC-777-renamed.mp4", []byte("rival"), 0644)
+		}
+	}
+	hook.failPair = func(oldPath, newPath string) bool {
+		return oldPath == "/new" && newPath == "/old" // rollback fails
+	}
+
+	_, err := strategy.Execute(plan)
+	require.Error(t, err, "refusal must still surface even when rollback fails")
+	assert.Contains(t, err.Error(), "refusing to overwrite")
+}
+
+func TestInPlaceStrategy_InnerRenameFails_WithAndWithoutRollbackFailure(t *testing.T) {
+	cfg := &Config{OperationMode: operationmode.OperationModeInPlace, FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}
+
+	run := func(t *testing.T, rollbackAlsoFails bool) {
+		base := afero.NewMemMapFs()
+		hook := &renamePolicyFs{Fs: base}
+		strategy := newInPlaceStrategy(hook, cfg, nil, nil)
+		require.NoError(t, afero.WriteFile(base, "/old/ABC-777.mp4", []byte("mine"), 0644))
+		plan := mkInPlacePlan("/old", "/new")
+		plan.SourcePath = "/old/ABC-777.mp4"
+		plan.TargetFile = "ABC-777-renamed.mp4"
+		plan.TargetPath = "/new/ABC-777-renamed.mp4"
+		plan.Match = models.FileMatchInfo{Path: "/old/ABC-777.mp4", Name: "ABC-777.mp4"}
+		hook.failPair = func(oldPath, newPath string) bool {
+			switch {
+			case oldPath == "/new/ABC-777.mp4" && newPath == "/new/ABC-777-renamed.mp4":
+				return true // inner rename fails
+			case rollbackAlsoFails && oldPath == "/new" && newPath == "/old":
+				return true
+			}
+			return false
+		}
+		_, err := strategy.Execute(plan)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to rename file after directory rename")
+	}
+
+	t.Run("rollback succeeds", func(t *testing.T) { run(t, false) })
+	t.Run("rollback fails too", func(t *testing.T) { run(t, true) })
+}
+
+// --- copy/link execution legs ----------------------------------------------------------
+
+func TestOrganizeStrategy_LinkMode_AuthorizedRemoveFailure(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	cfg := &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true, OperationMode: operationmode.OperationModeOrganize}
+	strategy := newOrganizeStrategy(mem, cfg, nil, &MemLinker{})
+	movie := testutil.NewMovieBuilder().WithID("IPX-123").Build()
+	require.NoError(t, afero.WriteFile(mem, "/src/IPX-123.mp4", []byte("new"), 0644))
+	require.NoError(t, afero.WriteFile(mem, "/dest/IPX-123/IPX-123.mp4", []byte("old"), 0644))
+
+	match := models.FileMatchInfo{Path: "/src/IPX-123.mp4", Name: "IPX-123.mp4", Extension: ".mp4", MovieID: "IPX-123"}
+	plan, err := strategy.Plan(match, movie, "/dest", true)
+	require.NoError(t, err)
+	plan.moveFiles = false
+	plan.LinkMode = LinkModeHard
+	plan.Conflicts = nil
+
+	strategy.fs = failRemovePathFs{Fs: mem, target: "/dest/IPX-123/IPX-123.mp4"}
+	_, err = strategy.Execute(plan)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to prepare target path for link")
+}
+
+func TestOrganizeStrategy_LinkMode_LexicalSelf_Idempotent(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	cfg := &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true, OperationMode: operationmode.OperationModeOrganize}
+	strategy := newOrganizeStrategy(mem, cfg, nil, &MemLinker{})
+	require.NoError(t, afero.WriteFile(mem, "/dest/A.mp4", []byte("same"), 0644))
+
+	plan := &OrganizePlan{
+		SourcePath: "/dest/A.mp4",
+		TargetDir:  "/dest",
+		TargetFile: "A.mp4",
+		TargetPath: "/dest/A.mp4",
+		WillMove:   true,
+		LinkMode:   LinkModeHard,
+		moveFiles:  false,
+		Match:      models.FileMatchInfo{Path: "/dest/A.mp4", Name: "A.mp4"},
+	}
+	result, err := strategy.Execute(plan)
+	require.NoError(t, err, "lexical self with link mode must be a no-op")
+	require.NotNil(t, result)
+}
+
+func TestOrganizeStrategy_LinkMode_SameInode_Idempotent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hardlink semantics differ on windows CI")
+	}
+	dir := t.TempDir()
+	base := afero.NewOsFs()
+	src := filepath.Join(dir, "src.mp4")
+	require.NoError(t, os.WriteFile(src, []byte("video"), 0644))
+	dst := filepath.Join(dir, "alias.mp4")
+	require.NoError(t, os.Link(src, dst)) // pre-existing hardlink alias
+
+	cfg := &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true, OperationMode: operationmode.OperationModeOrganize}
+
+	for _, mode := range []LinkMode{LinkModeHard, LinkModeNone} {
+		linker := &MemLinker{}
+		strategy := newOrganizeStrategy(base, cfg, nil, linker)
+		plan := &OrganizePlan{
+			SourcePath: src,
+			TargetDir:  dir,
+			TargetFile: "alias.mp4",
+			TargetPath: dst,
+			WillMove:   true,
+			LinkMode:   mode,
+			moveFiles:  false,
+			Match:      models.FileMatchInfo{Path: src, Name: "src.mp4"},
+		}
+		result, err := strategy.Execute(plan)
+		require.NoError(t, err, "same-inode destination in unauthorized mode must be an idempotent no-op")
+		require.NotNil(t, result)
+		assert.Empty(t, linker.Links, "no link operation should run against an already-satisfied inode")
+		content, _ := os.ReadFile(src)
+		assert.Equal(t, []byte("video"), content, "source content preserved")
+	}
+}
+
+func TestOrganizeStrategy_LinkMode_SoftPermissionDenied(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	cfg := &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true, OperationMode: operationmode.OperationModeOrganize}
+	strategy := newOrganizeStrategy(mem, cfg, nil, errLinker{softErr: os.ErrPermission})
+	require.NoError(t, afero.WriteFile(mem, "/src/A.mp4", []byte("v"), 0644))
+
+	plan := &OrganizePlan{
+		SourcePath: "/src/A.mp4",
+		TargetDir:  "/dest",
+		TargetFile: "A.mp4",
+		TargetPath: "/dest/A.mp4",
+		WillMove:   true,
+		LinkMode:   LinkModeSoft,
+		moveFiles:  false,
+		Match:      models.FileMatchInfo{Path: "/src/A.mp4", Name: "A.mp4"},
+	}
+	_, err := strategy.Execute(plan)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create soft link")
+}
+
+func TestOrganizeStrategy_LinkMode_SoftRelativeSourceResolutionFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cannot remove the working directory on windows")
+	}
+	mem := afero.NewMemMapFs()
+	cfg := &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true, OperationMode: operationmode.OperationModeOrganize}
+	strategy := newOrganizeStrategy(mem, cfg, nil, &MemLinker{})
+	require.NoError(t, afero.WriteFile(mem, "/src/A.mp4", []byte("v"), 0644))
+
+	plan := &OrganizePlan{
+		SourcePath:          "relative-src.mp4", // forces filepath.Abs
+		TargetDir:           "/dest",
+		TargetFile:          "A.mp4",
+		TargetPath:          "/dest/A.mp4",
+		WillMove:            true,
+		LinkMode:            LinkModeSoft,
+		moveFiles:           false,
+		overwriteAuthorized: true, // classification failure is benign under authorization
+		Match:               models.FileMatchInfo{Path: "relative-src.mp4", Name: "relative-src.mp4"},
+	}
+
+	doomed := t.TempDir()
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(doomed))
+	defer func() { _ = os.Chdir(prev) }()
+	require.NoError(t, os.Remove(doomed))
+
+	_, err = strategy.Execute(plan)
+	if err == nil {
+		t.Skipf("filepath.Abs still resolves with a removed cwd on %s; the failure branch is covered on linux CI", runtime.GOOS)
+	}
+	assert.Contains(t, err.Error(), "failed to resolve source path for symlink")
+}
+
+// --- subtitle destination check failure ------------------------------------------------
+
+func TestOrganize_SubtitleStatFailure_Surfaced(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	permErr := errors.New("permission denied")
+	fs := failStatPathsFs{Fs: mem, fail: map[string]error{"/dest/IPX-535/IPX-535.srt": permErr}}
+	cfg := &Config{
+		FolderFormat:       "<ID>",
+		FileFormat:         "<ID>",
+		RenameFile:         true,
+		MoveSubtitles:      true,
+		SubtitleExtensions: []string{".srt"},
+		OperationMode:      operationmode.OperationModeOrganize,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	org.fs = fs
+	movie := testutil.NewMovieBuilder().WithID("IPX-535").Build()
+
+	require.NoError(t, afero.WriteFile(mem, "/src/IPX-535.mp4", []byte("video"), 0644))
+	require.NoError(t, afero.WriteFile(mem, "/src/IPX-535.srt", []byte("subtitle"), 0644))
+
+	match := models.FileMatchInfo{Path: "/src/IPX-535.mp4", Name: "IPX-535.mp4", Extension: ".mp4", MovieID: "IPX-535"}
+	result, err := org.Organize(context.Background(), OrganizeCmd{
+		Match: match, Movie: movie, DestDir: "/dest", MoveFiles: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Subtitles, 1)
+	assert.Error(t, result.Subtitles[0].Error)
+	assert.Contains(t, result.Subtitles[0].Error.Error(), "failed to check subtitle destination")
+	assert.False(t, result.Subtitles[0].Moved)
+	assert.False(t, result.Subtitles[0].Skipped)
+}

--- a/internal/organizer/organize_pathclass_coverage_test.go
+++ b/internal/organizer/organize_pathclass_coverage_test.go
@@ -49,10 +49,13 @@ func (f plainStatFs) ReadlinkIfPossible(name string) (string, error) {
 	return "", os.ErrNotExist
 }
 
-// failStatPathsFs injects errors for chosen cleaned paths on both Stat and Lstat legs.
+// failStatPathsFs injects errors for chosen cleaned paths on Stat/Lstat legs;
+// failOpen (separate map) targets Open calls instead — keep them independent so a
+// Stat-failure setup does not break afero.ReadDir (which reaches into Open).
 type failStatPathsFs struct {
 	afero.Fs
-	fail map[string]error
+	fail     map[string]error
+	failOpen map[string]error
 }
 
 func (f failStatPathsFs) failFor(name string) (error, bool) {
@@ -77,6 +80,15 @@ func (f failStatPathsFs) LstatIfPossible(name string) (os.FileInfo, bool, error)
 	}
 	info, err := f.Fs.Stat(name)
 	return info, false, err
+}
+
+func (f failStatPathsFs) Open(name string) (afero.File, error) {
+	if f.failOpen != nil {
+		if err, ok := f.failOpen[normKey(name)]; ok {
+			return nil, err
+		}
+	}
+	return f.Fs.Open(name)
 }
 
 func (f failStatPathsFs) ReadlinkIfPossible(name string) (string, error) {
@@ -671,4 +683,19 @@ func TestInPlaceStrategy_InnerTargetSameInodeThroughSymlink_IsNoOp(t *testing.T)
 	link, lerr := os.Readlink(alias)
 	require.NoError(t, lerr)
 	assert.Equal(t, newDir, link, "alias symlink object must remain untouched")
+}
+
+// Plan-time propagation of a folder-dedication scan failure (matcher present).
+func TestInPlaceStrategy_Plan_DedicationScanErrorPropagates(t *testing.T) {
+	injErr := errors.New("injected readdir failure")
+	mem := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(mem, "/src/ABC-123/ABC-123.mp4", []byte("v"), 0644))
+	fs := failStatPathsFs{Fs: mem, failOpen: map[string]error{normKey("/src/ABC-123"): injErr}}
+	cfg := &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true, OperationMode: operationmode.OperationModeInPlace}
+	m, _ := matcher.NewMatcher(&matcher.Config{})
+	strategy := newInPlaceStrategy(fs, cfg, m, nil)
+
+	match := models.FileMatchInfo{MovieID: "ABC-123", Path: "/src/ABC-123/ABC-123.mp4", Name: "ABC-123.mp4", Extension: ".mp4"}
+	_, err := strategy.Plan(match, &models.Movie{ID: "ABC-123"}, "/dest", false)
+	require.ErrorIs(t, err, injErr, "dedication scan failures must abort planning, not silently proceed")
 }

--- a/internal/organizer/organize_pathclass_coverage_test.go
+++ b/internal/organizer/organize_pathclass_coverage_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/javinizer/javinizer-go/internal/matcher"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/operationmode"
 	"github.com/javinizer/javinizer-go/internal/testutil"
@@ -580,4 +581,94 @@ func TestOrganize_SubtitleStatFailure_Surfaced(t *testing.T) {
 	assert.Contains(t, result.Subtitles[0].Error.Error(), "failed to check subtitle destination")
 	assert.False(t, result.Subtitles[0].Moved)
 	assert.False(t, result.Subtitles[0].Skipped)
+}
+
+// Plan-time conflict: targetDir exists while OldDir stat fails → conflict recorded.
+func TestInPlaceStrategy_Plan_ConflictWhenOldDirStatFails(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	injErr := errors.New("injected stat failure")
+	fs := failStatPathsFs{Fs: mem, fail: map[string]error{normKey("/source/old-name"): injErr}}
+	cfg := &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true, OperationMode: operationmode.OperationModeInPlace}
+	m, _ := matcher.NewMatcher(&matcher.Config{})
+	strategy := newInPlaceStrategy(fs, cfg, m, nil)
+
+	require.NoError(t, afero.WriteFile(mem, "/source/old-name/ABC-123.mp4", []byte("video"), 0644))
+	require.NoError(t, mem.MkdirAll("/source/ABC-123", 0777)) // distinct existing target dir
+
+	match := models.FileMatchInfo{MovieID: "ABC-123", Path: "/source/old-name/ABC-123.mp4", Name: "ABC-123.mp4", Extension: ".mp4"}
+	movie := &models.Movie{ID: "ABC-123"}
+
+	plan, err := strategy.Plan(match, movie, "/dest", false)
+	require.NoError(t, err)
+	require.True(t, plan.InPlace, "dedicated folder must select in-place")
+	require.Contains(t, plan.Conflicts, filepath.FromSlash("/source/ABC-123"),
+		"an un-stat-able old dir with an existing target dir must still be a conflict")
+}
+
+// Execute-time: targetDir already exists; its follow-up Stat fails in the same-file
+// discrimination branch → treated as a conflict error, not a clobber.
+func TestInPlaceStrategy_Execute_TargetDirRestatFails(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	injErr := errors.New("injected restat failure")
+	fs := &countedStatFailFs{Fs: failStatPathsFs{Fs: mem, fail: map[string]error{}}, target: "/new", failOnCall: 2, err: injErr}
+	cfg := &Config{OperationMode: operationmode.OperationModeInPlace, FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}
+	strategy := newInPlaceStrategy(fs, cfg, nil, nil)
+
+	require.NoError(t, afero.WriteFile(mem, "/old/v.mp4", []byte("v"), 0644))
+	require.NoError(t, mem.MkdirAll("/new", 0755))
+
+	_, err := strategy.Execute(mkInPlacePlan("/old", "/new"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target directory already exists")
+}
+
+// countedStatFailFs fails the Nth call to a target Stat while other paths pass through.
+// It wraps an optional inner decorator so LstatIfPossible keeps delegating honestly.
+type countedStatFailFs struct {
+	afero.Fs
+	target     string
+	failOnCall int
+	n          int
+	err        error
+}
+
+func (f *countedStatFailFs) Stat(name string) (os.FileInfo, error) {
+	if normKey(name) == normKey(f.target) {
+		f.n++
+		if f.n == f.failOnCall {
+			return nil, f.err
+		}
+	}
+	return f.Fs.Stat(name)
+}
+
+// Inner-rename same-inode leg: currentFilePath and TargetPath lexically differ but reach
+// the same inode through a symlinked ancestor → refuse reports same-inode → no-op.
+func TestInPlaceStrategy_InnerTargetSameInodeThroughSymlink_IsNoOp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on windows CI")
+	}
+	dir := t.TempDir()
+	base := afero.NewOsFs()
+	oldDir := filepath.Join(dir, "old")
+	newDir := filepath.Join(dir, "new")
+	alias := filepath.Join(dir, "alias")
+	require.NoError(t, os.MkdirAll(oldDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(oldDir, "v.mp4"), []byte("video"), 0644))
+	require.NoError(t, os.Symlink(newDir, alias)) // dangling until the rename lands
+
+	cfg := &Config{OperationMode: operationmode.OperationModeInPlace, FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}
+	strategy := newInPlaceStrategy(base, cfg, nil, nil)
+
+	plan := mkInPlacePlan(oldDir, newDir)
+	plan.TargetPath = filepath.Join(alias, "v.mp4") // same entry as newDir/v.mp4 via alias
+	result, err := strategy.Execute(plan)
+	require.NoError(t, err, "target path reaching the same inode through a symlink must be a no-op")
+	require.NotNil(t, result)
+	data, rerr := os.ReadFile(filepath.Join(newDir, "v.mp4"))
+	require.NoError(t, rerr)
+	assert.Equal(t, []byte("video"), data, "file content intact under the new dir")
+	link, lerr := os.Readlink(alias)
+	require.NoError(t, lerr)
+	assert.Equal(t, newDir, link, "alias symlink object must remain untouched")
 }

--- a/internal/organizer/organize_pathclass_coverage_test.go
+++ b/internal/organizer/organize_pathclass_coverage_test.go
@@ -18,6 +18,12 @@ import (
 
 // forceStatFallbackFs wraps an fs so Lstater reports didLstat=false — exercising the
 // Stat-following fallback legs (readlink probes) even when the inner fs supports links.
+// normKey normalizes path comparisons across separators so injected failures match
+// both literal "/a/b" plans and filepath.Join-produced paths on every OS.
+func normKey(p string) string {
+	return filepath.ToSlash(filepath.Clean(p))
+}
+
 type forceStatFallbackFs struct{ afero.Fs }
 
 func (f forceStatFallbackFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
@@ -48,15 +54,20 @@ type failStatPathsFs struct {
 	fail map[string]error
 }
 
+func (f failStatPathsFs) failFor(name string) (error, bool) {
+	err, ok := f.fail[normKey(name)]
+	return err, ok
+}
+
 func (f failStatPathsFs) Stat(name string) (os.FileInfo, error) {
-	if err, ok := f.fail[filepath.Clean(name)]; ok {
+	if err, ok := f.failFor(name); ok {
 		return nil, err
 	}
 	return f.Fs.Stat(name)
 }
 
 func (f failStatPathsFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
-	if err, ok := f.fail[filepath.Clean(name)]; ok {
+	if err, ok := f.failFor(name); ok {
 		return nil, true, err
 	}
 	if lst, ok := f.Fs.(afero.Lstater); ok {
@@ -84,7 +95,7 @@ type statCountFs struct {
 }
 
 func (f *statCountFs) Stat(name string) (os.FileInfo, error) {
-	if filepath.Clean(name) == f.target {
+	if normKey(name) == normKey(f.target) {
 		f.n++
 		if f.n == f.failOn {
 			return nil, errors.New("injected transient stat failure")
@@ -118,7 +129,7 @@ type failRemovePathFs struct {
 }
 
 func (f failRemovePathFs) Remove(name string) error {
-	if filepath.Clean(name) == f.target {
+	if normKey(name) == normKey(f.target) {
 		return errors.New("injected remove failure")
 	}
 	return f.Fs.Remove(name)
@@ -187,7 +198,7 @@ func TestPathExistsBestEffort_Legs(t *testing.T) {
 		assert.False(t, ok)
 	})
 	t.Run("lstater non-NotExist error surfaces", func(t *testing.T) {
-		bad := failStatPathsFs{Fs: mem, fail: map[string]error{"/boom.txt": permErr}}
+		bad := failStatPathsFs{Fs: mem, fail: map[string]error{normKey("/boom.txt"): permErr}}
 		ok, err := pathExistsBestEffort(bad, "/boom.txt")
 		require.ErrorIs(t, err, permErr)
 		assert.False(t, ok)
@@ -317,7 +328,7 @@ func TestInPlaceStrategy_TargetDirCheckErrors_Surface(t *testing.T) {
 	t.Run("lstater non-NotExist error", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		require.NoError(t, afero.WriteFile(fs, "/old/v.mp4", []byte("v"), 0644))
-		bad := failStatPathsFs{Fs: fs, fail: map[string]error{"/new": permErr}}
+		bad := failStatPathsFs{Fs: fs, fail: map[string]error{normKey("/new"): permErr}}
 		strategy := newInPlaceStrategy(bad, cfg, nil, nil)
 		_, err := strategy.Execute(mkInPlacePlan("/old", "/new"))
 		require.Error(t, err)
@@ -359,12 +370,12 @@ func TestInPlaceStrategy_RollbackAlsoFails_RefusalStillReturned(t *testing.T) {
 	plan.Match = models.FileMatchInfo{Path: "/old/ABC-777.mp4", Name: "ABC-777.mp4"}
 
 	hook.after = func(_, newPath string) {
-		if newPath == "/new" {
+		if normKey(newPath) == "/new" {
 			_ = afero.WriteFile(base, "/new/ABC-777-renamed.mp4", []byte("rival"), 0644)
 		}
 	}
 	hook.failPair = func(oldPath, newPath string) bool {
-		return oldPath == "/new" && newPath == "/old" // rollback fails
+		return normKey(oldPath) == "/new" && normKey(newPath) == "/old" // rollback fails
 	}
 
 	_, err := strategy.Execute(plan)
@@ -387,9 +398,9 @@ func TestInPlaceStrategy_InnerRenameFails_WithAndWithoutRollbackFailure(t *testi
 		plan.Match = models.FileMatchInfo{Path: "/old/ABC-777.mp4", Name: "ABC-777.mp4"}
 		hook.failPair = func(oldPath, newPath string) bool {
 			switch {
-			case oldPath == "/new/ABC-777.mp4" && newPath == "/new/ABC-777-renamed.mp4":
+			case normKey(oldPath) == "/new/ABC-777.mp4" && normKey(newPath) == "/new/ABC-777-renamed.mp4":
 				return true // inner rename fails
-			case rollbackAlsoFails && oldPath == "/new" && newPath == "/old":
+			case rollbackAlsoFails && normKey(oldPath) == "/new" && normKey(newPath) == "/old":
 				return true
 			}
 			return false
@@ -543,7 +554,7 @@ func TestOrganizeStrategy_LinkMode_SoftRelativeSourceResolutionFailure(t *testin
 func TestOrganize_SubtitleStatFailure_Surfaced(t *testing.T) {
 	mem := afero.NewMemMapFs()
 	permErr := errors.New("permission denied")
-	fs := failStatPathsFs{Fs: mem, fail: map[string]error{"/dest/IPX-535/IPX-535.srt": permErr}}
+	fs := failStatPathsFs{Fs: mem, fail: map[string]error{normKey("/dest/IPX-535/IPX-535.srt"): permErr}}
 	cfg := &Config{
 		FolderFormat:       "<ID>",
 		FileFormat:         "<ID>",

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -461,20 +461,22 @@ func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, 
 			},
 		}
 
-		// Parent directory locked alongside the subtitle path: consistent with all other
-		// destination-touching ops so nothing lands mid-sequence in a renamed directory.
-		err := withDestFileLocks([]string{plan.TargetDir, newPath}, func() error {
-			// pathExistsBestEffort also sees dangling symlink objects: a filesystem whose
-			// Stat follows links (no true Lstat) would otherwise let this op replace one.
-			exists, statErr := pathExistsBestEffort(o.fs, newPath)
-			if statErr != nil {
-				return fmt.Errorf("failed to check subtitle destination: %w", statErr)
-			}
-			if exists {
-				sr.Skipped = true
-				return nil
-			}
-			return fileOp(o.fs, subtitle.OriginalPath, newPath)
+		// Shared parent-directory lock + per-subtitle file lock: child writes stay
+		// parallel per file, but a directory rename elsewhere drains us before moving.
+		err := withDestDirSharedLock(plan.TargetDir, func() error {
+			return withDestFileLock(newPath, func() error {
+				// pathExistsBestEffort also sees dangling symlink objects: a filesystem whose
+				// Stat follows links (no true Lstat) would otherwise let this op replace one.
+				exists, statErr := pathExistsBestEffort(o.fs, newPath)
+				if statErr != nil {
+					return fmt.Errorf("failed to check subtitle destination: %w", statErr)
+				}
+				if exists {
+					sr.Skipped = true
+					return nil
+				}
+				return fileOp(o.fs, subtitle.OriginalPath, newPath)
+			})
 		})
 		if err != nil {
 			sr.Error = fmt.Errorf("failed to handle subtitle: %w", err)

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -308,6 +308,10 @@ type OrganizePlan struct {
 	executeStrategy OperationStrategy
 	LinkMode        LinkMode
 	moveFiles       bool // true = move (rename); false = copy/link — determines which branch strategy.Execute takes
+	// overwriteAuthorized is true when the caller explicitly authorized replacing an existing
+	// destination (cmd.ForceUpdate). When false, move execution refuses to replace a file that
+	// exists at the target even if it appeared after plan-time conflict checks (TOCTOU guard).
+	overwriteAuthorized bool
 }
 
 // Plan creates an organization plan without executing it
@@ -457,11 +461,24 @@ func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, 
 			},
 		}
 
-		if _, err := o.fs.Stat(newPath); err == nil {
-			sr.Skipped = true
-		} else if err := fileOp(o.fs, subtitle.OriginalPath, newPath); err != nil {
+		// Parent directory locked alongside the subtitle path: consistent with all other
+		// destination-touching ops so nothing lands mid-sequence in a renamed directory.
+		err := withDestFileLocks([]string{plan.TargetDir, newPath}, func() error {
+			// pathExistsBestEffort also sees dangling symlink objects: a filesystem whose
+			// Stat follows links (no true Lstat) would otherwise let this op replace one.
+			exists, statErr := pathExistsBestEffort(o.fs, newPath)
+			if statErr != nil {
+				return fmt.Errorf("failed to check subtitle destination: %w", statErr)
+			}
+			if exists {
+				sr.Skipped = true
+				return nil
+			}
+			return fileOp(o.fs, subtitle.OriginalPath, newPath)
+		})
+		if err != nil {
 			sr.Error = fmt.Errorf("failed to handle subtitle: %w", err)
-		} else {
+		} else if !sr.Skipped {
 			sr.Moved = true
 		}
 

--- a/internal/organizer/softlink_hint_unix.go
+++ b/internal/organizer/softlink_hint_unix.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package organizer
+
+const softLinkPermDeniedHint = " (permission denied)"

--- a/internal/organizer/softlink_hint_windows.go
+++ b/internal/organizer/softlink_hint_windows.go
@@ -1,0 +1,6 @@
+//go:build windows
+
+package organizer
+
+// On Windows, symlinks require Developer Mode or elevated privileges.
+const softLinkPermDeniedHint = " (Windows requires Developer Mode or elevated privileges for symlinks)"

--- a/internal/organizer/strategy_inplace.go
+++ b/internal/organizer/strategy_inplace.go
@@ -223,98 +223,101 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 
 	if plan.InPlace {
 		// The WHOLE directory sequence — stat, renames, inner file step, and any rollback —
-		// runs while holding BOTH the TargetDir and TargetPath locks, acquired up front in
-		// sorted-key order: a sibling worker locking only the child path can never write a
-		// file between the directory rename and the inner file step, so rollback can never
-		// displace a sibling's entry.
-		err := withDestFileLocks([]string{plan.TargetDir, plan.TargetPath}, func() error {
-			info, err := s.fs.Stat(plan.OldDir)
-			if err != nil {
-				return fmt.Errorf("failed to stat old directory: %w", err)
-			}
-			if !info.IsDir() {
-				return fmt.Errorf("old path is not a directory: %s", plan.OldDir)
-			}
+		// runs while holding the EXCLUSIVE TargetDir lock plus the inner TargetPath file
+		// lock, acquired up front (dir before file): a sibling worker holding only the
+		// child path's shared dir lock can never write a file between the directory
+		// rename and the inner file step, so rollback can never displace a sibling's
+		// entry. Unrelated writes into OTHER directories stay fully parallel.
+		err := withDestDirExclusiveLock(plan.TargetDir, func() error {
+			return withDestFileLock(plan.TargetPath, func() error {
+				info, err := s.fs.Stat(plan.OldDir)
+				if err != nil {
+					return fmt.Errorf("failed to stat old directory: %w", err)
+				}
+				if !info.IsDir() {
+					return fmt.Errorf("old path is not a directory: %s", plan.OldDir)
+				}
 
-			dirExists := false
-			if lst, ok := s.fs.(afero.Lstater); ok {
-				info, didLstat, statErr := lst.LstatIfPossible(plan.TargetDir)
-				switch {
-				case statErr == nil:
-					dirExists = true
-					// didLstat=false means info came from a link-following Stat: re-probe with
-					// readlink so a non-dangling symlink (possibly pointing at OldDir, which
-					// would pass the os.SameFile check below) is not treated as the real dir.
-					if info.Mode()&os.ModeSymlink != 0 || (!didLstat && symlinkObjectExists(s.fs, plan.TargetDir)) {
+				dirExists := false
+				if lst, ok := s.fs.(afero.Lstater); ok {
+					info, didLstat, statErr := lst.LstatIfPossible(plan.TargetDir)
+					switch {
+					case statErr == nil:
+						dirExists = true
+						// didLstat=false means info came from a link-following Stat: re-probe with
+						// readlink so a non-dangling symlink (possibly pointing at OldDir, which
+						// would pass the os.SameFile check below) is not treated as the real dir.
+						if info.Mode()&os.ModeSymlink != 0 || (!didLstat && symlinkObjectExists(s.fs, plan.TargetDir)) {
+							return fmt.Errorf("target directory is a symlink: %s", plan.TargetDir)
+						}
+					case !errors.Is(statErr, os.ErrNotExist):
+						return fmt.Errorf("failed to check target directory: %w", statErr)
+					case !didLstat && symlinkObjectExists(s.fs, plan.TargetDir):
+						// link-following Stat fallback would hide a dangling symlink object
 						return fmt.Errorf("target directory is a symlink: %s", plan.TargetDir)
 					}
-				case !errors.Is(statErr, os.ErrNotExist):
+				} else if _, statErr := s.fs.Stat(plan.TargetDir); statErr == nil {
+					if symlinkObjectExists(s.fs, plan.TargetDir) {
+						return fmt.Errorf("target directory is a symlink: %s", plan.TargetDir)
+					}
+					dirExists = true
+				} else if !errors.Is(statErr, os.ErrNotExist) {
 					return fmt.Errorf("failed to check target directory: %w", statErr)
-				case !didLstat && symlinkObjectExists(s.fs, plan.TargetDir):
-					// link-following Stat fallback would hide a dangling symlink object
+				} else if symlinkObjectExists(s.fs, plan.TargetDir) {
 					return fmt.Errorf("target directory is a symlink: %s", plan.TargetDir)
 				}
-			} else if _, statErr := s.fs.Stat(plan.TargetDir); statErr == nil {
-				if symlinkObjectExists(s.fs, plan.TargetDir) {
-					return fmt.Errorf("target directory is a symlink: %s", plan.TargetDir)
+				if dirExists {
+					oldInfo, oldErr := s.fs.Stat(plan.OldDir)
+					sameDir := false
+					if oldErr == nil {
+						newInfo, newErr := s.fs.Stat(plan.TargetDir)
+						// Same directory reached through another name (alias/symlink): falling
+						// through is the no-op case — anything else is a real conflict.
+						sameDir = newErr == nil && os.SameFile(oldInfo, newInfo)
+					}
+					if !sameDir {
+						return fmt.Errorf("target directory already exists: %s", plan.TargetDir)
+					}
 				}
-				dirExists = true
-			} else if !errors.Is(statErr, os.ErrNotExist) {
-				return fmt.Errorf("failed to check target directory: %w", statErr)
-			} else if symlinkObjectExists(s.fs, plan.TargetDir) {
-				return fmt.Errorf("target directory is a symlink: %s", plan.TargetDir)
-			}
-			if dirExists {
-				oldInfo, oldErr := s.fs.Stat(plan.OldDir)
-				sameDir := false
-				if oldErr == nil {
-					newInfo, newErr := s.fs.Stat(plan.TargetDir)
-					// Same directory reached through another name (alias/symlink): falling
-					// through is the no-op case — anything else is a real conflict.
-					sameDir = newErr == nil && os.SameFile(oldInfo, newInfo)
+
+				if err := s.fs.Rename(plan.OldDir, plan.TargetDir); err != nil {
+					return fmt.Errorf("failed to rename directory: %w", err)
 				}
-				if !sameDir {
-					return fmt.Errorf("target directory already exists: %s", plan.TargetDir)
+
+				result.InPlaceRenamed = true
+				result.OldDirectoryPath = plan.OldDir
+				result.NewDirectoryPath = plan.TargetDir
+
+				oldFileName := plan.Match.Name
+				if oldFileName == "" {
+					oldFileName = filepath.Base(plan.SourcePath)
 				}
-			}
-
-			if err := s.fs.Rename(plan.OldDir, plan.TargetDir); err != nil {
-				return fmt.Errorf("failed to rename directory: %w", err)
-			}
-
-			result.InPlaceRenamed = true
-			result.OldDirectoryPath = plan.OldDir
-			result.NewDirectoryPath = plan.TargetDir
-
-			oldFileName := plan.Match.Name
-			if oldFileName == "" {
-				oldFileName = filepath.Base(plan.SourcePath)
-			}
-			currentFilePath := filepath.Join(plan.TargetDir, oldFileName)
-			if currentFilePath != plan.TargetPath {
-				// Both destination locks are already held (see above), so no sibling can slip a
-				// file into the renamed directory at plan.TargetPath between the directory
-				// rename and this inner step — refuse-then-rename with rollback is atomic.
-				if !plan.overwriteAuthorized {
-					lexicalSelf, sameIn, e2 := refuseExistingDestination(s.fs, currentFilePath, plan.TargetPath)
-					if e2 != nil {
+				currentFilePath := filepath.Join(plan.TargetDir, oldFileName)
+				if currentFilePath != plan.TargetPath {
+					// Both destination locks are already held (see above), so no sibling can slip a
+					// file into the renamed directory at plan.TargetPath between the directory
+					// rename and this inner step — refuse-then-rename with rollback is atomic.
+					if !plan.overwriteAuthorized {
+						lexicalSelf, sameIn, e2 := refuseExistingDestination(s.fs, currentFilePath, plan.TargetPath)
+						if e2 != nil {
+							if rb := s.fs.Rename(plan.TargetDir, plan.OldDir); rb != nil {
+								logging.Errorf("[in-place] Failed to rollback directory rename %s → %s: %v", plan.TargetDir, plan.OldDir, rb)
+							}
+							return e2
+						}
+						if lexicalSelf || sameIn {
+							return nil // inner target names the same file — nothing to rename
+						}
+					}
+					if err := s.fs.Rename(currentFilePath, plan.TargetPath); err != nil {
 						if rb := s.fs.Rename(plan.TargetDir, plan.OldDir); rb != nil {
 							logging.Errorf("[in-place] Failed to rollback directory rename %s → %s: %v", plan.TargetDir, plan.OldDir, rb)
 						}
-						return e2
-					}
-					if lexicalSelf || sameIn {
-						return nil // inner target names the same file — nothing to rename
+						return fmt.Errorf("failed to rename file after directory rename: %w", err)
 					}
 				}
-				if err := s.fs.Rename(currentFilePath, plan.TargetPath); err != nil {
-					if rb := s.fs.Rename(plan.TargetDir, plan.OldDir); rb != nil {
-						logging.Errorf("[in-place] Failed to rollback directory rename %s → %s: %v", plan.TargetDir, plan.OldDir, rb)
-					}
-					return fmt.Errorf("failed to rename file after directory rename: %w", err)
-				}
-			}
-			return nil
+				return nil
+			})
 		})
 		if err != nil {
 			result.Error = err
@@ -323,24 +326,26 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 		result.Moved = true
 		return result, nil
 	} else {
-		// Lock the parent directory alongside the target path: an in-place directory
-		// rename elsewhere holds {TargetDir, TargetPath} for its whole sequence, and a
-		// bare TargetPath lock alone would let this move land inside a renamed (possibly
-		// about-to-rollback) directory. Sorted acquisition keeps every site cycle-free.
-		err := withDestFileLocks([]string{plan.TargetDir, plan.TargetPath}, func() error {
-			if !plan.overwriteAuthorized {
-				lexicalSelf, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
-				if err != nil {
-					return err
+		// Shared parent-directory lock + target-file lock (dir before file): an in-place
+		// directory rename elsewhere drains shared holders before it may move the
+		// directory, so this move can never land inside a renamed (possibly
+		// about-to-rollback) directory.
+		err := withDestDirSharedLock(plan.TargetDir, func() error {
+			return withDestFileLock(plan.TargetPath, func() error {
+				if !plan.overwriteAuthorized {
+					lexicalSelf, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
+					if err != nil {
+						return err
+					}
+					if lexicalSelf || sameIn {
+						return nil
+					}
 				}
-				if lexicalSelf || sameIn {
-					return nil
+				if err := s.fs.MkdirAll(plan.TargetDir, config.DirPerm); err != nil {
+					return fmt.Errorf("failed to create directory: %w", err)
 				}
-			}
-			if err := s.fs.MkdirAll(plan.TargetDir, config.DirPerm); err != nil {
-				return fmt.Errorf("failed to create directory: %w", err)
-			}
-			return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
+				return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
+			})
 		})
 		if err != nil {
 			result.Error = fmt.Errorf("failed to move file: %w", err)

--- a/internal/organizer/strategy_inplace.go
+++ b/internal/organizer/strategy_inplace.go
@@ -1,6 +1,7 @@
 package organizer
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -186,26 +187,27 @@ func (s *inPlaceStrategy) Plan(match models.FileMatchInfo, movie *models.Movie, 
 	}
 
 	return &OrganizePlan{
-		Match:              match,
-		Movie:              movie,
-		SourcePath:         match.Path,
-		TargetDir:          targetDir,
-		TargetFile:         pc.FileName,
-		TargetPath:         targetPath,
-		WillMove:           willMove,
-		Conflicts:          conflicts,
-		InPlace:            inPlace,
-		OldDir:             oldDir,
-		IsDedicated:        isDedicated,
-		SkipInPlaceReason:  skipInPlaceReason,
-		FolderName:         folderName,
-		SubfolderPath:      "",
-		BaseFileName:       resolveBaseFileName(s.config, s.templateEngine, movie, match),
-		PreserveSourcePath: false,
-		RenameFolder:       inPlace,
-		strategy:           strategyInPlace,
-		executeStrategy:    s,
-		moveFiles:          true,
+		Match:               match,
+		Movie:               movie,
+		SourcePath:          match.Path,
+		TargetDir:           targetDir,
+		TargetFile:          pc.FileName,
+		TargetPath:          targetPath,
+		WillMove:            willMove,
+		Conflicts:           conflicts,
+		InPlace:             inPlace,
+		OldDir:              oldDir,
+		IsDedicated:         isDedicated,
+		SkipInPlaceReason:   skipInPlaceReason,
+		FolderName:          folderName,
+		SubfolderPath:       "",
+		BaseFileName:        resolveBaseFileName(s.config, s.templateEngine, movie, match),
+		PreserveSourcePath:  false,
+		RenameFolder:        inPlace,
+		strategy:            strategyInPlace,
+		executeStrategy:     s,
+		moveFiles:           true,
+		overwriteAuthorized: forceUpdate,
 	}, nil
 }
 
@@ -220,67 +222,126 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 	}
 
 	if plan.InPlace {
-		info, err := s.fs.Stat(plan.OldDir)
-		if err != nil {
-			result.Error = fmt.Errorf("failed to stat old directory: %w", err)
-			return result, result.Error
-		}
-		if !info.IsDir() {
-			result.Error = fmt.Errorf("old path is not a directory: %s", plan.OldDir)
-			return result, result.Error
-		}
+		// The WHOLE directory sequence — stat, renames, inner file step, and any rollback —
+		// runs while holding BOTH the TargetDir and TargetPath locks, acquired up front in
+		// sorted-key order: a sibling worker locking only the child path can never write a
+		// file between the directory rename and the inner file step, so rollback can never
+		// displace a sibling's entry.
+		err := withDestFileLocks([]string{plan.TargetDir, plan.TargetPath}, func() error {
+			info, err := s.fs.Stat(plan.OldDir)
+			if err != nil {
+				return fmt.Errorf("failed to stat old directory: %w", err)
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("old path is not a directory: %s", plan.OldDir)
+			}
 
-		if _, err := s.fs.Stat(plan.TargetDir); err == nil {
-			// NOTE: TOCTOU race — targetDir could be created between this Stat check and the
-			// Rename below. This is a known limitation mitigated by the Plan-phase conflict check,
-			// which validates exclusivity before Execute runs. A filesystem-level atomic rename
-			// would be required to fully eliminate this window.
-			oldInfo, oldErr := s.fs.Stat(plan.OldDir)
-			if oldErr == nil {
-				newInfo, newErr := s.fs.Stat(plan.TargetDir)
-				if newErr == nil && os.SameFile(oldInfo, newInfo) {
+			dirExists := false
+			if lst, ok := s.fs.(afero.Lstater); ok {
+				info, didLstat, statErr := lst.LstatIfPossible(plan.TargetDir)
+				switch {
+				case statErr == nil:
+					dirExists = true
+					// didLstat=false means info came from a link-following Stat: re-probe with
+					// readlink so a non-dangling symlink (possibly pointing at OldDir, which
+					// would pass the os.SameFile check below) is not treated as the real dir.
+					if info.Mode()&os.ModeSymlink != 0 || (!didLstat && symlinkObjectExists(s.fs, plan.TargetDir)) {
+						return fmt.Errorf("target directory is a symlink: %s", plan.TargetDir)
+					}
+				case !errors.Is(statErr, os.ErrNotExist):
+					return fmt.Errorf("failed to check target directory: %w", statErr)
+				case !didLstat && symlinkObjectExists(s.fs, plan.TargetDir):
+					// link-following Stat fallback would hide a dangling symlink object
+					return fmt.Errorf("target directory is a symlink: %s", plan.TargetDir)
+				}
+			} else if _, statErr := s.fs.Stat(plan.TargetDir); statErr == nil {
+				if symlinkObjectExists(s.fs, plan.TargetDir) {
+					return fmt.Errorf("target directory is a symlink: %s", plan.TargetDir)
+				}
+				dirExists = true
+			} else if !errors.Is(statErr, os.ErrNotExist) {
+				return fmt.Errorf("failed to check target directory: %w", statErr)
+			} else if symlinkObjectExists(s.fs, plan.TargetDir) {
+				return fmt.Errorf("target directory is a symlink: %s", plan.TargetDir)
+			}
+			if dirExists {
+				oldInfo, oldErr := s.fs.Stat(plan.OldDir)
+				if oldErr == nil {
+					newInfo, newErr := s.fs.Stat(plan.TargetDir)
+					if newErr == nil && os.SameFile(oldInfo, newInfo) {
+					} else {
+						return fmt.Errorf("target directory already exists: %s", plan.TargetDir)
+					}
 				} else {
-					result.Error = fmt.Errorf("target directory already exists: %s", plan.TargetDir)
-					return result, result.Error
+					return fmt.Errorf("target directory already exists: %s", plan.TargetDir)
 				}
-			} else {
-				result.Error = fmt.Errorf("target directory already exists: %s", plan.TargetDir)
-				return result, result.Error
 			}
-		}
 
-		if err := s.fs.Rename(plan.OldDir, plan.TargetDir); err != nil {
-			result.Error = fmt.Errorf("failed to rename directory: %w", err)
+			if err := s.fs.Rename(plan.OldDir, plan.TargetDir); err != nil {
+				return fmt.Errorf("failed to rename directory: %w", err)
+			}
+
+			result.InPlaceRenamed = true
+			result.OldDirectoryPath = plan.OldDir
+			result.NewDirectoryPath = plan.TargetDir
+
+			oldFileName := plan.Match.Name
+			if oldFileName == "" {
+				oldFileName = filepath.Base(plan.SourcePath)
+			}
+			currentFilePath := filepath.Join(plan.TargetDir, oldFileName)
+			if currentFilePath != plan.TargetPath {
+				// Both destination locks are already held (see above), so no sibling can slip a
+				// file into the renamed directory at plan.TargetPath between the directory
+				// rename and this inner step — refuse-then-rename with rollback is atomic.
+				if !plan.overwriteAuthorized {
+					lexicalSelf, sameIn, e2 := refuseExistingDestination(s.fs, currentFilePath, plan.TargetPath)
+					if e2 != nil {
+						if rb := s.fs.Rename(plan.TargetDir, plan.OldDir); rb != nil {
+							logging.Errorf("[in-place] Failed to rollback directory rename %s → %s: %v", plan.TargetDir, plan.OldDir, rb)
+						}
+						return e2
+					}
+					if lexicalSelf || sameIn {
+						return nil // inner target names the same file — nothing to rename
+					}
+				}
+				if err := s.fs.Rename(currentFilePath, plan.TargetPath); err != nil {
+					if rb := s.fs.Rename(plan.TargetDir, plan.OldDir); rb != nil {
+						logging.Errorf("[in-place] Failed to rollback directory rename %s → %s: %v", plan.TargetDir, plan.OldDir, rb)
+					}
+					return fmt.Errorf("failed to rename file after directory rename: %w", err)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			result.Error = err
 			return result, result.Error
 		}
-
-		result.InPlaceRenamed = true
-		result.OldDirectoryPath = plan.OldDir
-		result.NewDirectoryPath = plan.TargetDir
-
-		oldFileName := plan.Match.Name
-		if oldFileName == "" {
-			oldFileName = filepath.Base(plan.SourcePath)
-		}
-		currentFilePath := filepath.Join(plan.TargetDir, oldFileName)
-		if currentFilePath != plan.TargetPath {
-			if err := s.fs.Rename(currentFilePath, plan.TargetPath); err != nil {
-				if rollbackErr := s.fs.Rename(plan.TargetDir, plan.OldDir); rollbackErr != nil {
-					logging.Errorf("[in-place] Failed to rollback directory rename %s → %s: %v", plan.TargetDir, plan.OldDir, rollbackErr)
-				}
-				result.Error = fmt.Errorf("failed to rename file after directory rename: %w", err)
-				return result, result.Error
-			}
-		}
-
 		result.Moved = true
+		return result, nil
 	} else {
-		if err := s.fs.MkdirAll(plan.TargetDir, config.DirPerm); err != nil {
-			result.Error = fmt.Errorf("failed to create directory: %w", err)
-			return result, result.Error
-		}
-
-		if err := fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
+		// Lock the parent directory alongside the target path: an in-place directory
+		// rename elsewhere holds {TargetDir, TargetPath} for its whole sequence, and a
+		// bare TargetPath lock alone would let this move land inside a renamed (possibly
+		// about-to-rollback) directory. Sorted acquisition keeps every site cycle-free.
+		err := withDestFileLocks([]string{plan.TargetDir, plan.TargetPath}, func() error {
+			if !plan.overwriteAuthorized {
+				lexicalSelf, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
+				if err != nil {
+					return err
+				}
+				if lexicalSelf || sameIn {
+					return nil
+				}
+			}
+			if err := s.fs.MkdirAll(plan.TargetDir, config.DirPerm); err != nil {
+				return fmt.Errorf("failed to create directory: %w", err)
+			}
+			return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
+		})
+		if err != nil {
 			result.Error = fmt.Errorf("failed to move file: %w", err)
 			return result, result.Error
 		}

--- a/internal/organizer/strategy_inplace.go
+++ b/internal/organizer/strategy_inplace.go
@@ -266,13 +266,14 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 			}
 			if dirExists {
 				oldInfo, oldErr := s.fs.Stat(plan.OldDir)
+				sameDir := false
 				if oldErr == nil {
 					newInfo, newErr := s.fs.Stat(plan.TargetDir)
-					if newErr == nil && os.SameFile(oldInfo, newInfo) {
-					} else {
-						return fmt.Errorf("target directory already exists: %s", plan.TargetDir)
-					}
-				} else {
+					// Same directory reached through another name (alias/symlink): falling
+					// through is the no-op case — anything else is a real conflict.
+					sameDir = newErr == nil && os.SameFile(oldInfo, newInfo)
+				}
+				if !sameDir {
 					return fmt.Errorf("target directory already exists: %s", plan.TargetDir)
 				}
 			}

--- a/internal/organizer/strategy_inplace_miss_test.go
+++ b/internal/organizer/strategy_inplace_miss_test.go
@@ -2,6 +2,7 @@ package organizer
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/matcher"
@@ -165,13 +166,16 @@ func TestInPlaceStrategy_Execute_SameFileCheck(t *testing.T) {
 	}
 
 	result, err := strategy.Execute(plan)
-	// MemMapFs doesn't support os.SameFile properly, so this will fail with
-	// "target directory already exists" — this is expected behavior for the test
-	// environment. On a real filesystem, os.SameFile would detect the same inode.
-	if err != nil {
-		assert.Contains(t, err.Error(), "target directory already exists")
-		assert.False(t, result.Moved)
-	}
+	// MemMapFs FileInfo.Sys() is nil, so os.SameFile never recognizes the alias and the
+	// dir-exists guard refuses deterministically. An unexpected nil error here would mean
+	// the guard silently regressed, so require it rather than tolerating it.
+	require.Error(t, err, "same-dir in-place plan must conflict on MemMapFs where os.SameFile cannot detect identity")
+	require.NotNil(t, result)
+	assert.Contains(t, err.Error(), "target directory already exists")
+	assert.False(t, result.Moved)
+	data, rerr := afero.ReadFile(fs, "/source/ABC-123/ABC-123.mp4")
+	require.NoError(t, rerr, "source must remain untouched after refusal")
+	assert.Equal(t, []byte("video"), data)
 }
 
 func TestInPlaceStrategy_Execute_RollbackOnFileRenameFailure(t *testing.T) {
@@ -198,16 +202,20 @@ func TestInPlaceStrategy_Execute_RollbackOnFileRenameFailure(t *testing.T) {
 	}
 
 	result, err := strategy.Execute(plan)
-	// The rename from currentFilePath to targetPath should fail
-	// since targetPath is a directory path without filename
-	// This triggers the rollback path
-	if err != nil {
-		assert.Contains(t, err.Error(), "failed to rename file")
-		// Verify the old directory was restored (rollback)
-		exists, _ := afero.Exists(fs, "/source/old-folder")
-		assert.True(t, exists, "Old directory should be restored after rollback")
-	}
-	_ = result
+	// The rename from currentFilePath to targetPath must fail since targetPath is a
+	// directory path without filename — an implementation returning success here would
+	// indicate the inner rename (and its refuse guard) never ran.
+	require.Error(t, err, "inner rename to an empty target filename must fail")
+	require.NotNil(t, result)
+	isRenameOrConflict := strings.Contains(err.Error(), "failed to rename file") || strings.Contains(err.Error(), "refusing to overwrite")
+	assert.True(t, isRenameOrConflict, "expected rename-or-conflict error, got: %v", err)
+	assert.False(t, result.Moved)
+	// Verify the old directory was restored (rollback)
+	exists, _ := afero.Exists(fs, "/source/old-folder")
+	assert.True(t, exists, "Old directory should be restored after rollback")
+	src, serr := afero.ReadFile(fs, "/source/old-folder/old-name.mp4")
+	require.NoError(t, serr, "source file must survive the rollback")
+	assert.Equal(t, []byte("video"), src)
 }
 
 func TestInPlaceStrategy_Execute_MkdirAllFails(t *testing.T) {
@@ -288,10 +296,10 @@ func TestInPlaceStrategy_Plan_InPlaceConflictWithForceUpdate(t *testing.T) {
 	plan, err := strategy.Plan(match, movie, "/dest", false)
 	require.NoError(t, err)
 	assert.True(t, plan.InPlace, "Should be InPlace for dedicated folder")
-	// Conflicts should include targetDir since it exists and is not same as oldDir
-	if len(plan.Conflicts) > 0 {
-		assert.Contains(t, plan.Conflicts, filepath.FromSlash("/source/ABC-123"))
-	}
+	// Conflicts MUST include targetDir since it exists and is not same as oldDir —
+	// requiring the entry unconditionally catches a conflict-detection regression that
+	// reports an empty list.
+	require.Contains(t, plan.Conflicts, filepath.FromSlash("/source/ABC-123"), "existing distinct targetDir must appear in plan conflicts")
 }
 
 func TestInPlaceStrategy_Execute_OldDirStatFailsOnSameFileCheck(t *testing.T) {

--- a/internal/organizer/strategy_inplace_norenamefolder.go
+++ b/internal/organizer/strategy_inplace_norenamefolder.go
@@ -99,20 +99,23 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 		ShouldGenerateMetadata: true,
 	}
 
-	// See strategy_inplace.go: the parent directory is locked alongside the target
-	// path so this move can never land inside a directory a concurrent in-place op is
-	// renaming (sorted acquisition keeps every site cycle-free).
-	err := withDestFileLocks([]string{plan.TargetDir, plan.TargetPath}, func() error {
-		if !plan.overwriteAuthorized {
-			lexicalSelf, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
-			if err != nil {
-				return err
+	// Shared parent-directory lock + target-file lock (dir before file): an in-place
+	// rename elsewhere drains shared holders before moving the directory, so this move
+	// never lands inside a renamed (possibly about-to-rollback) directory — while
+	// concurrent copies into the same directory stay parallel.
+	err := withDestDirSharedLock(plan.TargetDir, func() error {
+		return withDestFileLock(plan.TargetPath, func() error {
+			if !plan.overwriteAuthorized {
+				lexicalSelf, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
+				if err != nil {
+					return err
+				}
+				if lexicalSelf || sameIn {
+					return nil
+				}
 			}
-			if lexicalSelf || sameIn {
-				return nil
-			}
-		}
-		return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
+			return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
+		})
 	})
 	if err != nil {
 		result.Error = fmt.Errorf("failed to rename file: %w", err)

--- a/internal/organizer/strategy_inplace_norenamefolder.go
+++ b/internal/organizer/strategy_inplace_norenamefolder.go
@@ -65,26 +65,27 @@ func (s *inPlaceNoRenameFolderStrategy) Plan(match models.FileMatchInfo, movie *
 	conflicts := checkTargetConflict(s.fs, match.Path, targetPath, forceUpdate, willMove)
 
 	return &OrganizePlan{
-		Match:              match,
-		Movie:              movie,
-		SourcePath:         match.Path,
-		TargetDir:          targetDir,
-		TargetFile:         pc.FileName,
-		TargetPath:         targetPath,
-		WillMove:           willMove,
-		Conflicts:          conflicts,
-		InPlace:            false,
-		OldDir:             "",
-		IsDedicated:        false,
-		SkipInPlaceReason:  "in-place-norenamefolder mode - file rename only",
-		FolderName:         "",
-		SubfolderPath:      "",
-		BaseFileName:       resolveBaseFileName(s.config, s.templateEngine, movie, match),
-		PreserveSourcePath: true,
-		RenameFolder:       false,
-		strategy:           strategyInPlaceNoRenameFolder,
-		executeStrategy:    s,
-		moveFiles:          true,
+		Match:               match,
+		Movie:               movie,
+		SourcePath:          match.Path,
+		TargetDir:           targetDir,
+		TargetFile:          pc.FileName,
+		TargetPath:          targetPath,
+		WillMove:            willMove,
+		Conflicts:           conflicts,
+		InPlace:             false,
+		OldDir:              "",
+		IsDedicated:         false,
+		SkipInPlaceReason:   "in-place-norenamefolder mode - file rename only",
+		FolderName:          "",
+		SubfolderPath:       "",
+		BaseFileName:        resolveBaseFileName(s.config, s.templateEngine, movie, match),
+		PreserveSourcePath:  true,
+		RenameFolder:        false,
+		strategy:            strategyInPlaceNoRenameFolder,
+		executeStrategy:     s,
+		moveFiles:           true,
+		overwriteAuthorized: forceUpdate,
 	}, nil
 }
 
@@ -98,7 +99,22 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 		ShouldGenerateMetadata: true,
 	}
 
-	if err := fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
+	// See strategy_inplace.go: the parent directory is locked alongside the target
+	// path so this move can never land inside a directory a concurrent in-place op is
+	// renaming (sorted acquisition keeps every site cycle-free).
+	err := withDestFileLocks([]string{plan.TargetDir, plan.TargetPath}, func() error {
+		if !plan.overwriteAuthorized {
+			lexicalSelf, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
+			if err != nil {
+				return err
+			}
+			if lexicalSelf || sameIn {
+				return nil
+			}
+		}
+		return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
+	})
+	if err != nil {
 		result.Error = fmt.Errorf("failed to rename file: %w", err)
 		return result, result.Error
 	}

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -66,29 +65,69 @@ func withDestFileLock(path string, fn func() error) error {
 	return fn()
 }
 
-// withDestFileLocks acquires destination locks for multiple paths with respect to other
-// multi-acquisitions: keys are cleaned, deduplicated, and acquired in sorted order so
-// concurrent operations can never form a hold-and-wait cycle.
-func withDestFileLocks(paths []string, fn func() error) error {
-	seen := make(map[string]struct{}, len(paths))
-	keys := make([]string, 0, len(paths))
-	for _, p := range paths {
-		k := filepath.Clean(p)
-		if _, dup := seen[k]; dup {
-			continue
-		}
-		seen[k] = struct{}{}
-		keys = append(keys, k)
+// dirOperationLocks coordinate directory-scope operations: a directory RENAME
+// (in-place organize) takes the exclusive lock, while any child-file operation inside
+// that directory takes the shared lock. Shared locks let unrelated copies into one
+// directory proceed concurrently; a rename (or its rollback) waits until all child
+// writes have drained, so it can never drag a freshly landed file to a path its owner
+// no longer expects. Entries are ref-counted exactly like operationLocks.
+type destDirLock struct {
+	mu   sync.RWMutex
+	refs int
+}
+
+type destDirLocker struct {
+	mu    sync.Mutex
+	items map[string]*destDirLock
+}
+
+var dirOperationLocks destDirLocker
+
+func withDestDirLock(dir string, exclusive bool, fn func() error) error {
+	key := filepath.Clean(dir)
+	dirOperationLocks.mu.Lock()
+	if dirOperationLocks.items == nil {
+		dirOperationLocks.items = make(map[string]*destDirLock)
 	}
-	sort.Strings(keys)
-	var run func(i int) error
-	run = func(i int) error {
-		if i == len(keys) {
-			return fn()
-		}
-		return withDestFileLock(keys[i], func() error { return run(i + 1) })
+	l := dirOperationLocks.items[key]
+	if l == nil {
+		l = &destDirLock{}
+		dirOperationLocks.items[key] = l
 	}
-	return run(0)
+	l.refs++
+	dirOperationLocks.mu.Unlock()
+
+	if exclusive {
+		l.mu.Lock()
+	} else {
+		l.mu.RLock()
+	}
+	defer func() {
+		if exclusive {
+			l.mu.Unlock()
+		} else {
+			l.mu.RUnlock()
+		}
+		dirOperationLocks.mu.Lock()
+		l.refs--
+		if l.refs == 0 && dirOperationLocks.items[key] == l {
+			delete(dirOperationLocks.items, key)
+		}
+		dirOperationLocks.mu.Unlock()
+	}()
+	return fn()
+}
+
+// withDestDirExclusiveLock serializes a directory-rename operation against every
+// child write already inside that directory and vice versa.
+func withDestDirExclusiveLock(dir string, fn func() error) error {
+	return withDestDirLock(dir, true, fn)
+}
+
+// withDestDirSharedLock lets independent child writes into one directory run in
+// parallel while excluding a concurrent rename of the directory itself.
+func withDestDirSharedLock(dir string, fn func() error) error {
+	return withDestDirLock(dir, false, fn)
 }
 
 // refuseExistingDestination enforces no-clobber at execution time with lexical-self vs
@@ -333,7 +372,12 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 			return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
 		}
 
-		err := withDestFileLocks([]string{plan.TargetDir, plan.TargetPath}, move)
+		// Shared dir lock: concurrent organizes into one directory proceed in parallel
+		// (only the per-file lock serializes same-file collisions), while an in-place
+		// directory rename elsewhere drains us before it may move the directory.
+		err := withDestDirSharedLock(plan.TargetDir, func() error {
+			return withDestFileLock(plan.TargetPath, move)
+		})
 		if err != nil {
 			result.Error = err
 			return result, result.Error
@@ -359,80 +403,81 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 	// Every destination-touching step runs under the destination lock: unauthorized
 	// paths guard inside it (a plain copy would otherwise overwrite a late-created file),
 	// and authorized Remove+link work must serialize against concurrent guarded calls.
-	// The parent directory is locked too: an in-place directory rename elsewhere holds
-	// {TargetDir, TargetPath} for its whole sequence, and a bare TargetPath lock alone
-	// would let this op land inside a renamed (possibly about-to-rollback) directory.
-	err := withDestFileLocks([]string{plan.TargetDir, plan.TargetPath}, func() error {
-		dstSameInode := false
-		dstLexicalSelf := false
-		// Always classify: lexical-self aliases must never be removed (any authorization
-		// mode), and unauthorized operations refuse any different-file destination.
-		{
-			self, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
-			if err != nil {
-				if !plan.overwriteAuthorized {
-					return err
-				}
-				// Authorized mode: classification failures are benign (overwrite intended).
-			} else {
-				dstLexicalSelf = self
-				dstSameInode = sameIn
-			}
-		}
-
-		if err := s.fs.MkdirAll(plan.TargetDir, config.DirPerm); err != nil {
-			return fmt.Errorf("failed to create directory: %w", err)
-		}
-
-		// Remove an existing target ONLY for an authorized replacement. Unauthorized
-		// paths never remove (their conversion output of choice must be won via
-		// refusal-and-fail). A lexical self-path is also never removed.
-		// Same-inode hardlinks under unauthorized mode are idempotent (returned early).
-		if plan.LinkMode != LinkModeNone && !dstLexicalSelf && plan.overwriteAuthorized {
-			if err := s.fs.Remove(plan.TargetPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("failed to prepare target path for link: %w", err)
-			}
-		}
-
-		if dstLexicalSelf || (dstSameInode && !plan.overwriteAuthorized && plan.LinkMode == LinkModeHard) {
-			return nil // self-path or already-satisfied hardlink output — idempotent
-		}
-
-		switch plan.LinkMode {
-		case LinkModeHard:
-			if err := s.linker.hardlink(plan.SourcePath, plan.TargetPath); err != nil {
-				if errors.Is(err, syscall.EXDEV) {
-					return fmt.Errorf("failed to create hard link (source and destination must be on the same filesystem): %w", err)
-				}
-				if errors.Is(err, os.ErrPermission) {
-					return fmt.Errorf("failed to create hard link (permission denied): %w", err)
-				}
-				return fmt.Errorf("failed to create hard link: %w", err)
-			}
-		case LinkModeSoft:
-			linkTarget := plan.SourcePath
-			if !filepath.IsAbs(linkTarget) {
-				abs, err := filepath.Abs(linkTarget)
+	// The shared parent-directory lock keeps concurrent copies into the same directory
+	// parallel while an in-place directory rename (exclusive holder) drains us first.
+	err := withDestDirSharedLock(plan.TargetDir, func() error {
+		return withDestFileLock(plan.TargetPath, func() error {
+			dstSameInode := false
+			dstLexicalSelf := false
+			// Always classify: lexical-self aliases must never be removed (any authorization
+			// mode), and unauthorized operations refuse any different-file destination.
+			{
+				self, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
 				if err != nil {
-					return fmt.Errorf("failed to resolve source path for symlink: %w", err)
+					if !plan.overwriteAuthorized {
+						return err
+					}
+					// Authorized mode: classification failures are benign (overwrite intended).
+				} else {
+					dstLexicalSelf = self
+					dstSameInode = sameIn
 				}
-				linkTarget = abs
 			}
-			if err := s.linker.symlink(linkTarget, plan.TargetPath); err != nil {
-				if errors.Is(err, os.ErrPermission) {
-					return fmt.Errorf("failed to create soft link%s: %w", softLinkPermDeniedHint, err)
+
+			if err := s.fs.MkdirAll(plan.TargetDir, config.DirPerm); err != nil {
+				return fmt.Errorf("failed to create directory: %w", err)
+			}
+
+			// Remove an existing target ONLY for an authorized replacement. Unauthorized
+			// paths never remove (their conversion output of choice must be won via
+			// refusal-and-fail). A lexical self-path is also never removed.
+			// Same-inode hardlinks under unauthorized mode are idempotent (returned early).
+			if plan.LinkMode != LinkModeNone && !dstLexicalSelf && plan.overwriteAuthorized {
+				if err := s.fs.Remove(plan.TargetPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf("failed to prepare target path for link: %w", err)
 				}
-				return fmt.Errorf("failed to create soft link: %w", err)
 			}
-		default:
-			if dstSameInode && !plan.overwriteAuthorized {
-				return nil
+
+			if dstLexicalSelf || (dstSameInode && !plan.overwriteAuthorized && plan.LinkMode == LinkModeHard) {
+				return nil // self-path or already-satisfied hardlink output — idempotent
 			}
-			if err := s.linker.copyFile(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
-				return fmt.Errorf("failed to copy file: %w", err)
+
+			switch plan.LinkMode {
+			case LinkModeHard:
+				if err := s.linker.hardlink(plan.SourcePath, plan.TargetPath); err != nil {
+					if errors.Is(err, syscall.EXDEV) {
+						return fmt.Errorf("failed to create hard link (source and destination must be on the same filesystem): %w", err)
+					}
+					if errors.Is(err, os.ErrPermission) {
+						return fmt.Errorf("failed to create hard link (permission denied): %w", err)
+					}
+					return fmt.Errorf("failed to create hard link: %w", err)
+				}
+			case LinkModeSoft:
+				linkTarget := plan.SourcePath
+				if !filepath.IsAbs(linkTarget) {
+					abs, err := filepath.Abs(linkTarget)
+					if err != nil {
+						return fmt.Errorf("failed to resolve source path for symlink: %w", err)
+					}
+					linkTarget = abs
+				}
+				if err := s.linker.symlink(linkTarget, plan.TargetPath); err != nil {
+					if errors.Is(err, os.ErrPermission) {
+						return fmt.Errorf("failed to create soft link%s: %w", softLinkPermDeniedHint, err)
+					}
+					return fmt.Errorf("failed to create soft link: %w", err)
+				}
+			default:
+				if dstSameInode && !plan.overwriteAuthorized {
+					return nil
+				}
+				if err := s.linker.copyFile(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
+					return fmt.Errorf("failed to copy file: %w", err)
+				}
 			}
-		}
-		return nil
+			return nil
+		})
 	})
 	if err != nil {
 		result.Error = err

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/javinizer/javinizer-go/internal/config"
@@ -15,6 +17,171 @@ import (
 	"github.com/javinizer/javinizer-go/internal/template"
 	"github.com/spf13/afero"
 )
+
+// operationLocks serializes destination-touching operations per destination so a
+// concurrent batch worker cannot slip a file between the existence check and the move
+// (TOCTOU). Entries are ref-counted: a lock stays registered while any goroutine waits
+// on it and is removed only once the last reference drops, which is race-free (unlike
+// try-lock delete flows that can unlink an entry with a waiter or a replacement).
+// Known residual (centralized hardening tracked separately as #224): keys are
+// lexically cleaned only, so symlink/case aliases of one destination can acquire
+// different locks.
+type destFileLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+type destFileLocker struct {
+	mu    sync.Mutex
+	items map[string]*destFileLock
+}
+
+var operationLocks destFileLocker
+
+func withDestFileLock(path string, fn func() error) error {
+	key := filepath.Clean(path)
+	operationLocks.mu.Lock()
+	if operationLocks.items == nil {
+		operationLocks.items = make(map[string]*destFileLock)
+	}
+	l := operationLocks.items[key]
+	if l == nil {
+		l = &destFileLock{}
+		operationLocks.items[key] = l
+	}
+	l.refs++
+	operationLocks.mu.Unlock()
+
+	l.mu.Lock()
+	defer func() {
+		l.mu.Unlock()
+		operationLocks.mu.Lock()
+		l.refs--
+		if l.refs == 0 {
+			if operationLocks.items[key] == l {
+				delete(operationLocks.items, key)
+			}
+		}
+		operationLocks.mu.Unlock()
+	}()
+	return fn()
+}
+
+// withDestFileLocks acquires destination locks for multiple paths with respect to other
+// multi-acquisitions: keys are cleaned, deduplicated, and acquired in sorted order so
+// concurrent operations can never form a hold-and-wait cycle.
+func withDestFileLocks(paths []string, fn func() error) error {
+	seen := make(map[string]struct{}, len(paths))
+	keys := make([]string, 0, len(paths))
+	for _, p := range paths {
+		k := filepath.Clean(p)
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var run func(i int) error
+	run = func(i int) error {
+		if i == len(keys) {
+			return fn()
+		}
+		return withDestFileLock(keys[i], func() error { return run(i + 1) })
+	}
+	return run(0)
+}
+
+// refuseExistingDestination enforces no-clobber at execution time with lexical-self vs
+// hardlink-alias distinction: identical lexical paths (./file vs file) are identical=true —
+// operators must not touch the destination at all; a DIFFERENT path to the same inode
+// (hardlink alias) is sameInode=true and may no-op when its output type is satisfied.
+// A destination symlink object (even dangling) or an existing directory always conflicts;
+// so does a different file. Same-directory ENTRY aliases (path reaching the identical
+// directory entry through lexically distinct routes like symlinks in ancestors or case
+// folding on a case-insensitive FS) are identical=true so they're never removed.
+// Identity is evaluated with no-follow Lstat on both sides; the source's own symlink
+// status is Mint vital — a source symlink pointing at the destination's regular inode
+// is NOT an alias (it doesn't share that destination's name-bearing link).
+func refuseExistingDestination(fs afero.Fs, src, dst string) (identical, sameInode bool, err error) {
+	if filepath.Clean(src) == filepath.Clean(dst) {
+		return true, true, nil
+	}
+	var lstatDst, lstatSrc os.FileInfo
+	var dstErr, srcErr error
+	// dstLstat/srcLstat record whether the filesystem actually performed an Lstat.
+	// Symlink checks are trustworthy only when true; when false the values are Stat-based.
+	var dstLstat, srcLstat bool
+	if lst, ok := fs.(afero.Lstater); ok {
+		var didDst, didSrc bool
+		lstatDst, didDst, dstErr = lst.LstatIfPossible(dst)
+		lstatSrc, didSrc, srcErr = lst.LstatIfPossible(src)
+		dstLstat, srcLstat = didDst, didSrc
+	} else {
+		lstatDst, dstErr = fs.Stat(dst)
+		lstatSrc, srcErr = fs.Stat(src)
+	}
+	// A filesystem whose Stat follows links reports a DANGLING destination symlink as
+	// absent. Whenever the destination came from a following lookup (no Lstater, or
+	// LstatIfPossible reporting didLstat=false), probe ReadlinkIfPossible so an
+	// unauthorized operation never silently replaces a symlink object.
+	if dstErr != nil && errors.Is(dstErr, os.ErrNotExist) && !dstLstat && symlinkObjectExists(fs, dst) {
+		return false, false, fmt.Errorf("file already exists at destination (refusing to overwrite): %s", dst)
+	}
+	if dstErr == nil {
+		if dstLstat && lstatDst.Mode()&os.ModeSymlink != 0 {
+			return false, false, fmt.Errorf("file already exists at destination (refusing to overwrite): %s", dst)
+		}
+		if lstatDst.IsDir() {
+			return false, false, fmt.Errorf("file already exists at destination (refusing to overwrite): %s", dst)
+		}
+		if srcErr != nil || (srcLstat && lstatSrc.Mode()&os.ModeSymlink != 0) || !os.SameFile(lstatSrc, lstatDst) {
+			return false, false, fmt.Errorf("file already exists at destination (refusing to overwrite): %s", dst)
+		}
+		return false, true, nil
+	}
+	if !errors.Is(dstErr, os.ErrNotExist) {
+		return false, false, fmt.Errorf("failed to check destination: %w", dstErr)
+	}
+	return false, false, nil
+}
+
+// symlinkObjectExists probes path specifically for a symlink OBJECT (including dangling
+// ones) on filesystems whose Stat follows links — where a dangling symlink otherwise
+// masquerades as not-exists.
+func symlinkObjectExists(fs afero.Fs, path string) bool {
+	lr, ok := fs.(afero.LinkReader)
+	if !ok {
+		return false
+	}
+	_, err := lr.ReadlinkIfPossible(path)
+	return err == nil
+}
+
+// pathExistsBestEffort reports whether path names any directory entry — file, directory,
+// or symlink object (even dangling) — regardless of whether the filesystem supports a
+// true Lstat; a Stat-following lookup alone would miss a dangling symlink.
+func pathExistsBestEffort(fs afero.Fs, path string) (bool, error) {
+	if lst, ok := fs.(afero.Lstater); ok {
+		_, didLstat, err := lst.LstatIfPossible(path)
+		switch {
+		case err == nil:
+			return true, nil
+		case !errors.Is(err, os.ErrNotExist):
+			return false, err
+		case didLstat:
+			// true Lstat miss: genuinely absent — no fallback probe needed
+			return false, nil
+		}
+		// didLstat=false: fs fell back to a link-following Stat; a dangling symlink
+		// would hide here, so probe readlink below.
+	} else if _, err := fs.Stat(path); err == nil {
+		return true, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	return symlinkObjectExists(fs, path), nil
+}
 
 type organizeStrategy struct {
 	fs             afero.Fs
@@ -108,26 +275,27 @@ func (s *organizeStrategy) Plan(match models.FileMatchInfo, movie *models.Movie,
 	}
 
 	return &OrganizePlan{
-		Match:              match,
-		Movie:              movie,
-		SourcePath:         match.Path,
-		TargetDir:          targetDir,
-		TargetFile:         pc.FileName,
-		TargetPath:         targetPath,
-		WillMove:           willMove,
-		Conflicts:          conflicts,
-		InPlace:            false,
-		OldDir:             "",
-		IsDedicated:        false,
-		SkipInPlaceReason:  "organize mode - always move to destination",
-		FolderName:         folderName,
-		SubfolderPath:      subfolderPath,
-		BaseFileName:       resolveBaseFileName(s.config, s.templateEngine, movie, match),
-		PreserveSourcePath: false,
-		RenameFolder:       false,
-		strategy:           strategyOrganize,
-		executeStrategy:    s,
-		moveFiles:          true,
+		Match:               match,
+		Movie:               movie,
+		SourcePath:          match.Path,
+		TargetDir:           targetDir,
+		TargetFile:          pc.FileName,
+		TargetPath:          targetPath,
+		WillMove:            willMove,
+		Conflicts:           conflicts,
+		InPlace:             false,
+		OldDir:              "",
+		IsDedicated:         false,
+		SkipInPlaceReason:   "organize mode - always move to destination",
+		FolderName:          folderName,
+		SubfolderPath:       subfolderPath,
+		BaseFileName:        resolveBaseFileName(s.config, s.templateEngine, movie, match),
+		PreserveSourcePath:  false,
+		RenameFolder:        false,
+		strategy:            strategyOrganize,
+		executeStrategy:     s,
+		moveFiles:           true,
+		overwriteAuthorized: forceUpdate,
 	}, nil
 }
 
@@ -148,13 +316,27 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 
 	// Move path: moveFiles=true (default) — rename source to target
 	if plan.moveFiles {
-		if err := s.fs.MkdirAll(plan.TargetDir, config.DirPerm); err != nil {
-			result.Error = fmt.Errorf("failed to create directory: %w", err)
-			return result, result.Error
+		move := func() error {
+			if !plan.overwriteAuthorized {
+				identical, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
+				if err != nil {
+					return err
+				}
+				if identical || sameIn {
+					return nil // same path or same file — nothing to move
+				}
+			}
+
+			if err := s.fs.MkdirAll(plan.TargetDir, config.DirPerm); err != nil {
+				return fmt.Errorf("failed to create directory: %w", err)
+			}
+
+			return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
 		}
 
-		if err := fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
-			result.Error = fmt.Errorf("failed to move file: %w", err)
+		err := withDestFileLocks([]string{plan.TargetDir, plan.TargetPath}, move)
+		if err != nil {
+			result.Error = err
 			return result, result.Error
 		}
 
@@ -175,62 +357,93 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 		return result, result.Error
 	}
 
-	// Create target directory
-	if err := s.fs.MkdirAll(plan.TargetDir, config.DirPerm); err != nil {
-		result.Error = fmt.Errorf("failed to create directory: %w", err)
-		return result, result.Error
-	}
-
-	// Remove existing target before creating link
-	if plan.LinkMode != LinkModeNone {
-		if err := s.fs.Remove(plan.TargetPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			result.Error = fmt.Errorf("failed to prepare target path for link: %w", err)
-			return result, result.Error
-		}
-	}
-
-	switch plan.LinkMode {
-	case LinkModeHard:
-		if err := s.linker.hardlink(plan.SourcePath, plan.TargetPath); err != nil {
-			if errors.Is(err, syscall.EXDEV) {
-				result.Error = fmt.Errorf("failed to create hard link (source and destination must be on the same filesystem): %w", err)
-				return result, result.Error
-			}
-			if errors.Is(err, os.ErrPermission) {
-				result.Error = fmt.Errorf("failed to create hard link (permission denied): %w", err)
-				return result, result.Error
-			}
-			result.Error = fmt.Errorf("failed to create hard link: %w", err)
-			return result, result.Error
-		}
-	case LinkModeSoft:
-		linkTarget := plan.SourcePath
-		if !filepath.IsAbs(linkTarget) {
-			abs, err := filepath.Abs(linkTarget)
+	// Every destination-touching step runs under the destination lock: unauthorized
+	// paths guard inside it (a plain copy would otherwise overwrite a late-created file),
+	// and authorized Remove+link work must serialize against concurrent guarded calls.
+	// The parent directory is locked too: an in-place directory rename elsewhere holds
+	// {TargetDir, TargetPath} for its whole sequence, and a bare TargetPath lock alone
+	// would let this op land inside a renamed (possibly about-to-rollback) directory.
+	err := withDestFileLocks([]string{plan.TargetDir, plan.TargetPath}, func() error {
+		dstSameInode := false
+		dstLexicalSelf := false
+		// Always classify: lexical-self aliases must never be removed (any authorization
+		// mode), and unauthorized operations refuse any different-file destination.
+		{
+			self, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
 			if err != nil {
-				result.Error = fmt.Errorf("failed to resolve source path for symlink: %w", err)
-				return result, result.Error
+				if !plan.overwriteAuthorized {
+					return err
+				}
+				// Authorized mode: classification failures are benign (overwrite intended).
+			} else {
+				dstLexicalSelf = self
+				dstSameInode = sameIn
 			}
-			linkTarget = abs
 		}
-		if err := s.linker.symlink(linkTarget, plan.TargetPath); err != nil {
-			if errors.Is(err, os.ErrPermission) && runtime.GOOS == "windows" {
-				result.Error = fmt.Errorf("failed to create soft link (Windows requires Developer Mode or elevated privileges for symlinks): %w", err)
-				return result, result.Error
+
+		if err := s.fs.MkdirAll(plan.TargetDir, config.DirPerm); err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+
+		// Remove an existing target ONLY for an authorized replacement. Unauthorized
+		// paths never remove (their conversion output of choice must be won via
+		// refusal-and-fail). A lexical self-path is also never removed.
+		// Same-inode hardlinks under unauthorized mode are idempotent (returned early).
+		if plan.LinkMode != LinkModeNone && !dstLexicalSelf && plan.overwriteAuthorized {
+			if err := s.fs.Remove(plan.TargetPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("failed to prepare target path for link: %w", err)
 			}
-			if errors.Is(err, os.ErrPermission) {
-				result.Error = fmt.Errorf("failed to create soft link (permission denied): %w", err)
-				return result, result.Error
+		}
+
+		if dstLexicalSelf || (dstSameInode && !plan.overwriteAuthorized && plan.LinkMode == LinkModeHard) {
+			return nil // self-path or already-satisfied hardlink output — idempotent
+		}
+
+		switch plan.LinkMode {
+		case LinkModeHard:
+			if dstSameInode && !plan.overwriteAuthorized {
+				return nil
 			}
-			result.Error = fmt.Errorf("failed to create soft link: %w", err)
-			return result, result.Error
+			if err := s.linker.hardlink(plan.SourcePath, plan.TargetPath); err != nil {
+				if errors.Is(err, syscall.EXDEV) {
+					return fmt.Errorf("failed to create hard link (source and destination must be on the same filesystem): %w", err)
+				}
+				if errors.Is(err, os.ErrPermission) {
+					return fmt.Errorf("failed to create hard link (permission denied): %w", err)
+				}
+				return fmt.Errorf("failed to create hard link: %w", err)
+			}
+		case LinkModeSoft:
+			linkTarget := plan.SourcePath
+			if !filepath.IsAbs(linkTarget) {
+				abs, err := filepath.Abs(linkTarget)
+				if err != nil {
+					return fmt.Errorf("failed to resolve source path for symlink: %w", err)
+				}
+				linkTarget = abs
+			}
+			if err := s.linker.symlink(linkTarget, plan.TargetPath); err != nil {
+				if errors.Is(err, os.ErrPermission) && runtime.GOOS == "windows" {
+					return fmt.Errorf("failed to create soft link (Windows requires Developer Mode or elevated privileges for symlinks): %w", err)
+				}
+				if errors.Is(err, os.ErrPermission) {
+					return fmt.Errorf("failed to create soft link (permission denied): %w", err)
+				}
+				return fmt.Errorf("failed to create soft link: %w", err)
+			}
+		default:
+			if dstSameInode && !plan.overwriteAuthorized {
+				return nil
+			}
+			if err := s.linker.copyFile(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
+				return fmt.Errorf("failed to copy file: %w", err)
+			}
 		}
-	default:
-		// LinkModeNone in copy path: use linker.CopyFile (replaces the manual io.Copy block)
-		if err := s.linker.copyFile(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
-			result.Error = fmt.Errorf("failed to copy file: %w", err)
-			return result, result.Error
-		}
+		return nil
+	})
+	if err != nil {
+		result.Error = err
+		return result, result.Error
 	}
 
 	result.Moved = true

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -401,9 +400,6 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 
 		switch plan.LinkMode {
 		case LinkModeHard:
-			if dstSameInode && !plan.overwriteAuthorized {
-				return nil
-			}
 			if err := s.linker.hardlink(plan.SourcePath, plan.TargetPath); err != nil {
 				if errors.Is(err, syscall.EXDEV) {
 					return fmt.Errorf("failed to create hard link (source and destination must be on the same filesystem): %w", err)
@@ -423,11 +419,8 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				linkTarget = abs
 			}
 			if err := s.linker.symlink(linkTarget, plan.TargetPath); err != nil {
-				if errors.Is(err, os.ErrPermission) && runtime.GOOS == "windows" {
-					return fmt.Errorf("failed to create soft link (Windows requires Developer Mode or elevated privileges for symlinks): %w", err)
-				}
 				if errors.Is(err, os.ErrPermission) {
-					return fmt.Errorf("failed to create soft link (permission denied): %w", err)
+					return fmt.Errorf("failed to create soft link%s: %w", softLinkPermDeniedHint, err)
 				}
 				return fmt.Errorf("failed to create soft link: %w", err)
 			}

--- a/internal/worker/job_runner.go
+++ b/internal/worker/job_runner.go
@@ -62,6 +62,24 @@ func (r *JobRunner) SetRunOptions(scrapeCfg ScrapePhaseConfig, applyCfg ApplyPha
 	r.applyCfg = &applyCfg
 }
 
+// defaultApplyPhaseConfig is the fallback apply configuration used when no explicit
+// apply config is supplied. It deliberately does NOT authorize destination overwrite
+// (ForceUpdate=false) — see the multipart data-loss fix, issue #223.
+func defaultApplyPhaseConfig(destination string) ApplyPhaseConfig {
+	return ApplyPhaseConfig{
+		OrganizeOptions: workflow.OrganizeOptions{
+			MoveFiles:   true,
+			ForceUpdate: false,
+		},
+		MergeOptions: workflow.MergeOptions{
+			ForceOverwrite: true,
+		},
+		Destination: destination,
+		GenerateNFO: true,
+		Download:    true,
+	}
+}
+
 // Run executes the full scrape→apply pipeline sequentially.
 // It runs the scrape phase, checks for completed results, and if any exist,
 // runs the apply phase. Returns nil on success or an error describing
@@ -121,18 +139,7 @@ func (r *JobRunner) Run(ctx context.Context) error {
 		return nil
 	}
 
-	applyCfg := ApplyPhaseConfig{
-		OrganizeOptions: workflow.OrganizeOptions{
-			MoveFiles:   true,
-			ForceUpdate: true,
-		},
-		MergeOptions: workflow.MergeOptions{
-			ForceOverwrite: true,
-		},
-		Destination: status.Destination,
-		GenerateNFO: true,
-		Download:    true,
-	}
+	applyCfg := defaultApplyPhaseConfig(status.Destination)
 	if r.applyCfg != nil {
 		applyCfg = *r.applyCfg
 	}

--- a/internal/worker/job_runner_default_overwrite_test.go
+++ b/internal/worker/job_runner_default_overwrite_test.go
@@ -1,0 +1,16 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression: the JobRunner fallback apply config used by batch jobs must not
+// authorize destination overwrite by default (multipart data-loss fix, issue #223).
+func TestDefaultApplyPhaseConfig_NoOverwriteAuthorization(t *testing.T) {
+	cfg := defaultApplyPhaseConfig("/lib")
+	assert.False(t, cfg.OrganizeOptions.ForceUpdate, "fallback must not authorize overwrite")
+	assert.True(t, cfg.OrganizeOptions.MoveFiles)
+	assert.Equal(t, "/lib", cfg.Destination)
+}

--- a/web/frontend/tests/fullstack/regressions/organize.spec.ts
+++ b/web/frontend/tests/fullstack/regressions/organize.spec.ts
@@ -36,6 +36,7 @@ import {
 	soleResult,
 	DEFAULT_INPUT_DIR,
 	DEFAULT_OUTPUT_DIR,
+	seedInputFiles,
 } from '../helpers';
 
 test.describe('Organize: real apply phase creates destination + subfolder on disk', () => {
@@ -74,6 +75,11 @@ test.describe('Organize: real apply phase creates destination + subfolder on dis
 	}) => {
 		await loginAgainstRealBackend(request);
 
+		// Test isolation: the shared canonical GOOD-001 fixture can already have been
+		// moved out of the input directory by the previous test's (unawaited) organize.
+		// Re-seed this test's input before driving its real apply phase.
+		await seedInputFiles(['GOOD-001.mp4']);
+
 		const job_id = await submitScrape(request, { files: [`${DEFAULT_INPUT_DIR}/GOOD-001.mp4`] });
 		await waitForJobCompletion(request, job_id);
 
@@ -90,8 +96,17 @@ test.describe('Organize: real apply phase creates destination + subfolder on dis
 		await waitForJobCompletion(request, job_id, { timeoutMs: 30_000 });
 
 		// The destination directory must exist + contain a subfolder named
-		// after the movie ID (the FolderFormat template = "<ID>").
-		expect(existsSync(destination), 'destination directory must exist after organize').toBeTruthy();
+		// after the movie ID (the FolderFormat template = "<ID>"). The job's
+		// completed status observed by waitForJobCompletion can be the STALE
+		// terminal state from the scrape phase (the apply phase reuses the job),
+		// so poll the durable signal rather than reading the filesystem in the
+		// instant the waiter returns.
+		await expect
+			.poll(() => existsSync(destination), {
+				message: 'destination directory must appear while the apply phase runs',
+				timeout: 30_000,
+			})
+			.toBeTruthy();
 		const entries = readdirSync(destination);
 		expect(entries, 'destination must contain a per-movie subfolder').toContain('GOOD-001');
 


### PR DESCRIPTION
## Summary

Undetected multipart batch organize operations raced onto one destination path — the loser silently clobbered the winner's bytes, and parallel workers could slip a file between plan-time conflict checks and the move. Fixes #223.

## Root causes & fixes

**Unprivileged overwrite at execution time**
- `refuseExistingDestination`: refuses any pre-existing destination (file, dir, symlink object) when the plan didn't authorize overwrite; distinguishes lexical-self aliases and hardlink same-inode aliases (idempotent no-op, source preserved).
- `symlinkObjectExists` / `pathExistsBestEffort`: catch dangling and link-followed symlinks on filesystems without true Lstat (`afero.Lstater` reporting `didLstat=false`, plain `Stat` fallbacks), via `ReadlinkIfPossible` probes.

**TOCTOU between plan and execute**
- `destFileLocker`: ref-counted per-destination process-wide locks; entries survive while any goroutine waits, no try-lock deletion races.
- `withDestFileLocks`: sorted multi-key acquisition; every destination-touching site locks `{parentDir, destPath}` as a pair (parent is a strict string prefix of child → total order → deadlock-free), covering organize move, organize copy/link, in-place, no-rename-folder in-place, and subtitles.

**In-place directory rename atomicity**
- The whole in-place sequence (stat, dir rename, inner refuse+rename, rollback) runs under both locks held up front — a sibling op can no longer write into a renamed directory mid-sequence and rollback can never displace a sibling's entry.

**Conservative defaults**
- API batch builder and worker job runner now default `ForceUpdate=false`; batch organize refuses clobbering unless the operator explicitly opts into force-update.

## Tests added
- `TestOrganize_UndetectedMultipartSiblings_*` (sequential + plans-first-concurrent race regression; asserts exactly one winner, all losing sources preserved byte-for-byte)
- `renameHookFs`-driven deterministic mid-sequence rival-write test
- Lock-registry overlap/serialization tests (max in-flight = 1, no lock leaks)
- Sibling in-place directory collision race test, subtitle late-create skip test
- Overwrite defaulting tests for the API batch builder and worker job runner

## Notes
- Verified under `-race` on `internal/organizer`, `internal/worker`, `internal/api/batch`.
- Known residual: lock keys are lexically cleaned only (symlink/case aliases of one destination can acquire different locks) — deliberately deferred to #224.
- Reviewed across 10 rounds of an automated review loop (converged to zero findings).

Closes #223.