### PR TITLE
fix(batch): honor rename_file=false for rename-in-place operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Honor the global rename_file setting for the "rename in place" video operation: web batch/apply with rename_file=false now renames only the (dedicated) folder and preserves video file names, instead of silently forcing a file rename. Note: rename_file=false + rename in place + a mixed-ID (non-dedicated) folder is now a no-op by design (#226)
+
 ## [v1.5.1] - 2026-08-12
 
 ### Added

--- a/internal/api/batch/apply_in_place_rename_file_test.go
+++ b/internal/api/batch/apply_in_place_rename_file_test.go
@@ -1,0 +1,133 @@
+package batch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+	"github.com/javinizer/javinizer-go/internal/applyplan"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+)
+
+// Issue #226, spec scenario "folder-only in-place rename via web batch apply":
+// a persisted rename-in-place apply plan + global rename_file=false must apply
+// as folder-only rename — folder renamed to folder_format, video file name
+// preserved. The apply config is resolved through the real plan projection
+// (resolveOrganizeApplyConfig) and the job's apply phase runs against a real
+// (temp-dir) filesystem, mirroring the web batch/apply path end to end.
+func TestApplyPlan_RenameInPlace_HonorsRenameFileFalse_FolderOnlyRename(t *testing.T) {
+	initTestWebSocket(t)
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.Output.Operation.RenameFile = false
+	cfg.Output.Template.FolderFormat = "<ID>"
+	cfg.Output.Template.FileFormat = "<ID>"
+	cfg.Output.Template.SubfolderFormat = []string{}
+	cfg.Output.Download.DownloadCover = false
+	cfg.Output.Download.DownloadPoster = false
+	cfg.Output.Download.DownloadExtrafanart = false
+	cfg.Output.Download.DownloadTrailer = false
+	cfg.Output.Download.DownloadActress = false
+	cfg.Metadata.NFO.Feature.Enabled = false
+
+	deps := createTestDeps(t, cfg, "")
+
+	// Dedicated folder: contains only the one movie's video, so the in-place
+	// folder rename is eligible (strategy_inplace.go dedicated-folder gate).
+	root := t.TempDir()
+	sourceFolder := filepath.Join(root, "old folder")
+	require.NoError(t, os.MkdirAll(sourceFolder, 0o755))
+	filePath := filepath.Join(sourceFolder, "IPX-777-anything.mp4")
+	require.NoError(t, os.WriteFile(filePath, []byte("video"), 0o644))
+
+	job := deps.JobStore.CreateJobBatch([]string{filePath})
+	setJobResult(job, filePath, &resultstore.MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: filePath, Name: "IPX-777-anything.mp4", MovieID: "IPX-777", Extension: ".mp4"},
+		Status:        models.JobStatusCompleted,
+		Movie:         &models.Movie{ID: "IPX-777", ContentID: "ipx777", Title: "Movie"},
+	})
+
+	// Resolve the apply config through the real projection, as the HTTP apply
+	// endpoint does, from a persisted rename-in-place plan.
+	plan := applyplan.Default(applyplan.VideoOperationRenameInPlace, "")
+	rt := testkit.GetTestRuntime(deps)
+	jobWithPlan := &stubControlledJob{status: statusWithPlan(t, plan)}
+	factory := rt.Snapshot().BatchJobFactory()
+	applyCfg, err := resolveOrganizeApplyConfig(rt.Snapshot(), factory, jobWithPlan, contracts.OrganizeRequest{})
+	require.NoError(t, err)
+	require.False(t, applyCfg.OrganizeOptions.ForceRenameFile, "rename-in-place must not force file rename (#226)")
+	require.Equal(t, operationmode.OperationModeInPlace, applyCfg.OperationModeOverride)
+
+	// Run the apply phase with the projection-resolved config.
+	fc, _ := workflow.NewFactoryConfigFromRepos(cfg, deps.CoreDeps.ScraperRegistry, deps.CoreDeps.DB.Repositories())
+	wfFactory, err := workflow.NewWorkflowFactory(fc)
+	require.NoError(t, err)
+	wf, err := wfFactory.NewWorkflow(job.ID.String())
+	require.NoError(t, err)
+	job.Controller().SetWorkflow(wf)
+	job.Controller().SetBatchCfg(worker.BatchJobConfig{
+		MaxWorkers:      cfg.Performance.MaxWorkers,
+		ScraperPriority: cfg.Scrapers.Priority,
+		NFOEnabled:      cfg.Metadata.NFO.Feature.Enabled,
+	})
+	setJobStatus(job, models.JobStatusCompleted)
+	require.NoError(t, job.Controller().StartApply(context.Background(), applyCfg))
+	require.NoError(t, job.Controller().Wait())
+
+	status := job.GetStatus()
+	require.Equal(t, models.JobStatusOrganized, status.Status, "apply should complete: %#v", status)
+
+	// Folder renamed to <ID>; original file name preserved.
+	assert.FileExists(t, filepath.Join(root, "IPX-777", "IPX-777-anything.mp4"))
+	_, statErr := os.Stat(sourceFolder)
+	assert.True(t, os.IsNotExist(statErr), "legacy folder name should be renamed away")
+
+	// Contrapositive guard for the default path: rename_file=true renames both.
+	fs2root := t.TempDir()
+	source2 := filepath.Join(fs2root, "another folder")
+	require.NoError(t, os.MkdirAll(source2, 0o755))
+	file2 := filepath.Join(source2, "IPX-778-anything.mp4")
+	require.NoError(t, os.WriteFile(file2, []byte("video"), 0o644))
+
+	cfg.Output.Operation.RenameFile = true
+	fc2, _ := workflow.NewFactoryConfigFromRepos(cfg, deps.CoreDeps.ScraperRegistry, deps.CoreDeps.DB.Repositories())
+	wfFactory2, err := workflow.NewWorkflowFactory(fc2)
+	require.NoError(t, err)
+	job2 := deps.JobStore.CreateJobBatch([]string{file2})
+	setJobResult(job2, file2, &resultstore.MovieResult{
+		FileMatchInfo: models.FileMatchInfo{Path: file2, Name: "IPX-778-anything.mp4", MovieID: "IPX-778", Extension: ".mp4"},
+		Status:        models.JobStatusCompleted,
+		Movie:         &models.Movie{ID: "IPX-778", ContentID: "ipx778", Title: "Movie 2"},
+	})
+	// Re-resolve a fresh apply config for the second job: half one's applyCfg
+	// carries broadcasters bound to the stub job identity, so re-resolving keeps
+	// attribution honest rather than reusing cross-job plumbing.
+	job2WithPlan := &stubControlledJob{status: statusWithPlan(t, plan)}
+	applyCfg2, err := resolveOrganizeApplyConfig(rt.Snapshot(), factory, job2WithPlan, contracts.OrganizeRequest{})
+	require.NoError(t, err)
+	require.False(t, applyCfg2.OrganizeOptions.ForceRenameFile)
+	wf2, err := wfFactory2.NewWorkflow(job2.ID.String())
+	require.NoError(t, err)
+	job2.Controller().SetWorkflow(wf2)
+	job2.Controller().SetBatchCfg(worker.BatchJobConfig{
+		MaxWorkers:      cfg.Performance.MaxWorkers,
+		ScraperPriority: cfg.Scrapers.Priority,
+		NFOEnabled:      cfg.Metadata.NFO.Feature.Enabled,
+	})
+	setJobStatus(job2, models.JobStatusCompleted)
+	require.NoError(t, job2.Controller().StartApply(context.Background(), applyCfg2))
+	require.NoError(t, job2.Controller().Wait())
+	require.Equal(t, models.JobStatusOrganized, job2.GetStatus().Status)
+	assert.FileExists(t, filepath.Join(fs2root, "IPX-778", "IPX-778.mp4"))
+}

