### PR TITLE
fix(organize): atomic no-clobber terminal ops via fsutil composites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Organize file writes are atomically no-clobbering: unauthorized moves/copies publish through the fsutil no-replace composites (renameat2 / hard-link-tiered / MoveFileEx per OS), so a foreign writer claiming a destination mid-run conflicts atomically instead of being overwritten; cross-device copy failures no longer remove foreign destination bytes, and sources are cleaned up only via identity-verified removal. On volumes that cannot express an atomic no-replace publish (e.g. exFAT under macOS), unauthorized organizes now fail closed with a dedicated "cannot express an atomic no-clobber write" error instead of succeeding non-atomically (#224 partial — phases C/D/E remain open)
 - The "Rename in place" operation description in the Browse apply-plan selector now reflects the rename_file setting: with rename files off, the copy no longer claims videos are renamed (#229)
 
 ### Added

--- a/docs/10-troubleshooting.md
+++ b/docs/10-troubleshooting.md
@@ -214,6 +214,20 @@ video_file.avi
 
 ## Organization Issues
 
+### "destination volume cannot express an atomic no-clobber write"
+
+**Problem**: Organize/move jobs fail per-file with this error when the destination volume cannot express an atomic no-replace publish — e.g. non-Linux POSIX volumes without hard links (exFAT on macOS is the typical case).
+
+**Why**: Unauthorized organize writes are fail-closed: the alternative is a non-atomic publish that could overwrite a foreign file inside a race window — exactly what the #224 hardening rules out. Nothing was moved or deleted when this surfaces.
+
+**Solutions**:
+
+- Move the library destination onto a volume with atomic no-replace publish support (native Linux/Windows, or full POSIX volumes with hard links), or
+- run the organize in **force-update** mode deliberately for that library (authorized replace paths are unchanged), or
+- treat the affected files as conflicts and re-run after migrating the destination.
+
+
+
 ### "File already exists"
 
 **Problem**: Target file conflicts with existing file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,14 @@ func StoreUmask(mask int) {
 	cachedUmask.Store(int32(mask))
 }
 
+// UmaskValue returns the cached process umask bits (0 when unset). The value
+// is used to re-derive the mode an OpenFile-style create would have inherited
+// from the kernel — exclusive staging asserts exact modes through Chmod, which
+// bypasses the umask, so parity requires masking explicitly (#224 codex P1).
+func UmaskValue() int {
+	return int(cachedUmask.Load())
+}
+
 // ValidateHTTPBaseURL checks that raw is a valid HTTP or HTTPS URL.
 // An empty string is accepted (the field is optional).
 func ValidateHTTPBaseURL(path, raw string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,10 @@ const (
 var cachedUmask atomic.Int32
 
 func init() {
-	cachedUmask.Store(0)
+	// Capture the process's inherited umask up front (probe-and-restore is
+	// thread-unsafe; init runs before anything else). StoreUmask from config
+	// overrides this at startup when a setting is applied.
+	cachedUmask.Store(int32(currentProcessUmask()))
 }
 
 // StoreUmask caches the provided umask value for later use.

--- a/internal/config/umask_unix.go
+++ b/internal/config/umask_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package config
+
+import "syscall"
+
+// currentProcessUmask probes the process's inherited umask via set-and-restore.
+// Safe at package init (nothing else runs concurrently yet).
+func currentProcessUmask() int {
+	m := syscall.Umask(0)
+	syscall.Umask(m)
+	return m
+}

--- a/internal/config/umask_windows.go
+++ b/internal/config/umask_windows.go
@@ -1,0 +1,6 @@
+//go:build windows
+
+package config
+
+// Windows has no umask concept; the effective mask is always 0.
+func currentProcessUmask() int { return 0 }

--- a/internal/fsutil/move.go
+++ b/internal/fsutil/move.go
@@ -86,15 +86,13 @@ func copyFileDataFs(fs afero.Fs, src, dst string) error {
 	}
 
 	p := StagedPublish{
-		FS:      fs,
-		Publish: ReplaceFile,
-		Staged:  staged,
-		Handle:  handle,
-		Dest:    dst,
-		Suffix:  ".mvstg",
-		NextOrdinal: func() uint64 {
-			return noreplaceOrdinal.Add(1)
-		},
+		FS:          fs,
+		Publish:     ReplaceFile,
+		Staged:      staged,
+		Handle:      handle,
+		Dest:        dst,
+		Suffix:      ".mvstg",
+		NextOrdinal: nextNoReplaceOrdinal,
 	}
 	if err := PublishStagedBound(p); err != nil {
 		// Same discard discipline as the no-replace composites: the old

--- a/internal/fsutil/move.go
+++ b/internal/fsutil/move.go
@@ -3,9 +3,7 @@ package fsutil
 import (
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/javinizer/javinizer-go/internal/config"
 	"github.com/spf13/afero"
@@ -48,12 +46,16 @@ func MoveFileFs(fs afero.Fs, src, dst string) error {
 
 func crossDeviceMoveFs(fs afero.Fs, src, dst string) error {
 	if err := copyFileDataFs(fs, src, dst); err != nil {
-		_ = fs.Remove(dst) // clean up partial destination file
+		// The copy leg never writes to dst directly (staging only), so there is
+		// NOTHING of ours at dst to "clean up": removing it could delete a
+		// pre-existing foreign file (#224). Keep both, surface the failure.
 		return fmt.Errorf("failed to copy file across devices: %w", err)
 	}
 
 	if err := fs.Remove(src); err != nil {
-		_ = fs.Remove(dst)
+		// dst was fully published via the bound replace; the source remove is
+		// the only failed step — keep BOTH objects rather than deleting the
+		// published destination, and surface the ambiguity (#224).
 		return fmt.Errorf("failed to remove source after cross-device copy: %w", err)
 	}
 
@@ -67,30 +69,38 @@ func copyFileDataFs(fs afero.Fs, src, dst string) error {
 	}
 	defer func() { _ = srcFile.Close() }()
 
-	// Write to a temp file in the same directory as dst so the final rename
-	// is same-filesystem and atomic. On any failure the temp file is removed
-	// and dst is never left in a partial or truncated state.
-	tmp := filepath.Join(filepath.Dir(dst),
-		fmt.Sprintf(".%s.tmp-%d-%d", filepath.Base(dst), time.Now().UnixNano(), os.Getpid()))
-
-	dstFile, err := fs.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, config.FilePerm)
-	if err != nil {
-		return fmt.Errorf("failed to create destination: %w", err)
+	// Stage dest-adjacent with O_EXCL (a predictable O_TRUNC name could
+	// truncate a racing peer's staged bytes), stream through the open handle,
+	// and publish through the bound discipline — a substitute planted on the
+	// staged name is never published nor unbound-removed (#224). Publish keeps
+	// REPLACE semantics (authorized overwrite); no-clobber uses the separate
+	// NoReplace composites.
+	staged, handle, sErr := CreateExclusiveStagingFile(fs, dst, ".mvstg", noreplaceOrdinal.Add(1), config.FilePerm)
+	if sErr != nil {
+		return fmt.Errorf("failed to create destination: %w", sErr)
 	}
 
-	if _, err := io.Copy(dstFile, srcFile); err != nil {
-		_ = dstFile.Close()
-		_ = fs.Remove(tmp)
+	if _, err := io.Copy(handle, srcFile); err != nil {
+		DiscardFailedExclusiveStaging(fs, staged, handle)
 		return fmt.Errorf("failed to copy data: %w", err)
 	}
 
-	if err := dstFile.Close(); err != nil {
-		_ = fs.Remove(tmp)
-		return fmt.Errorf("failed to close destination: %w", err)
+	p := StagedPublish{
+		FS:      fs,
+		Publish: ReplaceFile,
+		Staged:  staged,
+		Handle:  handle,
+		Dest:    dst,
+		Suffix:  ".mvstg",
+		NextOrdinal: func() uint64 {
+			return noreplaceOrdinal.Add(1)
+		},
 	}
-
-	if err := fs.Rename(tmp, dst); err != nil {
-		_ = fs.Remove(tmp)
+	if err := PublishStagedBound(p); err != nil {
+		// Same discard discipline as the no-replace composites: the old
+		// implementation removed its temp on failure; keep that cleanliness
+		// without ever deleting a possibly-foreign staged name.
+		discardStagedAfterFailedPublish(fs, staged, err)
 		return fmt.Errorf("failed to rename temp file to destination: %w", err)
 	}
 

--- a/internal/fsutil/move.go
+++ b/internal/fsutil/move.go
@@ -75,7 +75,7 @@ func copyFileDataFs(fs afero.Fs, src, dst string) error {
 	// staged name is never published nor unbound-removed (#224). Publish keeps
 	// REPLACE semantics (authorized overwrite); no-clobber uses the separate
 	// NoReplace composites.
-	staged, handle, sErr := CreateExclusiveStagingFile(fs, dst, ".mvstg", noreplaceOrdinal.Add(1), config.FilePerm)
+	staged, handle, sErr := CreateExclusiveStagingFile(fs, dst, ".mvstg", noreplaceOrdinal.Add(1), stagingFileMode())
 	if sErr != nil {
 		return fmt.Errorf("failed to create destination: %w", sErr)
 	}
@@ -84,6 +84,8 @@ func copyFileDataFs(fs afero.Fs, src, dst string) error {
 		DiscardFailedExclusiveStaging(fs, staged, handle)
 		return fmt.Errorf("failed to copy data: %w", err)
 	}
+
+	stagedIdentity := stagingIdentity(handle)
 
 	p := StagedPublish{
 		FS:          fs,
@@ -98,7 +100,7 @@ func copyFileDataFs(fs afero.Fs, src, dst string) error {
 		// Same discard discipline as the no-replace composites: the old
 		// implementation removed its temp on failure; keep that cleanliness
 		// without ever deleting a possibly-foreign staged name.
-		discardStagedAfterFailedPublish(fs, staged, err)
+		discardStagedAfterFailedPublish(fs, staged, stagedIdentity, err)
 		return fmt.Errorf("failed to rename temp file to destination: %w", err)
 	}
 

--- a/internal/fsutil/move_coverage_test.go
+++ b/internal/fsutil/move_coverage_test.go
@@ -58,7 +58,7 @@ func TestMoveFileFs_SourceNotFoundMemMap(t *testing.T) {
 
 // --- crossDeviceMoveFs coverage ---
 
-func TestCrossDeviceMoveFs_SourceRemoveFailure_CleansUpDest(t *testing.T) {
+func TestCrossDeviceMoveFs_SourceRemoveFailure_KeepsBoth(t *testing.T) {
 	// Use a filesystem where copy succeeds but Remove fails.
 	// We simulate this with a custom Fs wrapper.
 	memFs := afero.NewMemMapFs()
@@ -69,9 +69,31 @@ func TestCrossDeviceMoveFs_SourceRemoveFailure_CleansUpDest(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to remove source")
 
-	// Destination should be cleaned up
-	_, statErr := memFs.Stat("/dst.txt")
-	assert.True(t, os.IsNotExist(statErr), "dest should be removed after source remove failure")
+	// #224: keep-both postcondition — the published destination bytes and the
+	// unremovable source BOTH survive; nothing is deleted out from under a
+	// failure (the old behavior removed dst, quietly destroying the copy).
+	dstContent, statErr := afero.ReadFile(memFs, "/dst.txt")
+	assert.NoError(t, statErr, "dest must be kept after source remove failure")
+	assert.Equal(t, "data", string(dstContent))
+	_, srcErr := memFs.Stat("/src.txt")
+	assert.NoError(t, srcErr, "source must survive when its removal failed")
+}
+
+func TestCrossDeviceMoveFs_CopyFailureKeepsForeignDest(t *testing.T) {
+	// #224: on copy-leg failure the destination is NEVER deleted — the old
+	// implementation removed dst (an entry this operation never wrote), which
+	// deleted pre-existing foreign content.
+	memFs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(memFs, "/dst.txt", []byte("foreign"), 0644))
+
+	fs := &openFailFs{Fs: memFs, failOn: "/src.txt"}
+	err := crossDeviceMoveFs(fs, "/src.txt", "/dst.txt")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to copy file across devices")
+
+	dstContent, statErr := afero.ReadFile(memFs, "/dst.txt")
+	assert.NoError(t, statErr)
+	assert.Equal(t, "foreign", string(dstContent), "foreign destination must survive a failed move")
 }
 
 // removeFailFs wraps afero.Fs and fails on Remove for a specific path.
@@ -85,6 +107,19 @@ func (r *removeFailFs) Remove(name string) error {
 		return fmt.Errorf("simulated remove failure")
 	}
 	return r.Fs.Remove(name)
+}
+
+// openFailFs wraps afero.Fs and fails on Open for a specific path.
+type openFailFs struct {
+	afero.Fs
+	failOn string
+}
+
+func (o *openFailFs) Open(name string) (afero.File, error) {
+	if name == o.failOn {
+		return nil, fmt.Errorf("simulated open failure")
+	}
+	return o.Fs.Open(name)
 }
 
 // --- AferoRemoveAll coverage ---

--- a/internal/fsutil/move_noreplace.go
+++ b/internal/fsutil/move_noreplace.go
@@ -1,0 +1,174 @@
+package fsutil
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/spf13/afero"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+)
+
+// move_noreplace.go — the organize-side atomic no-clobber composites (#224
+// phases A+B). MoveFileFs/CopyFileFs keep REPLACE semantics for authorized
+// overwrites; these two are the never-clobber variants built from the
+// poster-write-hardening toolkit (CreateExclusiveStagingFile /
+// PublishStagedBound / UnlinkVerified / PublishNoReplace).
+//
+// Vocabulary is deliberately the existing one: occupancy refuses with
+// ErrPublishCollision, inexpressible volumes with ErrPublishNoReplaceUnsupported;
+// both are PublishRefusal() subclasses. On every refusal/ambiguous failure,
+// src AND dst are both preserved byte-intact.
+
+// noreplaceOrdinal is the process-local staging-name nonce for the
+// no-replace composites (exclusive staging retries ordinals inside).
+var noreplaceOrdinal atomic.Uint64
+
+// classifyNoreplaceDestination runs the adoption/classification pre-check:
+// PublishNoReplace carries NO adoption semantics (every occupied dst refuses),
+// while organize keeps #225's no-op rules — lexical self, and same-inode
+// (hardlink) aliases of the source. A symlink SOURCE pointing at dst's regular
+// inode is NOT an alias (mirrors refuseExistingDestination's exclusion).
+//
+// Returns done=true with nil when the caller must return success without
+// touching anything.
+func classifyNoreplaceDestination(fs afero.Fs, src, dst string) (done bool, err error) {
+	if filepath.Clean(src) == filepath.Clean(dst) {
+		return true, nil
+	}
+	srcInfo, statErr := asideLstat(fs, src)
+	if statErr != nil {
+		return false, fmt.Errorf("no-replace: probe source %s: %w", src, statErr)
+	}
+	dstInfo, dstErr := asideLstat(fs, dst)
+	if dstErr == nil {
+		if !asideIsSymlink(srcInfo) && os.SameFile(srcInfo, dstInfo) {
+			return true, nil
+		}
+		return false, fmt.Errorf("%w: %s", ErrPublishCollision, dst)
+	}
+	if !os.IsNotExist(dstErr) {
+		// Indeterminate destination state — refuse without touching (the same
+		// posture history holds for its restores).
+		return false, fmt.Errorf("no-replace: probe destination %s: %w", dst, dstErr)
+	}
+	return false, nil
+}
+
+// asideIsSymlink reports whether info names a symlink.
+func asideIsSymlink(info os.FileInfo) bool {
+	return info != nil && info.Mode()&os.ModeSymlink != 0
+}
+
+// MoveFileNoReplace moves src to dst without ever replacing destination
+// content.
+//
+// Symlink-source corners (spec decision note): an EXDEV move of a symlink
+// publishes the TARGET's bytes as a regular file and necessarily refuses the
+// source cleanup (the identity check rejects symlink identities), surfacing an
+// ambiguity error with both objects preserved; and on non-Linux POSIX the
+// same-volume fallback's link(2) dereferences symlink sources, so some
+// same-volume fallback implementations may link the target inode rather than
+// renaming the link itself (POSIX leaves symlink-source link(2) behavior
+// implementation-defined).
+// Organizer sources are scanner-yielded regular files, so neither arises in
+// production. Same-volume is PublishNoReplace (src consumed by the rename);
+// cross-device stages dest-adjacent with O_EXCL, streams through the open
+// handle, publishes with bound identity (PublishStagedBound), and removes src
+// ONLY via identity-checked unlink — a source swapped after the publish is
+// preserved and reported (both objects then exist; the move is done at dst
+// but reported as ambiguous rather than silently destroying the foreign src).
+func MoveFileNoReplace(fs afero.Fs, src, dst string) error {
+	done, err := classifyNoreplaceDestination(fs, src, dst)
+	if done || err != nil {
+		return err
+	}
+	if err := fs.MkdirAll(filepath.Dir(dst), config.DirPerm); err != nil {
+		return fmt.Errorf("no-replace move: create destination directory: %w", err)
+	}
+	if pubErr := PublishNoReplace(fs, src, dst); pubErr == nil {
+		return nil
+	} else if !isCrossDeviceError(pubErr) {
+		return pubErr
+	}
+
+	// Cross-device leg: stage, stream, bound publish, verified source cleanup.
+	srcPre, err := asideLstat(fs, src)
+	if err != nil {
+		return fmt.Errorf("no-replace move: re-probe source %s before staging: %w", src, err)
+	}
+	if err := CopyFileNoReplace(fs, src, dst); err != nil {
+		return err
+	}
+	if rmErr := UnlinkVerified(fs, src, srcPre); rmErr != nil {
+		// dst was published; src could not be proven the pre-move object —
+		// keep BOTH (a swapped source is foreign) and surface the ambiguity.
+		return fmt.Errorf("no-replace move: published to %s but source cleanup refused (%w) — source preserved", dst, rmErr)
+	}
+	return nil
+}
+
+// CopyFileNoReplace copies src to dst via dest-adjacent exclusive staging and
+// a bound no-replace publish. src is never modified. On every failure leg the
+// staged name is discarded via the bound discipline (a planted substitute is
+// never unlinked), dst content is never replaced, and a foreign plant wins the
+// name with ErrPublishCollision.
+func CopyFileNoReplace(fs afero.Fs, src, dst string) error {
+	done, err := classifyNoreplaceDestination(fs, src, dst)
+	if done || err != nil {
+		return err
+	}
+	if err := fs.MkdirAll(filepath.Dir(dst), config.DirPerm); err != nil {
+		return fmt.Errorf("no-replace copy: create destination directory: %w", err)
+	}
+
+	srcFile, err := fs.Open(src)
+	if err != nil {
+		return fmt.Errorf("no-replace copy: open source %s: %w", src, err)
+	}
+	defer func() { _ = srcFile.Close() }()
+
+	staged, handle, err := CreateExclusiveStagingFile(fs, dst, ".nrstg", noreplaceOrdinal.Add(1), config.FilePerm)
+	if err != nil {
+		return fmt.Errorf("no-replace copy: exclusive staging for %s: %w", dst, err)
+	}
+	if _, err := io.Copy(handle, srcFile); err != nil {
+		DiscardFailedExclusiveStaging(fs, staged, handle)
+		return fmt.Errorf("no-replace copy: stream into staging for %s: %w", dst, err)
+	}
+
+	p := StagedPublish{
+		FS:        fs,
+		Publish:   func(fsys afero.Fs, s, d string) error { return PublishNoReplace(fsys, s, d) },
+		NoReplace: true,
+		Staged:    staged,
+		Handle:    handle,
+		Dest:      dst,
+		Suffix:    ".nrstg",
+		NextOrdinal: func() uint64 {
+			return noreplaceOrdinal.Add(1)
+		},
+	}
+	if err := PublishStagedBound(p); err != nil {
+		discardStagedAfterFailedPublish(fs, staged, err)
+		return fmt.Errorf("no-replace copy: publish %s: %w", dst, err)
+	}
+	return nil
+}
+
+// discardStagedAfterFailedPublish removes the staged copy after a failed
+// bound publish. Per PublishStagedBound's contract, every class except the
+// pre-publish verify failure and the ErrPublishCompleted-carrying classes has
+// the staged name either still provably ours or already consumed — removing it
+// is safe. The forbidden classes keep the name in place deliberately
+// (identity-unproven staged names may address a foreign object).
+func discardStagedAfterFailedPublish(fs afero.Fs, staged string, err error) {
+	if errors.Is(err, ErrPublishStagedVerify) || PublishCompleted(err) {
+		return
+	}
+	_ = fs.Remove(staged)
+}

--- a/internal/fsutil/move_noreplace.go
+++ b/internal/fsutil/move_noreplace.go
@@ -110,7 +110,10 @@ func MoveFileNoReplace(fs afero.Fs, src, dst string) error {
 	if rmErr := UnlinkVerified(fs, src, srcPre); rmErr != nil {
 		// dst was published; src could not be proven the pre-move object —
 		// keep BOTH (a swapped source is foreign) and surface the ambiguity.
-		return fmt.Errorf("no-replace move: published to %s but source cleanup refused (%w) — source preserved", dst, rmErr)
+		// The wrap JOINS ErrPublishCompleted (publish already landed — callers
+		// must never classify this as a pre-publish refusal) with the typed
+		// cleanup error so diagnostics survive without either class lying.
+		return fmt.Errorf("%w: no-replace move: published to %s but source cleanup refused (%w) — source preserved", ErrPublishCompleted, dst, rmErr)
 	}
 	return nil
 }

--- a/internal/fsutil/move_noreplace.go
+++ b/internal/fsutil/move_noreplace.go
@@ -205,15 +205,35 @@ func discardStagedAfterFailedPublish(fs afero.Fs, staged string, identity os.Fil
 		return
 	}
 	if identity == nil {
-		return // identity could not be shown — keep both
+		return // identity unknowable — keep both, never unbound-remove
 	}
-	// Staged names are ours by construction (O_EXCL created); no vacate is
-	// needed, and UnlinkVerified would need the no-replace publish these
-	// volumes can't express (codex P1: on exFAT that leaked full-size staged
-	// copies per attempt). Prove identity in place, remove directly.
-	cur, lerr := asideLstat(fs, staged)
-	if lerr != nil || !asideSameObject(cur, identity) {
-		return // already consumed by the publish or substituted: keep both
+	// Removal must be bound to the verified staged INODE, never the name:
+	// a directory writer who renames the staged name away and plants a
+	// substitute would otherwise get ITS file deleted between our proof and
+	// the unlink. Vacate via a plain rename (no no-replace primitive needed —
+	// this works on exFAT too, codex r4), then re-prove the vacated object
+	// matches the staged identity; any mismatch or move-away restores the
+	// occupancy without deleting anything.
+	vac, claimInfo, claimErr := claimTakeAsideVacName(fs, staged)
+	if claimErr != nil {
+		return // could not claim a vacated sibling; keep both
 	}
-	_ = fs.Remove(staged)
+	if relErr := releaseTakeAsideVacClaim(fs, vac, claimInfo); relErr != nil {
+		return
+	}
+	if err := fs.Rename(staged, vac); err != nil {
+		return // staged already gone or foreign-won window — keep both
+	}
+	vacInfo, lerr := asideLstat(fs, vac)
+	if lerr != nil || !asideSameObject(vacInfo, identity) {
+		// The object renamed into vac is NOT the verified staged copy — a plant
+		// won the rename window. Restore occupancy: put it back on the staged
+		// name (best-effort) and delete nothing.
+		// A failed restore keeps both names live; the caller's error still
+		// propagates the publish outcome. `rb` is informational only.
+		rb := fs.Rename(vac, staged)
+		_ = rb
+		return
+	}
+	_ = fs.Remove(vac)
 }

--- a/internal/fsutil/move_noreplace.go
+++ b/internal/fsutil/move_noreplace.go
@@ -204,8 +204,16 @@ func discardStagedAfterFailedPublish(fs afero.Fs, staged string, identity os.Fil
 	if errors.Is(pubErr, ErrPublishStagedVerify) || PublishCompleted(pubErr) {
 		return
 	}
-	// UnlinkFailed means the staged object could not be re-proven (already
-	// consumed by the publish, or swapped out and re-planted) — both spell
-	//	// "do nothing", and keep the codex-reviewed keep-both postcondition.
-	_ = UnlinkVerified(fs, staged, identity)
+	if identity == nil {
+		return // identity could not be shown — keep both
+	}
+	// Staged names are ours by construction (O_EXCL created); no vacate is
+	// needed, and UnlinkVerified would need the no-replace publish these
+	// volumes can't express (codex P1: on exFAT that leaked full-size staged
+	// copies per attempt). Prove identity in place, remove directly.
+	cur, lerr := asideLstat(fs, staged)
+	if lerr != nil || !asideSameObject(cur, identity) {
+		return // already consumed by the publish or substituted: keep both
+	}
+	_ = fs.Remove(staged)
 }

--- a/internal/fsutil/move_noreplace.go
+++ b/internal/fsutil/move_noreplace.go
@@ -24,6 +24,16 @@ import (
 // both are PublishRefusal() subclasses. On every refusal/ambiguous failure,
 // src AND dst are both preserved byte-intact.
 
+// stagingFileMode restores the pre-#224 mode semantics for staging writes:
+// the legacy OpenFile path let the kernel apply the process umask,
+// CreateExclusiveStagingFile deliberately Chmods the exact requested mode
+// instead. Without re-masking, organized files would land wider than the
+// configured umask permits (codex P1). With no cached umask this degenerates
+// to config.FilePerm unchanged.
+func stagingFileMode() os.FileMode {
+	return config.FilePerm &^ os.FileMode(config.UmaskValue())
+}
+
 // noreplaceOrdinal is the process-local staging-name nonce for the
 // no-replace composites (exclusive staging retries ordinals inside).
 var noreplaceOrdinal atomic.Uint64
@@ -138,7 +148,7 @@ func CopyFileNoReplace(fs afero.Fs, src, dst string) error {
 	}
 	defer func() { _ = srcFile.Close() }()
 
-	staged, handle, err := CreateExclusiveStagingFile(fs, dst, ".nrstg", noreplaceOrdinal.Add(1), config.FilePerm)
+	staged, handle, err := CreateExclusiveStagingFile(fs, dst, ".nrstg", noreplaceOrdinal.Add(1), stagingFileMode())
 	if err != nil {
 		return fmt.Errorf("no-replace copy: exclusive staging for %s: %w", dst, err)
 	}
@@ -146,6 +156,8 @@ func CopyFileNoReplace(fs afero.Fs, src, dst string) error {
 		DiscardFailedExclusiveStaging(fs, staged, handle)
 		return fmt.Errorf("no-replace copy: stream into staging for %s: %w", dst, err)
 	}
+
+	stagedIdentity := stagingIdentity(handle)
 
 	p := StagedPublish{
 		FS:          fs,
@@ -158,21 +170,42 @@ func CopyFileNoReplace(fs afero.Fs, src, dst string) error {
 		NextOrdinal: nextNoReplaceOrdinal,
 	}
 	if err := PublishStagedBound(p); err != nil {
-		discardStagedAfterFailedPublish(fs, staged, err)
+		discardStagedAfterFailedPublish(fs, staged, stagedIdentity, err)
 		return fmt.Errorf("no-replace copy: publish %s: %w", dst, err)
 	}
 	return nil
 }
 
+// stagingIdentity captures the staged object's identity while its handle is
+// pinned (identity-bearing opens), so post-failure cleanup can re-prove the
+// name before unlinking (see discardStagedAfterFailedPublish).
+func stagingIdentity(fh afero.File) os.FileInfo {
+	if fh == nil {
+		return nil
+	}
+	info, err := fh.Stat()
+	if err != nil {
+		return nil
+	}
+	return info
+}
+
 // discardStagedAfterFailedPublish removes the staged copy after a failed
-// bound publish. Per PublishStagedBound's contract, every class except the
-// pre-publish verify failure and the ErrPublishCompleted-carrying classes has
-// the staged name either still provably ours or already consumed — removing it
-// is safe. The forbidden classes keep the name in place deliberately
-// (identity-unproven staged names may address a foreign object).
-func discardStagedAfterFailedPublish(fs afero.Fs, staged string, err error) {
-	if errors.Is(err, ErrPublishStagedVerify) || PublishCompleted(err) {
+// bound publish. The staged name is ordinal-shaped and attacker-observable;
+// a racer can substitute a foreign file within remove windows, so the removal
+// is executed via UnlinkVerified bound to the identity captured at staging
+// time (#224 codex finding) — a foreign substitute is never unlinked.
+//
+// It is skipped for classes where the contract deliberately retains the
+// staged name: ErrPublishStagedVerify (name unproven from the start) and any
+// ErrPublishCompleted-carrying class (the name was left in place and may
+// already address a foreign object).
+func discardStagedAfterFailedPublish(fs afero.Fs, staged string, identity os.FileInfo, pubErr error) {
+	if errors.Is(pubErr, ErrPublishStagedVerify) || PublishCompleted(pubErr) {
 		return
 	}
-	_ = fs.Remove(staged)
+	// UnlinkFailed means the staged object could not be re-proven (already
+	// consumed by the publish, or swapped out and re-planted) — both spell
+	//	// "do nothing", and keep the codex-reviewed keep-both postcondition.
+	_ = UnlinkVerified(fs, staged, identity)
 }

--- a/internal/fsutil/move_noreplace.go
+++ b/internal/fsutil/move_noreplace.go
@@ -28,6 +28,9 @@ import (
 // no-replace composites (exclusive staging retries ordinals inside).
 var noreplaceOrdinal atomic.Uint64
 
+// nextNoReplaceOrdinal hands out the next ordinal for staging-name generation.
+func nextNoReplaceOrdinal() uint64 { return noreplaceOrdinal.Add(1) }
+
 // classifyNoreplaceDestination runs the adoption/classification pre-check:
 // PublishNoReplace carries NO adoption semantics (every occupied dst refuses),
 // while organize keeps #225's no-op rules — lexical self, and same-inode
@@ -142,16 +145,14 @@ func CopyFileNoReplace(fs afero.Fs, src, dst string) error {
 	}
 
 	p := StagedPublish{
-		FS:        fs,
-		Publish:   func(fsys afero.Fs, s, d string) error { return PublishNoReplace(fsys, s, d) },
-		NoReplace: true,
-		Staged:    staged,
-		Handle:    handle,
-		Dest:      dst,
-		Suffix:    ".nrstg",
-		NextOrdinal: func() uint64 {
-			return noreplaceOrdinal.Add(1)
-		},
+		FS:          fs,
+		Publish:     func(fsys afero.Fs, s, d string) error { return PublishNoReplace(fsys, s, d) },
+		NoReplace:   true,
+		Staged:      staged,
+		Handle:      handle,
+		Dest:        dst,
+		Suffix:      ".nrstg",
+		NextOrdinal: nextNoReplaceOrdinal,
 	}
 	if err := PublishStagedBound(p); err != nil {
 		discardStagedAfterFailedPublish(fs, staged, err)

--- a/internal/fsutil/move_noreplace_coverage_test.go
+++ b/internal/fsutil/move_noreplace_coverage_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
+
+	"github.com/javinizer/javinizer-go/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -172,17 +174,23 @@ func TestCoverCopyNoReplace_PublishFailureDiscardsStaging(t *testing.T) {
 	// pre-seeding dst before Delete? Simplest coverage: directly exercise
 	// discardStagedAfterFailedPublish semantics.
 	require.NoError(t, afero.WriteFile(fs, "/out/a.mp4.nrstg.0", []byte("staged"), 0644))
-	discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.0", fsutil_cropErr("discarded"))
+	info0, statErr0 := fs.Stat("/out/a.mp4.nrstg.0")
+	require.NoError(t, statErr0)
+	discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.0", info0, fsutil_cropErr("discarded"))
 	_, err := fs.Stat("/out/a.mp4.nrstg.0")
 	assert.True(t, os.IsNotExist(err), "staged discarded on ordinary failure")
 
 	require.NoError(t, afero.WriteFile(fs, "/out/a.mp4.nrstg.1", []byte("staged"), 0644))
-	discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.1", cropVerifyErr())
+	info1, statErr1 := fs.Stat("/out/a.mp4.nrstg.1")
+	require.NoError(t, statErr1)
+	discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.1", info1, cropVerifyErr())
 	_, err = fs.Stat("/out/a.mp4.nrstg.1")
 	assert.NoError(t, err, "ErrPublishStagedVerify keeps the name in place")
 
 	require.NoError(t, afero.WriteFile(fs, "/out/a.mp4.nrstg.2", []byte("staged"), 0644))
-	discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.2", cropCompletedErr())
+	info2, statErr2 := fs.Stat("/out/a.mp4.nrstg.2")
+	require.NoError(t, statErr2)
+	discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.2", info2, cropCompletedErr())
 	_, err = fs.Stat("/out/a.mp4.nrstg.2")
 	assert.NoError(t, err, "ErrPublishCompleted-carrying keeps the name in place")
 }
@@ -200,7 +208,7 @@ type renameFailFs struct {
 }
 
 func (r *renameFailFs) Rename(oldname, newname string) error {
-	if strings.HasPrefix(filepath.Clean(newname), filepath.Clean(r.failRenameDst)) {
+	if filepath.Clean(newname) == filepath.Clean(r.failRenameDst) {
 		return errors.New("simulated publish rename failure")
 	}
 	return r.Fs.Rename(oldname, newname)
@@ -288,4 +296,42 @@ func TestCoverMoveNoReplace_EXDEVCopyPublishRefusal(t *testing.T) {
 	assert.Equal(t, "foreign", string(content))
 	content, _ = os.ReadFile(src)
 	assert.Equal(t, "x", string(content), "source preserved after copy refusal")
+}
+
+// #224 codex P1: staging honors the configured umask — chmod-reasserted staging
+// must not widen published permissions beyond FilePerm &^ umask.
+func TestStagingFileMode_HonorsCachedUmask(t *testing.T) {
+	prev := config.UmaskValue()
+	config.StoreUmask(0o002)
+	t.Cleanup(func() { config.StoreUmask(prev) })
+
+	fs := afero.NewMemMapFs()
+	seedSrc(t, fs)
+	require.NoError(t, CopyFileNoReplace(fs, "/in/a.mp4", "/out/a.mp4"))
+	info, err := fs.Stat("/out/a.mp4")
+	require.NoError(t, err)
+	// MemMapFs doesn't apply umask at all, so whatever stagingFileMode() decided
+	// is the truth being published.
+	assert.Equal(t, config.FilePerm&^os.FileMode(0o002), info.Mode().Perm())
+}
+
+// #224 codex P2: the discard binds by identity — a substitute planted at the
+// staged name after our staging is never unlinked.
+func TestDiscardBound_PlantSubstitutePreserved(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/out", 0777))
+	staged := "/out/a.mp4.nrstg.9"
+	require.NoError(t, afero.WriteFile(fs, staged, []byte("staged-content"), 0644))
+	info, err := fs.Stat(staged)
+	require.NoError(t, err)
+
+	// Substitute the staged name with a foreign object (different identity).
+	require.NoError(t, fs.Remove(staged))
+	require.NoError(t, afero.WriteFile(fs, staged, []byte("foreign"), 0644))
+
+	discardStagedAfterFailedPublish(fs, staged, info, fsutil_cropErr("publish failed"))
+
+	content, rerr := afero.ReadFile(fs, staged)
+	require.NoError(t, rerr)
+	assert.Equal(t, "foreign", string(content), "foreign substitute must be preserved, never unlinked")
 }

--- a/internal/fsutil/move_noreplace_coverage_test.go
+++ b/internal/fsutil/move_noreplace_coverage_test.go
@@ -1,0 +1,291 @@
+package fsutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failFs selectively fails fs operations for named paths. Used to drive every
+// defensive failure leg of the composites.
+type failFs struct {
+	afero.Fs
+	failMkdirAll string
+	failOpen     string
+	failOpenFile string
+	failLstat    string
+}
+
+func (f *failFs) MkdirAll(path string, perm os.FileMode) error {
+	if f.failMkdirAll != "" && filepath.Clean(path) == filepath.Clean(f.failMkdirAll) {
+		return errors.New("simulated mkdir failure")
+	}
+	return f.Fs.MkdirAll(path, perm)
+}
+
+func (f *failFs) Open(name string) (afero.File, error) {
+	if f.failOpen != "" && filepath.Clean(name) == filepath.Clean(f.failOpen) {
+		return nil, errors.New("simulated open failure")
+	}
+	return f.Fs.Open(name)
+}
+
+func (f *failFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	if f.failOpenFile != "" && strings.HasPrefix(filepath.Clean(name), filepath.Clean(f.failOpenFile)) {
+		return nil, errors.New("simulated openfile failure")
+	}
+	return f.Fs.OpenFile(name, flag, perm)
+}
+
+func (f *failFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	if f.failLstat != "" && filepath.Clean(name) == filepath.Clean(f.failLstat) {
+		return nil, false, errors.New("simulated lstat failure")
+	}
+	return f.Fs.(interface {
+		LstatIfPossible(string) (os.FileInfo, bool, error)
+	}).LstatIfPossible(name)
+}
+
+func seedSrc(t *testing.T, fs afero.Fs) {
+	t.Helper()
+	require.NoError(t, afero.WriteFile(fs, "/in/a.mp4", []byte("data"), 0644))
+}
+
+func TestCoverMoveNoReplace_MissingSource(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	err := MoveFileNoReplace(fs, "/in/nope.mp4", "/out/nope.mp4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "probe source")
+}
+
+func TestCoverMoveNoReplace_DestIndeterminate(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	seedSrc(t, fs)
+	wrapped := &failFs{Fs: fs, failLstat: "/out/a.mp4"}
+	err := MoveFileNoReplace(wrapped, "/in/a.mp4", "/out/a.mp4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "probe destination")
+}
+
+func TestCoverMoveNoReplace_MkdirAllFailure(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	seedSrc(t, fs)
+	wrapped := &failFs{Fs: fs, failMkdirAll: "/out"}
+	err := MoveFileNoReplace(wrapped, "/in/a.mp4", "/out/a.mp4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create destination directory")
+}
+
+func TestCoverMoveNoReplace_EXDEVLegCopyErrorSurfaces(t *testing.T) {
+	if !forceNoReplaceEXDEV(t, 1) {
+		t.Skip("no publish seams")
+	}
+	dir := t.TempDir()
+	fs := afero.NewOsFs()
+	src := filepath.Join(dir, "a.mp4")
+	dst := filepath.Join(dir, "sub", "a.mp4")
+	require.NoError(t, os.WriteFile(src, []byte("x"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0755))
+	require.NoError(t, os.WriteFile(dst, []byte("foreign"), 0644))
+	// Wait: EXDEV forced but dst occupied → classification refuses before staging.
+	err := MoveFileNoReplace(fs, src, dst)
+	require.ErrorIs(t, err, ErrPublishCollision)
+	content, _ := os.ReadFile(dst)
+	assert.Equal(t, "foreign", string(content))
+}
+
+func TestCoverCopyNoReplace_MkdirAllFailure(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	seedSrc(t, fs)
+	wrapped := &failFs{Fs: fs, failMkdirAll: "/out"}
+	err := CopyFileNoReplace(wrapped, "/in/a.mp4", "/out/a.mp4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create destination directory")
+}
+
+func TestCoverCopyNoReplace_OpenSourceFailure(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	seedSrc(t, fs)
+	wrapped := &failFs{Fs: fs, failOpen: "/in/a.mp4"}
+	err := CopyFileNoReplace(wrapped, "/in/a.mp4", "/out/a.mp4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open source")
+}
+
+func TestCoverCopyNoReplace_StagingFailure(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	seedSrc(t, fs)
+	wrapped := &failFs{Fs: fs, failOpenFile: "/out/a.mp4.nrstg."}
+	err := CopyFileNoReplace(wrapped, "/in/a.mp4", "/out/a.mp4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exclusive staging")
+}
+
+func TestCoverCopyNoReplace_StreamFailureDiscardsStaging(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	seedSrc(t, fs)
+	// kill the copy mid-stream by failing Reads: wrap Open to return a file
+	// whose Read always fails.
+	wrapped := &readFailFs{Fs: fs}
+	err := CopyFileNoReplace(wrapped, "/in/a.mp4", "/out/a.mp4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stream into staging")
+	entries, derr := afero.ReadDir(fs, "/out")
+	require.NoError(t, derr)
+	assert.Empty(t, entries, "staged discard must not leave leftovers")
+}
+
+type readFailFile struct {
+	afero.File
+}
+
+func (r *readFailFile) Read(p []byte) (int, error) { return 0, errors.New("simulated read failure") }
+
+type readFailFs struct{ afero.Fs }
+
+func (r *readFailFs) Open(name string) (afero.File, error) {
+	fh, err := r.Fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &readFailFile{File: fh}, nil
+}
+
+// TestCoverCopyNoReplace_PublishFailureDiscardsStaging drives a collision INSIDE
+// the publish (occupied after classification via direct pre-plant of BOTH
+// outcomes) — plus the discard legs on the virtual fs where publication of a
+// planted name must refuse cleanly.
+func TestCoverCopyNoReplace_PublishFailureDiscardsStaging(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	seedSrc(t, fs)
+	// Pre-claim the ordinal staging name so .nrstg.0 is OURS-like but then a
+	// foreign target exists by publish time — trivially reproduced by making
+	// the virtual publish fail: don't rewrite its internal state; instead,
+	// force destination occupancy between classification and publish by
+	// pre-seeding dst before Delete? Simplest coverage: directly exercise
+	// discardStagedAfterFailedPublish semantics.
+	require.NoError(t, afero.WriteFile(fs, "/out/a.mp4.nrstg.0", []byte("staged"), 0644))
+	discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.0", fsutil_cropErr("discarded"))
+	_, err := fs.Stat("/out/a.mp4.nrstg.0")
+	assert.True(t, os.IsNotExist(err), "staged discarded on ordinary failure")
+
+	require.NoError(t, afero.WriteFile(fs, "/out/a.mp4.nrstg.1", []byte("staged"), 0644))
+	discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.1", cropVerifyErr())
+	_, err = fs.Stat("/out/a.mp4.nrstg.1")
+	assert.NoError(t, err, "ErrPublishStagedVerify keeps the name in place")
+
+	require.NoError(t, afero.WriteFile(fs, "/out/a.mp4.nrstg.2", []byte("staged"), 0644))
+	discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.2", cropCompletedErr())
+	_, err = fs.Stat("/out/a.mp4.nrstg.2")
+	assert.NoError(t, err, "ErrPublishCompleted-carrying keeps the name in place")
+}
+
+// helper wrappers producing the discard-stable error classes
+func fsutil_cropErr(msg string) error { return errors.New(msg) }
+func cropVerifyErr() error            { return fmt.Errorf("verify failed: %w", ErrPublishStagedVerify) }
+func cropCompletedErr() error         { return fmt.Errorf("published then failed: %w", ErrPublishCompleted) }
+
+// renameFailFs fails Rename for a named destination — drives the replace-leg
+// publish-failure path of copyFileDataFs (covered line: discard of .mvstg).
+type renameFailFs struct {
+	afero.Fs
+	failRenameDst string
+}
+
+func (r *renameFailFs) Rename(oldname, newname string) error {
+	if strings.HasPrefix(filepath.Clean(newname), filepath.Clean(r.failRenameDst)) {
+		return errors.New("simulated publish rename failure")
+	}
+	return r.Fs.Rename(oldname, newname)
+}
+
+func TestCoverMoveFsCopyFileData_PublishFailureDiscards(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	seedSrc(t, fs)
+	wrapped := &renameFailFs{Fs: fs, failRenameDst: "/out/a.mp4"}
+	err := copyFileDataFs(wrapped, "/in/a.mp4", "/out/a.mp4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to rename temp file to destination")
+	entries, derr := afero.ReadDir(fs, "/out")
+	require.NoError(t, derr)
+	// The freshly staged .mvstg file must be discarded — no leftovers.
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".mvstg", "staged file left behind: %s", e.Name())
+	}
+}
+
+func TestCoverCopyNoReplace_PublishErrorLeg(t *testing.T) {
+	// All renames fail → the bound publish of the staged copy fails with a
+	// generic error → discardStagedAfterFailedPublish removes the .nrstg name.
+	fs := afero.NewMemMapFs()
+	seedSrc(t, fs)
+	wrapped := &renameFailFs{Fs: fs, failRenameDst: "/out/a.mp4"}
+	err := CopyFileNoReplace(wrapped, "/in/a.mp4", "/out/a.mp4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "publish")
+	// no .nrstg leftovers
+	exists, _ := afero.Exists(fs, "/out/a.mp4.nrstg.0")
+	assert.False(t, exists)
+}
+
+func TestCoverNextOrdinalMonotonic(t *testing.T) {
+	a := nextNoReplaceOrdinal()
+	b := nextNoReplaceOrdinal()
+	assert.Greater(t, b, a)
+}
+
+func TestCoverMoveNoReplace_EXDEVReProbeFailure(t *testing.T) {
+	// src vanishes exactly as the publish refuses EXDEV, so the composite's
+	// re-probe before staging finds nothing.
+	dir := t.TempDir()
+	fs := afero.NewOsFs()
+	src := filepath.Join(dir, "a.mp4")
+	dst := filepath.Join(dir, "sub", "a.mp4")
+	require.NoError(t, os.WriteFile(src, []byte("x"), 0644))
+	if !forceNoReplaceEXDEV(t, 1) {
+		t.Skip("no publish seams")
+	}
+	if !hookNoReplacePlantSeamsFirstCall(t, func() { _ = os.Remove(src) }) {
+		t.Skip("no publish seams")
+	}
+	err := MoveFileNoReplace(fs, src, dst)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "re-probe source")
+}
+
+func TestCoverMoveNoReplace_EXDEVCopyPublishRefusal(t *testing.T) {
+	// EXDEV forced; dst planted right at the second publish-seam call so the
+	// cross-device copy's publish refuses the occupied destination.
+	dir := t.TempDir()
+	fs := afero.NewOsFs()
+	src := filepath.Join(dir, "a.mp4")
+	dst := filepath.Join(dir, "sub", "a.mp4")
+	require.NoError(t, os.WriteFile(src, []byte("x"), 0644))
+	if !forceNoReplaceEXDEV(t, 1) {
+		t.Skip("no publish seams")
+	}
+	// Plant foreign content at dst right as the 2nd publish-seam call begins
+	// (the staged EXDEV-leg publish), so its classification refuses.
+	plant := func() {
+		if _, err := os.Stat(dst); os.IsNotExist(err) {
+			_ = os.MkdirAll(filepath.Dir(dst), 0755)
+			_ = os.WriteFile(dst, []byte("foreign"), 0644)
+		}
+	}
+	if !hookNoReplacePlantSeamsLater(t, 2, plant) {
+		t.Skip("no publish seams")
+	}
+	err := MoveFileNoReplace(fs, src, dst)
+	require.ErrorIs(t, err, ErrPublishCollision)
+	content, _ := os.ReadFile(dst)
+	assert.Equal(t, "foreign", string(content))
+	content, _ = os.ReadFile(src)
+	assert.Equal(t, "x", string(content), "source preserved after copy refusal")
+}

--- a/internal/fsutil/move_noreplace_hooks_linux_test.go
+++ b/internal/fsutil/move_noreplace_hooks_linux_test.go
@@ -1,0 +1,76 @@
+//go:build linux
+
+package fsutil
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// hookNoReplacePlantSeams installs a plant-then-delegate around every publish
+// seam (renameat2 kernel leg and the hard-link fallback).
+func hookNoReplacePlantSeams(t *testing.T, plant func()) bool {
+	t.Helper()
+	prevK := renameNoReplaceKernel
+	prevL := publishNoReplaceLink
+	renameNoReplaceKernel = func(s, d string) error { plant(); return prevK(s, d) }
+	publishNoReplaceLink = func(s, d string) error { plant(); return prevL(s, d) }
+	t.Cleanup(func() {
+		renameNoReplaceKernel = prevK
+		publishNoReplaceLink = prevL
+	})
+	return true
+}
+
+// forceNoReplaceEXDEV makes both publish seams fail with a wrapped EXDEV
+// (simulating a cross-device source) for N calls each, then restores them.
+func forceNoReplaceEXDEV(t *testing.T, nCalls int) bool {
+	t.Helper()
+	remaining := nCalls
+	prevK := renameNoReplaceKernel
+	prevL := publishNoReplaceLink
+	delegate := func(prev func(string, string) error) func(string, string) error {
+		return func(s, d string) error {
+			if remaining > 0 {
+				remaining--
+				return syscall.EXDEV
+			}
+			return prev(s, d)
+		}
+	}
+	renameNoReplaceKernel = delegate(prevK)
+	publishNoReplaceLink = delegate(prevL)
+	t.Cleanup(func() {
+		renameNoReplaceKernel = prevK
+		publishNoReplaceLink = prevL
+	})
+	return true
+}
+
+// swapFileAfterNPublishCalls replaces the file at path with new content after
+// exactly n publish-seam calls (used to simulate a post-publish source swap).
+func swapFileAfterNPublishCalls(t *testing.T, n int, path string, content []byte) bool {
+	t.Helper()
+	calls := 0
+	prevK := renameNoReplaceKernel
+	prevL := publishNoReplaceLink
+	wrap := func(prev func(string, string) error) func(string, string) error {
+		return func(s, d string) error {
+			calls++
+			if calls == n {
+				if err := os.WriteFile(path, content, 0o644); err != nil {
+					return err
+				}
+			}
+			return prev(s, d)
+		}
+	}
+	renameNoReplaceKernel = wrap(prevK)
+	publishNoReplaceLink = wrap(prevL)
+	t.Cleanup(func() {
+		renameNoReplaceKernel = prevK
+		publishNoReplaceLink = prevL
+	})
+	return true
+}

--- a/internal/fsutil/move_noreplace_hooks_linux_test.go
+++ b/internal/fsutil/move_noreplace_hooks_linux_test.go
@@ -74,3 +74,53 @@ func swapFileAfterNPublishCalls(t *testing.T, n int, path string, content []byte
 	})
 	return true
 }
+
+// hookNoReplacePlantSeamsLater invokes plant() immediately BEFORE the n-th
+// total publish-seam call (counting across both seams).
+func hookNoReplacePlantSeamsLater(t *testing.T, n int, plant func()) bool {
+	t.Helper()
+	calls := 0
+	prevK := renameNoReplaceKernel
+	prevL := publishNoReplaceLink
+	wrap := func(prev func(string, string) error) func(string, string) error {
+		return func(s, d string) error {
+			calls++
+			if calls == n {
+				plant()
+			}
+			return prev(s, d)
+		}
+	}
+	renameNoReplaceKernel = wrap(prevK)
+	publishNoReplaceLink = wrap(prevL)
+	t.Cleanup(func() {
+		renameNoReplaceKernel = prevK
+		publishNoReplaceLink = prevL
+	})
+	return true
+}
+
+// hookNoReplacePlantSeamsFirstCall runs action() during the FIRST publish-seam
+// call (before it binds anything), then restores.
+func hookNoReplacePlantSeamsFirstCall(t *testing.T, action func()) bool {
+	t.Helper()
+	calls := 0
+	prevK := renameNoReplaceKernel
+	prevL := publishNoReplaceLink
+	wrap := func(prev func(string, string) error) func(string, string) error {
+		return func(s, d string) error {
+			if calls == 0 {
+				calls++
+				action()
+			}
+			return prev(s, d)
+		}
+	}
+	renameNoReplaceKernel = wrap(prevK)
+	publishNoReplaceLink = wrap(prevL)
+	t.Cleanup(func() {
+		renameNoReplaceKernel = prevK
+		publishNoReplaceLink = prevL
+	})
+	return true
+}

--- a/internal/fsutil/move_noreplace_hooks_posix_test.go
+++ b/internal/fsutil/move_noreplace_hooks_posix_test.go
@@ -49,3 +49,37 @@ func swapFileAfterNPublishCalls(t *testing.T, n int, path string, content []byte
 	t.Cleanup(func() { publishNoReplaceLink = prev })
 	return true
 }
+
+// hookNoReplacePlantSeamsLater invokes plant() immediately BEFORE the n-th
+// publish-link seam call.
+func hookNoReplacePlantSeamsLater(t *testing.T, n int, plant func()) bool {
+	t.Helper()
+	calls := 0
+	prev := publishNoReplaceLink
+	publishNoReplaceLink = func(s, d string) (err error) {
+		calls++
+		if calls == n {
+			plant()
+		}
+		return prev(s, d)
+	}
+	t.Cleanup(func() { publishNoReplaceLink = prev })
+	return true
+}
+
+// hookNoReplacePlantSeamsFirstCall runs action() during the FIRST
+// publish-link seam call, then restores.
+func hookNoReplacePlantSeamsFirstCall(t *testing.T, action func()) bool {
+	t.Helper()
+	calls := 0
+	prev := publishNoReplaceLink
+	publishNoReplaceLink = func(s, d string) (err error) {
+		if calls == 0 {
+			calls++
+			action()
+		}
+		return prev(s, d)
+	}
+	t.Cleanup(func() { publishNoReplaceLink = prev })
+	return true
+}

--- a/internal/fsutil/move_noreplace_hooks_posix_test.go
+++ b/internal/fsutil/move_noreplace_hooks_posix_test.go
@@ -1,0 +1,51 @@
+//go:build darwin || freebsd || openbsd || netbsd || dragonfly || solaris
+
+package fsutil
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// On non-Linux POSIX, PublishNoReplace's only seam is the hard-link fallback,
+// which serves both the initial same-volume publish and the staged publish.
+func hookNoReplacePlantSeams(t *testing.T, plant func()) bool {
+	t.Helper()
+	prev := publishNoReplaceLink
+	publishNoReplaceLink = func(s, d string) error { plant(); return prev(s, d) }
+	t.Cleanup(func() { publishNoReplaceLink = prev })
+	return true
+}
+
+func forceNoReplaceEXDEV(t *testing.T, nCalls int) bool {
+	t.Helper()
+	remaining := nCalls
+	prev := publishNoReplaceLink
+	publishNoReplaceLink = func(s, d string) (err error) {
+		if remaining > 0 {
+			remaining--
+			return &os.LinkError{Op: "link", Old: s, New: d, Err: syscall.EXDEV}
+		}
+		return prev(s, d)
+	}
+	t.Cleanup(func() { publishNoReplaceLink = prev })
+	return true
+}
+
+func swapFileAfterNPublishCalls(t *testing.T, n int, path string, content []byte) bool {
+	t.Helper()
+	calls := 0
+	prev := publishNoReplaceLink
+	publishNoReplaceLink = func(s, d string) (err error) {
+		calls++
+		if calls == n {
+			if werr := os.WriteFile(path, content, 0o644); werr != nil {
+				return werr
+			}
+		}
+		return prev(s, d)
+	}
+	t.Cleanup(func() { publishNoReplaceLink = prev })
+	return true
+}

--- a/internal/fsutil/move_noreplace_hooks_windows_test.go
+++ b/internal/fsutil/move_noreplace_hooks_windows_test.go
@@ -9,3 +9,7 @@ import "testing"
 func hookNoReplacePlantSeams(_ *testing.T, _ func()) bool                     { return false }
 func forceNoReplaceEXDEV(_ *testing.T, _ int) bool                            { return false }
 func swapFileAfterNPublishCalls(_ *testing.T, _ int, _ string, _ []byte) bool { return false }
+
+func hookNoReplacePlantSeamsLater(_ *testing.T, _ int, _ func()) bool { return false }
+
+func hookNoReplacePlantSeamsFirstCall(_ *testing.T, _ func()) bool { return false }

--- a/internal/fsutil/move_noreplace_hooks_windows_test.go
+++ b/internal/fsutil/move_noreplace_hooks_windows_test.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package fsutil
+
+import "testing"
+
+// The Windows publish leg drives MoveFileExW without an injectable seam in
+// this package; these helpers no-op and the caller skips.
+func hookNoReplacePlantSeams(_ *testing.T, _ func()) bool                     { return false }
+func forceNoReplaceEXDEV(_ *testing.T, _ int) bool                            { return false }
+func swapFileAfterNPublishCalls(_ *testing.T, _ int, _ string, _ []byte) bool { return false }

--- a/internal/fsutil/move_noreplace_test.go
+++ b/internal/fsutil/move_noreplace_test.go
@@ -185,6 +185,9 @@ func TestMoveFileNoReplace_EXDEV_SourceSwapRefusesCleanup(t *testing.T) {
 	err := MoveFileNoReplace(fs, src, dst)
 	require.Error(t, err, "source-swap must surface as an ambiguous failure")
 	assert.Contains(t, err.Error(), "source cleanup refused")
+	// #224 P2: the post-publish ambiguity is marked ErrPublishCompleted so
+	// callers never mis-map it as a pre-publish refusal.
+	assert.True(t, PublishCompleted(err))
 
 	content, rerr := os.ReadFile(dst)
 	require.NoError(t, rerr)

--- a/internal/fsutil/move_noreplace_test.go
+++ b/internal/fsutil/move_noreplace_test.go
@@ -1,0 +1,195 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- MoveFileNoReplace ---
+
+func TestMoveFileNoReplace_HappyPath(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/in/movie.mp4", []byte("content"), 0644))
+
+	require.NoError(t, MoveFileNoReplace(fs, "/in/movie.mp4", "/out/movie.mp4"))
+
+	content, err := afero.ReadFile(fs, "/out/movie.mp4")
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+	_, err = fs.Stat("/in/movie.mp4")
+	assert.True(t, os.IsNotExist(err), "source must be consumed")
+}
+
+func TestMoveFileNoReplace_LexicalSelfNoOp(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/a.mp4", []byte("content"), 0644))
+
+	require.NoError(t, MoveFileNoReplace(fs, "/a.mp4", "/a.mp4"))
+	content, err := afero.ReadFile(fs, "/a.mp4")
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+}
+
+func TestMoveFileNoReplace_SameInodeNoOp(t *testing.T) {
+	// Adoption: the destination is a hardlink alias of the source.
+	dir := t.TempDir()
+	fs := afero.NewOsFs()
+	src := filepath.Join(dir, "a.mp4")
+	require.NoError(t, os.WriteFile(src, []byte("content"), 0644))
+	require.NoError(t, os.Link(src, filepath.Join(dir, "alias.mp4")))
+
+	require.NoError(t, MoveFileNoReplace(fs, src, filepath.Join(dir, "alias.mp4")))
+
+	content, err := os.ReadFile(src)
+	require.NoError(t, err, "source survives (idempotent no-op)")
+	assert.Equal(t, "content", string(content))
+	content, err = os.ReadFile(filepath.Join(dir, "alias.mp4"))
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+	names, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, names, 2, "both aliases remain")
+}
+
+func TestMoveFileNoReplace_OccupiedRefusesForeignPreserved(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/in/movie.mp4", []byte("ours"), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/out/movie.mp4", []byte("foreign"), 0644))
+
+	err := MoveFileNoReplace(fs, "/in/movie.mp4", "/out/movie.mp4")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPublishCollision, "occupied destination refuses (never overwritten)")
+
+	content, _ := afero.ReadFile(fs, "/out/movie.mp4")
+	assert.Equal(t, "foreign", string(content), "foreign destination preserved")
+	content, _ = afero.ReadFile(fs, "/in/movie.mp4")
+	assert.Equal(t, "ours", string(content), "source preserved after refusal")
+}
+
+func TestMoveFileNoReplace_ForeignPlantInWindow(t *testing.T) {
+	// Real-Fs + seam-instrumented: the publish seams are planted right before
+	// they act on dst, reproducing a foreign win inside the classification→
+	// publish window. The no-replace leg (kernel rename or link fallback)
+	// must refuse with the collision class, never overwrite. (Virtual fs's
+	// classify-then-rename leg cannot demonstrate this; same convention as
+	// the fsutil per-platform publish tests.)
+	dir := t.TempDir()
+	fs := afero.NewOsFs()
+	inPath := filepath.Join(dir, "in.mp4")
+	outPath := filepath.Join(dir, "out.mp4")
+	require.NoError(t, os.WriteFile(inPath, []byte("ours"), 0644))
+
+	plant := func() {
+		if _, err := os.Stat(outPath); os.IsNotExist(err) {
+			_ = os.WriteFile(outPath, []byte("foreign"), 0644)
+		}
+	}
+	if !hookNoReplacePlantSeams(t, plant) {
+		t.Skip("no publish seams to instrument on this platform")
+	}
+
+	err := MoveFileNoReplace(fs, inPath, outPath)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPublishCollision)
+
+	content, _ := os.ReadFile(outPath)
+	assert.Equal(t, "foreign", string(content), "the plant wins the name; our content must not overwrite it")
+	content, _ = os.ReadFile(inPath)
+	assert.Equal(t, "ours", string(content), "our source is preserved")
+}
+
+// --- CopyFileNoReplace ---
+
+func TestCopyFileNoReplace_HappyPath(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/in/poster.jpg", []byte("img"), 0644))
+
+	require.NoError(t, CopyFileNoReplace(fs, "/in/poster.jpg", "/out/poster.jpg"))
+	content, err := afero.ReadFile(fs, "/out/poster.jpg")
+	require.NoError(t, err)
+	assert.Equal(t, "img", string(content))
+	content, err = afero.ReadFile(fs, "/in/poster.jpg")
+	require.NoError(t, err)
+	assert.Equal(t, "img", string(content), "source untouched by copy")
+}
+
+func TestCopyFileNoReplace_OccupiedRefusesForeignPreserved(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/in/poster.jpg", []byte("ours"), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/out/poster.jpg", []byte("foreign"), 0644))
+
+	err := CopyFileNoReplace(fs, "/in/poster.jpg", "/out/poster.jpg")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPublishCollision)
+
+	content, _ := afero.ReadFile(fs, "/out/poster.jpg")
+	assert.Equal(t, "foreign", string(content))
+	content, _ = afero.ReadFile(fs, "/in/poster.jpg")
+	assert.Equal(t, "ours", string(content))
+}
+
+func TestCopyFileNoReplace_StagingLeftoverFree(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/in/x", []byte("x"), 0644))
+	require.NoError(t, CopyFileNoReplace(fs, "/in/x", "/out/x"))
+	entries, err := afero.ReadDir(fs, "/out")
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "no staging remnants at the destination")
+}
+
+func TestMoveFileNoReplace_EXDEVLeg(t *testing.T) {
+	if !forceNoReplaceEXDEV(t, 1) {
+		t.Skip("no publish seams to instrument on this platform")
+	}
+	dir := t.TempDir()
+	fs := afero.NewOsFs()
+	src := filepath.Join(dir, "a.mp4")
+	dst := filepath.Join(dir, "sub", "a.mp4")
+	require.NoError(t, os.WriteFile(src, []byte("move me"), 0644))
+
+	require.NoError(t, MoveFileNoReplace(fs, src, dst))
+
+	content, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "move me", string(content))
+	_, err = os.Stat(src)
+	assert.True(t, os.IsNotExist(err), "identity-checked source cleanup consumed src")
+	entries, err := os.ReadDir(filepath.Dir(dst))
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "no staging remnants after EXDEV publish")
+}
+
+func TestMoveFileNoReplace_EXDEV_SourceSwapRefusesCleanup(t *testing.T) {
+	// After the EXDEV publish succeeds, someone swaps the SOURCE; the
+	// identity-checked cleanup must refuse (both objects survive).
+	dir := t.TempDir()
+	fs := afero.NewOsFs()
+	src := filepath.Join(dir, "a.mp4")
+	dst := filepath.Join(dir, "sub", "a.mp4")
+	require.NoError(t, os.WriteFile(src, []byte("original"), 0644))
+
+	if !forceNoReplaceEXDEV(t, 1) {
+		t.Skip("no publish seams to instrument on this platform")
+	}
+	// First seam call = the failed same-volume publish (EXDEV). Second = the
+	// staged publish; swap the source right as it lands.
+	if !swapFileAfterNPublishCalls(t, 2, src, []byte("foreign swap")) {
+		t.Skip("no publish seams to instrument on this platform")
+	}
+
+	err := MoveFileNoReplace(fs, src, dst)
+	require.Error(t, err, "source-swap must surface as an ambiguous failure")
+	assert.Contains(t, err.Error(), "source cleanup refused")
+
+	content, rerr := os.ReadFile(dst)
+	require.NoError(t, rerr)
+	assert.Equal(t, "original", string(content), "published bytes intact")
+	content, rerr = os.ReadFile(src)
+	require.NoError(t, rerr)
+	assert.Equal(t, "foreign swap", string(content), "swapped source never unlinked")
+}

--- a/internal/fsutil/staging_identity_pin_test.go
+++ b/internal/fsutil/staging_identity_pin_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // stagingIdentity's defensive legs: a nil handle or a Stat failure yield nil
@@ -21,3 +22,12 @@ func TestStagingIdentity_DefensiveLegs(t *testing.T) {
 type statFailFile struct{ afero.File }
 
 func (s *statFailFile) Stat() (os.FileInfo, error) { return nil, errors.New("simulated stat failure") }
+
+func TestDiscardBound_NilIdentityKeepsBoth(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/out/a.mp4.nrstg.9", []byte("staged"), 0644))
+	discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.9", nil, fsutil_cropErr("boom"))
+	content, err := afero.ReadFile(fs, "/out/a.mp4.nrstg.9")
+	require.NoError(t, err)
+	assert.Equal(t, "staged", string(content))
+}

--- a/internal/fsutil/staging_identity_pin_test.go
+++ b/internal/fsutil/staging_identity_pin_test.go
@@ -1,0 +1,23 @@
+package fsutil
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+// stagingIdentity's defensive legs: a nil handle or a Stat failure yield nil
+// (UnlinkVerified then never binds; the keep-both postcondition holds).
+func TestStagingIdentity_DefensiveLegs(t *testing.T) {
+	assert.Nil(t, stagingIdentity(nil))
+
+	fh := &statFailFile{}
+	assert.Nil(t, stagingIdentity(fh))
+}
+
+type statFailFile struct{ afero.File }
+
+func (s *statFailFile) Stat() (os.FileInfo, error) { return nil, errors.New("simulated stat failure") }

--- a/internal/fsutil/staging_identity_pin_test.go
+++ b/internal/fsutil/staging_identity_pin_test.go
@@ -3,6 +3,8 @@ package fsutil
 import (
 	"errors"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -30,4 +32,114 @@ func TestDiscardBound_NilIdentityKeepsBoth(t *testing.T) {
 	content, err := afero.ReadFile(fs, "/out/a.mp4.nrstg.9")
 	require.NoError(t, err)
 	assert.Equal(t, "staged", string(content))
+}
+
+// vacateSwapFs substitutes the staged name's object as our vacate-rename
+// begins — the goal: the object arriving at vac is NOT ours; bound removal
+// must refuse it and restore it onto the staged name without unlinking.
+type vacateSwapFs struct {
+	afero.Fs
+	on string
+}
+
+func (v *vacateSwapFs) Rename(oldname, newname string) error {
+	if filepath.Clean(oldname) == filepath.Clean(v.on) {
+		// plant a foreign occupant in place of the staged object right before
+		// the vacate rename is issued.
+		_ = v.Fs.Remove(oldname)
+		_ = afero.WriteFile(v.Fs, oldname, []byte("substitute"), 0644)
+	}
+	return v.Fs.Rename(oldname, newname)
+}
+
+func TestDiscardBound_VacateSwapPreservesSubstitution(t *testing.T) {
+	fs := &vacateSwapFs{Fs: afero.NewMemMapFs(), on: "/out/a.mp4.nrstg.9"}
+	require.NoError(t, fs.Fs.MkdirAll("/out", 0777))
+	require.NoError(t, afero.WriteFile(fs.Fs, "/out/a.mp4.nrstg.9", []byte("staged"), 0644))
+	info, err := fs.Stat("/out/a.mp4.nrstg.9")
+	require.NoError(t, err)
+
+	discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.9", info, fsutil_cropErr("publish failed"))
+
+	content, rerr := afero.ReadFile(fs.Fs, "/out/a.mp4.nrstg.9")
+	require.NoError(t, rerr)
+	assert.Equal(t, "substitute", string(content))
+	entries, derr := afero.ReadDir(fs.Fs, "/out")
+	require.NoError(t, derr)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".vac.", "no vac residue left")
+	}
+}
+
+// The three keep-both aborts of the vacate-discard: claim cannot reserve a vac
+// name (entropy fail), the vac release refuses (its Remove fails), or the vacate
+// rename itself errors — every failure leaves the staged object untouched.
+func TestDiscardBound_AbortLegsKeepStaged(t *testing.T) {
+	t.Run("claim-fail", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/out/a.mp4.nrstg.9", []byte("staged"), 0644))
+		info, err := fs.Stat("/out/a.mp4.nrstg.9")
+		require.NoError(t, err)
+
+		prev := takeAsideVacRandReader
+		takeAsideVacRandReader = failingReaderR4{}
+		t.Cleanup(func() { takeAsideVacRandReader = prev })
+
+		discardStagedAfterFailedPublish(fs, "/out/a.mp4.nrstg.9", info, fsutil_cropErr("pub failed"))
+		content, _ := afero.ReadFile(fs, "/out/a.mp4.nrstg.9")
+		assert.Equal(t, "staged", string(content))
+	})
+
+	t.Run("release-refuses-remove-vac-fails", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/out/a.mp4.nrstg.9", []byte("staged"), 0644))
+		info, err := fs.Stat("/out/a.mp4.nrstg.9")
+		require.NoError(t, err)
+
+		// Releasing the vacated claim calls fs.Remove(claimName) — refuse it.
+		wrapped := &removeVacFailFs{Fs: fs}
+		discardStagedAfterFailedPublish(wrapped, "/out/a.mp4.nrstg.9", info, fsutil_cropErr("pub failed"))
+		content, _ := afero.ReadFile(fs, "/out/a.mp4.nrstg.9")
+		assert.Equal(t, "staged", string(content))
+	})
+
+	t.Run("rename-vacate-fail", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/out/a.mp4.nrstg.9", []byte("staged"), 0644))
+		info, err := fs.Stat("/out/a.mp4.nrstg.9")
+		require.NoError(t, err)
+
+		notRenamed := &renameNeverFs{Fs: fs, failPrefix: "/out/a.mp4.nrstg.9"}
+		discardStagedAfterFailedPublish(notRenamed, "/out/a.mp4.nrstg.9", info, fsutil_cropErr("pub failed"))
+		content, _ := afero.ReadFile(fs, "/out/a.mp4.nrstg.9")
+		assert.Equal(t, "staged", string(content))
+	})
+}
+
+type failingReaderR4 struct{}
+
+func (f failingReaderR4) Read(p []byte) (int, error) { return 0, errors.New("rand reader disabled") }
+
+// renameNeverFs refuses any rename whose source path starts with the prefix.
+type renameNeverFs struct {
+	afero.Fs
+	failPrefix string
+}
+
+func (r *renameNeverFs) Rename(oldname, newname string) error {
+	if strings.HasPrefix(oldname, r.failPrefix) {
+		return errors.New("simulated rename refusal")
+	}
+	return r.Fs.Rename(oldname, newname)
+}
+
+// removeVacFailFs refuses fs.Remove for any ".vac." name — that refuses the
+// claim's release (covered leg: release-fail → keep both).
+type removeVacFailFs struct{ afero.Fs }
+
+func (r *removeVacFailFs) Remove(name string) error {
+	if strings.Contains(name, ".vac.") {
+		return errors.New("simulated release refusal")
+	}
+	return r.Fs.Remove(name)
 }

--- a/internal/organizer/finish_inplace_inner_rename_test.go
+++ b/internal/organizer/finish_inplace_inner_rename_test.go
@@ -1,0 +1,54 @@
+package organizer
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/fsutil"
+)
+
+// finishInPlaceInnerRename branches (#224 codex P2): a completed inner publish
+// MUST NOT roll back the directory (file already lives at the new location);
+// plain publish failures roll back to OldDir as before.
+func TestFinishInPlaceInnerRename_Completed_PublishesNoRollback(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/new", 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/new/x.mp4", []byte("v"), 0o644))
+
+	strategy := &inPlaceStrategy{fs: fs}
+	plan := &OrganizePlan{TargetDir: "/new", OldDir: "/old", TargetPath: "/new/x.mp4"}
+
+	refusal := fmt.Errorf("publish link worked, cleanup refused: %w", fsutil.ErrPublishCompleted)
+	err := strategy.finishInPlaceInnerRename(plan, refusal)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "directory left at /new")
+	assert.Contains(t, err.Error(), "ambiguous")
+
+	// The directory stays at the NEW name — no rollback applied.
+	exists, _ := afero.Exists(fs, "/new/x.mp4")
+	assert.True(t, exists)
+}
+
+func TestFinishInPlaceInnerRename_Collision_RollsBack(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/new", 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/new/x.mp4", []byte("v"), 0o644))
+
+	strategy := &inPlaceStrategy{fs: fs}
+	plan := &OrganizePlan{TargetDir: "/new", OldDir: "/old", TargetPath: "/new/x.mp4"}
+
+	collision := fmt.Errorf("%w", fsutil.ErrPublishCollision)
+	err := strategy.finishInPlaceInnerRename(plan, collision)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to rename file after directory rename")
+	// Rollback applied: /new renamed to /old.
+	exists, _ := afero.Exists(fs, "/old/x.mp4")
+	assert.True(t, exists)
+}
+
+var _ = errors.New

