### PR TITLE
test(api): deflake background-task blocking asserts

### DIFF
--- a/internal/api/core/background_tasks_test.go
+++ b/internal/api/core/background_tasks_test.go
@@ -21,15 +21,30 @@ func TestAPIRuntime_BackgroundTaskTracking(t *testing.T) {
 		rt.EnsureRuntime()
 		done := rt.TrackBackgroundTask()
 
-		const settleAfter = 150 * time.Millisecond
+		release := make(chan struct{})
 		go func() {
-			time.Sleep(settleAfter)
+			<-release
 			done()
 		}()
 
-		start := time.Now()
-		assert.True(t, rt.WaitBackgroundTasks(5*time.Second))
-		assert.GreaterOrEqual(t, time.Since(start), settleAfter)
+		settled := make(chan bool, 1)
+		go func() {
+			settled <- rt.WaitBackgroundTasks(5 * time.Second)
+		}()
+
+		select {
+		case ok := <-settled:
+			t.Fatalf("wait returned %v while the tracked task was still held", ok)
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		close(release)
+		select {
+		case ok := <-settled:
+			assert.True(t, ok)
+		case <-time.After(5 * time.Second):
+			t.Fatal("wait did not return after the tracked task released")
+		}
 	})
 
 	t.Run("timeout reports false while task is still tracked", func(t *testing.T) {

--- a/internal/api/testkit/helpers_drain_test.go
+++ b/internal/api/testkit/helpers_drain_test.go
@@ -31,20 +31,31 @@ func TestDrainBackgroundTasks_WaitsForTrackedTask(t *testing.T) {
 	deps := CreateTestDeps(t, cfg, "")
 	rt := GetTestRuntime(deps)
 
+	release := make(chan struct{})
 	done := rt.TrackBackgroundTask()
-	const settleAfter = 150 * time.Millisecond
 	go func() {
-		time.Sleep(settleAfter)
+		<-release
 		done()
 	}()
 
-	start := time.Now()
-	drainBackgroundTasks(t, rt, 10*time.Second)
-	elapsed := time.Since(start)
-	assert.GreaterOrEqual(t, elapsed, settleAfter,
-		"drain must block until the tracked goroutine releases")
-	assert.Less(t, elapsed, 5*time.Second,
-		"drain must return soon after the task releases")
+	drained := make(chan struct{})
+	go func() {
+		drainBackgroundTasks(t, rt, 10*time.Second)
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+		t.Fatal("drain returned while the tracked task was still held")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-drained:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drain did not return after the tracked task released")
+	}
 }
 
 func TestDrainBackgroundTasks_BudgetExpiryDoesNotHang(t *testing.T) {
@@ -61,7 +72,7 @@ func TestDrainBackgroundTasks_BudgetExpiryDoesNotHang(t *testing.T) {
 	start := time.Now()
 	drainBackgroundTasks(t, rt, budget)
 	elapsed := time.Since(start)
-	assert.GreaterOrEqual(t, elapsed, budget,
+	assert.GreaterOrEqual(t, elapsed, budget-100*time.Millisecond,
 		"drain should keep waiting until the budget expires for a stuck task")
 	assert.Less(t, elapsed, 3*time.Second,
 		"drain must give up shortly after the budget, not hang forever")

--- a/internal/api/testkit/helpers_release_test.go
+++ b/internal/api/testkit/helpers_release_test.go
@@ -239,7 +239,7 @@ func TestWaitForFileRelease_LogsOnTimeoutWhenNeverReleased(t *testing.T) {
 
 	// Should have polled past the deadline (covers the sleep + remaining cap
 	// branches) and then logged. Allow a small buffer over the deadline.
-	assert.GreaterOrEqual(t, elapsed, 30*time.Millisecond, "should have polled until the deadline, took %v", elapsed)
+	assert.GreaterOrEqual(t, elapsed, 20*time.Millisecond, "should have polled until the deadline, took %v", elapsed)
 	assert.Less(t, elapsed, 500*time.Millisecond, "should not run far past the deadline, took %v", elapsed)
 }
 


### PR DESCRIPTION
## Summary

The race-detector CI job flaked twice within ~3 hours because drain/background-task tests demanded a **single sampled** wall-clock `elapsed >= 150ms` under `-race` on shared runners (observed misses: 149.03ms and 148.58ms — ~1% short, scheduling jitter, unrelated to the PRs' diffs).

**Fix:** make blocking behavior deterministic instead of timing-based:
- `TestDrainBackgroundTasks_WaitsForTrackedTask` / `TestAPIRuntime_BackgroundTaskTracking/waits_until_the_task_releases`: task held on a release channel; test proves drain **does not** return while held (poll, not a sample), then releases and asserts prompt completion. No wall-clock lower bound remains.
- `BudgetExpiryDoesNotHang` / `helpers_release_test.go` deadline asserts keep their intent ("didn't give up early") with slack (`>= budget-100ms`, `>= 20ms`) far beyond observed early-timer misses.

Sibling audit across api/worker/tui/websocket included; only same-shape brittle asserts were adjusted.

## Test plan
- [x] `go test -race -count=20 -run 'DrainBackgroundTasks|BackgroundTaskTracking' ./internal/api/testkit/ ./internal/api/core/` — green
- [x] `go test -count=1 ./internal/api/...` — all 22 packages green

Closes #237