### PR TITLE
fix(web): reflect rename_file setting in rename-in-place description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The "Rename in place" operation description in the Browse apply-plan selector now reflects the rename_file setting: with rename files off, the copy no longer claims videos are renamed (#229)
+
 ### Added
 
 - Wildcard match mode for word replacements: per-entry `match_mode` (`literal` default / `wildcard`) across DB (migration 000015), CLI (`word add --mode`), REST, and the /words page. In wildcard mode, `?`/`？` match a run of one-or-more censor glyphs (`*`, `＊`, `○`, `◯`, `〇`, `●`, `×`, `✕`, `✖`), so one entry uncensors every censor variant of a word (#228)

--- a/web/frontend/messages/en-XA.json
+++ b/web/frontend/messages/en-XA.json
@@ -1977,5 +1977,6 @@
   "words_mode_label": "[ Måtçh möðë ]",
   "words_mode_literal": "[ Éxåçt måtçh ]",
   "words_mode_wildcard": "[ Çëñsör wïldçård (?) ]",
-  "words_mode_badge_wildcard": "[ wïldçård ]"
+  "words_mode_badge_wildcard": "[ wïldçård ]",
+  "browse_plan_rename_in_place_desc_files_off": "[ Rëñåmë ëlïgïblë ðëðïçåtëð fölðërs wïthöüt çhåñgïñg thëír pårëñt löçåtïöñ; vídëö fïlë ñåmës ärë képt (rëñåmë fïlës ïs öff). ]"
 }

--- a/web/frontend/messages/en.json
+++ b/web/frontend/messages/en.json
@@ -2634,5 +2634,6 @@
   "words_mode_label": "Match mode",
   "words_mode_literal": "Exact match",
   "words_mode_wildcard": "Censor wildcard (?)",
-  "words_mode_badge_wildcard": "wildcard"
+  "words_mode_badge_wildcard": "wildcard",
+  "browse_plan_rename_in_place_desc_files_off": "Rename eligible dedicated folders without changing their parent location; video file names are kept (rename files is off)."
 }

--- a/web/frontend/messages/ja.json
+++ b/web/frontend/messages/ja.json
@@ -2634,5 +2634,6 @@
   "words_mode_label": "マッチモード",
   "words_mode_literal": "完全一致",
   "words_mode_wildcard": "伏字ワイルドカード（?）",
-  "words_mode_badge_wildcard": "ワイルドカード"
+  "words_mode_badge_wildcard": "ワイルドカード",
+  "browse_plan_rename_in_place_desc_files_off": "対象の専用フォルダのみを、親の場所を変えずにリネームします（ファイル名のリネームはオフ）。"
 }

--- a/web/frontend/messages/zh-Hans.json
+++ b/web/frontend/messages/zh-Hans.json
@@ -2634,5 +2634,6 @@
   "words_mode_label": "匹配模式",
   "words_mode_literal": "精确匹配",
   "words_mode_wildcard": "屏蔽字通配符（?）",
-  "words_mode_badge_wildcard": "通配符"
+  "words_mode_badge_wildcard": "通配符",
+  "browse_plan_rename_in_place_desc_files_off": "仅重命名符合条件的专用文件夹，不改变所在位置；保留视频文件名（已关闭重命名文件）。"
 }

--- a/web/frontend/messages/zh-Hant.json
+++ b/web/frontend/messages/zh-Hant.json
@@ -2634,5 +2634,6 @@
   "words_mode_label": "匹配模式",
   "words_mode_literal": "精確匹配",
   "words_mode_wildcard": "遮蔽字萬用字元（?）",
-  "words_mode_badge_wildcard": "萬用字元"
+  "words_mode_badge_wildcard": "萬用字元",
+  "browse_plan_rename_in_place_desc_files_off": "僅重新命名符合條件的專用資料夾，不改變所在位置；保留影片檔名（已關閉重新命名檔案）。"
 }

--- a/web/frontend/src/routes/browse/+page.svelte
+++ b/web/frontend/src/routes/browse/+page.svelte
@@ -749,7 +749,7 @@
 						<span class="mt-2 hidden w-px flex-1 bg-border sm:block"></span>
 					</div>
 					<div class="min-w-0">
-						<VideoOperationSelector bind:value={selectedVideoOperation} errorId={planErrors.length > 0 ? 'apply-plan-errors' : undefined} />
+						<VideoOperationSelector bind:value={selectedVideoOperation} errorId={planErrors.length > 0 ? 'apply-plan-errors' : undefined} renameFile={config?.output?.rename_file} />
 					</div>
 				</div>
 