--- a/internal/organizer/map_noreplace_refusal_test.go
+++ b/internal/organizer/map_noreplace_refusal_test.go
@@ -1,0 +1,80 @@
+package organizer
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/fsutil"
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+// mapNoReplaceRefusal translations (#224): occupancy → the existing conflict
+// wording; unsupported-volume → distinct infrastructure error; anything else
+// passes through untouched.
+func TestMapNoReplaceRefusal(t *testing.T) {
+	collision := mapNoReplaceRefusal(fmt.Errorf("wrapped: %w", fsutil.ErrPublishCollision), "/dst/x.mp4")
+	require.Error(t, collision)
+	assert.Contains(t, collision.Error(), "refusing to overwrite")
+	assert.Contains(t, collision.Error(), "/dst/x.mp4")
+
+	unsupported := mapNoReplaceRefusal(fmt.Errorf("wrapped: %w", fsutil.ErrPublishNoReplaceUnsupported), "/dst/x.mp4")
+	require.Error(t, unsupported)
+	assert.Contains(t, unsupported.Error(), "cannot express an atomic no-clobber write")
+	assert.NotContains(t, unsupported.Error(), "refusing to overwrite")
+
+	plain := errors.New("io failure")
+	assert.ErrorIs(t, mapNoReplaceRefusal(plain, "/dst/x.mp4"), plain)
+}
+
+// Subtitle refusal→skip: occupancy AND unsupported-volume publish refusals map
+// to the skip leg (never an error, never an overwrite).
+func TestHandleSubtitles_PublishRefusalMapsToSkip(t *testing.T) {
+	for name, ferr := range map[string]error{
+		"collision":   fmt.Errorf("publish: %w", fsutil.ErrPublishCollision),
+		"unsupported": fmt.Errorf("publish: %w", fsutil.ErrPublishNoReplaceUnsupported),
+		"realfailure": errors.New("disk read died"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			require.NoError(t, fs.MkdirAll("/in", 0o755))
+			require.NoError(t, afero.WriteFile(fs, "/in/ABC-123.mp4", []byte("v"), 0o644))
+			require.NoError(t, afero.WriteFile(fs, "/in/ABC-123.srt", []byte("srt"), 0o644))
+
+			o := NewOrganizer(fs, &Config{
+				MoveSubtitles:      true,
+				SubtitleExtensions: []string{".srt"},
+			}, nil, nil)
+
+			plan := &OrganizePlan{
+				Match: models.FileMatchInfo{
+					MovieID: "ABC-123",
+					Path:    "/in/ABC-123.mp4", Name: "ABC-123.mp4", Extension: ".mp4",
+				},
+				SourcePath: "/in/ABC-123.mp4",
+				TargetDir:  "/out",
+				TargetFile: "ABC-123.mp4",
+				TargetPath: "/out/ABC-123.mp4",
+				WillMove:   true,
+			}
+			result := &OrganizeResult{}
+
+			o.handleSubtitles(plan, result, func(afero.Fs, string, string) error { return ferr })
+
+			require.Len(t, result.Subtitles, 1)
+			sr := result.Subtitles[0].SubtitleMove
+			if name == "realfailure" {
+				// A genuine failure surfaces, no skip, no move.
+				assert.Contains(t, result.Subtitles[0].Error.Error(), "failed to handle subtitle")
+			} else {
+				assert.True(t, result.Subtitles[0].Skipped)
+				assert.False(t, sr.Moved)
+				assert.Nil(t, result.Subtitles[0].Error)
+			}
+		})
+	}
+}

