### PR TITLE
fix(aggregator): match censored-token word replacements in CJK text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Honor the global rename_file setting for the "rename in place" video operation: web batch/apply with rename_file=false now renames only the (dedicated) folder and preserves video file names, instead of silently forcing a file rename. Note: rename_file=false + rename in place + a mixed-ID (non-dedicated) folder is now a no-op by design (#226)
+- Word-replacement entries containing `*` (the censor character) now match when embedded in Japanese/other non-Latin text: only `*` and Latin-script letters extend a censored token; non-Latin letters (kana, kanji, Cyrillic, …) now count as boundaries. Deliberate behavior flip: a Latin censored token directly abutting CJK letters now replaces (e.g. `F***ドラマ` → `Fuckドラマ`); the #106 over-extension guard (`F***` not firing inside `F****d`) is unchanged (#227)
 
 ## [v1.5.1] - 2026-08-12
 

--- a/docs/05-genre-management.md
+++ b/docs/05-genre-management.md
@@ -32,7 +32,7 @@ metadata:
 
 Both default to `true`, so replacement is active out of the box. Disable `enabled` to bypass replacement entirely without deleting your mappings.
 
-> **Note:** Genre replacement is distinct from word replacement. Word replacements (`metadata.word_replacement`, disabled by default) do substring search-and-replace across all text fields **and each genre token**, and run *before* genre replacement — see the [`word` command](./03-cli-reference.md#word) and [Metadata Management Defaults](./02-configuration.md#metadata-management-defaults). See [How It Works](#how-it-works) for the full pipeline.
+> **Note:** Genre replacement is distinct from word replacement. Word replacements (`metadata.word_replacement`, disabled by default) replace text across all text fields **and each genre token**, and run *before* genre replacement. Entries without `*` match as plain substrings; entries containing `*` (the censor character) match as whole tokens — a candidate match is rejected when immediately preceded or followed by `*` or a Latin-script letter (#106/#227) — see the [`word` command](./03-cli-reference.md#word) and [Metadata Management Defaults](./02-configuration.md#metadata-management-defaults). See [How It Works](#how-it-works) for the full pipeline.
 
 ## Commands
 
@@ -156,7 +156,7 @@ An empty array (`[]`) is rejected with an error; invalid JSON fails with `failed
 Scraper → Original Genres → Apply Word Replacements → Apply Genre Replacements → Apply Ignore Filter → Final Genres
 ```
 
-- **Word replacements** (optional, `metadata.word_replacement`) normalize substrings in each token first.
+- **Word replacements** (optional, `metadata.word_replacement`) normalize each token first (substring for plain entries, whole-token for `*` entries — see above).
 - **Genre replacements** then map the resulting token via an exact, case-sensitive lookup.
 - **Ignore filter** (`metadata.ignore_genres`) drops matching tokens last.
 

--- a/internal/aggregator/word_processor.go
+++ b/internal/aggregator/word_processor.go
@@ -84,10 +84,11 @@ func NewWordProcessor(cfg *MetadataConfig, repo wordLookup) *wordProcessor {
 //
 //   - Patterns WITH '*' (censored-word tokens, e.g. "F***"): matched as a whole
 //     token using replaceTokenBounded. The match must be bounded on both sides
-//     by string start/end or a char that is neither a letter nor '*'. This
-//     prevents a short censored token from matching as a substring inside a
-//     longer, unlisted censored token — e.g. "F***" no longer fires inside
-//     "F****d" (which would yield "Fuck*d"). Issue #106.
+//     by string start/end or a char that cannot extend a censored token — i.e.
+//     anything other than '*' or a Latin-script character (#106 keeps "F***" from
+//     firing inside "F****d"; #227 narrows letter-extension to the Latin script
+//     so CJK letters count as boundaries and embedded patterns like "チ*ポ"
+//     match inside unsegmented Japanese titles).
 //   - Patterns WITHOUT '*' (e.g. the "[Recommended For Smartphones] " prefix
 //     strip): matched as a plain substring via strings.ReplaceAll, preserving
 //     the original behavior for patterns that are genuinely meant to match
@@ -123,11 +124,12 @@ func (wp *wordProcessor) Apply(text string) string {
 
 // replaceTokenBounded replaces every non-overlapping occurrence of orig in text
 // with repl, but only when the match is bounded on both sides by string
-// start/end or a character that is neither a Unicode letter nor '*'. This is
-// the "whole censored token" rule: '*' is the censor character, so a run like
-// "F***" is a complete censored word only if the char after it is not a letter
+// start/end or a boundary character per isCensorBoundary. This is the "whole
+// censored token" rule: '*' is the censor character, so a run like "F***" is a
+// complete censored word only if the char after it is not a Latin-script character
 // (which would extend the word) and not '*' (which would mean it's actually a
-// longer censored token, e.g. "F****d").
+// longer censored token, e.g. "F****d"). CJK letters can never be part of a
+// Latin censored token, so they act as boundaries (#227).
 //
 // The boundary chars are INSPECTED but not consumed, so two censored tokens
 // separated by a single space ("F*** S***e") both match — the space serves as
@@ -165,10 +167,13 @@ func replaceTokenBounded(text, orig, repl string) string {
 }
 
 // isCensorBoundary reports whether r may act as a boundary for a censored-word
-// token: any char that is NOT a Unicode letter and NOT '*'. Digits, spaces,
-// punctuation, and symbols all qualify; letters and '*' extend the token.
+// token: any char that cannot extend the token — i.e. anything other than '*'
+// or a Latin-script character (the unicode.Latin table is script-based and
+// also contains Roman numerals in category Nl — immaterial here). Digits,
+// spaces, punctuation, symbols, and CJK or other non-Latin letters all qualify
+// (#227); '*' and Latin-script characters extend the token (#106).
 func isCensorBoundary(r rune) bool {
-	return r != '*' && !unicode.IsLetter(r)
+	return r != '*' && !unicode.In(r, unicode.Latin)
 }
 
 // boundaryRuneBefore decodes the full rune immediately preceding byte index

--- a/internal/aggregator/word_processor_boundary_test.go
+++ b/internal/aggregator/word_processor_boundary_test.go
@@ -145,11 +145,14 @@ func TestApplyWordReplacements_CensoredTokenInTitle(t *testing.T) {
 // full UTF-8 runes (not single bytes) when classifying the char adjacent to a
 // censored token. This matters for r18dev titles, which can be Japanese.
 //
-// A censored token directly abutting a multibyte rune (Japanese katakana/kanji,
-// or full-width punctuation like 「」) must be classified by the actual rune:
-// a Japanese letter extends the word (blocks the match), while a Japanese
-// punctuation char is a boundary (allows the match). The old byte-level read
-// misclassified lead/continuation bytes and got these wrong.
+// Since #227, only '*' and Latin-script letters extend a censored token; a
+// Japanese letter is a boundary, so a censored English word directly abutting
+// one DOES replace (e.g. "F***ドラマ" -> "Fuckドラマ": the title contains the
+// complete censored word, and the katakana can never be part of it). The old
+// behavior ("a Japanese letter extends the word") is the bug #227 fixes. This
+// case is also the rune-decode guard: a byte-level read of the lead byte of a
+// multibyte rune (e.g. ド = 0xE3...) would misclassify it as a Latin-script
+// letter and wrongly block the replacement.
 func TestApplyWordReplacement_MultibyteBoundary(t *testing.T) {
 	cfg := &config.Config{
 		Metadata: config.MetadataConfig{
@@ -161,8 +164,8 @@ func TestApplyWordReplacement_MultibyteBoundary(t *testing.T) {
 	})
 
 	// Censored token followed directly by a Japanese letter (no separator):
-	// ド is a letter and extends the word, so F*** must NOT fire.
-	assert.Equal(t, "F***ドラマ", wp.Apply("F***ドラマ"))
+	// since #227 the katakana is a boundary, so F*** fires.
+	assert.Equal(t, "Fuckドラマ", wp.Apply("F***ドラマ"))
 	// With a separator it replaces.
 	assert.Equal(t, "Fuck ドラマ", wp.Apply("F*** ドラマ"))
 	// Japanese full-width brackets 「」 are punctuation (boundaries), so the

--- a/internal/aggregator/word_processor_cjk_test.go
+++ b/internal/aggregator/word_processor_cjk_test.go
@@ -1,0 +1,96 @@
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+// TestApplyWordReplacement_CJKExtensionRule locks the #227 extension predicate:
+// only '*' and Latin-script letters extend a censored token; CJK and other
+// non-Latin letters are boundaries, so '*' entries match when embedded in
+// unsegmented Japanese text, while the #106 over-extension guards still hold.
+func TestApplyWordReplacement_CJKExtensionRule(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"チ*ポ":   "チンポ",
+		"F***":  "Fuck",
+		"F***e": "Force",
+	})
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Core #227 fix: CJK pattern embedded in unsegmented Japanese text.
+		{"cjk pattern embedded mid-sentence", "チ*ポを咥える人妻", "チンポを咥える人妻"},
+		{"cjk pattern standalone", "チ*ポ", "チンポ"},
+		{"cjk pattern full-width brackets", "「チ*ポ」", "「チンポ」"},
+		{"cjk pattern space separated", "彼は チ*ポ が好き", "彼は チンポ が好き"},
+		{"japanese title end to end", "某女優のチ*ポ地獄", "某女優のチンポ地獄"},
+		// Over-extension must still be rejected through the predicate: the
+		// pattern IS a substring and the adjacent trailing '*' extends it.
+		{"trailing asterisk extends", "人気のチ*ポ*", "人気のチ*ポ*"},
+		// #106 guard must survive the narrower predicate.
+		{"latin over-extension unchanged", "F****d", "F****d"},
+		// #227 deliberate flip: Latin token abutting CJS letters replaces.
+		{"latin token abutting katakana", "F***ドラマ", "Fuckドラマ"},
+		// Latin letter in boundary position extends regardless of accent:
+		// pins the rule to the Latin script, guarding against an ASCII-only
+		// narrowing of the extender classification.
+		{"accented latin boundary position extends", "F***éve", "F***éve"},
+		{"latin letter suffix extends", "F***bsuffix", "F***bsuffix"},
+		// Multi-entry CJK seam: with {F***, F***e} present, the F***e entry
+		// must apply cleanly at the seam and the F*** pass must leave the
+		// result alone (pins inter-pattern stability at a non-Latin seam).
+		{"multi entry at cjk seam", "F***eドラマ", "Forceドラマ"},
+		// Sponsor-class coverage for the changelog's "other non-Latin" claim:
+		// halfwidth katakana and Cyrillic letters are also boundaries now.
+		{"halfwidth katakana boundary", "F***ｶﾀｶﾅ", "Fuckｶﾀｶﾅ"},
+		{"cyrillic boundary", "F***Анна", "FuckАнна"},
+		// Full-width asterisk is not the censor char; no substring, no match.
+		{"full width asterisk untouched", "チ＊ポを咥える", "チ＊ポを咥える"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, wp.Apply(tc.in))
+		})
+	}
+}
+
+// TestApplyToMovie_CJKEmbeddedCensoredToken covers the aggregator pipeline
+// path (spec: movie-field application), including translation entries.
+func TestApplyToMovie_CJKEmbeddedCensoredToken(t *testing.T) {
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			WordReplacement: config.WordReplacementConfig{Enabled: true},
+		},
+	}
+	wp := newWordProcessorWithCache(MetadataConfigFromApp(&cfg.Metadata), nil, map[string]string{
+		"チ*ポ": "チンポ",
+	})
+	require.NotNil(t, wp)
+
+	movie := &models.Movie{
+		Title:       "某女優のチ*ポ地獄",
+		Description: "彼女のチ*ポ物語",
+		Translations: []models.MovieTranslation{
+			{Language: "en", Title: "She loves チ*ポ"},
+		},
+	}
+	wp.applyToMovie(movie)
+
+	assert.Equal(t, "某女優のチンポ地獄", movie.Title)
+	assert.Equal(t, "彼女のチンポ物語", movie.Description)
+	require.Len(t, movie.Translations, 1)
+	assert.Equal(t, "She loves チンポ", movie.Translations[0].Title)
+}


### PR DESCRIPTION
## Summary

- **Fix:** word-replacement entries containing `*` (the literal censor character, e.g. `チ*ポ`) almost never fired inside real Japanese titles. The whole-token boundary predicate from #106 (`isCensorBoundary`) treated *every* Unicode letter as a token extender — but unsegmented Japanese text gives no non-letter neighbors, so the boundary virtually never existed. The predicate narrows to: only `*` and **Latin-script** characters extend a censored token; CJK and other non-Latin letters are boundaries. `チ*ポを咥える人妻` → `チンポを咥える人妻` now works.
- **Deliberate flip:** a Latin censored token abutting CJK now replaces (`F***ドラマ` → `Fuckドラマ`) — the katakana can never be part of an English censored word; the old test asserting otherwise is rewritten with the principle documented.
- **Unchanged:** the #106 guard (`F***` never fires inside `F****d`), non-`*` substring matching, seeded-shipped defaults (all Latin-side), digit/punctuation classification, full-width `＊` (not the censor char — that's #228 territory).

Closes #227

## Test plan

- [x] 15-row discriminating matrix (new `word_processor_cjk_test.go`): CJK-embedded pattern, standalone, full-width brackets, predicate-exercising reject (`チ*ポ*`), `F****d`, `F***éve` (Latin-script vs ASCII narrowing pin), multi-entry at a CJK seam (`F***e` + `F***`), halfwidth katakana + Cyrillic boundary rows, `チ＊ポ` untouched, `applyToMovie` incl. translation fields
- [x] Rewritten `TestApplyWordReplacement_MultibyteBoundary` documents the flip and carries the UTF-8 rune-decode guard
- [x] All pre-existing #106 regression tests pass unmodified
- [x] `go test -race` on `internal/aggregator/`, full `go test -short ./...`, vet, whole-repo golangci-lint clean

Review history: OpenSpec change (local) reviewed over 3 kimi-k3/max-thinking rounds to zero findings; the patch itself reviewed over 2 kimi-k3 rounds (R1 caught an inverted docs sentence — fixed; R2 READY).