--- a/internal/api/batch/apply_plan_trace_integration_test.go
+++ b/internal/api/batch/apply_plan_trace_integration_test.go
@@ -47,7 +47,7 @@ func TestApplyPlanTrace_RequestPersistenceAndEffectiveConfig(t *testing.T) {
 		wantForceName bool
 	}{
 		{"organize", applyplan.VideoOperationOrganize, false, operationmode.OperationModeOrganize, false, false},
-		{"rename in place", applyplan.VideoOperationRenameInPlace, false, operationmode.OperationModeInPlace, false, true},
+		{"rename in place", applyplan.VideoOperationRenameInPlace, false, operationmode.OperationModeInPlace, false, false},
 		{"rename file", applyplan.VideoOperationRenameFile, false, operationmode.OperationModeInPlaceNoRenameFolder, false, true},
 		{"leave in place", applyplan.VideoOperationLeaveInPlace, true, operationmode.OperationModeMetadataArtwork, true, false},
 	}

--- a/internal/applyplan/plan.go
+++ b/internal/applyplan/plan.go
@@ -127,8 +127,13 @@ type Projection struct {
 	SkipNFO                bool
 	SkipDownload           bool
 	OverwriteExistingMedia bool
-	ForceRenameFile        bool
-	ForceNFO               bool
+	// ForceRenameFile renames video files even when the global rename_file
+	// setting is disabled. Only VideoOperationRenameFile sets it: renaming the
+	// file is the definition of that operation. VideoOperationRenameInPlace
+	// deliberately does not force — it honors rename_file (folder-only rename
+	// when disabled), fixing the silent override reported in #226.
+	ForceRenameFile bool
+	ForceNFO        bool
 }
 
 // Default .