--- a/internal/organizer/map_noreplace_refusal_test.go
+++ b/internal/organizer/map_noreplace_refusal_test.go
@@ -83,11 +83,14 @@ func TestHandleSubtitles_PublishRefusalMapsToSkip(t *testing.T) {
 				// A genuine failure surfaces, no skip, no move.
 				assert.Contains(t, result.Subtitles[0].Error.Error(), "failed to handle subtitle")
 			} else if name == "completed" {
-				// Post-publish: bytes delivered; source left in place by the
-				// composite — count a move, NOT a skip (#224 P2).
-				assert.True(t, result.Subtitles[0].Moved)
+				// Post-publish ambiguity: bytes delivered BUT the source was
+				// retained — recording a clean move would let revert journaling
+				// (MoveBack of new→original) overwrite the retained source's
+				// newer contents. It must surface as an error slot (#224 codex P2).
+				assert.False(t, result.Subtitles[0].Moved)
 				assert.False(t, result.Subtitles[0].Skipped)
-				assert.Nil(t, result.Subtitles[0].Error)
+				require.Error(t, result.Subtitles[0].Error)
+				assert.Contains(t, result.Subtitles[0].Error.Error(), "both copies retained")
 			} else {
 				assert.True(t, result.Subtitles[0].Skipped)
 				assert.False(t, sr.Moved)

--- a/internal/organizer/map_noreplace_refusal_test.go
+++ b/internal/organizer/map_noreplace_refusal_test.go
@@ -3,6 +3,7 @@ package organizer
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -29,6 +30,16 @@ func TestMapNoReplaceRefusal(t *testing.T) {
 
 	plain := errors.New("io failure")
 	assert.ErrorIs(t, mapNoReplaceRefusal(plain, "/dst/x.mp4"), plain)
+
+	// Completed-first: a post-publish cleanup refusal never lands on the
+	// refusal labels even when it transitively carries them.
+	completed := fmt.Errorf("%w: cleanup: %w", fsutil.ErrPublishCompleted, fmt.Errorf("vacate: %w", fsutil.ErrPublishNoReplaceUnsupported))
+	done := mapNoReplaceRefusal(completed, "/dst/x.mp4")
+	require.Error(t, done)
+	// The completed case yields its OWN classification line as the message;
+	// preserved refusal classes may appear inside the joined diagnostics.
+	assert.True(t, strings.HasPrefix(done.Error(), "published to destination but source cleanup refused"))
+	assert.NotContains(t, done.Error(), "refusing to overwrite")
 }
 
 // Subtitle refusal→skip: occupancy AND unsupported-volume publish refusals map
@@ -38,6 +49,7 @@ func TestHandleSubtitles_PublishRefusalMapsToSkip(t *testing.T) {
 		"collision":   fmt.Errorf("publish: %w", fsutil.ErrPublishCollision),
 		"unsupported": fmt.Errorf("publish: %w", fsutil.ErrPublishNoReplaceUnsupported),
 		"realfailure": errors.New("disk read died"),
+		"completed":   fmt.Errorf("%w: cleanup: %w", fsutil.ErrPublishCompleted, fsutil.ErrPublishCollision),
 	} {
 		t.Run(name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
@@ -70,6 +82,12 @@ func TestHandleSubtitles_PublishRefusalMapsToSkip(t *testing.T) {
 			if name == "realfailure" {
 				// A genuine failure surfaces, no skip, no move.
 				assert.Contains(t, result.Subtitles[0].Error.Error(), "failed to handle subtitle")
+			} else if name == "completed" {
+				// Post-publish: bytes delivered; source left in place by the
+				// composite — count a move, NOT a skip (#224 P2).
+				assert.True(t, result.Subtitles[0].Moved)
+				assert.False(t, result.Subtitles[0].Skipped)
+				assert.Nil(t, result.Subtitles[0].Error)
 			} else {
 				assert.True(t, result.Subtitles[0].Skipped)
 				assert.False(t, sr.Moved)

--- a/internal/organizer/miss2_test.go
+++ b/internal/organizer/miss2_test.go
@@ -278,6 +278,10 @@ func TestOrganizeStrategy_Execute_CopyFileError(t *testing.T) {
 		moveFiles:  false,
 		LinkMode:   LinkModeNone,
 		Conflicts:  []string{},
+		// #224: unauthorized copies route through fsutil.CopyFileNoReplace
+		// (no linker involvement); the linker's copy error seam lives on the
+		// authorized leg, so this seam test authorizes explicitly.
+		overwriteAuthorized: true,
 	}
 
 	result, err := strategy.Execute(plan)

--- a/internal/organizer/organize_atomic_plant_test.go
+++ b/internal/organizer/organize_atomic_plant_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/models"
 )
 
 // #224 tasks 2.6: an occupied-by-foreign destination on the REAL filesystem
@@ -49,4 +51,41 @@ func TestOrganizeStrategy_AtomicNoClobber_ForeignPlantWins(t *testing.T) {
 	content, rerr = os.ReadFile(src)
 	require.NoError(t, rerr)
 	assert.Equal(t, "ours", string(content), "our source byte-preserved")
+}
+
+// Authorized leg parity: a dedicated-folder in-place rename under
+// overwriteAuthorized keeps the plain inner rename (the unauthorized window
+// is covered by the no-replace leg; this proves the leg flip is reachable).
+func TestInPlaceStrategy_AuthorizedInnerRenameUsesPlainRename(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/source/mixed", 0777))
+	require.NoError(t, afero.WriteFile(fs, "/source/mixed/ABC-123.mp4", []byte("video"), 0644))
+	// Occupy the inner target so ONLY the replace-capable (authorized) inner
+	// rename can succeed.
+	require.NoError(t, afero.WriteFile(fs, "/source/mixed/ABC-123-KEEP.mp4", []byte("prior"), 0644))
+
+	cfg := &Config{FileFormat: "<ID>", FolderFormat: "<ID>", RenameFile: true}
+	strategy := newInPlaceStrategy(fs, cfg, nil, nil)
+
+	// TargetFile DIFFERS from the sitting name so the inner rename leg runs.
+	plan := &OrganizePlan{
+		SourcePath:          "/source/mixed/ABC-123.mp4",
+		TargetDir:           "/source/ABC-123",
+		TargetPath:          "/source/ABC-123/ABC-123-new.mp4",
+		TargetFile:          "ABC-123-new.mp4",
+		OldDir:              "/source/mixed",
+		WillMove:            true,
+		InPlace:             true,
+		IsDedicated:         true,
+		Match:               models.FileMatchInfo{MovieID: "ABC-123", Path: "/source/mixed/ABC-123.mp4", Name: "ABC-123.mp4", Extension: ".mp4"},
+		overwriteAuthorized: true,
+		Conflicts:           []string{},
+	}
+
+	result, err := strategy.Execute(plan)
+	require.NoError(t, err)
+	assert.True(t, result.Moved)
+	content, rerr := afero.ReadFile(fs, "/source/ABC-123/ABC-123-new.mp4")
+	require.NoError(t, rerr)
+	assert.Equal(t, "video", string(content))
 }

--- a/internal/organizer/organize_atomic_plant_test.go
+++ b/internal/organizer/organize_atomic_plant_test.go
@@ -1,0 +1,52 @@
+package organizer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #224 tasks 2.6: an occupied-by-foreign destination on the REAL filesystem
+// must conflict and be preserved byte-intact, with our source preserved too.
+// OsFs-backed (MemMapFs exercises the virtual classify leg, not the syscall
+// no-replace legs that are the point of this change).
+func TestOrganizeStrategy_AtomicNoClobber_ForeignPlantWins(t *testing.T) {
+	dir := t.TempDir()
+	fs := afero.NewOsFs()
+
+	srcDir := filepath.Join(dir, "in")
+	dstDir := filepath.Join(dir, "out", "ABC-123")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	require.NoError(t, os.MkdirAll(dstDir, 0o755))
+	src := filepath.Join(srcDir, "ABC-123.mp4")
+	dst := filepath.Join(dstDir, "ABC-123.mp4")
+	require.NoError(t, os.WriteFile(src, []byte("ours"), 0o644))
+	// Foreign claim at the destination first (post-plan plant).
+	require.NoError(t, os.WriteFile(dst, []byte("foreign — a user file"), 0o644))
+
+	strategy := newOrganizeStrategy(fs, &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}, nil, &MemLinker{})
+	plan := &OrganizePlan{
+		SourcePath: src,
+		TargetDir:  dstDir,
+		TargetPath: dst,
+		TargetFile: "ABC-123.mp4",
+		WillMove:   true,
+		moveFiles:  true,
+		Conflicts:  []string{},
+	}
+
+	_, err := strategy.Execute(plan)
+	require.Error(t, err, "foreign-occupied destination must conflict")
+	assert.Contains(t, err.Error(), "refusing to overwrite")
+
+	content, rerr := os.ReadFile(dst)
+	require.NoError(t, rerr)
+	assert.Equal(t, "foreign — a user file", string(content), "foreign destination byte-preserved")
+	content, rerr = os.ReadFile(src)
+	require.NoError(t, rerr)
+	assert.Equal(t, "ours", string(content), "our source byte-preserved")
+}

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -477,11 +477,14 @@ func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, 
 				}
 				err := fileOp(o.fs, subtitle.OriginalPath, newPath)
 				if err != nil && fsutil.PublishCompleted(err) {
-					// Post-publish cleanup refusal (#224 P2): bytes ARE at the
-					// destination; the refusal is about the source cleanup, not
-					// the publication. Deliver — never report it as a skip.
-					sr.Moved = true
-					return nil
+					// Post-publish cleanup refusal (#224 codex P2): bytes at the
+					// destination AND the source retained — an ambiguous delivery,
+					// NOT a clean move. Recording Moved here would let revert
+					// journaling (workflow/revert_log.go MoveBack, executed by
+					// history/reverter.go) overwrite the retained source's newer
+					// contents with a stale copy. Record the ambiguity as an
+					// error slot: never Moved, never Skipped.
+					return fmt.Errorf("subtitle published but source cleanup refused — both copies retained (%w)", err)
 				}
 				if err != nil && fsutil.PublishRefusal(err) {
 					// #224: subtitle destinations accept the publish-refusal classes

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -400,7 +400,7 @@ func (o *Organizer) execute(plan *OrganizePlan) (*OrganizeResult, error) {
 	}
 
 	if o.config.MoveSubtitles {
-		o.handleSubtitles(plan, strategyResult, fsutil.MoveFileFs)
+		o.handleSubtitles(plan, strategyResult, fsutil.MoveFileNoReplace)
 	}
 
 	return strategyResult, nil
@@ -475,7 +475,18 @@ func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, 
 					sr.Skipped = true
 					return nil
 				}
-				return fileOp(o.fs, subtitle.OriginalPath, newPath)
+				err := fileOp(o.fs, subtitle.OriginalPath, newPath)
+				if err != nil && fsutil.PublishRefusal(err) {
+					// #224: subtitle destinations accept the publish-refusal classes
+					// as a skip — occupancy (a foreign subtitle won the name inside
+					// the check→publish window: same outcome as the pre-check) and
+					// no-replace-unsupported volumes (the subtitle is simply not
+					// delivered; nothing was installed that could have overwritten
+					// the foreign bytes).
+					sr.Skipped = true
+					return nil
+				}
+				return err
 			})
 		})
 		if err != nil {
@@ -556,9 +567,9 @@ func (o *Organizer) Organize(ctx context.Context, cmd OrganizeCmd) (*OrganizeRes
 
 	// Subtitle handling is centralized here — applies to both move and copy/link paths.
 	if cmd.MoveFiles && o.config.MoveSubtitles {
-		o.handleSubtitles(plan, strategyResult, fsutil.MoveFileFs)
+		o.handleSubtitles(plan, strategyResult, fsutil.MoveFileNoReplace)
 	} else if !cmd.MoveFiles && o.config.MoveSubtitles {
-		o.handleSubtitles(plan, strategyResult, fsutil.CopyFileFs)
+		o.handleSubtitles(plan, strategyResult, fsutil.CopyFileNoReplace)
 	}
 
 	return strategyResult, nil

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -476,6 +476,13 @@ func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, 
 					return nil
 				}
 				err := fileOp(o.fs, subtitle.OriginalPath, newPath)
+				if err != nil && fsutil.PublishCompleted(err) {
+					// Post-publish cleanup refusal (#224 P2): bytes ARE at the
+					// destination; the refusal is about the source cleanup, not
+					// the publication. Deliver — never report it as a skip.
+					sr.Moved = true
+					return nil
+				}
 				if err != nil && fsutil.PublishRefusal(err) {
 					// #224: subtitle destinations accept the publish-refusal classes
 					// as a skip — occupancy (a foreign subtitle won the name inside

--- a/internal/organizer/strategy_inplace.go
+++ b/internal/organizer/strategy_inplace.go
@@ -318,10 +318,7 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 						innerOp = func(fs afero.Fs, a, b string) error { return fs.Rename(a, b) }
 					}
 					if err := innerOp(s.fs, currentFilePath, plan.TargetPath); err != nil {
-						if rb := s.fs.Rename(plan.TargetDir, plan.OldDir); rb != nil {
-							logging.Errorf("[in-place] Failed to rollback directory rename %s → %s: %v", plan.TargetDir, plan.OldDir, rb)
-						}
-						return fmt.Errorf("failed to rename file after directory rename: %w", mapNoReplaceRefusal(err, plan.TargetPath))
+						return s.finishInPlaceInnerRename(plan, err)
 					}
 				}
 				return nil
