### PR TITLE
feat(organizer): per-destination lock registry unification

### DIFF
--- a/internal/fsutil/keyed_lock.go
+++ b/internal/fsutil/keyed_lock.go
@@ -873,7 +873,12 @@ func (r *KeyedLockRegistry) AcquireShared(key string) func() {
 // ".." components but never drops a trailing non-dot segment.
 const dirLockTierSuffix = "\x00dir"
 
-func dirTierKey(dir string) string { return dir + dirLockTierSuffix }
+// dirTierKey normalizes BEFORE appending the suffix: with the marker already
+// attached, filepath.Clean sees it as a new trailing component and can no
+// longer strip a trailing separator or terminal "."/".." — '/dst' and
+// '/dst/' would derive distinct keys and stop contending. normalizeDestPath
+// (not bare filepath.Clean) so the separator policy matches the file tier.
+func dirTierKey(dir string) string { return normalizeDestPath(dir) + dirLockTierSuffix }
 
 // AcquireDirExclusive is the directory tier's writer hold (a directory
 // rename/install draining child writes): same keyspace as Acquire, but

--- a/internal/fsutil/keyed_lock.go
+++ b/internal/fsutil/keyed_lock.go
@@ -32,7 +32,7 @@ type KeyedLockRegistry struct {
 }
 
 type keyedLock struct {
-	mu   sync.Mutex
+	mu   sync.RWMutex
 	refs int
 }
 
@@ -833,6 +833,63 @@ func (r *KeyedLockRegistry) AcquireMany(keys []string) func() {
 	}
 }
 
+// AcquireShared blocks until the key is held in shared (read) mode and
+// returns a release function. Concurrent shared holds overlap; an exclusive
+// Acquire excludes them. A goroutine holding a shared (or exclusive) hold
+// must NEVER acquire the same folded key again: sync.RWMutex has no
+// re-entrancy, and writer preference deadlocks even read-read recursion once
+// a writer queues. The release function MUST be called exactly once.
+func (r *KeyedLockRegistry) AcquireShared(key string) func() {
+	folded := foldKeyedLock(key)
+	r.mu.Lock()
+	kl, ok := r.locks[folded]
+	if !ok {
+		kl = &keyedLock{}
+		r.locks[folded] = kl
+	}
+	kl.refs++
+	r.mu.Unlock()
+
+	kl.mu.RLock()
+
+	return func() {
+		kl.mu.RUnlock()
+		r.mu.Lock()
+		kl.refs--
+		if kl.refs == 0 {
+			delete(r.locks, folded)
+		}
+		r.mu.Unlock()
+	}
+}
+
+// dirLockTierSuffix namespaces the DIRECTORY tier inside one registry. A NUL
+// byte can never appear in a real destination path (POSIX and Windows reject
+// it in name components), so a directory-tier key never aliases a file-tier
+// key of the same cleaned spelling: nesting an ancestor-directory hold with a
+// descendant — or degenerately SAME-named — file hold on one goroutine stays
+// deadlock-free without re-entrant mutexes. The marker is a SUFFIX because
+// filepath.Clean inside foldKeyedLock can cancel leading segments against
+// ".." components but never drops a trailing non-dot segment.
+const dirLockTierSuffix = "\x00dir"
+
+func dirTierKey(dir string) string { return dir + dirLockTierSuffix }
+
+// AcquireDirExclusive is the directory tier's writer hold (a directory
+// rename/install draining child writes): same keyspace as Acquire, but
+// namespaced so it contends only with other directory-tier holds of the same
+// spelling.
+func (r *KeyedLockRegistry) AcquireDirExclusive(dir string) func() {
+	return r.Acquire(dirTierKey(dir))
+}
+
+// AcquireDirShared is the directory tier's reader hold (child writes into the
+// directory): concurrent shared holds overlap, and a queued AcquireDirExclusive
+// drains them by sync.RWMutex writer preference.
+func (r *KeyedLockRegistry) AcquireDirShared(dir string) func() {
+	return r.AcquireShared(dirTierKey(dir))
+}
+
 // sharedJournalLocks serializes read-modify-write mutation of one journal
 // ROW across the workflow recorder, the reverter's consumption, and the
 // sweeper (codex P3 R15-1): a sweeper updating a row snapshot from an
@@ -843,9 +900,12 @@ var sharedJournalLocks = NewKeyedLockRegistry()
 func SharedJournalLocks() *KeyedLockRegistry { return sharedJournalLocks }
 
 // sharedDestLocks is the process-wide destination lock registry shared by