--- a/web/frontend/src/routes/browse/VideoOperationSelector.svelte
+++ b/web/frontend/src/routes/browse/VideoOperationSelector.svelte
@@ -3,16 +3,18 @@
 	import { FolderOutput, FolderPen, FilePenLine, ShieldCheck, FileText } from 'lucide-svelte';
 	import type { VideoOperation } from '$lib/api/types';
 
-	let { value = $bindable<VideoOperation | null>(), errorId }: { value: VideoOperation | null; errorId?: string } = $props();
+	let { value = $bindable<VideoOperation | null>(), errorId, renameFile }: { value: VideoOperation | null; errorId?: string; renameFile?: boolean } = $props();
 	let describedBy = $derived(errorId ? `video-operation-help ${errorId}` : 'video-operation-help');
 	let radios: HTMLInputElement[] = $state([]);
-	const options = [
+	// #229: the rename-in-place description reflects the rename_file setting —
+	// with rename_file=false only the (dedicated) folder is renamed.
+	const options = $derived([
 		{ value: 'organize' as const, label: m.browse_plan_organize(), description: m.browse_plan_organize_desc(), icon: FolderOutput },
-		{ value: 'rename-in-place' as const, label: m.browse_plan_rename_in_place(), description: m.browse_plan_rename_in_place_desc(), icon: FolderPen },
+		{ value: 'rename-in-place' as const, label: m.browse_plan_rename_in_place(), description: renameFile === false ? m.browse_plan_rename_in_place_desc_files_off() : m.browse_plan_rename_in_place_desc(), icon: FolderPen },
 		{ value: 'rename-file' as const, label: m.browse_plan_rename_file(), description: m.browse_plan_rename_file_desc(), icon: FilePenLine },
 		{ value: 'leave-in-place' as const, label: m.browse_plan_leave_in_place(), description: m.browse_plan_leave_in_place_desc(), icon: ShieldCheck },
 		{ value: 'metadata-artwork' as const, label: m.browse_plan_metadata_artwork(), description: m.browse_plan_metadata_artwork_desc(), icon: FileText }
-	];
+	]);
 
 	function handleKeydown(event: KeyboardEvent, index: number) {
 		let next = index;

--- a/web/frontend/src/routes/browse/VideoOperationSelector.test.ts
+++ b/web/frontend/src/routes/browse/VideoOperationSelector.test.ts
@@ -26,6 +26,19 @@ describe('VideoOperationSelector', () => {
 		expect(getByText('✓')).toBeTruthy();
 	});
 
+	it('describes rename-in-place accurately per the rename_file setting (#229)', () => {
+		const on = render(VideoOperationSelector, { value: null, renameFile: true });
+		expect(on.getByText('Rename videos and eligible dedicated folders without changing their parent location.')).toBeTruthy();
+		on.unmount();
+		const off = render(VideoOperationSelector, { value: null, renameFile: false });
+		expect(off.getByText(/dedicated folders without changing their parent location; video file names are kept/)).toBeTruthy();
+		off.unmount();
+		// Unknown config (undefined) keeps the default (files-renamed) copy.
+		const def = render(VideoOperationSelector, { value: null });
+		expect(def.getByText(/Rename videos and eligible dedicated folders/)).toBeTruthy();
+		def.unmount();
+	});
+
 	it('associates dynamic validation with the radio group', () => {
 		const { getByRole } = render(VideoOperationSelector, { value: null, errorId: 'apply-plan-errors' });
 		expect(getByRole('group', { name: 'Video file operation' }).getAttribute('aria-describedby')).toBe('video-operation-help apply-plan-errors');


### PR DESCRIPTION
## Summary

- The Browse apply-plan "Rename in place" card described the operation as *"Rename videos and eligible dedicated folders…"* unconditionally. Since #226 made the operation honor the global `rename_file` setting, that copy is wrong when rename files is off — the card now flips to folder-only copy driven by the live config.
- Mechanism: `VideoOperationSelector` takes an optional `renameFile?: boolean` prop (undefined → existing default copy); `browse/+page.svelte` passes `config?.output?.rename_file` from the already-present `createConfigQuery()`; options list converted to a `$derived` so copy reacts to both the setting and locale switches.
- New message key in all 5 locale catalogs; note the paraglide cache had to be busted for `messages/_index.js` to pick it up (`rm -rf project.inlang/cache` + compile with the pinned `--project/--outdir` from `prepare`).

Closes #229

## Test plan

- [x] New test covers all three states: `renameFile=true` → files-renamed copy; `renameFile=false` → folder-only copy; prop omitted → default copy
- [x] `npm run test` (611), `npx svelte-check --threshold error`, `make i18n-check` all green