@@ -370,4 +367,16 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 	}
 
 	return result, nil
+}
+
+// finishInPlaceInnerRename is only invoked on an inner-op failure (call site
+// guarantees err != nil), so branches reach every classification.
+func (s *inPlaceStrategy) finishInPlaceInnerRename(plan *OrganizePlan, err error) error {
+	if fsutil.PublishCompleted(err) {
+		return fmt.Errorf("in-place inner rename published to %s but finished ambiguously (directory left at %s): %w", plan.TargetPath, plan.TargetDir, err)
+	}
+	if rb := s.fs.Rename(plan.TargetDir, plan.OldDir); rb != nil {
+		logging.Errorf("[in-place] Failed to rollback directory rename %s → %s: %v", plan.TargetDir, plan.OldDir, rb)
+	}
+	return fmt.Errorf("failed to rename file after directory rename: %w", mapNoReplaceRefusal(err, plan.TargetPath))
 }

--- a/internal/organizer/strategy_inplace.go
+++ b/internal/organizer/strategy_inplace.go
@@ -309,11 +309,19 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 							return nil // inner target names the same file — nothing to rename
 						}
 					}
-					if err := s.fs.Rename(currentFilePath, plan.TargetPath); err != nil {
+					// #224: inner file rename is a terminal op of the same race class
+					// — publish no-replace so a plant inside the renamed dir conflicts
+					// atomically instead of being replaced. On collision, roll the
+					// directory rename back exactly as before.
+					innerOp := fsutil.PublishNoReplace
+					if plan.overwriteAuthorized {
+						innerOp = func(fs afero.Fs, a, b string) error { return fs.Rename(a, b) }
+					}
+					if err := innerOp(s.fs, currentFilePath, plan.TargetPath); err != nil {
 						if rb := s.fs.Rename(plan.TargetDir, plan.OldDir); rb != nil {
 							logging.Errorf("[in-place] Failed to rollback directory rename %s → %s: %v", plan.TargetDir, plan.OldDir, rb)
 						}
-						return fmt.Errorf("failed to rename file after directory rename: %w", err)
+						return fmt.Errorf("failed to rename file after directory rename: %w", mapNoReplaceRefusal(err, plan.TargetPath))
 					}
 				}
 				return nil