-// the downloader's overwrite discipline and the history reverter's restore
-// path (POSTER-WRITE-HARDENING P3 D8).
+// the downloader's overwrite discipline, the history reverter's restore
+// path, and every organizer terminal operation (#224 phase D).
 var sharedDestLocks = NewKeyedLockRegistry()
 
 // SharedDestLocks returns the process-wide per-destination lock registry.
+// One registry, two namespaced tiers: file destinations via Acquire/
+// AcquireShared, directory destinations via AcquireDirShared/
+// AcquireDirExclusive (see dirLockTierSuffix for why the tiers cannot alias).
 func SharedDestLocks() *KeyedLockRegistry { return sharedDestLocks }

--- a/internal/fsutil/keyed_lock_dirtier_norm_test.go
+++ b/internal/fsutil/keyed_lock_dirtier_norm_test.go
@@ -1,0 +1,96 @@
+package fsutil
+
+// Codex P2 (PR #239): dirTierKey must normalize the directory path BEFORE the
+// "\x00dir" tier suffix is appended. With the suffix already attached,
+// filepath.Clean sees it as a new trailing path component and can no longer
+// strip a trailing separator or a terminal "."/".." — '/dst' and '/dst/'
+// derived distinct keys, so a directory rename could overlap a child write.
+// These tables pin that every equivalent spelling of one directory derives
+// ONE tier key (the same normalization the file tier gets) and that the
+// spellings serialize against each other in both shared/exclusive directions.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var dirTierEquivalentSpellings = []struct {
+	name     string
+	spelling string
+}{
+	{"canonical", "/beta/dst"},
+	{"trailing slash", "/beta/dst/"},
+	{"double slash", "/beta//dst//"},
+	{"terminal dot", "/beta/dst/."},
+	{"terminal dot then slash", "/beta/dst/./"},
+	{"interior dotdot", "/beta/other/../dst"},
+	{"terminal dotdot", "/beta/dst/x/.."},
+	{"terminal dotdot with slash", "/beta/dst/x/../"},
+	{"case variant", "/BETA/DsT"},
+	{"backslash spelling", `\beta\dst\`},
+}
+
+func TestKeyedLock_DirTier_EquivalentSpellingsDeriveOneKey(t *testing.T) {
+	previous := PathBackslashesAreSeparators
+	PathBackslashesAreSeparators = true
+	t.Cleanup(func() { PathBackslashesAreSeparators = previous })
+
+	want := foldKeyedLock(dirTierKey("/beta/dst"))
+	for _, tc := range dirTierEquivalentSpellings {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, want, foldKeyedLock(dirTierKey(tc.spelling)),
+				"equivalent directory spellings must derive one tier key")
+		})
+	}
+}
+
+func TestKeyedLock_DirTier_EquivalentSpellingsSerialize(t *testing.T) {
+	previous := PathBackslashesAreSeparators
+	PathBackslashesAreSeparators = true
+	t.Cleanup(func() { PathBackslashesAreSeparators = previous })
+
+	for _, tc := range dirTierEquivalentSpellings {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("rename waits for child write", func(t *testing.T) {
+				r := NewKeyedLockRegistry()
+				child := r.AcquireDirShared(tc.spelling)
+				rename := make(chan func(), 1)
+				go func() { rename <- r.AcquireDirExclusive("/beta/dst") }()
+				select {
+				case rel := <-rename:
+					rel()
+					t.Fatalf("exclusive hold must block behind a shared hold on equivalent spelling %q", tc.spelling)
+				case <-time.After(50 * time.Millisecond):
+				}
+				child()
+				select {
+				case rel := <-rename:
+					rel()
+				case <-time.After(2 * time.Second):
+					t.Fatal("exclusive acquisition never granted after shared release")
+				}
+			})
+			t.Run("child write waits for rename", func(t *testing.T) {
+				r := NewKeyedLockRegistry()
+				rename := r.AcquireDirExclusive("/beta/dst")
+				child := make(chan func(), 1)
+				go func() { child <- r.AcquireDirShared(tc.spelling) }()
+				select {
+				case rel := <-child:
+					rel()
+					t.Fatalf("shared hold on equivalent spelling %q must block behind an exclusive hold", tc.spelling)
+				case <-time.After(50 * time.Millisecond):
+				}
+				rename()
+				select {
+				case rel := <-child:
+					rel()
+				case <-time.After(2 * time.Second):
+					t.Fatal("shared acquisition never granted after exclusive release")
+				}
+			})
+		})
+	}
+}

--- a/internal/fsutil/keyed_lock_shared_test.go
+++ b/internal/fsutil/keyed_lock_shared_test.go
@@ -1,0 +1,366 @@
+package fsutil
+
+// #224 phase D: the shared-acquisition mode lifts the organizer's per-directory
+// reader/writer discipline onto the process-wide destination registry. These
+// tests pin the RW semantics, the refcount/white-box eviction discipline under
+// mixed-mode churn (the registry must stay bounded), queued-writer preference
+// (a directory rename must eventually win against streaming child writes), and
+// key-folding parity with the exclusive path.
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyedLock_AcquireShared_ConcurrentHoldersOverlap(t *testing.T) {
+	r := NewKeyedLockRegistry()
+	entered := make(chan struct{}, 2)
+	releaseEnter := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rel := r.AcquireShared("/shared/dir")
+			entered <- struct{}{}
+			<-releaseEnter
+			rel()
+		}()
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for i := 0; i < 2; i++ {
+		select {
+		case <-entered:
+		case <-time.After(time.Until(deadline)):
+			t.Fatal("second shared holder must overlap the first")
+		}
+	}
+	close(releaseEnter)
+	wg.Wait()
+}
+
+func TestKeyedLock_AcquireShared_ExclusiveExcludesBothWays(t *testing.T) {
+	t.Run("exclusive waits for shared drain", func(t *testing.T) {
+		r := NewKeyedLockRegistry()
+		hold := r.AcquireShared("/rw/dir")
+		granted := make(chan func(), 1)
+		go func() { granted <- r.Acquire("/rw/dir") }()
+		select {
+		case rel := <-granted:
+			rel()
+			t.Fatal("exclusive acquisition proceeded while a shared hold was live")
+		case <-time.After(50 * time.Millisecond):
+		}
+		hold()
+		select {
+		case rel := <-granted:
+			rel()
+		case <-time.After(2 * time.Second):
+			t.Fatal("exclusive acquisition never granted after shared drain")
+		}
+	})
+	t.Run("shared waits behind exclusive", func(t *testing.T) {
+		r := NewKeyedLockRegistry()
+		hold := r.Acquire("/rw/dir2")
+		granted := make(chan func(), 1)
+		go func() { granted <- r.AcquireShared("/rw/dir2") }()
+		select {
+		case rel := <-granted:
+			rel()
+			t.Fatal("shared acquisition proceeded while an exclusive hold was live")
+		case <-time.After(50 * time.Millisecond):
+		}
+		hold()
+		select {
+		case rel := <-granted:
+			rel()
+		case <-time.After(2 * time.Second):
+			t.Fatal("shared acquisition never granted after exclusive release")
+		}
+	})
+}
+
+// A queued writer must win over readers that arrive after it queued — a
+// directory rename permanently starved by streaming child writes would never
+// drain the directory (Go sync.RWMutex writer-preference, pinned).
+func TestKeyedLock_AcquireShared_QueuedExclusiveWinsOverLateReaders(t *testing.T) {
+	r := NewKeyedLockRegistry()
+	hold := r.AcquireShared("/prio")
+	excl := make(chan func(), 1)
+	go func() { excl <- r.Acquire("/prio") }()
+	time.Sleep(50 * time.Millisecond) // let the exclusive acquisition queue
+	late := make(chan func(), 1)
+	go func() { late <- r.AcquireShared("/prio") }()
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case rel := <-late:
+		rel()
+		t.Fatal("late shared hold must queue behind the already-waiting exclusive acquisition")
+	default:
+	}
+	hold()
+	select {
+	case rel := <-excl:
+		rel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued exclusive acquisition never granted")
+	}
+	select {
+	case rel := <-late:
+		rel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("late shared hold never granted after the exclusive released")
+	}
+}
+
+func TestKeyedLock_AcquireShared_VacuumOnRelease(t *testing.T) {
+	r := NewKeyedLockRegistry()
+	r.AcquireShared("gone-shared")()
+	r.mu.Lock()
+	_, present := r.locks[foldKeyedLock("gone-shared")]
+	r.mu.Unlock()
+	require.False(t, present, "released shared keys are evicted")
+}
+
+// A queued exclusive waiter pins the entry: releasing the last live SHARED
+// hold must NOT evict while the waiter is still registered, or the waiter
+// would acquire a stale lock object nobody else contends on.
+func TestKeyedLock_SharedReleaseKeepsEntryWhileExclusiveWaits(t *testing.T) {
+	r := NewKeyedLockRegistry()
+	hold := r.AcquireShared("/waiter-pin")
+	done := make(chan func(), 1)
+	go func() { done <- r.Acquire("/waiter-pin") }()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		r.mu.Lock()
+		refs := r.locks[foldKeyedLock("/waiter-pin")].refs
+		r.mu.Unlock()
+		if refs == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("exclusive waiter never registered on the entry")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	hold()
+	r.mu.Lock()
+	_, present := r.locks[foldKeyedLock("/waiter-pin")]
+	r.mu.Unlock()
+	require.True(t, present, "entry must survive while an exclusive waiter is queued on it")
+	rel := <-done
+	rel()
+	r.mu.Lock()
+	_, present = r.locks[foldKeyedLock("/waiter-pin")]
+	r.mu.Unlock()
+	require.False(t, present, "entry evicted once the final waiter releases")
+}
+
+func TestKeyedLock_SharedExclusiveChurn_Bounded(t *testing.T) {
+	r := NewKeyedLockRegistry()
+	var wg sync.WaitGroup
+	const keyCount = 25
+	var inFlight [keyCount]atomic.Int32
+	var maxExclusive [keyCount]atomic.Int32
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				ki := j % keyCount
+				key := fmt.Sprintf("/churn-%d", ki)
+				if i%2 == 0 {
+					rel := r.Acquire(key)
+					cur := inFlight[ki].Add(1)
+					for {
+						m := maxExclusive[ki].Load()
+						if cur <= m || maxExclusive[ki].CompareAndSwap(m, cur) {
+							break
+						}
+					}
+					time.Sleep(time.Millisecond)
+					inFlight[ki].Add(-1)
+					rel()
+				} else {
+					rel := r.AcquireShared(key)
+					rel()
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+	for ki := 0; ki < keyCount; ki++ {
+		require.Equal(t, int32(1), maxExclusive[ki].Load(), "exclusive holders of one key must never overlap, under shared traffic too (key /churn-%d)", ki)
+	}
+	r.mu.Lock()
+	size := len(r.locks)
+	r.mu.Unlock()
+	require.Equal(t, 0, size, "mixed shared/exclusive churn must leave the registry empty (bounded)")
+}
+
+// Shared acquisition folds exactly like the exclusive path: differently-spelled
+// keys of one destination contend in either mode combination.
+func TestKeyedLock_AcquireShared_FoldsLikeExclusive(t *testing.T) {
+	previous := PathBackslashesAreSeparators
+	PathBackslashesAreSeparators = true
+	t.Cleanup(func() { PathBackslashesAreSeparators = previous })
+
+	r := NewKeyedLockRegistry()
+	hold := r.AcquireShared("/DST/Sub")
+	granted := make(chan func(), 1)
+	go func() { granted <- r.Acquire("\\dst\\sub") }()
+	select {
+	case rel := <-granted:
+		rel()
+		t.Fatal("differently-spelled key must contend with the shared hold")
+	case <-time.After(50 * time.Millisecond):
+	}
+	hold()
+	select {
+	case rel := <-granted:
+		rel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("folded exclusive acquisition never granted after shared release")
+	}
+}
+
+// Directory tier: writer/reader discipline identical to the file tier, on
+// the same registry, under namespaced keys.
+func TestKeyedLock_DirTier_RWDiscipline(t *testing.T) {
+	r := NewKeyedLockRegistry()
+	a := r.AcquireDirShared("/tier/dir")
+	b := r.AcquireDirShared("/tier/dir") // overlapping readers proceed
+	excl := make(chan func(), 1)
+	go func() { excl <- r.AcquireDirExclusive("/tier/dir") }()
+	select {
+	case rel := <-excl:
+		rel()
+		t.Fatal("exclusive dir hold must wait for shared dir holds to drain")
+	case <-time.After(50 * time.Millisecond):
+	}
+	a()
+	b()
+	select {
+	case rel := <-excl:
+		rel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("exclusive dir hold never granted after shared drain")
+	}
+
+	hold := r.AcquireDirExclusive("/tier/dir2")
+	sh := make(chan func(), 1)
+	go func() { sh <- r.AcquireDirShared("/tier/dir2") }()
+	select {
+	case rel := <-sh:
+		rel()
+		t.Fatal("shared dir hold entered under a live exclusive dir hold")
+	case <-time.After(50 * time.Millisecond):
+	}
+	hold()
+	select {
+	case rel := <-sh:
+		rel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("shared dir hold never granted after exclusive release")
+	}
+}
+
+// The tiers must never alias: a file-tier hold of one spelling and a
+// directory-tier hold of the SAME spelling proceed concurrently — that is the
+// property keeping nested ancestor-dir/descendant-file (and degenerate
+// same-name) acquisitions deadlock-free without re-entrant mutexes.
+func TestKeyedLock_DirTier_NeverAliasesFileTier(t *testing.T) {
+	r := NewKeyedLockRegistry()
+	dirHold := r.AcquireDirExclusive("/same/name")
+	fileGranted := make(chan func(), 1)
+	go func() { fileGranted <- r.Acquire("/same/name") }()
+	select {
+	case rel := <-fileGranted:
+		rel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("file-tier acquisition must not contend with the directory tier")
+	}
+	dirHold()
+
+	fileHold := r.Acquire("/same/name2")
+	dirGranted := make(chan func(), 1)
+	go func() { dirGranted <- r.AcquireDirExclusive("/same/name2") }()
+	select {
+	case rel := <-dirGranted:
+		rel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("directory-tier acquisition must not contend with the file tier")
+	}
+	fileHold()
+}
+
+// ".." components can cancel LEADING segments under filepath.Clean; the tier
+// marker is a suffix, so cleaning never strips it: dotdot spellings of one
+// directory still contend.
+func TestKeyedLock_DirTier_DotDotSpellingContends(t *testing.T) {
+	r := NewKeyedLockRegistry()
+	hold := r.AcquireDirExclusive("/x/../tiered")
+	blocked := make(chan func(), 1)
+	go func() { blocked <- r.AcquireDirShared("/tiered") }()
+	select {
+	case rel := <-blocked:
+		rel()
+		t.Fatal("dotdot-cleaned spelling of one directory must contend on one tier key")
+	case <-time.After(50 * time.Millisecond):
+	}
+	hold()
+	select {
+	case rel := <-blocked:
+		rel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("tier acquisition never granted after release")
+	}
+}
+
+// The organizer's universal holding pattern — ancestor directory (shared or
+// exclusive) then descendant file (exclusive) on DISTINCT keys — must never
+// deadlock under mixed concurrency, including alongside exclusive directory
+// acquisitions (the in-place rename shape).
+func TestKeyedLock_NestedDirThenFileDistinctKeys_NoDeadlock(t *testing.T) {
+	r := NewKeyedLockRegistry()
+	const dir = "/nest"
+	file := dir + "/movie.mkv"
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			relDir := r.AcquireDirShared(dir)
+			relFile := r.Acquire(file)
+			relFile()
+			relDir()
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			relDir := r.AcquireDirExclusive(dir)
+			relFile := r.Acquire(file)
+			relFile()
+			relDir()
+		}()
+	}
+	close(start)
+	waitCh := make(chan struct{})
+	go func() { wg.Wait(); close(waitCh) }()
+	select {
+	case <-waitCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("nested dir-then-file acquisitions deadlocked")
+	}
+	r.mu.Lock()
+	size := len(r.locks)
+	r.mu.Unlock()
+	require.Equal(t, 0, size)
+}

--- a/internal/organizer/organize_conflict_guards_test.go
+++ b/internal/organizer/organize_conflict_guards_test.go
@@ -47,7 +47,10 @@ func TestOrganize_Subtitle_LateExistingSkipped(t *testing.T) {
 	assert.Equal(t, []byte("subtitle-existing"), data, "existing subtitle preserved")
 }
 
-func TestLockRegistry_BoundedUnderChurn(t *testing.T) {
+// Boundedness/GC of the underlying registry is pinned white-box in
+// internal/fsutil (keyed_lock_shared_test.go); these churn cases pin that the
+// organizer wrappers ride it without wedging.
+func TestLockRegistry_ChurnThroughSharedRegistry(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
 		wg.Add(1)
@@ -60,10 +63,16 @@ func TestLockRegistry_BoundedUnderChurn(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
-	operationLocks.mu.Lock()
-	size := len(operationLocks.items)
-	operationLocks.mu.Unlock()
-	assert.Equal(t, 0, size, "unused entries must be evicted when last waiter releases")
+	done := make(chan struct{})
+	go func() {
+		_ = withDestFileLock("/dst-1", func() error { return nil })
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a churned destination key must be handed out again once traffic drains")
+	}
 }
 
 // Verifies a lock mutually excludes simultaneous waiters: the in-flight counter must
@@ -172,7 +181,7 @@ func TestDirOperationLocks_SharedChildrenRunInParallel(t *testing.T) {
 	assert.Greater(t, maxSeen.Load(), int32(1), "shared directory locks must permit concurrent child writes (batch copy throughput)")
 }
 
-func TestDirOperationLocks_EvictsIdleEntries(t *testing.T) {
+func TestDirOperationLocks_DrainedSharedChurnAdmitsExclusive(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 4; i++ {
 		wg.Add(1)
@@ -182,8 +191,14 @@ func TestDirOperationLocks_EvictsIdleEntries(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
-	dirOperationLocks.mu.Lock()
-	size := len(dirOperationLocks.items)
-	dirOperationLocks.mu.Unlock()
-	assert.Equal(t, 0, size, "directory lock entries must be evicted when unused")
+	done := make(chan struct{})
+	go func() {
+		_ = withDestDirExclusiveLock("/evictable-1", func() error { return nil })
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("exclusive directory lock starved after shared child traffic drained")
+	}
 }

--- a/internal/organizer/organize_destlocks_unified_test.go
+++ b/internal/organizer/organize_destlocks_unified_test.go
@@ -1,0 +1,207 @@
+package organizer
+
+// #224 phase D: the organizer's destination locks ARE fsutil.SharedDestLocks —
+// one process-wide registry shared with the downloader's install paths and the
+// history reverter. These tests pin the shared keyspace directly: a direct
+// registry acquisition must contend with (or admit) the organizer wrappers
+// exactly as the two-tier reader/writer discipline dictates.
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/fsutil"
+)
+
+func TestDestLocks_FileLockSharesProcessRegistry(t *testing.T) {
+	release := fsutil.SharedDestLocks().Acquire("/phase-d-unify/file.mp4")
+	held := true
+	defer func() {
+		if held {
+			release()
+		}
+	}()
+
+	blocked := make(chan struct{})
+	go func() {
+		_ = withDestFileLock("/phase-d-unify/file.mp4", func() error { return nil })
+		close(blocked)
+	}()
+	select {
+	case <-blocked:
+		t.Fatal("organizer file lock bypassed the shared destination registry")
+	case <-time.After(100 * time.Millisecond):
+	}
+	release()
+	held = false
+	select {
+	case <-blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("organizer file lock never acquired after registry release")
+	}
+}
+
+// Folded keys: a direct acquisition of one CASE SPELLING of a destination
+// contends with the organizer's file lock on another spelling of it, even on a
+// case-sensitive host volume (registry folding is unconditional).
+func TestDestLocks_FileLockContendsAcrossCaseSpellings(t *testing.T) {
+	release := fsutil.SharedDestLocks().Acquire("/PHASE-D-CASE/Movie.MKV")
+	blocked := make(chan struct{})
+	go func() {
+		_ = withDestFileLock("/phase-d-case/movie.mkv", func() error { return nil })
+		close(blocked)
+	}()
+	select {
+	case <-blocked:
+		t.Fatal("case spelling variant bypassed the shared destination lock")
+	case <-time.After(100 * time.Millisecond):
+	}
+	release()
+	select {
+	case <-blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("organizer file lock never acquired after case-variant release")
+	}
+}
+
+func TestDestLocks_DirLocksShareProcessRegistry(t *testing.T) {
+	// An exclusive registry hold on the directory tier excludes BOTH organizer dir modes.
+	release := fsutil.SharedDestLocks().AcquireDirExclusive("/phase-d-unify/dir")
+	exBlocked := make(chan struct{})
+	go func() {
+		_ = withDestDirExclusiveLock("/phase-d-unify/dir", func() error { return nil })
+		close(exBlocked)
+	}()
+	select {
+	case <-exBlocked:
+		t.Fatal("exclusive dir lock entered while the registry key was held exclusively")
+	case <-time.After(100 * time.Millisecond):
+	}
+	shBlocked := make(chan struct{})
+	go func() {
+		_ = withDestDirSharedLock("/phase-d-unify/dir", func() error { return nil })
+		close(shBlocked)
+	}()
+	select {
+	case <-shBlocked:
+		t.Fatal("shared dir lock entered while the registry key was held exclusively")
+	case <-time.After(100 * time.Millisecond):
+	}
+	release()
+	select {
+	case <-exBlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("exclusive dir lock never acquired after registry release")
+	}
+	select {
+	case <-shBlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shared dir lock never acquired after registry release")
+	}
+
+	// A shared registry hold ADMITS organizer shared dir locks and excludes
+	// exclusive ones; a child-FILE lock (distinct descendant key) always proceeds.
+	shRelease := fsutil.SharedDestLocks().AcquireDirShared("/phase-d-unify/dir2")
+	sharedEntered := make(chan struct{})
+	go func() {
+		_ = withDestDirSharedLock("/phase-d-unify/dir2", func() error { return nil })
+		close(sharedEntered)
+	}()
+	select {
+	case <-sharedEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shared dir hold must admit concurrent shared dir locks")
+	}
+	childEntered := make(chan struct{})
+	go func() {
+		_ = withDestFileLock("/phase-d-unify/dir2/file.mp4", func() error { return nil })
+		close(childEntered)
+	}()
+	select {
+	case <-childEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("descendant file lock must never contend with the ancestor dir hold (distinct keys)")
+	}
+	exBlocked2 := make(chan struct{})
+	go func() {
+		_ = withDestDirExclusiveLock("/phase-d-unify/dir2", func() error { return nil })
+		close(exBlocked2)
+	}()
+	select {
+	case <-exBlocked2:
+		t.Fatal("exclusive dir lock entered while a shared hold was live")
+	case <-time.After(100 * time.Millisecond):
+	}
+	shRelease()
+	select {
+	case <-exBlocked2:
+	case <-time.After(2 * time.Second):
+		t.Fatal("exclusive dir lock never acquired after shared release")
+	}
+}
+
+// The organizer's universal holding pattern — ancestor directory first (shared
+// for child writes, exclusive for in-place renames), then the descendant file —
+// must never deadlock under mixed concurrency on one keyspace.
+func TestDestLocks_NestedDirThenFile_NoDeadlock(t *testing.T) {
+	const dir = "/phase-d-nest"
+	file := filepath.Join(dir, "movie.mkv")
+	start := make(chan struct{})
+	done := make(chan struct{}, 16)
+	for i := 0; i < 8; i++ {
+		go func() {
+			<-start
+			_ = withDestDirSharedLock(dir, func() error {
+				return withDestFileLock(file, func() error { return nil })
+			})
+			done <- struct{}{}
+		}()
+		go func() {
+			<-start
+			_ = withDestDirExclusiveLock(dir, func() error {
+				return withDestFileLock(file, func() error { return nil })
+			})
+			done <- struct{}{}
+		}()
+	}
+	close(start)
+	for i := 0; i < 16; i++ {
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("nested dir-then-file acquisitions deadlocked")
+		}
+	}
+}
+
+// Degenerate plans exist (an execute-time fixture or a target file rendering to
+// ""): TargetPath can clean to the very string TargetDir holds. The directory
+// tier's key namespace must keep that nesting deadlock-free — pre-unification
+// this shape survived only because file and dir locks lived in separate maps.
+func TestDestLocks_DegenerateDirEqualsFile_NoDeadlock(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		_ = withDestDirExclusiveLock("/phase-d-degenerate", func() error {
+			return withDestFileLock("/phase-d-degenerate/", func() error { return nil })
+		})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("exclusive dir hold + same-named file hold self-deadlocked (tiers must not alias)")
+	}
+	done = make(chan struct{})
+	go func() {
+		_ = withDestDirSharedLock("/phase-d-degenerate2", func() error {
+			return withDestFileLock("/phase-d-degenerate2", func() error { return nil })
+		})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shared dir hold + same-named file hold self-deadlocked (tiers must not alias)")
+	}
+}

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"syscall"
 
 	"github.com/javinizer/javinizer-go/internal/config"
@@ -15,118 +14,40 @@ import (
 	"github.com/spf13/afero"
 )
 
-// operationLocks serializes destination-touching operations per destination so a
-// concurrent batch worker cannot slip a file between the existence check and the move
-// (TOCTOU). Entries are ref-counted: a lock stays registered while any goroutine waits
-// on it and is removed only once the last reference drops, which is race-free (unlike
-// try-lock delete flows that can unlink an entry with a waiter or a replacement).
-// Known residual (centralized hardening tracked separately as #224): keys are
-// lexically cleaned only, so symlink/case aliases of one destination can acquire
-// different locks.
-type destFileLock struct {
-	mu   sync.Mutex
-	refs int
-}
-
-type destFileLocker struct {
-	mu    sync.Mutex
-	items map[string]*destFileLock
-}
-
-var operationLocks destFileLocker
-
+// Destination locking is unified on ONE process-wide registry,
+// fsutil.SharedDestLocks (#224 phase D): every organizer-reachable terminal
+// operation — file moves/copies/links, subtitle installs, MkdirAll directory
+// creation, and in-place directory renames — serializes per destination with
+// the downloader's install paths and the history reverter, not just with
+// other organizer legs. The registry folds key case/separator spelling and
+// refcounts entries to zero-GC; locks remain an intra-process ordering aid —
+// the atomic no-replace publish syscalls stay the cross-process safety net.
+// File destinations ride the shared file tier; the directory tier is
+// key-namespaced inside the same registry (fsutil dirLockTierSuffix), so the
+// universal holding pattern — ancestor DIRECTORY before descendant FILE — can
+// never re-acquire a key the goroutine already holds, even for degenerate
+// plans whose cleaned TargetPath equals TargetDir (sync.RWMutex has no
+// re-entrancy).
 func withDestFileLock(path string, fn func() error) error {
-	key := filepath.Clean(path)
-	operationLocks.mu.Lock()
-	if operationLocks.items == nil {
-		operationLocks.items = make(map[string]*destFileLock)
-	}
-	l := operationLocks.items[key]
-	if l == nil {
-		l = &destFileLock{}
-		operationLocks.items[key] = l
-	}
-	l.refs++
-	operationLocks.mu.Unlock()
-
-	l.mu.Lock()
-	defer func() {
-		l.mu.Unlock()
-		operationLocks.mu.Lock()
-		l.refs--
-		if l.refs == 0 {
-			if operationLocks.items[key] == l {
-				delete(operationLocks.items, key)
-			}
-		}
-		operationLocks.mu.Unlock()
-	}()
-	return fn()
-}
-
-// dirOperationLocks coordinate directory-scope operations: a directory RENAME
-// (in-place organize) takes the exclusive lock, while any child-file operation inside
-// that directory takes the shared lock. Shared locks let unrelated copies into one
-// directory proceed concurrently; a rename (or its rollback) waits until all child
-// writes have drained, so it can never drag a freshly landed file to a path its owner
-// no longer expects. Entries are ref-counted exactly like operationLocks.
-type destDirLock struct {
-	mu   sync.RWMutex
-	refs int
-}
-
-type destDirLocker struct {
-	mu    sync.Mutex
-	items map[string]*destDirLock
-}
-
-var dirOperationLocks destDirLocker
-
-func withDestDirLock(dir string, exclusive bool, fn func() error) error {
-	key := filepath.Clean(dir)
-	dirOperationLocks.mu.Lock()
-	if dirOperationLocks.items == nil {
-		dirOperationLocks.items = make(map[string]*destDirLock)
-	}
-	l := dirOperationLocks.items[key]
-	if l == nil {
-		l = &destDirLock{}
-		dirOperationLocks.items[key] = l
-	}
-	l.refs++
-	dirOperationLocks.mu.Unlock()
-
-	if exclusive {
-		l.mu.Lock()
-	} else {
-		l.mu.RLock()
-	}
-	defer func() {
-		if exclusive {
-			l.mu.Unlock()
-		} else {
-			l.mu.RUnlock()
-		}
-		dirOperationLocks.mu.Lock()
-		l.refs--
-		if l.refs == 0 && dirOperationLocks.items[key] == l {
-			delete(dirOperationLocks.items, key)
-		}
-		dirOperationLocks.mu.Unlock()
-	}()
+	release := fsutil.SharedDestLocks().Acquire(path)
+	defer release()
 	return fn()
 }
 
 // withDestDirExclusiveLock serializes a directory-rename operation against every
 // child write already inside that directory and vice versa.
 func withDestDirExclusiveLock(dir string, fn func() error) error {
-	return withDestDirLock(dir, true, fn)
+	release := fsutil.SharedDestLocks().AcquireDirExclusive(dir)
+	defer release()
+	return fn()
 }
 
 // withDestDirSharedLock lets independent child writes into one directory run in
 // parallel while excluding a concurrent rename of the directory itself.
 func withDestDirSharedLock(dir string, fn func() error) error {
-	return withDestDirLock(dir, false, fn)
+	release := fsutil.SharedDestLocks().AcquireDirShared(dir)
+	defer release()
+	return fn()
 }
 
 // refuseExistingDestination classifies destination state at execution time with lexical-self vs


### PR DESCRIPTION
## Summary

Issue #224 phase D — unifies destination locking onto one process-scoped registry.

- **One registry for all organizer-reachable destination ops**: the organizer's two local registries (#225-era `destFileLocker` / `destDirLocker` maps, ~110 LoC) are deleted; all guard regions now ride `fsutil.SharedDestLocks()` — the refcounted, folded-key registry downloader installs and history reverts already used. Organize moves now serialize with downloader installs and history reverts of the same destination.
- **Directory tier, namespaced**: directory destinations share the same registry/refcount/GC under a NUL-suffixed key (NUL is impossible in real paths; suffix survives `filepath.Clean`'s `..`-cancellation where a prefix would be consumed). This structurally kills a degenerate-plan self-deadlock class (`TargetPath` cleaning to `TargetDir`) — regression-pinned.
- **Directory creation is covered** by construction: all production `MkdirAll` calls already sat inside the migrated lock regions.
- Case/separator folding now applies consistently to organizer keys (closes part of the old "case aliases acquire different locks" residual).
- Locks remain intra-process ordering aids; #234's atomic no-replace publishes stay the cross-process safety net; #235 typed-conflict semantics untouched.

**Non-goals**: `SharedJournalLocks` (row-scoped) and worker edit-locks (ID-scoped) are deliberately not unified; symlink-ancestor aliasing remains lexically distinct (atomic syscalls cover it); hierarchical ancestor-rename locking stays the documented non-goal.

Advances #224 (phase D; D/E/multipart-detection tracked there).

## Test plan
- [x] `go test ./internal/organizer/ ./internal/fsutil/ ./internal/worker/` + `-race` on organizer/fsutil/worker — green
- [x] Downstream registry consumers (downloader/history/workflow) — green
- [x] New functions at 100% function-block coverage; eviction/GC pinned under 50-goroutine mixed churn