@@ -269,7 +274,9 @@ func Validate(plan *Plan) error {
 	return nil
 }
 
-// Project .
+// Project projects a plan into execution knobs. ForceRenameFile is set only
+// for VideoOperationRenameFile; all other operations respect the resolved
+// rename_file configuration.
 func Project(plan *Plan) (Projection, error) {
 	normalized, err := Normalize(plan)
 	if err != nil {
@@ -287,7 +294,6 @@ func Project(plan *Plan) (Projection, error) {
 		projection.OperationMode = operationmode.OperationModeOrganize
 	case VideoOperationRenameInPlace:
 		projection.OperationMode = operationmode.OperationModeInPlace
-		projection.ForceRenameFile = true
 	case VideoOperationRenameFile:
 		projection.OperationMode = operationmode.OperationModeInPlaceNoRenameFolder
 		projection.ForceRenameFile = true

--- a/internal/applyplan/plan_test.go
+++ b/internal/applyplan/plan_test.go
@@ -19,7 +19,7 @@ func TestNormalizeAndProject(t *testing.T) {
 		forceName bool
 	}{
 		{"organize", Default(VideoOperationOrganize, "/dest"), false, operationmode.OperationModeOrganize, "/dest", false},
-		{"rename in place", Default(VideoOperationRenameInPlace, "/stale"), false, operationmode.OperationModeInPlace, "", true},
+		{"rename in place", Default(VideoOperationRenameInPlace, "/stale"), false, operationmode.OperationModeInPlace, "", false},
 		{"rename file", Default(VideoOperationRenameFile, "/stale"), false, operationmode.OperationModeInPlaceNoRenameFolder, "", true},
 		{"leave in place", Default(VideoOperationLeaveInPlace, "/stale"), true, operationmode.OperationModeMetadataArtwork, "", false},
 		{"metadata artwork", Default(VideoOperationMetadataArtwork, "/stale"), false, operationmode.OperationModeMetadataArtwork, "", false},

--- a/internal/organizer/in_place_honors_rename_file_test.go
+++ b/internal/organizer/in_place_honors_rename_file_test.go
@@ -1,0 +1,103 @@
+package organizer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/matcher"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/testutil"
+)
+
+func setupInPlaceRenameFileFixture(t *testing.T) (afero.Fs, models.FileMatchInfo, *models.Movie) {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	src := "/source/old folder/IPX-535-original.mp4"
+	require.NoError(t, fs.MkdirAll("/source/old folder", 0o755))
+	require.NoError(t, afero.WriteFile(fs, src, []byte("video"), 0o644))
+	match := models.FileMatchInfo{
+		Path: src, Name: "IPX-535-original.mp4", Extension: ".mp4", MovieID: "IPX-535",
+	}
+	movie := testutil.NewMovieBuilder().WithID("IPX-535").Build()
+	return fs, match, movie
+}
+
+// Issue #226: rename-in-place projected from a web apply plan must honor the
+// global rename_file=false setting — the plan projection no longer sets
+// ForceRenameFile, so the organizer must rename only the folder.
+func TestInPlace_HonorsRenameFileFalse_FolderOnly(t *testing.T) {
+	fs, match, movie := setupInPlaceRenameFileFixture(t)
+	m, err := matcher.NewMatcher(&matcher.Config{})
+	require.NoError(t, err)
+	org := NewOrganizer(fs, &Config{
+		FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: false,
+		OperationMode: operationmode.OperationModeInPlace,
+	}, nil, m)
+
+	result, err := org.Organize(context.Background(), OrganizeCmd{
+		Match: match, Movie: movie, MoveFiles: true,
+		OperationMode: operationmode.OperationModeInPlace,
+		// No ForceRenameFile: this mirrors the post-fix projection output.
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	exists, err := afero.Exists(fs, "/source/IPX-535/IPX-535-original.mp4")
+	require.NoError(t, err)
+	assert.True(t, exists, "folder renamed to <ID>, original file name preserved")
+
+	targetDir, err := afero.Exists(fs, "/source/old folder")
+	require.NoError(t, err)
+	assert.False(t, targetDir, "legacy folder should be renamed away")
+}
+
+// Default configuration (rename_file=true) behavior must remain unchanged:
+// rename-in-place renames both folder and file.
+func TestInPlace_RenameFileDefault_RenamesFolderAndFile(t *testing.T) {
+	fs, match, movie := setupInPlaceRenameFileFixture(t)
+	m, err := matcher.NewMatcher(&matcher.Config{})
+	require.NoError(t, err)
+	org := NewOrganizer(fs, &Config{
+		FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true,
+		OperationMode: operationmode.OperationModeInPlace,
+	}, nil, m)
+
+	_, err = org.Organize(context.Background(), OrganizeCmd{
+		Match: match, Movie: movie, MoveFiles: true,
+		OperationMode: operationmode.OperationModeInPlace,
+	})
+	require.NoError(t, err)
+
+	exists, err := afero.Exists(fs, "/source/IPX-535/IPX-535.mp4")
+	require.NoError(t, err)
+	assert.True(t, exists, "folder and file both renamed when rename_file=true")
+}
+
+// The rename-file operation (in-place-norenamefolder) keeps forcing file
+// renaming even with rename_file=false — renaming the file is the definition
+// of that operation. Folder must stay untouched.
+func TestInPlaceNoRenameFolder_ForceStillRenamesFileOnly(t *testing.T) {
+	fs, match, movie := setupInPlaceRenameFileFixture(t)
+	m, err := matcher.NewMatcher(&matcher.Config{})
+	require.NoError(t, err)
+	org := NewOrganizer(fs, &Config{
+		FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: false,
+		OperationMode: operationmode.OperationModeInPlaceNoRenameFolder,
+	}, nil, m)
+
+	_, err = org.Organize(context.Background(), OrganizeCmd{
+		Match: match, Movie: movie, MoveFiles: true,
+		OperationMode:   operationmode.OperationModeInPlaceNoRenameFolder,
+		ForceRenameFile: true,
+	})
+	require.NoError(t, err)
+
+	exists, err := afero.Exists(fs, "/source/old folder/IPX-535.mp4")
+	require.NoError(t, err)
+	assert.True(t, exists, "file renamed in the untouched source folder")
+}

--- a/internal/workflow/preview_rename_file_parity_test.go
+++ b/internal/workflow/preview_rename_file_parity_test.go
@@ -1,0 +1,82 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/nfo"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/template"
+)
+
+// Issue #226, spec requirement "preview and apply agree": the preview
+// orchestrator must engage the forced-rename strategy only when the projected
+// ForceRenameFile flag is set. rename-in-place projects false(applyplan), so
+// preview must use the normal resolver and reflect the honest rename_file config.
+func TestPreview_ForceRenameGate_FollowsProjectedFlag(t *testing.T) {
+	cases := []struct {
+		name        string
+		forceRename bool
+		wantForced  bool
+	}{
+		{"rename-in-place projection applies no force", false, false},
+		{"rename-file projection keeps the force", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			forcedUsed := 0
+			normalUsed := 0
+			fs := afero.NewMemMapFs()
+			strategy := &mockStrategyPlan{plan: &organizer.OrganizePlan{
+				TargetDir:    "/source/ABC-123",
+				TargetPath:   "/source/ABC-123/ABC-123.mp4",
+				FolderName:   "ABC-123",
+				BaseFileName: "ABC-123",
+			}}
+			orch := newPreviewOrchestrator(
+				fs,
+				&mockMatcherForPreview{},
+				PreviewConfig{
+					PathCfg: PreviewPathConfig{MediaFormatConfig: organizer.MediaFormatConfig{
+						PosterFormat: ".jpg", FanartFormat: ".jpg",
+					}},
+					ResolveStrategy: func(_ operationmode.OperationMode) organizer.OperationStrategy {
+						normalUsed++
+						return strategy
+					},
+					ResolveForcedRenameStrategy: func(_ operationmode.OperationMode) organizer.OperationStrategy {
+						forcedUsed++
+						return strategy
+					},
+					OpMode: operationmode.OperationModeInPlace,
+				},
+				nfo.NFONameConfig{},
+				template.NewEngine(),
+				&mockNFOFieldMergerForPreview{},
+				nil,
+			).(*previewOrchImpl)
+
+			result, err := orch.Execute(context.Background(), PreviewCmd{
+				Movie:           &models.Movie{ID: "ABC-123", Title: "T"},
+				FileResults:     []models.FileMatchInfo{{Path: "/source/ABC-123.mp4", Name: "ABC-123.mp4", Extension: ".mp4", MovieID: "ABC-123"}},
+				OperationMode:   operationmode.OperationModeInPlace,
+				ForceRenameFile: tc.forceRename,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			if tc.wantForced {
+				assert.GreaterOrEqual(t, forcedUsed, 1, "forced rename strategy must be used")
+				assert.Equal(t, 0, normalUsed)
+			} else {
+				assert.Equal(t, 0, forcedUsed, "forced rename strategy must NOT be used when projection emits no force")
+				assert.GreaterOrEqual(t, normalUsed, 1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Fix:** the apply-plan projection (`applyplan.Project`) unconditionally set `ForceRenameFile = true` for the `rename-in-place` video operation, so web batch/apply silently overrode the global `rename_file: false` setting and renamed video files anyway. The `organize` operation never forced it — this restores parity: `rename-in-place` now renames the (dedicated) folder and honors `rename_file` for the file.
- **Kept deliberately:** `rename-file` (`in-place-norenamefolder`) retains the force — renaming the file *is* the definition of that operation; without the force it would silently no-op (verified in tests).
- Users on defaults (`rename_file=true`) see zero behavioral change. CLI/TUI paths never set the flag and are untouched.

Closes #226

Known follow-up: the `rename-in-place` UI description is now conditionally imprecise across 5 locale files — tracked in #229.

## Test plan

- [x] Projection matrix: `rename-in-place` → `ForceRenameFile=false`, `rename-file` → `true` (`plan_test.go`)
- [x] Batch wire: persisted rename-in-place plan resolves `ForceRenameFile=false` through the real HTTP-path builder (`apply_plan_trace_integration_test.go`)
- [x] End-to-end batch apply on real FS: persisted plan + `rename_file=false` renames folder to `folder_format` and preserves the video file name; contrapositive with `rename_file=true` renames both (new `apply_in_place_rename_file_test.go` — drives `job.Controller().StartApply` with the projection-resolved config)
- [x] Organizer triad: folder-only with `rename_file=false`, default both-renamed regression guard, explicit force still works for `in-place-norenamefolder` (new `in_place_honors_rename_file_test.go`)
- [x] Preview/apply parity: forced-rename strategy resolver engaged iff the projected flag is set (new `preview_rename_file_parity_test.go`)
- [x] `go test -race` on api/batch + workflow + applyplan; full `go test -short ./...`; whole-repo golangci-lint clean

Review history: OpenSpec change (`openspec/changes/honor-rename-file-in-rename-in-place`, local) reviewed twice by a kimi-k3/max-thinking subagent pre-implementation (findings folded); the patch itself then went through a 2-round kimi-k3 review loop ending READY with no test vacuity (restoring the force line provably fails 3 independent tests).