@@ -343,6 +351,12 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 				}
 				if err := s.fs.MkdirAll(plan.TargetDir, config.DirPerm); err != nil {
 					return fmt.Errorf("failed to create directory: %w", err)
+				}
+				if !plan.overwriteAuthorized {
+					if err := fsutil.MoveFileNoReplace(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
+						return mapNoReplaceRefusal(err, plan.TargetPath)
+					}
+					return nil
 				}
 				return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
 			})

--- a/internal/organizer/strategy_inplace_norenamefolder.go
+++ b/internal/organizer/strategy_inplace_norenamefolder.go
@@ -114,6 +114,12 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 					return nil
 				}
 			}
+			if !plan.overwriteAuthorized {
+				if err := fsutil.MoveFileNoReplace(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
+					return mapNoReplaceRefusal(err, plan.TargetPath)
+				}
+				return nil
+			}
 			return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
 		})
 	})

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -130,7 +130,11 @@ func withDestDirSharedLock(dir string, fn func() error) error {
 	return withDestDirLock(dir, false, fn)
 }
 
-// refuseExistingDestination enforces no-clobber at execution time with lexical-self vs
+// refuseExistingDestination classifies destination state at execution time with lexical-self vs
+// #224: this remains the CLASSIFICATION authority (no-op/conflict kinds); the
+// no-clobber guarantee itself is carried syscall-atomically by the fsutil
+// no-replace composites on every unauthorized terminal leg — a foreign writer
+// landing after this classification is refused at publish, not overwritten.
 // hardlink-alias distinction: identical lexical paths (./file vs file) are identical=true —
 // operators must not touch the destination at all; a DIFFERENT path to the same inode
 // (hardlink alias) is sameInode=true and may no-op when its output type is satisfied.
@@ -182,6 +186,22 @@ func refuseExistingDestination(fs afero.Fs, src, dst string) (identical, sameIno
 		return false, false, fmt.Errorf("failed to check destination: %w", dstErr)
 	}
 	return false, false, nil
+}
+
+// mapNoReplaceRefusal translates the fsutil no-replace failure classes into the
+// organizer's existing failure vocabulary (#224): occupancy becomes the same
+// conflict the classifier reports, while a volume that cannot express an
+// atomic no-replace publish surfaces as a DISTINCT infrastructure refusal —
+// never as a content conflict.
+func mapNoReplaceRefusal(err error, dst string) error {
+	switch {
+	case errors.Is(err, fsutil.ErrPublishNoReplaceUnsupported):
+		return fmt.Errorf("destination volume cannot express an atomic no-clobber write (no-replace unsupported): %s: %w", dst, err)
+	case errors.Is(err, fsutil.ErrPublishCollision):
+		return fmt.Errorf("file already exists at destination (refusing to overwrite): %s", dst)
+	default:
+		return err
+	}
 }
 
 // symlinkObjectExists probes path specifically for a symlink OBJECT (including dangling
@@ -369,6 +389,15 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				return fmt.Errorf("failed to create directory: %w", err)
 			}
 
+			if !plan.overwriteAuthorized {
+				// #224: the atomic no-replace composite — a foreign writer
+				// claiming the name after classification conflicts atomically
+				// instead of being replaced by the rename inside the window.
+				if err := fsutil.MoveFileNoReplace(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
+					return mapNoReplaceRefusal(err, plan.TargetPath)
+				}
+				return nil
+			}
 			return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
 		}
 
@@ -470,6 +499,13 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				}
 			default:
 				if dstSameInode && !plan.overwriteAuthorized {
+					return nil
+				}
+				if !plan.overwriteAuthorized {
+					// #224: copy leg is atomically no-clobbering too.
+					if err := fsutil.CopyFileNoReplace(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
+						return mapNoReplaceRefusal(fmt.Errorf("failed to copy file: %w", err), plan.TargetPath)
+					}
 					return nil
 				}
 				if err := s.linker.copyFile(s.fs, plan.SourcePath, plan.TargetPath); err != nil {

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -195,6 +195,12 @@ func refuseExistingDestination(fs afero.Fs, src, dst string) (identical, sameIno
 // never as a content conflict.
 func mapNoReplaceRefusal(err error, dst string) error {
 	switch {
+	// Completed-first (#224 P2): a cleanup-refusal error carries publish
+	// refusal classes transitively (collision/unsupported inside rmErr); it
+	// must NEVER be reported as a pre-publish refusal — the destination was
+	// already published and the source is preserved.
+	case fsutil.PublishCompleted(err):
+		return fmt.Errorf("published to destination but source cleanup refused (both files preserved): %s: %w", dst, err)
 	case errors.Is(err, fsutil.ErrPublishNoReplaceUnsupported):
 		return fmt.Errorf("destination volume cannot express an atomic no-clobber write (no-replace unsupported): %s: %w", dst, err)
 	case errors.Is(err, fsutil.ErrPublishCollision):

--- a/internal/organizer/strategy_organize_execute_test.go
+++ b/internal/organizer/strategy_organize_execute_test.go
@@ -134,7 +134,12 @@ func TestOrganizeStrategy_Execute_LinkModes(t *testing.T) {
 		result, err := strategy.Execute(plan)
 		require.NoError(t, err)
 		assert.True(t, result.Moved)
-		assert.True(t, ml.copyCalled)
+		// #224: unauthorized copy legs run through fsutil.CopyFileNoReplace,
+		// not the linker; destination lands with the right bytes regardless.
+		assert.False(t, ml.copyCalled)
+		content, rerr := afero.ReadFile(fs, "/dest/ABC-123/ABC-123.mp4")
+		require.NoError(t, rerr)
+		assert.Equal(t, "video", string(content))
 	})
 
 	t.Run("invalid link mode returns error", func(t *testing.T) {

--- a/internal/organizer/strategy_organize_test.go
+++ b/internal/organizer/strategy_organize_test.go
@@ -336,7 +336,8 @@ func TestOrganizeStrategy_Execute_RenameError(t *testing.T) {
 
 	result, err := strategy.Execute(plan)
 	assert.Error(t, err, "Should fail when source file does not exist for rename")
-	assert.Contains(t, err.Error(), "failed to move file")
+	// #224: an absent source surfaces via the composite's probe error.
+	assert.Contains(t, err.Error(), "no-replace: probe source")
 	assert.False(t, result.Moved)
 }
 

--- a/internal/organizer/uncovered_test.go
+++ b/internal/organizer/uncovered_test.go
@@ -256,7 +256,12 @@ func TestOrganizeStrategy_Execute_CopyPath(t *testing.T) {
 	result, err := strategy.Execute(plan)
 	require.NoError(t, err)
 	assert.True(t, result.Moved)
-	assert.True(t, ml.copyCalled)
+	// #224: unauthorized copy legs run through fsutil.CopyFileNoReplace, not
+	// the linker; the destination still materializes with the right bytes.
+	assert.False(t, ml.copyCalled)
+	content, rerr := afero.ReadFile(fs, "/dest/ABC-123/ABC-123.mp4")
+	require.NoError(t, rerr)
+	assert.Equal(t, "video", string(content))
 }
 
 func TestOrganizeStrategy_Execute_InvalidLinkMode(t *testing.T) {


### PR DESCRIPTION
## Summary

Phases A+B of #224: make every **unauthorized** organize terminal file op *syscall-atomic* no-clobber, by wiring the already-reviewed poster-write-hardening toolkit into the organize path (today's guard closes intra-process races only).

- **New fsutil composites** (`internal/fsutil/move_noreplace.go`): `MoveFileNoReplace` / `CopyFileNoReplace` — classify-first (lexical-self and same-inode adoption kept intact, with the source-symlink exclusion), same-volume `PublishNoReplace`, EXDEV via dest-adjacent `CreateExclusiveStagingFile` + bound `PublishStagedBound(NoReplace)`, and `UnlinkVerified` source cleanup (a swapped source is never unlinked; ambiguous failures keep both byte-intact).
- **Hazards removed** on the shared EXDEV leg (`move.go`): `crossDeviceMoveFs`'s `_ = fs.Remove(dst)` (deleted a foreign destination the operation never wrote) and the predictable HALF-predictable/O_TRUNC staging name; staging now runs O_EXCL with bound-publish; the replace-semantics legs are unchanged.
- **Organizer wiring**: all unauthorized legs — organize move + copy, both in-place strategies, the dedicated-folder inner rename (`PublishNoReplace` + identical rollback shape), subtitle writes (occupancy/unsupported refusals map to the existing skip leg). `refuseExistingDestination` becomes classification-only authority (its comment now says so).
- **Fail-closed on inexpressible volumes**: non-Linux/Windows volumes without hard-link ability (e.g. exFAT on macOS) refuse with a distinct infrastructure error ("destination volume cannot express an atomic no-clobber write") instead of masking a non-atomic publish — documented in `docs/10-troubleshooting.md`.
- Forced-update (authorized) paths: unchanged replace semantics, by design; force-update typing belongs to #224 phase C.

Advances #224 (its bullet-1 for the organize path). C/D/E (typed conflicts, lock-registry unification, preview preflight, subtitle result-mode) remain open; cdN detection awaits reporter sample filenames.

## Test plan

- [x] New fsutil composites matrix (`move_noreplace_test.go`): happy paths, lexical-self no-op, same-inode adoption (hardlink alias, OS-Fs), occupied-destination refusal preserving foreign+source, plant-in-window via per-platform publish seams (OsFs only — MemMapFs cannot demonstrate the guarantee), EXDEV happy + staging-leftover-free, EXDEV source-swap refusal
- [x] Per-platform seam hooks (`move_noreplace_hooks_{linux,posix,windows}_test.go`); `GOOS=windows`/`GOOS=linux` vet clean (R1's blocker)
- [x] Organizer: `mapNoReplaceRefusal` mapper table; subtitle refusal→skip incl. real-failure distinction; `TestOrganizeStrategy_AtomicNoClobber_ForeignPlantWins` (real FS)
- [x] Existing #225/#221 suites untouched-green; `go test -race` on fsutil+organizer; full `-short` suite; whole-repo `golangci-lint` (0 issues)
- [x] `move_coverage_test.go` keep-both pins inverted (the hazard they asserted is removed; a new test asserts a foreign destination survives a failed cross-device move)

## Review history

- Spec: 3 k3/max rounds → READY (caught: missed inner-rename terminal op, exFAT/macOS parity trap, PublishNoReplace lacking adoption semantics, staged-name discard discipline, symbol-anchor fixes).
- Patch: 2 k3/max rounds → READY (caught: Windows test-build break, staged-name residue violating PublishStagedBound's contract, EXDEV-leg zero coverage, refusal-mapper unexercised).