### PR TITLE
feat(organizer): dry-run duplicate preflight + subtitle modes (#224 E)

### DIFF
--- a/internal/api/batch/apply_config_builder.go
+++ b/internal/api/batch/apply_config_builder.go
@@ -124,6 +124,14 @@ func resolveOrganizeApplyConfig(
 				newPath = afr.Result.OrganizeResult.NewPath
 			}
 			_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organized %s", afc.Movie.ID), models.SeverityInfo, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "apply_generation": loadApplyGeneration(applyGenerationRef)})
+			// #224 phase E: authorized intra-batch duplicates are demoted from
+			// conflicts to per-file warnings; each warning gets its own audit
+			// event via the existing eventlog.
+			if afr.Result != nil && afr.Result.OrganizeResult != nil {
+				for _, warning := range afr.Result.OrganizeResult.Warnings {
+					_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning, "apply_generation": loadApplyGeneration(applyGenerationRef)})
+				}
+			}
 		}
 	}
 

--- a/internal/api/batch/apply_config_builder_coverage_test.go
+++ b/internal/api/batch/apply_config_builder_coverage_test.go
@@ -125,3 +125,45 @@ func TestApplyProgressHelpers_NilAndGenerationPaths(t *testing.T) {
 	assert.Equal(t, "organize failed", got.Error)
 	assert.Equal(t, uint64(13), got.ApplyGeneration)
 }
+
+// TestResolveApplyConfig_PostApplyEmitsDuplicateWarningAudit pins the #224
+// phase E audit lane: authorized intra-batch duplicates surface on the
+// per-file result as warnings, and each warning becomes its own SeverityWarn
+// organize event through the existing eventlog.
+func TestResolveApplyConfig_PostApplyEmitsDuplicateWarningAudit(t *testing.T) {
+	emitter := &applyConfigEventEmitter{}
+	rt := core.NewAPIRuntime(&core.APIDeps{EventEmitter: emitter})
+	snapshot := core.NewSnapshotForTesting(rt, core.APIConfig{})
+	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
+	job := &stubControlledJob{}
+
+	organize, err := resolveOrganizeApplyConfig(snapshot, factory, job, contracts.OrganizeRequest{
+		OperationMode: string(operationmode.OperationModeInPlace),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, organize.PostApplyFunc)
+	*organize.ApplyGenerationRef = 3
+
+	organize.PostApplyFunc(context.Background(), &worker.ApplyFileContext{
+		FilePath: "/source/movie.mp4",
+		Movie:    &models.Movie{ID: "MOV-9"},
+	}, &worker.ApplyFileResult{Result: &workflow.ApplyResult{
+		OrganizeResult: &organizer.OrganizeResult{
+			NewPath: "/dest/movie.mp4",
+			Warnings: []string{
+				"duplicate destination within batch: /dest/movie.mp4 already claimed by /source/other.mp4 (overwrite authorized)",
+			},
+		},
+	}})
+
+	require.Len(t, emitter.calls, 2)
+	assert.Equal(t, models.SeverityInfo, emitter.calls[0].severity)
+	warn := emitter.calls[1]
+	assert.Equal(t, "file_move", warn.source)
+	assert.Equal(t, models.SeverityWarn, warn.severity)
+	assert.Contains(t, warn.message, "duplicate destination within batch")
+	assert.Equal(t, "MOV-9", warn.context["movie_id"])
+	assert.Equal(t, "/dest/movie.mp4", warn.context["new_path"])
+	assert.Contains(t, warn.context["warning"], "already claimed by /source/other.mp4")
+	assert.Equal(t, uint64(3), warn.context["apply_generation"])
+}

--- a/internal/fsutil/keyed_lock.go
+++ b/internal/fsutil/keyed_lock.go
@@ -299,6 +299,66 @@ func (r *DestKeyResolver) Key(p string) string {
 	return posture.key(p)
 }
 
+// KeyNonProbing derives p's canonical key WITHOUT writing to the filesystem
+// (#240 finding B — dry runs perform zero probe writes). Posture resolution:
+//  1. this resolver's frozen per-root posture, as with Key;
+//  2. the process-wide definitive probe caches — when BOTH legs are cached
+//     the posture is exactly what Key would probe, so it freezes into the
+//     resolver like a first Key derivation;
+//  3. any UNKNOWN leg falls back to the conservative distinction-preserving
+//     posture (case-sensitive, normalization-sensitive) — the same
+//     fail-closed posture a probe ERROR yields, and, like a probe error, a
+//     fallback is undecidable rather than a posture, so it is NEVER frozen:
+//     a later derivation with definitive cache knowledge (or Key itself)
+//     resolves the root's true posture.
+//
+// The cost on an uncached root is only that case/normalization variants do
+// not group until a definitive posture exists; the probe root itself is
+// selected stat-only by destinationProbeRoot, so nothing is created, renamed,
+// or removed.
+func (r *DestKeyResolver) KeyNonProbing(p string) string {
+	root := destinationProbeRoot(p)
+	if posture, ok := r.postures[root]; ok {
+		return posture.key(p)
+	}
+	caseSensitive, caseDefinitive := cachedCaseSensitivity(root)
+	normInsensitive, normDefinitive := cachedNormalizationInsensitivity(root)
+	posture := destKeyPosture{caseSensitive: caseSensitive, normInsensitive: normInsensitive}
+	if caseDefinitive && normDefinitive {
+		r.postures[root] = posture
+	}
+	return posture.key(p)
+}
+
+// cachedCaseSensitivity reads the process cache's case posture for root
+// WITHOUT probing: an uncached (or merely in-flight) root yields the
+// conservative case-SENSITIVE fallback with definitive=false — the same
+// fail-closed outcome a probe error produces, likewise never publishable.
+// root arrives already cleaned (destinationProbeRoot), matching the cache
+// keys IsCaseSensitiveRoot writes under.
+func cachedCaseSensitivity(root string) (sensitive, definitive bool) {
+	caseSensitivityCacheMu.Lock()
+	defer caseSensitivityCacheMu.Unlock()
+	result, ok := caseSensitivityCache[root]
+	if !ok {
+		return true, false
+	}
+	return result, true
+}
+
+// cachedNormalizationInsensitivity mirrors cachedCaseSensitivity for the
+// normalization leg: uncached roots fall back to normalization-SENSITIVE
+// (distinctions preserved) with definitive=false.
+func cachedNormalizationInsensitivity(root string) (insensitive, definitive bool) {
+	normalizationCacheMu.Lock()
+	defer normalizationCacheMu.Unlock()
+	result, ok := normalizationCache[root]
+	if !ok {
+		return false, false
+	}
+	return result, true
+}
+
 // NormalizationProbe is the process-wide Unicode-normalization probe seam,
 // mirroring CaseSensitiveProbe. A probe error is undecidable, so
 // IsNormalizationInsensitiveRoot keeps normalization distinctions for that

--- a/internal/fsutil/keyed_lock_nonprobing_test.go
+++ b/internal/fsutil/keyed_lock_nonprobing_test.go
@@ -1,0 +1,121 @@
+package fsutil
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingProbeSeams installs definitive probe stubs that count every probe,
+// resets both process caches, and restores everything afterwards. Landing the
+// counters at zero proves a derivation never touched the filesystem.
+func countingProbeSeams(t *testing.T, caseSensitive, normInsensitive bool) (caseCalls, normCalls *int) {
+	t.Helper()
+	ResetCaseSensitivityCache()
+	ResetNormalizationCache()
+	cc, nc := 0, 0
+	prevCase, prevNorm := CaseSensitiveProbe, NormalizationProbe
+	CaseSensitiveProbe = func(string) (bool, error) { cc++; return caseSensitive, nil }
+	NormalizationProbe = func(string) (bool, error) { nc++; return normInsensitive, nil }
+	t.Cleanup(func() {
+		CaseSensitiveProbe = prevCase
+		NormalizationProbe = prevNorm
+		ResetCaseSensitivityCache()
+		ResetNormalizationCache()
+	})
+	return &cc, &nc
+}
+
+func TestDestKeyResolver_KeyNonProbing(t *testing.T) {
+	t.Run("uncached roots fall back to the conservative posture without probing", func(t *testing.T) {
+		// Stubs would fold EVERYTHING if wrongly probed — distinct keys prove
+		// the fallback stayed distinction-preserving.
+		caseCalls, normCalls := countingProbeSeams(t, false, true)
+		dir := t.TempDir()
+		r := NewDestKeyResolver()
+		upper := r.KeyNonProbing(filepath.Join(dir, "Movie.mkv"))
+		lower := r.KeyNonProbing(filepath.Join(dir, "movie.mkv"))
+		assert.NotEqual(t, upper, lower, "unknown case posture preserves case distinctions")
+		nfc := r.KeyNonProbing(filepath.Join(dir, "caf\u00e9.mkv"))
+		nfd := r.KeyNonProbing(filepath.Join(dir, "cafe\u0301.mkv"))
+		assert.NotEqual(t, nfc, nfd, "unknown normalization posture preserves normalization distinctions")
+		assert.Equal(t, 0, *caseCalls, "no case probe")
+		assert.Equal(t, 0, *normCalls, "no normalization probe")
+	})
+
+	t.Run("fallback postures are never frozen into the resolver", func(t *testing.T) {
+		caseCalls, normCalls := countingProbeSeams(t, false, true)
+		dir := t.TempDir()
+		r := NewDestKeyResolver()
+		before := r.KeyNonProbing(filepath.Join(dir, "Movie.mkv"))
+		require.Equal(t, 0, *caseCalls)
+
+		// Both legs acquire definitive cached postures (as an earlier live
+		// probe would have published); the same resolver must re-derive from
+		// the cache instead of clinging to the fallback.
+		IsCaseSensitiveRoot(dir)
+		IsNormalizationInsensitiveRoot(dir)
+		require.Equal(t, 1, *caseCalls)
+		require.Equal(t, 1, *normCalls)
+
+		foldedUpper := r.Key(filepath.Join(dir, "Movie.mkv"))
+		foldedLower := r.Key(filepath.Join(dir, "movie.mkv"))
+		assert.Equal(t, 1, *caseCalls, "Key reuses definitive caches without re-probing")
+		assert.Equal(t, 1, *normCalls)
+		assert.Equal(t, foldedUpper, foldedLower, "post-fill derivation folds case variants again")
+		assert.NotEqual(t, before, foldedUpper, "the fallback posture was not frozen")
+	})
+
+	t.Run("fully cached roots derive the definitive posture with zero probes and freeze it", func(t *testing.T) {
+		caseCalls, normCalls := countingProbeSeams(t, false, true)
+		dir := t.TempDir()
+		IsCaseSensitiveRoot(dir)
+		IsNormalizationInsensitiveRoot(dir)
+		require.Equal(t, 1, *caseCalls)
+		require.Equal(t, 1, *normCalls)
+
+		r := NewDestKeyResolver()
+		key := r.KeyNonProbing(filepath.Join(dir, "Movie.mkv"))
+		assert.Equal(t, 1, *caseCalls, "no new case probe")
+		assert.Equal(t, 1, *normCalls, "no new normalization probe")
+		assert.Equal(t, r.KeyNonProbing(filepath.Join(dir, "movie.mkv")), key,
+			"cached-insensitive postures fold case variants")
+		assert.Equal(t, r.KeyNonProbing(filepath.Join(dir, "caf\u00e9.mkv")), r.KeyNonProbing(filepath.Join(dir, "cafe\u0301.mkv")),
+			"cached normalization-insensitivity folds NFC/NFD variants")
+		// Postures frozen from definitive caches: the frozen hit-leg serves
+		// every later key of the root without any cache dependence.
+		assert.Equal(t, r.Key(filepath.Join(dir, "MOVIE.mkv")), key, "frozen posture matches Key derivation")
+		assert.Equal(t, 1, *caseCalls)
+		assert.Equal(t, 1, *normCalls)
+	})
+
+	t.Run("partially cached roots overlay the known leg on the conservative fallback", func(t *testing.T) {
+		caseCalls, normCalls := countingProbeSeams(t, false, true)
+		dir := t.TempDir()
+		IsCaseSensitiveRoot(dir) // case leg definitive-insensitive; norm leg stays unknown
+		require.Equal(t, 1, *caseCalls)
+		require.Equal(t, 0, *normCalls)
+
+		r := NewDestKeyResolver()
+		assert.Equal(t,
+			r.KeyNonProbing(filepath.Join(dir, "Movie.mkv")),
+			r.KeyNonProbing(filepath.Join(dir, "movie.mkv")),
+			"the cached case-insensitive leg folds case variants")
+		assert.NotEqual(t,
+			r.KeyNonProbing(filepath.Join(dir, "caf\u00e9.mkv")),
+			r.KeyNonProbing(filepath.Join(dir, "cafe\u0301.mkv")),
+			"the unknown normalization leg conservatively keeps NFD/NFC distinct")
+		assert.Equal(t, 0, *normCalls, "the unknown leg is never probed")
+
+		// Partially-known derivations freeze nothing: once the missing leg is
+		// cached definitively, Key re-derives the true full posture.
+		IsNormalizationInsensitiveRoot(dir)
+		require.Equal(t, 1, *normCalls)
+		assert.Equal(t,
+			r.Key(filepath.Join(dir, "caf\u00e9.mkv")),
+			r.Key(filepath.Join(dir, "cafe\u0301.mkv")),
+			"post-fill derivation folds normalization variants — no frozen partial posture")
+	})
+}

--- a/internal/models/subtitle_move.go
+++ b/internal/models/subtitle_move.go
@@ -1,8 +1,12 @@
 package models
 
 // SubtitleMove records the original and new path of a moved subtitle file.
+// Mode distinction (#224 phase E): Moved means the source was relocated
+// (revert moves it back); Copied means the source was retained and the
+// destination holds our installed copy (revert deletes that copy).
 type SubtitleMove struct {
 	OriginalPath string
 	NewPath      string
 	Moved        bool
+	Copied       bool
 }

--- a/internal/organizer/conflict.go
+++ b/internal/organizer/conflict.go
@@ -27,6 +27,14 @@ const (
 	// file path — never authorizable-over (replacement would destroy the link
 	// target's metadata chain).
 	ConflictSymlink
+	// ConflictDuplicate is an intra-batch destination collision detected at
+	// plan time (#224 phase E): an earlier file of the same batch already
+	// claimed the proven-equal canonical target key. It is reserved from the
+	// destination-occupation kinds (no object exists at the destination yet —
+	// the collision is between planned outcomes) and flows through the same
+	// plan-conflict pipeline; overwrite authorization demotes it to a persisted
+	// per-file warning + audit event instead of silently suppressing it.
+	ConflictDuplicate
 )
 
 // PlanConflict is a destination occupation recorded on a plan.
@@ -49,6 +57,7 @@ const (
 	kindNameFile      = "file"
 	kindNameDirectory = "directory"
 	kindNameSymlink   = "symlink"
+	kindNameDuplicate = "duplicate"
 	kindNameUnknown   = folderFallbackUnknown
 )
 
@@ -62,6 +71,8 @@ func (c PlanConflict) kindName() string {
 		return kindNameDirectory
 	case ConflictSymlink:
 		return kindNameSymlink
+	case ConflictDuplicate:
+		return kindNameDuplicate
 	default:
 		return kindNameUnknown
 	}

--- a/internal/organizer/duplicates.go
+++ b/internal/organizer/duplicates.go
@@ -1,0 +1,90 @@
+package organizer
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/javinizer/javinizer-go/internal/fsutil"
+)
+
+// duplicateClaim records one batch file's plan-time claim on a canonical
+// destination key.
+type duplicateClaim struct {
+	source string
+	target string
+}
+
+// DuplicateTracker performs intra-batch duplicate-destination preflight
+// (#224 phase E). One tracker is shared across every file of a batch apply
+// run; each plan's destination registers against the proven-equal canonical
+// grouping keys of fsutil.DestKeyResolver — the folded-key discipline whose
+// per-root case/normalization postures freeze once for a grouping pass — so
+// spelling variants of one destination group together exactly when the
+// destination volume proves them aliases, and byte-distinct names on
+// case-sensitive volumes never do. Detection is plan-only: execution keeps
+// the atomic no-replace publish composites as the backstop for collisions the
+// preflight cannot see (cross-batch writers, post-plan plants).
+type DuplicateTracker struct {
+	mu       sync.Mutex
+	resolver *fsutil.DestKeyResolver
+	claims   map[string]duplicateClaim
+}
+
+// NewDuplicateTracker returns an empty tracker for one batch run.
+func NewDuplicateTracker() *DuplicateTracker {
+	return &DuplicateTracker{
+		resolver: fsutil.NewDestKeyResolver(),
+		claims:   make(map[string]duplicateClaim),
+	}
+}
+
+// observe registers the plan's source→target claim and reports the earlier
+// claim when the proven-equal canonical target key was already claimed by a
+// DIFFERENT source. Plans that move nothing (WillMove=false) are never
+// registered: their target is the already-occupied source location, and the
+// destination-occupation conflict checks own that class. Re-observing the
+// same source file is idempotent so retried or re-planned files never
+// self-conflict.
+func (t *DuplicateTracker) observe(plan *OrganizePlan) (duplicateClaim, bool) {
+	if t == nil || plan == nil || !plan.WillMove || plan.TargetPath == "" {
+		return duplicateClaim{}, false
+	}
+	// DestKeyResolver deliberately carries NO internal locking (it is built
+	// for single-goroutine grouping passes), so key resolution happens under
+	// the tracker mutex alongside claim registration. First-key-per-root
+	// probes single-flight inside fsutil; later keys are pure map reads.
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	key := t.resolver.Key(plan.TargetPath)
+	prior, ok := t.claims[key]
+	if !ok {
+		t.claims[key] = duplicateClaim{source: plan.SourcePath, target: plan.TargetPath}
+		return duplicateClaim{}, false
+	}
+	if filepath.Clean(prior.source) == filepath.Clean(plan.SourcePath) {
+		return duplicateClaim{}, false
+	}
+	return prior, true
+}
+
+// applyDuplicatePreflight registers the freshly computed plan against the
+// batch's duplicate tracker (#224 phase E). An unauthorized duplicate
+// appends a ConflictDuplicate to plan.Conflicts — the identical failure
+// pipeline as destination-occupation conflicts ("conflicts detected: …"),
+// in dry-run and live runs alike. An authorized duplicate returns a per-file
+// warning instead: authorization may demote it, never hide it, so the caller
+// persists the warning and emits the audit event.
+func applyDuplicatePreflight(plan *OrganizePlan, tracker *DuplicateTracker, overwriteAuthorized bool) []string {
+	prior, dup := tracker.observe(plan)
+	if !dup {
+		return nil
+	}
+	if overwriteAuthorized {
+		return []string{fmt.Sprintf(
+			"duplicate destination within batch: %s already claimed by %s (overwrite authorized)",
+			plan.TargetPath, prior.source)}
+	}
+	plan.Conflicts = append(plan.Conflicts, PlanConflict{Path: plan.TargetPath, Kind: ConflictDuplicate})
+	return nil
+}

--- a/internal/organizer/duplicates.go
+++ b/internal/organizer/duplicates.go
@@ -15,6 +15,16 @@ type duplicateClaim struct {
 	target string
 }
 
+// DuplicatePriming is one batch file's plan-time destination claim, computed
+// by the apply phase's pre-fan-out planning pass and registered in sorted
+// order so each canonical key's owner is pre-assigned before any apply worker
+// starts (#240 finding A).
+type DuplicatePriming struct {
+	SourcePath string
+	TargetPath string
+	WillMove   bool
+}
+
 // DuplicateTracker performs intra-batch duplicate-destination preflight
 // (#224 phase E). One tracker is shared across every file of a batch apply
 // run; each plan's destination registers against the proven-equal canonical
@@ -25,38 +35,97 @@ type duplicateClaim struct {
 // case-sensitive volumes never do. Detection is plan-only: execution keeps
 // the atomic no-replace publish composites as the backstop for collisions the
 // preflight cannot see (cross-batch writers, post-plan plants).
+//
+// Ownership is DETERMINISTIC (#240 finding A): the apply phase plans each
+// sorted batch item exactly once BEFORE worker fan-out and primes the
+// tracker via PrimeBatch in that sorted order, so the first sorted item wins
+// its canonical key regardless of goroutine arrival order. Identical batches
+// therefore reject and move identical files, and under ForceUpdate only the
+// primed winner's bytes can land — the loser demotes to a warning and skips
+// execution instead of racing the winner onto one destination.
+//
+// A nonProbing tracker (dry runs, #240 finding B) derives keys through
+// fsutil.DestKeyResolver.KeyNonProbing: postures come ONLY from previously
+// frozen or process-cached postures, with an uncached root falling back to
+// the conservative distinction-preserving posture — a fresh-process dry run
+// performs zero probe writes and leaves no probe artifacts on disk.
 type DuplicateTracker struct {
-	mu       sync.Mutex
-	resolver *fsutil.DestKeyResolver
-	claims   map[string]duplicateClaim
+	mu         sync.Mutex
+	resolver   *fsutil.DestKeyResolver
+	claims     map[string]duplicateClaim
+	nonProbing bool
+	primed     bool
 }
 
-// NewDuplicateTracker returns an empty tracker for one batch run.
-func NewDuplicateTracker() *DuplicateTracker {
+// NewDuplicateTracker returns an empty tracker for one batch run. nonProbing
+// MUST be true whenever the run must not write (dry runs): key derivation
+// then consults only frozen/cached postures with a conservative fallback.
+func NewDuplicateTracker(nonProbing bool) *DuplicateTracker {
 	return &DuplicateTracker{
-		resolver: fsutil.NewDestKeyResolver(),
-		claims:   make(map[string]duplicateClaim),
+		resolver:   fsutil.NewDestKeyResolver(),
+		claims:     make(map[string]duplicateClaim),
+		nonProbing: nonProbing,
 	}
 }
 
-// observe registers the plan's source→target claim and reports the earlier
-// claim when the proven-equal canonical target key was already claimed by a
-// DIFFERENT source. Plans that move nothing (WillMove=false) are never
-// registered: their target is the already-occupied source location, and the
-// destination-occupation conflict checks own that class. Re-observing the
-// same source file is idempotent so retried or re-planned files never
-// self-conflict.
+// PrimeBatch pre-assigns each canonical key's winner from the run's sorted
+// plan-time claims (#240 finding A). It MUST be called exactly once per run,
+// before any worker observes — a run plans once, so later calls are ignored.
+// The first registered claim per key owns it for the whole run;
+// WillMove=false and empty-target primings register nothing, mirroring
+// observe's guard.
+func (t *DuplicateTracker) PrimeBatch(primings []DuplicatePriming) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.primed {
+		return
+	}
+	t.primed = true
+	for _, p := range primings {
+		if !p.WillMove || p.TargetPath == "" {
+			continue
+		}
+		key := t.keyLocked(p.TargetPath)
+		if _, ok := t.claims[key]; ok {
+			continue
+		}
+		t.claims[key] = duplicateClaim{source: p.SourcePath, target: p.TargetPath}
+	}
+}
+
+// keyLocked derives the canonical key under the tracker's probing policy.
+// Callers hold t.mu below; DestKeyResolver deliberately carries NO internal
+// locking (it is built for single-goroutine grouping passes), so key
+// resolution always happens under the tracker mutex. First-key-per-root
+// probes single-flight inside fsutil; later keys are pure map reads, and
+// nonProbing keys never touch the filesystem at all.
+func (t *DuplicateTracker) keyLocked(target string) string {
+	if t.nonProbing {
+		return t.resolver.KeyNonProbing(target)
+	}
+	return t.resolver.Key(target)
+}
+
+// observe reports the plan's earlier claimant when the proven-equal canonical
+// target key is owned by a DIFFERENT source. Primed runs consult the
+// pre-assigned winner map, so the sorted-first owner wins even when a loser
+// observes first; only an unprimed key (a plan that diverged from the run's
+// priming pass, or a tracker that was never primed) falls back to first-come
+// registration, which keeps single-file and unprimed callers functional.
+// Plans that move nothing (WillMove=false) are never registered: their target
+// is the already-occupied source location, and the destination-occupation
+// conflict checks own that class. Re-observing the same source file is
+// idempotent so retried or re-planned files never self-conflict.
 func (t *DuplicateTracker) observe(plan *OrganizePlan) (duplicateClaim, bool) {
 	if t == nil || plan == nil || !plan.WillMove || plan.TargetPath == "" {
 		return duplicateClaim{}, false
 	}
-	// DestKeyResolver deliberately carries NO internal locking (it is built
-	// for single-goroutine grouping passes), so key resolution happens under
-	// the tracker mutex alongside claim registration. First-key-per-root
-	// probes single-flight inside fsutil; later keys are pure map reads.
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	key := t.resolver.Key(plan.TargetPath)
+	key := t.keyLocked(plan.TargetPath)
 	prior, ok := t.claims[key]
 	if !ok {
 		t.claims[key] = duplicateClaim{source: plan.SourcePath, target: plan.TargetPath}
@@ -74,17 +143,19 @@ func (t *DuplicateTracker) observe(plan *OrganizePlan) (duplicateClaim, bool) {
 // pipeline as destination-occupation conflicts ("conflicts detected: …"),
 // in dry-run and live runs alike. An authorized duplicate returns a per-file
 // warning instead: authorization may demote it, never hide it, so the caller
-// persists the warning and emits the audit event.
-func applyDuplicatePreflight(plan *OrganizePlan, tracker *DuplicateTracker, overwriteAuthorized bool) []string {
+// persists the warning and emits the audit event. skip=true on the authorized
+// path is the #240 finding A contract: the duplicate NEVER executes its move,
+// so only the primed winner's bytes can land on a claimed destination.
+func applyDuplicatePreflight(plan *OrganizePlan, tracker *DuplicateTracker, overwriteAuthorized bool) (warnings []string, skip bool) {
 	prior, dup := tracker.observe(plan)
 	if !dup {
-		return nil
+		return nil, false
 	}
 	if overwriteAuthorized {
 		return []string{fmt.Sprintf(
 			"duplicate destination within batch: %s already claimed by %s (overwrite authorized)",
-			plan.TargetPath, prior.source)}
+			plan.TargetPath, prior.source)}, true
 	}
 	plan.Conflicts = append(plan.Conflicts, PlanConflict{Path: plan.TargetPath, Kind: ConflictDuplicate})
-	return nil
+	return nil, false
 }

--- a/internal/organizer/duplicates_test.go
+++ b/internal/organizer/duplicates_test.go
@@ -3,6 +3,7 @@ package organizer
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -27,6 +28,19 @@ func forceCasePosture(t *testing.T, sensitive bool) {
 	})
 }
 
+// resetProbeCaches clears BOTH process-wide probe caches so non-probing key
+// derivations observe a fully uncached posture; cleanup restores a clean
+// slate for later tests.
+func resetProbeCaches(t *testing.T) {
+	t.Helper()
+	fsutil.ResetCaseSensitivityCache()
+	fsutil.ResetNormalizationCache()
+	t.Cleanup(func() {
+		fsutil.ResetCaseSensitivityCache()
+		fsutil.ResetNormalizationCache()
+	})
+}
+
 func dupPlanFor(src, target string) *OrganizePlan {
 	return &OrganizePlan{SourcePath: src, TargetPath: target, WillMove: true}
 }
@@ -34,7 +48,7 @@ func dupPlanFor(src, target string) *OrganizePlan {
 func TestDuplicateTracker_Grouping(t *testing.T) {
 	t.Run("identical target distinct sources", func(t *testing.T) {
 		forceCasePosture(t, true)
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		_, dup := tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
 		assert.False(t, dup, "first claim registers cleanly")
 		prior, dup := tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/x.mkv"))
@@ -44,7 +58,7 @@ func TestDuplicateTracker_Grouping(t *testing.T) {
 
 	t.Run("casefold variants group when root proven insensitive", func(t *testing.T) {
 		forceCasePosture(t, false)
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/Movie.mkv"))
 		prior, dup := tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/movie.mkv"))
 		require.True(t, dup, "case variants of one name are proven-equal on insensitive roots")
@@ -53,7 +67,7 @@ func TestDuplicateTracker_Grouping(t *testing.T) {
 
 	t.Run("case variants stay distinct when root proven sensitive", func(t *testing.T) {
 		forceCasePosture(t, true)
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/Movie.mkv"))
 		_, dup := tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/movie.mkv"))
 		assert.False(t, dup, "never proven equal, so byte-distinct names keep distinct keys")
@@ -61,7 +75,7 @@ func TestDuplicateTracker_Grouping(t *testing.T) {
 
 	t.Run("lexical spelling variants of one path group", func(t *testing.T) {
 		forceCasePosture(t, true)
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
 		_, dup := tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/./x.mkv"))
 		assert.True(t, dup, "cleaned spellings of one destination are the same canonical key")
@@ -69,7 +83,7 @@ func TestDuplicateTracker_Grouping(t *testing.T) {
 
 	t.Run("multipart suffixes stay distinct", func(t *testing.T) {
 		forceCasePosture(t, false)
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		tracker.observe(dupPlanFor("/in/m-cd1.mkv", "/dest/lib/m-cd1.mkv"))
 		_, dup := tracker.observe(dupPlanFor("/in/m-cd2.mkv", "/dest/lib/m-cd2.mkv"))
 		assert.False(t, dup, "cdN part suffixes name distinct destinations")
@@ -77,7 +91,7 @@ func TestDuplicateTracker_Grouping(t *testing.T) {
 
 	t.Run("same source re-observe is idempotent", func(t *testing.T) {
 		forceCasePosture(t, true)
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
 		_, dup := tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
 		assert.False(t, dup, "retries and dry-run re-plans of one file never self-conflict")
@@ -85,7 +99,7 @@ func TestDuplicateTracker_Grouping(t *testing.T) {
 
 	t.Run("third duplicate reports the first claim", func(t *testing.T) {
 		forceCasePosture(t, true)
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
 		tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/x.mkv"))
 		prior, dup := tracker.observe(dupPlanFor("/in/C.mkv", "/dest/lib/x.mkv"))
@@ -95,7 +109,7 @@ func TestDuplicateTracker_Grouping(t *testing.T) {
 
 	t.Run("plans that move nothing are never registered", func(t *testing.T) {
 		forceCasePosture(t, true)
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		still := &OrganizePlan{SourcePath: "/in/A.mkv", TargetPath: "/in/A.mkv", WillMove: false}
 		_, dup := tracker.observe(still)
 		assert.False(t, dup)
@@ -108,16 +122,28 @@ func TestDuplicateTracker_Grouping(t *testing.T) {
 		var nilTracker *DuplicateTracker
 		_, dup := nilTracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
 		assert.False(t, dup, "nil tracker disables detection")
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		_, dup = tracker.observe(nil)
 		assert.False(t, dup)
 		_, dup = tracker.observe(dupPlanFor("/in/A.mkv", ""))
 		assert.False(t, dup)
 	})
 
+	t.Run("unprimed observes keep first-come registration", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker(false)
+		// No PrimeBatch at all: the first observer owns the key (single-file
+		// and unprimed callers), deterministic batches never take this leg.
+		_, dup := tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/x.mkv"))
+		assert.False(t, dup)
+		prior, dup := tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
+		require.True(t, dup)
+		assert.Equal(t, "/in/B.mkv", prior.source, "unprimed = first-come, documenting the legacy fallback")
+	})
+
 	t.Run("concurrent observations are race-free and total", func(t *testing.T) {
 		forceCasePosture(t, true)
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		var wg sync.WaitGroup
 		var mu sync.Mutex
 		claimsPerKey := map[string]int{}
@@ -143,33 +169,39 @@ func TestDuplicateTracker_Grouping(t *testing.T) {
 
 func TestApplyDuplicatePreflight(t *testing.T) {
 	forceCasePosture(t, true)
-	tracker := NewDuplicateTracker()
+	tracker := NewDuplicateTracker(false)
 	tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
 
 	t.Run("unauthorized duplicate joins plan conflicts", func(t *testing.T) {
 		plan := dupPlanFor("/in/B.mkv", "/dest/lib/x.mkv")
-		warnings := applyDuplicatePreflight(plan, tracker, false)
+		warnings, skip := applyDuplicatePreflight(plan, tracker, false)
 		assert.Nil(t, warnings)
+		assert.False(t, skip)
 		require.Len(t, plan.Conflicts, 1)
 		assert.Equal(t, ConflictDuplicate, plan.Conflicts[0].Kind)
 		assert.Equal(t, "/dest/lib/x.mkv", plan.Conflicts[0].Path)
 		assert.Equal(t, "duplicate", plan.Conflicts[0].kindName())
 	})
 
-	t.Run("authorized duplicate demotes to warning", func(t *testing.T) {
+	t.Run("authorized duplicate demotes to warning and skips execution", func(t *testing.T) {
 		plan := dupPlanFor("/in/C.mkv", "/dest/lib/x.mkv")
-		warnings := applyDuplicatePreflight(plan, tracker, true)
+		warnings, skip := applyDuplicatePreflight(plan, tracker, true)
 		assert.Empty(t, plan.Conflicts, "authorization demotes the duplicate out of the conflict pipeline")
 		require.Len(t, warnings, 1)
 		assert.Contains(t, warnings[0], "/dest/lib/x.mkv")
 		assert.Contains(t, warnings[0], "/in/A.mkv")
 		assert.Contains(t, warnings[0], "overwrite authorized")
+		assert.True(t, skip, "#240 finding A: an authorized duplicate never moves bytes — only the winner lands")
 	})
 
 	t.Run("no duplicate yields nothing", func(t *testing.T) {
 		plan := dupPlanFor("/in/D.mkv", "/dest/lib/y.mkv")
-		assert.Nil(t, applyDuplicatePreflight(plan, tracker, false))
-		assert.Nil(t, applyDuplicatePreflight(plan, nil, false), "nil tracker disables detection")
+		warnings, skip := applyDuplicatePreflight(plan, tracker, false)
+		assert.Nil(t, warnings)
+		assert.False(t, skip)
+		warnings, skip = applyDuplicatePreflight(plan, nil, false)
+		assert.Nil(t, warnings, "nil tracker disables detection")
+		assert.False(t, skip)
 		assert.Empty(t, plan.Conflicts)
 	})
 }
@@ -207,7 +239,9 @@ func dupBatchCmd(match models.FileMatchInfo, tracker *DuplicateTracker, force, d
 func TestOrganize_DryRunDuplicatePreflight_ConflictEquivalence(t *testing.T) {
 	forceCasePosture(t, true)
 	org, _ := dupBatchFixture(t)
-	tracker := NewDuplicateTracker()
+	// Non-probing tracker: the exact policy the apply phase constructs for dry
+	// runs (#240 finding B) — key derivation must never touch the filesystem.
+	tracker := NewDuplicateTracker(true)
 	movie := &models.Movie{ID: "ABC-123"}
 
 	// Case (a): batch duplicate — file B plans onto the destination file A's
@@ -246,7 +280,7 @@ func TestOrganize_DryRunDuplicatePreflight_ConflictEquivalence(t *testing.T) {
 func TestOrganize_DryRunAuthorizedDuplicate_WarnsPersistably(t *testing.T) {
 	forceCasePosture(t, true)
 	org, _ := dupBatchFixture(t)
-	tracker := NewDuplicateTracker()
+	tracker := NewDuplicateTracker(true) // dry runs construct the non-probing variant
 
 	cmdA := dupBatchCmd(models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}, tracker, true, true)
 	_, err := org.Organize(context.Background(), cmdA)
@@ -265,7 +299,7 @@ func TestOrganize_LiveDuplicatePreflight(t *testing.T) {
 
 	t.Run("unauthorized duplicate fails through the same pipeline", func(t *testing.T) {
 		org, fs := dupBatchFixture(t)
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		// First file dry-run claims the destination without moving anything.
 		_, err := org.Organize(context.Background(), dupBatchCmd(
 			models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}, tracker, false, true))
@@ -282,10 +316,10 @@ func TestOrganize_LiveDuplicatePreflight(t *testing.T) {
 		assert.Equal(t, []byte("b-bytes"), content, "the losing duplicate's source is untouched")
 	})
 
-	t.Run("authorized duplicate executes and reports the warning", func(t *testing.T) {
+	t.Run("authorized duplicate warns and never moves bytes", func(t *testing.T) {
 		forceCasePosture(t, true)
 		org, fs := dupBatchFixture(t)
-		tracker := NewDuplicateTracker()
+		tracker := NewDuplicateTracker(false)
 		_, err := org.Organize(context.Background(), dupBatchCmd(
 			models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}, tracker, false, true))
 		require.NoError(t, err)
@@ -294,9 +328,415 @@ func TestOrganize_LiveDuplicatePreflight(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result.Warnings, 1, "live authorized result carries the persisted-warning payload")
 		assert.Contains(t, result.Warnings[0], "overwrite authorized")
-		assert.True(t, result.Moved)
-		content, readErr := afero.ReadFile(fs, "/dest/ABC-123/ABC-123.mkv")
+		assert.False(t, result.Moved, "#240 finding A: an authorized duplicate skips execution")
+		assert.True(t, result.ShouldGenerateMetadata, "the skip mirrors the dry-run result shape")
+		destExists, statErr := afero.Exists(fs, "/dest/ABC-123/ABC-123.mkv")
+		require.NoError(t, statErr)
+		assert.False(t, destExists, "the loser's bytes never reach a claimed destination")
+		content, readErr := afero.ReadFile(fs, "/in/B.mkv")
 		require.NoError(t, readErr)
-		assert.Equal(t, []byte("b-bytes"), content)
+		assert.Equal(t, []byte("b-bytes"), content, "the skipped duplicate's source is untouched")
+	})
+}
+
+// TestDuplicateTracker_PrimingDeterministicOwnership pins #240 finding A:
+// PrimeBatch pre-assigns each canonical key's winner in sorted order BEFORE
+// any worker observes, so goroutine arrival order can no longer pick the
+// batch winner — the first sorted item wins its key every time.
+func TestDuplicateTracker_PrimingDeterministicOwnership(t *testing.T) {
+	for _, order := range [][]string{
+		{"/in/A.mkv", "/in/B.mkv", "/in/C.mkv"}, // primed order arrival
+		{"/in/C.mkv", "/in/B.mkv", "/in/A.mkv"}, // fully reversed arrival
+		{"/in/B.mkv", "/in/C.mkv", "/in/A.mkv"}, // loser interleaved first
+	} {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker(false)
+		tracker.PrimeBatch([]DuplicatePriming{
+			{SourcePath: "/in/A.mkv", TargetPath: "/dest/lib/x.mkv", WillMove: true},
+			{SourcePath: "/in/B.mkv", TargetPath: "/dest/lib/x.mkv", WillMove: true},
+			{SourcePath: "/in/C.mkv", TargetPath: "/dest/lib/x.mkv", WillMove: true},
+		})
+		for _, src := range order {
+			_, dup := tracker.observe(dupPlanFor(src, "/dest/lib/x.mkv"))
+			if src == "/in/A.mkv" {
+				assert.False(t, dup, "the sorted-first item wins even when it observes last (order %v)", order)
+			} else {
+				require.True(t, dup, "primed losers see the winner even when they observe first (order %v)", order)
+				prior, _ := tracker.observe(dupPlanFor(src+"#retry", "/dest/lib/x.mkv"))
+				assert.Equal(t, "/in/A.mkv", prior.source)
+			}
+		}
+	}
+
+	t.Run("forced out-of-order concurrent observes keep the primed winner", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker(false)
+		tracker.PrimeBatch([]DuplicatePriming{
+			{SourcePath: "/in/A.mkv", TargetPath: "/dest/lib/x.mkv", WillMove: true},
+			{SourcePath: "/in/B.mkv", TargetPath: "/dest/lib/x.mkv", WillMove: true},
+			{SourcePath: "/in/C.mkv", TargetPath: "/dest/lib/x.mkv", WillMove: true},
+		})
+		// Each goroutine waits for its own start gate; main opens the gates in
+		// reverse sorted order, so C and B are IN observe before A starts.
+		type outcome struct {
+			src   string
+			prior duplicateClaim
+			dup   bool
+		}
+		gates := map[string]chan struct{}{}
+		results := make(chan outcome, 3)
+		for _, src := range []string{"/in/A.mkv", "/in/B.mkv", "/in/C.mkv"} {
+			gates[src] = make(chan struct{})
+		}
+		var wg sync.WaitGroup
+		for _, src := range []string{"/in/A.mkv", "/in/B.mkv", "/in/C.mkv"} {
+			wg.Add(1)
+			go func(src string) {
+				defer wg.Done()
+				<-gates[src]
+				prior, dup := tracker.observe(dupPlanFor(src, "/dest/lib/x.mkv"))
+				results <- outcome{src: src, prior: prior, dup: dup}
+			}(src)
+		}
+		for _, src := range []string{"/in/C.mkv", "/in/B.mkv", "/in/A.mkv"} {
+			close(gates[src])
+		}
+		wg.Wait()
+		close(results)
+		bySrc := map[string]outcome{}
+		for o := range results {
+			bySrc[o.src] = o
+		}
+		assert.False(t, bySrc["/in/A.mkv"].dup, "the primed winner never conflicts")
+		require.True(t, bySrc["/in/B.mkv"].dup)
+		require.True(t, bySrc["/in/C.mkv"].dup)
+		assert.Equal(t, "/in/A.mkv", bySrc["/in/B.mkv"].prior.source)
+		assert.Equal(t, "/in/A.mkv", bySrc["/in/C.mkv"].prior.source)
+	})
+
+	t.Run("a primed run observes exactly one winner per key", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker(false)
+		primings := make([]DuplicatePriming, 0, 64)
+		for i := 0; i < 64; i++ {
+			primings = append(primings, DuplicatePriming{
+				SourcePath: fmt.Sprintf("/in/src-%02d.mkv", i),
+				TargetPath: fmt.Sprintf("/dest/lib/movie-%d.mkv", i%8),
+				WillMove:   true,
+			})
+		}
+		tracker.PrimeBatch(primings)
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		winners := map[string][]string{}
+		for i := 0; i < 64; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				src := fmt.Sprintf("/in/src-%02d.mkv", i)
+				key := fmt.Sprintf("/dest/lib/movie-%d.mkv", i%8)
+				_, dup := tracker.observe(dupPlanFor(src, key))
+				if !dup {
+					mu.Lock()
+					winners[key] = append(winners[key], src)
+					mu.Unlock()
+				}
+			}(i)
+		}
+		wg.Wait()
+		require.Len(t, winners, 8)
+		for key, srcs := range winners {
+			require.Len(t, srcs, 1, "%s must have exactly one winner", key)
+			// Sorted priming order is src-00..src-63, so key movie-N's first
+			// sorted claimant is src-N — the deterministic owner every time.
+			d := int(key[len("/dest/lib/movie-")] - '0')
+			assert.Equal(t, fmt.Sprintf("/in/src-%02d.mkv", d), srcs[0], "the sorted-first priming owns %s", key)
+		}
+	})
+}
+
+// TestDuplicateTracker_PrimeBatchOncePerRun pins the run-lifecycle contract:
+// planning happens exactly once per run — later PrimeBatch calls never
+// re-assign ownership.
+func TestDuplicateTracker_PrimeBatchOncePerRun(t *testing.T) {
+	t.Run("second prime batch is ignored", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker(false)
+		tracker.PrimeBatch([]DuplicatePriming{
+			{SourcePath: "/in/A.mkv", TargetPath: "/dest/lib/x.mkv", WillMove: true},
+		})
+		tracker.PrimeBatch([]DuplicatePriming{
+			{SourcePath: "/in/B.mkv", TargetPath: "/dest/lib/x.mkv", WillMove: true},
+			{SourcePath: "/in/C.mkv", TargetPath: "/dest/lib/y.mkv", WillMove: true},
+		})
+		prior, dup := tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/x.mkv"))
+		require.True(t, dup)
+		assert.Equal(t, "/in/A.mkv", prior.source, "the first batch's owner survives the ignored re-prime")
+		_, dup = tracker.observe(dupPlanFor("/in/D.mkv", "/dest/lib/y.mkv"))
+		assert.False(t, dup, "the ignored batch never registered /dest/lib/y.mkv")
+	})
+
+	t.Run("nil tracker tolerates priming", func(t *testing.T) {
+		var tracker *DuplicateTracker
+		tracker.PrimeBatch([]DuplicatePriming{{SourcePath: "/in/A.mkv", TargetPath: "/dest/lib/x.mkv", WillMove: true}})
+	})
+
+	t.Run("non-moving and empty-target primings register nothing", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker(false)
+		tracker.PrimeBatch([]DuplicatePriming{
+			{SourcePath: "/in/A.mkv", TargetPath: "/in/A.mkv", WillMove: false},
+			{SourcePath: "/in/B.mkv", TargetPath: "", WillMove: true},
+		})
+		_, dup := tracker.observe(dupPlanFor("/in/C.mkv", "/in/A.mkv"))
+		assert.False(t, dup, "WillMove=false primings stay owned by destination-occupation checks")
+	})
+
+	t.Run("duplicate primings within one batch keep the sorted-first owner", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker(false)
+		tracker.PrimeBatch([]DuplicatePriming{
+			{SourcePath: "/in/A.mkv", TargetPath: "/dest/lib/x.mkv", WillMove: true},
+			{SourcePath: "/in/A-reshuffled.mkv", TargetPath: "/dest/lib/./x.mkv", WillMove: true},
+		})
+		prior, dup := tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/x.mkv"))
+		require.True(t, dup)
+		assert.Equal(t, "/in/A.mkv", prior.source, "same-key re-registration inside one batch keeps the first sorted claim")
+	})
+}
+
+// countingProbeSeams installs probe stubs that count any probe that runs
+// (returning the given definitive postures), and resets both process caches
+// so every subtest starts from a truly unknown posture.
+func countingProbeSeams(t *testing.T, caseSensitive, normInsensitive bool) (caseCalls, normCalls *int) {
+	t.Helper()
+	resetProbeCaches(t)
+	cc, nc := 0, 0
+	prevCase, prevNorm := fsutil.CaseSensitiveProbe, fsutil.NormalizationProbe
+	fsutil.CaseSensitiveProbe = func(string) (bool, error) { cc++; return caseSensitive, nil }
+	fsutil.NormalizationProbe = func(string) (bool, error) { nc++; return normInsensitive, nil }
+	t.Cleanup(func() {
+		fsutil.CaseSensitiveProbe = prevCase
+		fsutil.NormalizationProbe = prevNorm
+	})
+	return &cc, &nc
+}
+
+// TestDuplicateTracker_NonProbingDryRun pins #240 finding B: a non-probing
+// (dry-run) tracker derives keys with ZERO filesystem probes — postures come
+// from previously-known caches or the conservative distinction-preserving
+// fallback documented on NewDuplicateTracker.
+func TestDuplicateTracker_NonProbingDryRun(t *testing.T) {
+	t.Run("uncached root falls back conservatively with zero probes", func(t *testing.T) {
+		caseCalls, normCalls := countingProbeSeams(t, false, true)
+		dir := t.TempDir()
+		tracker := NewDuplicateTracker(true)
+		target := filepath.Join(dir, "Movie.mkv")
+		_, dup := tracker.observe(dupPlanFor("/in/A.mkv", target))
+		assert.False(t, dup)
+		_, dup = tracker.observe(dupPlanFor("/in/B.mkv", target))
+		require.True(t, dup, "identical spellings group under every posture")
+		// The uncached fallback preserves case distinctions rather than
+		// aliasing byte-distinct names on a guess.
+		_, dup = tracker.observe(dupPlanFor("/in/C.mkv", filepath.Join(dir, "movie.mkv")))
+		assert.False(t, dup, "uncached dry-run roots keep case variants distinct (conservative)")
+		assert.Equal(t, 0, *caseCalls, "case probe never ran")
+		assert.Equal(t, 0, *normCalls, "normalization probe never ran")
+	})
+
+	t.Run("previously-cached postures still fold with zero new probes", func(t *testing.T) {
+		caseCalls, normCalls := countingProbeSeams(t, false, true)
+		dir := t.TempDir()
+		// Populate the process caches definitively (this is the ONLY probing
+		// moment, owned by an earlier live run in production terms).
+		fsutil.IsCaseSensitiveRoot(dir)
+		fsutil.IsNormalizationInsensitiveRoot(dir)
+		require.Equal(t, 1, *caseCalls)
+		require.Equal(t, 1, *normCalls)
+		tracker := NewDuplicateTracker(true)
+		target := filepath.Join(dir, "Movie.mkv")
+		tracker.observe(dupPlanFor("/in/A.mkv", target))
+		_, dup := tracker.observe(dupPlanFor("/in/B.mkv", filepath.Join(dir, "movie.mkv")))
+		require.True(t, dup, "cached-insensitive postures fold case variants without new probes")
+		assert.Equal(t, 1, *caseCalls, "no new case probe during non-probing derivation")
+		assert.Equal(t, 1, *normCalls, "no new normalization probe during non-probing derivation")
+	})
+
+	t.Run("probing tracker behavior is unchanged for live runs", func(t *testing.T) {
+		caseCalls, normCalls := countingProbeSeams(t, false, true)
+		dir := t.TempDir()
+		tracker := NewDuplicateTracker(false) // live policy
+		target := filepath.Join(dir, "Movie.mkv")
+		tracker.observe(dupPlanFor("/in/A.mkv", target))
+		_, dup := tracker.observe(dupPlanFor("/in/B.mkv", filepath.Join(dir, "movie.mkv")))
+		require.True(t, dup, "live runs probe and fold case variants")
+		assert.Equal(t, 1, *caseCalls, "one case probe per root per process")
+		assert.Equal(t, 1, *normCalls, "one normalization probe per root per process")
+	})
+}
+
+// TestOrganize_ForceUpdatePrimedDuplicate_OnlyWinnerBytesLand pins #240
+// finding A end-to-end: under ForceUpdate only the deterministic winner's
+// bytes land, regardless of goroutine order.
+func TestOrganize_ForceUpdatePrimedDuplicate_OnlyWinnerBytesLand(t *testing.T) {
+	forceCasePosture(t, true)
+	const target = "/dest/ABC-123/ABC-123.mkv"
+
+	primedFixture := func(t *testing.T) (*Organizer, afero.Fs, *DuplicateTracker, OrganizeCmd, OrganizeCmd) {
+		org, fs := dupBatchFixture(t)
+		tracker := NewDuplicateTracker(false)
+		tracker.PrimeBatch([]DuplicatePriming{
+			{SourcePath: "/in/A.mkv", TargetPath: target, WillMove: true}, // sorted first: /in/A.mkv < /in/B.mkv
+			{SourcePath: "/in/B.mkv", TargetPath: target, WillMove: true},
+		})
+		cmdA := dupBatchCmd(models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}, tracker, true, false)
+		cmdB := dupBatchCmd(models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, tracker, true, false)
+		return org, fs, tracker, cmdA, cmdB
+	}
+	assertWinnerBytes := func(t *testing.T, fs afero.Fs) {
+		content, err := afero.ReadFile(fs, target)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("a-bytes"), content, "only the sorted-first winner's bytes land")
+		loser, err := afero.ReadFile(fs, "/in/B.mkv")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("b-bytes"), loser, "the primed loser keeps its source untouched")
+		_, err = fs.Stat("/in/A.mkv")
+		assert.Error(t, err, "the winner actually moved out of its source")
+	}
+
+	t.Run("loser observes first", func(t *testing.T) {
+		org, fs, _, cmdA, cmdB := primedFixture(t)
+		resultB, err := org.Organize(context.Background(), cmdB)
+		require.NoError(t, err)
+		assert.False(t, resultB.Moved)
+		require.Len(t, resultB.Warnings, 1)
+		assert.Contains(t, resultB.Warnings[0], "already claimed by /in/A.mkv")
+		resultA, err := org.Organize(context.Background(), cmdA)
+		require.NoError(t, err)
+		assert.True(t, resultA.Moved)
+		assertWinnerBytes(t, fs)
+	})
+
+	t.Run("winner observes first", func(t *testing.T) {
+		org, fs, _, cmdA, cmdB := primedFixture(t)
+		resultA, err := org.Organize(context.Background(), cmdA)
+		require.NoError(t, err)
+		assert.True(t, resultA.Moved)
+		resultB, err := org.Organize(context.Background(), cmdB)
+		require.NoError(t, err)
+		assert.False(t, resultB.Moved)
+		require.Len(t, resultB.Warnings, 1)
+		assertWinnerBytes(t, fs)
+	})
+
+	t.Run("concurrent", func(t *testing.T) {
+		org, fs, _, cmdA, cmdB := primedFixture(t)
+		start := make(chan struct{})
+		results := make(chan *OrganizeResult, 2)
+		errs := make(chan error, 2)
+		var wg sync.WaitGroup
+		for _, cmd := range []OrganizeCmd{cmdA, cmdB} {
+			wg.Add(1)
+			go func(cmd OrganizeCmd) {
+				defer wg.Done()
+				<-start
+				res, err := org.Organize(context.Background(), cmd)
+				results <- res
+				errs <- err
+			}(cmd)
+		}
+		close(start)
+		wg.Wait()
+		close(results)
+		close(errs)
+		var resA, resB *OrganizeResult
+		for res := range results {
+			if res.OriginalPath == "/in/A.mkv" {
+				resA = res
+			} else {
+				resB = res
+			}
+		}
+		for err := range errs {
+			require.NoError(t, err)
+		}
+		assert.True(t, resA.Moved, "the winner moves under any schedule")
+		assert.False(t, resB.Moved, "the loser skips under any schedule")
+		require.Len(t, resB.Warnings, 1)
+		assertWinnerBytes(t, fs)
+	})
+}
+
+// TestOrganizer_PlanOrganize pins the read-only planning seam #240 finding A
+// primes from: identical planner selection as Organize, no duplicate
+// preflight, no validation, no filesystem mutation.
+func TestOrganizer_PlanOrganize(t *testing.T) {
+	t.Run("matches Organize's planning half with zero side effects", func(t *testing.T) {
+		org, fs := dupBatchFixture(t)
+		match := models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}
+		plan, err := org.PlanOrganize(context.Background(), OrganizeCmd{
+			Match: match, Movie: &models.Movie{ID: "ABC-123"}, DestDir: "/dest", MoveFiles: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, plan)
+		assert.Equal(t, "/in/A.mkv", plan.SourcePath)
+		assert.Equal(t, "/dest/ABC-123/ABC-123.mkv", filepath.ToSlash(plan.TargetPath))
+		assert.True(t, plan.WillMove)
+		destExists, statErr := afero.Exists(fs, "/dest")
+		require.NoError(t, statErr)
+		assert.False(t, destExists, "planning performs no filesystem mutation")
+	})
+
+	t.Run("canceled context aborts before planning", func(t *testing.T) {
+		org, _ := dupBatchFixture(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		plan, err := org.PlanOrganize(ctx, OrganizeCmd{})
+		assert.Nil(t, plan)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("plan errors propagate", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		org := NewOrganizer(fs, &Config{
+			FolderFormat:  "<IF:SERIES><SERIES>",
+			FileFormat:    "<ID>",
+			RenameFile:    true,
+			OperationMode: operationmode.OperationModeOrganize,
+		}, nil, nil)
+		_, err := org.PlanOrganize(context.Background(), OrganizeCmd{
+			Match:   models.FileMatchInfo{Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv", MovieID: "ABC-123"},
+			Movie:   &models.Movie{ID: "ABC-123", Series: "x"},
+			DestDir: "/dest",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unclosed <IF> block")
+	})
+
+	t.Run("ForceRenameFile shares Organize's planner override", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, fs.MkdirAll("/source", 0o755))
+		require.NoError(t, afero.WriteFile(fs, "/source/old.mkv", []byte("video"), 0o644))
+		org := NewOrganizer(fs, &Config{
+			FileFormat:    "<ID>",
+			RenameFile:    false, // disabled globally; the command forces it
+			OperationMode: operationmode.OperationModeInPlaceNoRenameFolder,
+		}, nil, nil)
+		match := models.FileMatchInfo{Path: "/source/old.mkv", Name: "old.mkv", Extension: ".mkv", MovieID: "ABC-123"}
+		movie := &models.Movie{ID: "ABC-123"}
+
+		plan, err := org.PlanOrganize(context.Background(), OrganizeCmd{
+			Match: match, Movie: movie, DestDir: "/source", MoveFiles: true, ForceRenameFile: true,
+			OperationMode: operationmode.OperationModeInPlaceNoRenameFolder,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "/source/ABC-123.mkv", filepath.ToSlash(plan.TargetPath), "the forced planner clone renames")
+
+		plan, err = org.PlanOrganize(context.Background(), OrganizeCmd{
+			Match: match, Movie: movie, DestDir: "/source", MoveFiles: true,
+			OperationMode: operationmode.OperationModeInPlaceNoRenameFolder,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "/source/old.mkv", filepath.ToSlash(plan.TargetPath), "without the override the planner keeps the source name")
 	})
 }

--- a/internal/organizer/duplicates_test.go
+++ b/internal/organizer/duplicates_test.go
@@ -1,0 +1,302 @@
+package organizer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/fsutil"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+)
+
+func forceCasePosture(t *testing.T, sensitive bool) {
+	t.Helper()
+	prev := fsutil.CaseSensitiveProbe
+	fsutil.CaseSensitiveProbe = func(string) (bool, error) { return sensitive, nil }
+	fsutil.ResetCaseSensitivityCache()
+	t.Cleanup(func() {
+		fsutil.CaseSensitiveProbe = prev
+		fsutil.ResetCaseSensitivityCache()
+	})
+}
+
+func dupPlanFor(src, target string) *OrganizePlan {
+	return &OrganizePlan{SourcePath: src, TargetPath: target, WillMove: true}
+}
+
+func TestDuplicateTracker_Grouping(t *testing.T) {
+	t.Run("identical target distinct sources", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker()
+		_, dup := tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
+		assert.False(t, dup, "first claim registers cleanly")
+		prior, dup := tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/x.mkv"))
+		require.True(t, dup)
+		assert.Equal(t, "/in/A.mkv", prior.source)
+	})
+
+	t.Run("casefold variants group when root proven insensitive", func(t *testing.T) {
+		forceCasePosture(t, false)
+		tracker := NewDuplicateTracker()
+		tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/Movie.mkv"))
+		prior, dup := tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/movie.mkv"))
+		require.True(t, dup, "case variants of one name are proven-equal on insensitive roots")
+		assert.Equal(t, "/in/A.mkv", prior.source)
+	})
+
+	t.Run("case variants stay distinct when root proven sensitive", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker()
+		tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/Movie.mkv"))
+		_, dup := tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/movie.mkv"))
+		assert.False(t, dup, "never proven equal, so byte-distinct names keep distinct keys")
+	})
+
+	t.Run("lexical spelling variants of one path group", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker()
+		tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
+		_, dup := tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/./x.mkv"))
+		assert.True(t, dup, "cleaned spellings of one destination are the same canonical key")
+	})
+
+	t.Run("multipart suffixes stay distinct", func(t *testing.T) {
+		forceCasePosture(t, false)
+		tracker := NewDuplicateTracker()
+		tracker.observe(dupPlanFor("/in/m-cd1.mkv", "/dest/lib/m-cd1.mkv"))
+		_, dup := tracker.observe(dupPlanFor("/in/m-cd2.mkv", "/dest/lib/m-cd2.mkv"))
+		assert.False(t, dup, "cdN part suffixes name distinct destinations")
+	})
+
+	t.Run("same source re-observe is idempotent", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker()
+		tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
+		_, dup := tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
+		assert.False(t, dup, "retries and dry-run re-plans of one file never self-conflict")
+	})
+
+	t.Run("third duplicate reports the first claim", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker()
+		tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
+		tracker.observe(dupPlanFor("/in/B.mkv", "/dest/lib/x.mkv"))
+		prior, dup := tracker.observe(dupPlanFor("/in/C.mkv", "/dest/lib/x.mkv"))
+		require.True(t, dup)
+		assert.Equal(t, "/in/A.mkv", prior.source, "first claim wins — mirrors first-publish-wins at execute")
+	})
+
+	t.Run("plans that move nothing are never registered", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker()
+		still := &OrganizePlan{SourcePath: "/in/A.mkv", TargetPath: "/in/A.mkv", WillMove: false}
+		_, dup := tracker.observe(still)
+		assert.False(t, dup)
+		_, dup = tracker.observe(dupPlanFor("/in/B.mkv", "/in/A.mkv"))
+		assert.False(t, dup, "WillMove=false targets are owned by destination-occupation checks")
+	})
+
+	t.Run("empty and nil plans are never registered", func(t *testing.T) {
+		forceCasePosture(t, true)
+		var nilTracker *DuplicateTracker
+		_, dup := nilTracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
+		assert.False(t, dup, "nil tracker disables detection")
+		tracker := NewDuplicateTracker()
+		_, dup = tracker.observe(nil)
+		assert.False(t, dup)
+		_, dup = tracker.observe(dupPlanFor("/in/A.mkv", ""))
+		assert.False(t, dup)
+	})
+
+	t.Run("concurrent observations are race-free and total", func(t *testing.T) {
+		forceCasePosture(t, true)
+		tracker := NewDuplicateTracker()
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		claimsPerKey := map[string]int{}
+		for i := 0; i < 64; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				key := fmt.Sprintf("/dest/lib/movie-%d.mkv", i%8)
+				_, dup := tracker.observe(dupPlanFor(fmt.Sprintf("/in/src-%d.mkv", i), key))
+				if !dup {
+					mu.Lock()
+					claimsPerKey[key]++
+					mu.Unlock()
+				}
+			}(i)
+		}
+		wg.Wait()
+		for key, claims := range claimsPerKey {
+			assert.Equal(t, 1, claims, "%s must have exactly one winning claim", key)
+		}
+	})
+}
+
+func TestApplyDuplicatePreflight(t *testing.T) {
+	forceCasePosture(t, true)
+	tracker := NewDuplicateTracker()
+	tracker.observe(dupPlanFor("/in/A.mkv", "/dest/lib/x.mkv"))
+
+	t.Run("unauthorized duplicate joins plan conflicts", func(t *testing.T) {
+		plan := dupPlanFor("/in/B.mkv", "/dest/lib/x.mkv")
+		warnings := applyDuplicatePreflight(plan, tracker, false)
+		assert.Nil(t, warnings)
+		require.Len(t, plan.Conflicts, 1)
+		assert.Equal(t, ConflictDuplicate, plan.Conflicts[0].Kind)
+		assert.Equal(t, "/dest/lib/x.mkv", plan.Conflicts[0].Path)
+		assert.Equal(t, "duplicate", plan.Conflicts[0].kindName())
+	})
+
+	t.Run("authorized duplicate demotes to warning", func(t *testing.T) {
+		plan := dupPlanFor("/in/C.mkv", "/dest/lib/x.mkv")
+		warnings := applyDuplicatePreflight(plan, tracker, true)
+		assert.Empty(t, plan.Conflicts, "authorization demotes the duplicate out of the conflict pipeline")
+		require.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], "/dest/lib/x.mkv")
+		assert.Contains(t, warnings[0], "/in/A.mkv")
+		assert.Contains(t, warnings[0], "overwrite authorized")
+	})
+
+	t.Run("no duplicate yields nothing", func(t *testing.T) {
+		plan := dupPlanFor("/in/D.mkv", "/dest/lib/y.mkv")
+		assert.Nil(t, applyDuplicatePreflight(plan, tracker, false))
+		assert.Nil(t, applyDuplicatePreflight(plan, nil, false), "nil tracker disables detection")
+		assert.Empty(t, plan.Conflicts)
+	})
+}
+
+// dupBatchFixture builds an organizer whose template maps every source of one
+// movie onto ONE destination file — the intra-batch collision shape.
+func dupBatchFixture(t *testing.T) (*Organizer, afero.Fs) {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	cfg := &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	require.NoError(t, fs.MkdirAll("/in", 0755))
+	require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("a-bytes"), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/in/B.mkv", []byte("b-bytes"), 0644))
+	return org, fs
+}
+
+func dupBatchCmd(match models.FileMatchInfo, tracker *DuplicateTracker, force, dryRun bool) OrganizeCmd {
+	return OrganizeCmd{
+		Match:            match,
+		Movie:            &models.Movie{ID: "ABC-123"},
+		DestDir:          "/dest",
+		MoveFiles:        true,
+		ForceUpdate:      force,
+		DryRun:           dryRun,
+		DuplicateTracker: tracker,
+	}
+}
+
+func TestOrganize_DryRunDuplicatePreflight_ConflictEquivalence(t *testing.T) {
+	forceCasePosture(t, true)
+	org, _ := dupBatchFixture(t)
+	tracker := NewDuplicateTracker()
+	movie := &models.Movie{ID: "ABC-123"}
+
+	// Case (a): batch duplicate — file B plans onto the destination file A's
+	// dry-run already claimed, while nothing exists there on disk yet.
+	cmdA := dupBatchCmd(models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}, tracker, false, true)
+	resultA, err := org.Organize(context.Background(), cmdA)
+	require.NoError(t, err)
+	require.NotNil(t, resultA)
+
+	cmdB := dupBatchCmd(models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, tracker, false, true)
+	_, dupErr := org.Organize(context.Background(), cmdB)
+	require.Error(t, dupErr)
+	assert.True(t, strings.HasPrefix(dupErr.Error(), "organization validation failed: ["), dupErr.Error())
+	assert.Contains(t, dupErr.Error(), resultA.NewPath)
+
+	// Case (b): destination occupation — file B targets a path occupied on
+	// disk by an unrelated file at plan time. Both cases must surface through
+	// the identical failure pipeline (validatePlan's issue rendering, byte for
+	// byte).
+	const occupiedErrPrefix = "organization validation failed: ["
+	org2, fs2 := dupBatchFixture(t)
+	require.NoError(t, fs2.MkdirAll("/dest/ABC-123", 0755))
+	require.NoError(t, afero.WriteFile(fs2, "/dest/ABC-123/ABC-123.mkv", []byte("foreign"), 0644))
+	_, occErr := org2.Organize(context.Background(), OrganizeCmd{
+		Match:     models.FileMatchInfo{MovieID: movie.ID, Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"},
+		Movie:     movie,
+		DestDir:   "/dest",
+		MoveFiles: true,
+		DryRun:    true,
+	})
+	require.Error(t, occErr)
+	assert.True(t, strings.HasPrefix(occErr.Error(), occupiedErrPrefix))
+	assert.Equal(t, occErr.Error(), dupErr.Error(), "duplicate preflight short-circuits into the identical conflict outcome as destination occupation")
+}
+
+func TestOrganize_DryRunAuthorizedDuplicate_WarnsPersistably(t *testing.T) {
+	forceCasePosture(t, true)
+	org, _ := dupBatchFixture(t)
+	tracker := NewDuplicateTracker()
+
+	cmdA := dupBatchCmd(models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}, tracker, true, true)
+	_, err := org.Organize(context.Background(), cmdA)
+	require.NoError(t, err)
+
+	cmdB := dupBatchCmd(models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, tracker, true, true)
+	resultB, err := org.Organize(context.Background(), cmdB)
+	require.NoError(t, err, "authorized duplicates warn, never block")
+	require.Len(t, resultB.Warnings, 1)
+	assert.Contains(t, resultB.Warnings[0], "duplicate destination within batch")
+	assert.Contains(t, resultB.Warnings[0], "/in/A.mkv")
+}
+
+func TestOrganize_LiveDuplicatePreflight(t *testing.T) {
+	forceCasePosture(t, true)
+
+	t.Run("unauthorized duplicate fails through the same pipeline", func(t *testing.T) {
+		org, fs := dupBatchFixture(t)
+		tracker := NewDuplicateTracker()
+		// First file dry-run claims the destination without moving anything.
+		_, err := org.Organize(context.Background(), dupBatchCmd(
+			models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}, tracker, false, true))
+		require.NoError(t, err)
+		// The live second file targets an on-disk VACANT path — pre-#224-E
+		// this would succeed silently; the plan-only preflight must stop it.
+		_, err = org.Organize(context.Background(), dupBatchCmd(
+			models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, tracker, false, false))
+		require.Error(t, err)
+		assert.True(t, strings.HasPrefix(err.Error(), "organization validation failed: ["), err.Error())
+		assert.Contains(t, err.Error(), "/dest/ABC-123/ABC-123.mkv")
+		content, readErr := afero.ReadFile(fs, "/in/B.mkv")
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("b-bytes"), content, "the losing duplicate's source is untouched")
+	})
+
+	t.Run("authorized duplicate executes and reports the warning", func(t *testing.T) {
+		forceCasePosture(t, true)
+		org, fs := dupBatchFixture(t)
+		tracker := NewDuplicateTracker()
+		_, err := org.Organize(context.Background(), dupBatchCmd(
+			models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}, tracker, false, true))
+		require.NoError(t, err)
+		result, err := org.Organize(context.Background(), dupBatchCmd(
+			models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, tracker, true, false))
+		require.NoError(t, err)
+		require.Len(t, result.Warnings, 1, "live authorized result carries the persisted-warning payload")
+		assert.Contains(t, result.Warnings[0], "overwrite authorized")
+		assert.True(t, result.Moved)
+		content, readErr := afero.ReadFile(fs, "/dest/ABC-123/ABC-123.mkv")
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("b-bytes"), content)
+	})
+}

--- a/internal/organizer/handlesubtitles_test.go
+++ b/internal/organizer/handlesubtitles_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/javinizer/javinizer-go/internal/fsutil"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/operationmode"
 	"github.com/spf13/afero"
@@ -36,7 +35,7 @@ func TestHandleSubtitles_NilFileOp_SetsPlannedTrue(t *testing.T) {
 	}
 
 	result := &OrganizeResult{}
-	org.handleSubtitles(plan, result, nil)
+	org.handleSubtitles(plan, result, subtitleInstall{})
 
 	require.Len(t, result.Subtitles, 1)
 	assert.True(t, result.Subtitles[0].Planned, "Planned should be true when fileOp is nil")
@@ -45,7 +44,7 @@ func TestHandleSubtitles_NilFileOp_SetsPlannedTrue(t *testing.T) {
 	assert.Equal(t, filepath.ToSlash("/dest/ABC-123/ABC-123.srt"), filepath.ToSlash(result.Subtitles[0].NewPath))
 }
 
-func TestHandleSubtitles_MoveFileOp_SetsMovedTrue(t *testing.T) {
+func TestHandleSubtitles_MoveInstall_SetsMovedTrue(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	cfg := &Config{
 		MoveSubtitles:      true,
@@ -68,14 +67,15 @@ func TestHandleSubtitles_MoveFileOp_SetsMovedTrue(t *testing.T) {
 	}
 
 	result := &OrganizeResult{}
-	org.handleSubtitles(plan, result, fsutil.MoveFileFs)
+	org.handleSubtitles(plan, result, subtitleMoveInstall)
 
 	require.Len(t, result.Subtitles, 1)
-	assert.True(t, result.Subtitles[0].Moved, "Moved should be true after MoveFileFs succeeds")
+	assert.True(t, result.Subtitles[0].Moved, "Moved should be true after a move install")
+	assert.False(t, result.Subtitles[0].Copied, "Copied should be false for a move install")
 	assert.False(t, result.Subtitles[0].Planned, "Planned should be false when fileOp is provided")
 }
 
-func TestHandleSubtitles_CopyFileOp_SetsMovedTrue(t *testing.T) {
+func TestHandleSubtitles_CopyInstall_SetsCopiedTrue(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	cfg := &Config{
 		MoveSubtitles:      true,
@@ -98,10 +98,11 @@ func TestHandleSubtitles_CopyFileOp_SetsMovedTrue(t *testing.T) {
 	}
 
 	result := &OrganizeResult{}
-	org.handleSubtitles(plan, result, fsutil.CopyFileFs)
+	org.handleSubtitles(plan, result, subtitleCopyInstall)
 
 	require.Len(t, result.Subtitles, 1)
-	assert.True(t, result.Subtitles[0].Moved, "Moved should be true after CopyFileFs succeeds")
+	assert.True(t, result.Subtitles[0].Copied, "Copied should be true after a copy install")
+	assert.False(t, result.Subtitles[0].Moved, "Moved should be false for a copy install (#224 E mode distinction)")
 
 	exists, _ := afero.Exists(fs, "/source/ABC-123.srt")
 	assert.True(t, exists, "Source subtitle should still exist after copy")
@@ -131,7 +132,7 @@ func TestHandleSubtitles_SkipsWhenTargetExists(t *testing.T) {
 	}
 
 	result := &OrganizeResult{}
-	org.handleSubtitles(plan, result, fsutil.MoveFileFs)
+	org.handleSubtitles(plan, result, subtitleMoveInstall)
 
 	require.Len(t, result.Subtitles, 1)
 	assert.True(t, result.Subtitles[0].Skipped, "Skipped should be true when target already exists")
@@ -159,7 +160,7 @@ func TestHandleSubtitles_NoSubtitles_NoResults(t *testing.T) {
 	}
 
 	result := &OrganizeResult{}
-	org.handleSubtitles(plan, result, nil)
+	org.handleSubtitles(plan, result, subtitleInstall{})
 
 	assert.Len(t, result.Subtitles, 0, "No subtitles found should produce no results")
 }
@@ -190,7 +191,7 @@ func TestHandleSubtitles_FileOpError_SetsError(t *testing.T) {
 	}
 
 	result := &OrganizeResult{}
-	org.handleSubtitles(plan, result, failingOp)
+	org.handleSubtitles(plan, result, subtitleInstall{op: failingOp})
 
 	require.Len(t, result.Subtitles, 1)
 	assert.Error(t, result.Subtitles[0].Error, "Error should be set when fileOp fails")
@@ -289,5 +290,6 @@ func TestOrganize_UsesHandleSubtitlesForCopyPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result.Moved)
 	require.Len(t, result.Subtitles, 1, "Copy path via Organize should copy subtitles via handleSubtitles")
-	assert.True(t, result.Subtitles[0].Moved, "Subtitle should be copied (Moved=true)")
+	assert.True(t, result.Subtitles[0].Copied, "Subtitle via copy entry point records Copied (#224 E mode distinction)")
+	assert.False(t, result.Subtitles[0].Moved, "Copied subtitles are not moves")
 }

--- a/internal/organizer/map_noreplace_refusal_test.go
+++ b/internal/organizer/map_noreplace_refusal_test.go
@@ -75,7 +75,7 @@ func TestHandleSubtitles_PublishRefusalMapsToSkip(t *testing.T) {
 			}
 			result := &OrganizeResult{}
 
-			o.handleSubtitles(plan, result, func(afero.Fs, string, string) error { return ferr })
+			o.handleSubtitles(plan, result, subtitleInstall{op: func(afero.Fs, string, string) error { return ferr }})
 
 			require.Len(t, result.Subtitles, 1)
 			sr := result.Subtitles[0].SubtitleMove

--- a/internal/organizer/miss3_test.go
+++ b/internal/organizer/miss3_test.go
@@ -378,16 +378,14 @@ func TestOrganizeStrategy_Execute_LinkModeTargetNotExist(t *testing.T) {
 	assert.True(t, result.Moved)
 }
 
-// --- subtitles: MoveSubtitles with directory entries ---
+// --- subtitles: FindSubtitles with directory entries ---
 
-func TestSubtitleHandler_MoveSubtitles_SkipsDirectories(t *testing.T) {
+func TestSubtitleHandler_FindSubtitles_SkipsDirectories(t *testing.T) {
 	tmpDir := t.TempDir()
 	fs := afero.NewOsFs()
 
 	sourceDir := fmt.Sprintf("%s/src", tmpDir)
-	targetDir := fmt.Sprintf("%s/dest", tmpDir)
 	require.NoError(t, fs.MkdirAll(sourceDir, 0755))
-	require.NoError(t, fs.MkdirAll(targetDir, 0755))
 	require.NoError(t, afero.WriteFile(fs, fmt.Sprintf("%s/ABC-123.srt", sourceDir), []byte("sub"), 0644))
 	// Create a directory that looks like a subtitle file
 	require.NoError(t, fs.MkdirAll(fmt.Sprintf("%s/ABC-123.eng.srt", sourceDir), 0755))
@@ -395,12 +393,12 @@ func TestSubtitleHandler_MoveSubtitles_SkipsDirectories(t *testing.T) {
 	sh := newSubtitleHandler(fs, []string{".srt", ".ass"})
 
 	subtitles := sh.FindSubtitles(models.FileMatchInfo{
-		Path:      sourceDir,
+		Path:      fmt.Sprintf("%s/ABC-123.mp4", sourceDir),
 		Name:      "ABC-123.mp4",
 		Extension: ".mp4",
 	})
-	err := sh.MoveSubtitles(subtitles, targetDir, "ABC-123", false)
-	require.NoError(t, err)
+	require.Len(t, subtitles, 1, "subtitle-looking directory entries must not match")
+	assert.Equal(t, fmt.Sprintf("%s/ABC-123.srt", sourceDir), subtitles[0].OriginalPath)
 }
 
 // --- extractLanguageCode: remaining != "" ---

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -249,6 +249,10 @@ type OrganizeCmd struct {
 	// config still carries the global default. Empty = use config mode.
 	OperationMode   operationmode.OperationMode
 	ForceRenameFile bool
+	// DuplicateTracker shares intra-batch duplicate-destination preflight
+	// across the plans of one batch run (#224 phase E). Nil disables
+	// detection (single-file callers have no batch to collide with).
+	DuplicateTracker *DuplicateTracker
 }
 
 // OrganizerInterface is the single-method seam for file organization.
@@ -287,20 +291,27 @@ func NewOrganizer(fs afero.Fs, cfg *Config, engine template.EngineInterface, m m
 
 // OrganizeResult represents the result of organizing a file
 type OrganizeResult struct {
-	OriginalPath           string
-	NewPath                string
-	FolderPath             string
-	FileName               string
-	Moved                  bool
-	Error                  error
-	Subtitles              []subtitleResult
+	OriginalPath string
+	NewPath      string
+	FolderPath   string
+	FileName     string
+	Moved        bool
+	Error        error
+	// Warnings carries non-fatal per-file advisories an authorized run must
+	// not silently drop (#224 phase E): authorized intra-batch duplicates land
+	// here so the worker history rows and the API eventlog can persist them.
+	Warnings               []string
+	Subtitles              []SubtitleResult
 	InPlaceRenamed         bool   // Whether an in-place directory rename occurred
 	OldDirectoryPath       string // Original directory path (for updating subsequent file paths)
 	NewDirectoryPath       string // New directory path after in-place rename
 	ShouldGenerateMetadata bool   // Whether NFO/media should be generated for this result
 }
 
-type subtitleResult struct {
+// SubtitleResult records the outcome for one matched subtitle file: planned
+// (dry run), skipped (skip-on-exists), error, or installed — with the mode
+// distinction carried on the embedded SubtitleMove (Moved vs Copied, #224 E).
+type SubtitleResult struct {
 	models.SubtitleMove
 	Skipped bool
 	Planned bool
@@ -422,7 +433,7 @@ func (o *Organizer) execute(plan *OrganizePlan) (*OrganizeResult, error) {
 
 	if !plan.WillMove {
 		result.ShouldGenerateMetadata = true
-		o.handleSubtitles(plan, result, nil)
+		o.handleSubtitles(plan, result, subtitleInstall{})
 		return result, nil
 	}
 
@@ -437,7 +448,7 @@ func (o *Organizer) execute(plan *OrganizePlan) (*OrganizeResult, error) {
 	}
 
 	if o.config.MoveSubtitles {
-		o.handleSubtitles(plan, strategyResult, fsutil.MoveFileNoReplace)
+		o.handleSubtitles(plan, strategyResult, subtitleMoveInstall)
 	}
 
 	return strategyResult, nil
@@ -464,13 +475,28 @@ func (o *Organizer) subtitleFileInfo(plan *OrganizePlan) models.FileMatchInfo {
 	return fileInfoForSubtitles
 }
 
-func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, fileOp func(afero.Fs, string, string) error) {
+// subtitleInstall selects how handleSubtitles delivers subtitle files. A nil
+// op plans only (no filesystem changes); a non-nil op installs through one of
+// the fsutil no-replace composites, and copied records the mode distinction in
+// results (#224 phase E): a copy install retains the source (revert deletes
+// the installed copy), a move install does not (revert moves it back).
+type subtitleInstall struct {
+	op     func(afero.Fs, string, string) error
+	copied bool
+}
+
+var (
+	subtitleMoveInstall = subtitleInstall{op: fsutil.MoveFileNoReplace}
+	subtitleCopyInstall = subtitleInstall{op: fsutil.CopyFileNoReplace, copied: true}
+)
+
+func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, install subtitleInstall) {
 	subtitles := o.subtitleHandler.FindSubtitles(o.subtitleFileInfo(plan))
 	if len(subtitles) == 0 {
 		return
 	}
 
-	subtitleResults := make([]subtitleResult, len(subtitles))
+	subtitleResults := make([]SubtitleResult, len(subtitles))
 	for i, subtitle := range subtitles {
 		videoNameWithoutExt := strings.TrimSuffix(plan.TargetFile, filepath.Ext(plan.TargetFile))
 		newSubtitleName := o.subtitleHandler.generateSubtitleFileName(
@@ -480,8 +506,8 @@ func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, 
 		)
 		newPath := filepath.Join(plan.TargetDir, newSubtitleName)
 
-		if fileOp == nil {
-			subtitleResults[i] = subtitleResult{
+		if install.op == nil {
+			subtitleResults[i] = SubtitleResult{
 				SubtitleMove: models.SubtitleMove{
 					OriginalPath: subtitle.OriginalPath,
 					NewPath:      newPath,
@@ -491,7 +517,7 @@ func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, 
 			continue
 		}
 
-		sr := subtitleResult{
+		sr := SubtitleResult{
 			SubtitleMove: models.SubtitleMove{
 				OriginalPath: subtitle.OriginalPath,
 				NewPath:      newPath,
@@ -512,7 +538,7 @@ func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, 
 					sr.Skipped = true
 					return nil
 				}
-				err := fileOp(o.fs, subtitle.OriginalPath, newPath)
+				err := install.op(o.fs, subtitle.OriginalPath, newPath)
 				if err != nil && fsutil.PublishCompleted(err) {
 					// Post-publish cleanup refusal (#224 codex P2): bytes at the
 					// destination AND the source retained — an ambiguous delivery,
@@ -539,7 +565,11 @@ func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, 
 		if err != nil {
 			sr.Error = fmt.Errorf("failed to handle subtitle: %w", err)
 		} else if !sr.Skipped {
-			sr.Moved = true
+			if install.copied {
+				sr.Copied = true
+			} else {
+				sr.Moved = true
+			}
 		}
 
 		subtitleResults[i] = sr
@@ -571,6 +601,12 @@ func (o *Organizer) Organize(ctx context.Context, cmd OrganizeCmd) (*OrganizeRes
 		return nil, err
 	}
 
+	// Intra-batch duplicate preflight (#224 phase E): plan-only grouping by
+	// proven-equal canonical destination keys. Unauthorized duplicates join
+	// plan.Conflicts and short-circuit through the identical failure pipeline;
+	// authorized duplicates return as persisted per-file warnings.
+	dupWarnings := applyDuplicatePreflight(plan, cmd.DuplicateTracker, cmd.ForceUpdate)
+
 	if !cmd.ForceUpdate {
 		if issues := o.validatePlan(plan); len(issues) > 0 {
 			return nil, fmt.Errorf("organization validation failed: %v", issues)
@@ -598,6 +634,7 @@ func (o *Organizer) Organize(ctx context.Context, cmd OrganizeCmd) (*OrganizeRes
 			FolderPath:             plan.TargetDir,
 			FileName:               plan.TargetFile,
 			Moved:                  false,
+			Warnings:               dupWarnings,
 			ShouldGenerateMetadata: true,
 		}, nil
 	}
@@ -611,12 +648,15 @@ func (o *Organizer) Organize(ctx context.Context, cmd OrganizeCmd) (*OrganizeRes
 	if err != nil {
 		return strategyResult, err
 	}
+	strategyResult.Warnings = append(strategyResult.Warnings, dupWarnings...)
 
 	// Subtitle handling is centralized here — applies to both move and copy/link paths.
+	// Authorization never reaches subtitle destinations: both entry points
+	// install strictly skip-on-exists through the no-replace composites.
 	if cmd.MoveFiles && o.config.MoveSubtitles {
-		o.handleSubtitles(plan, strategyResult, fsutil.MoveFileNoReplace)
+		o.handleSubtitles(plan, strategyResult, subtitleMoveInstall)
 	} else if !cmd.MoveFiles && o.config.MoveSubtitles {
-		o.handleSubtitles(plan, strategyResult, fsutil.CopyFileNoReplace)
+		o.handleSubtitles(plan, strategyResult, subtitleCopyInstall)
 	}
 
 	return strategyResult, nil

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -577,6 +577,37 @@ func (o *Organizer) handleSubtitles(plan *OrganizePlan, result *OrganizeResult, 
 	result.Subtitles = subtitleResults
 }
 
+// withForceRename returns the planner that honors a per-command force-rename
+// request: when the config disables RenameFile but the command demands it,
+// planning runs against a clone with RenameFile enabled. Shared by Organize
+// and PlanOrganize so primed claims and executed plans always derive from the
+// identical planner selection (#240 finding A).
+func (o *Organizer) withForceRename(forceRename bool) *Organizer {
+	if forceRename && o.config != nil && !o.config.RenameFile {
+		clone := *o
+		cfg := *o.config
+		cfg.RenameFile = true
+		clone.config = &cfg
+		return &clone
+	}
+	return o
+}
+
+// PlanOrganize computes cmd's organization plan WITHOUT validating,
+// registering duplicate preflight, or executing anything — the read-only
+// planning seam the apply phase calls exactly once per sorted batch item
+// before worker fan-out, to prime deterministic duplicate ownership (#240
+// finding A). Planner selection is shared with Organize, so a primed claim
+// always matches the plan the item's worker later computes.
+func (o *Organizer) PlanOrganize(ctx context.Context, cmd OrganizeCmd) (*OrganizePlan, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	return o.withForceRename(cmd.ForceRenameFile).plan(cmd.Match, cmd.Movie, cmd.DestDir, cmd.ForceUpdate, cmd.OperationMode)
+}
+
 // Organize is the single-method seam that plans, validates, and executes
 // file organization in one call. Per Phase 48: Plan/ValidatePlan/Execute
 // are internal implementation details — callers use Organize instead of a
@@ -588,15 +619,7 @@ func (o *Organizer) Organize(ctx context.Context, cmd OrganizeCmd) (*OrganizeRes
 	default:
 	}
 
-	planner := o
-	if cmd.ForceRenameFile && o.config != nil && !o.config.RenameFile {
-		clone := *o
-		cfg := *o.config
-		cfg.RenameFile = true
-		clone.config = &cfg
-		planner = &clone
-	}
-	plan, err := planner.plan(cmd.Match, cmd.Movie, cmd.DestDir, cmd.ForceUpdate, cmd.OperationMode)
+	plan, err := o.withForceRename(cmd.ForceRenameFile).plan(cmd.Match, cmd.Movie, cmd.DestDir, cmd.ForceUpdate, cmd.OperationMode)
 	if err != nil {
 		return nil, err
 	}
@@ -604,8 +627,9 @@ func (o *Organizer) Organize(ctx context.Context, cmd OrganizeCmd) (*OrganizeRes
 	// Intra-batch duplicate preflight (#224 phase E): plan-only grouping by
 	// proven-equal canonical destination keys. Unauthorized duplicates join
 	// plan.Conflicts and short-circuit through the identical failure pipeline;
-	// authorized duplicates return as persisted per-file warnings.
-	dupWarnings := applyDuplicatePreflight(plan, cmd.DuplicateTracker, cmd.ForceUpdate)
+	// authorized duplicates return as persisted per-file warnings and skip
+	// execution — only the primed winner's bytes land (#240 finding A).
+	dupWarnings, dupSkip := applyDuplicatePreflight(plan, cmd.DuplicateTracker, cmd.ForceUpdate)
 
 	if !cmd.ForceUpdate {
 		if issues := o.validatePlan(plan); len(issues) > 0 {
@@ -628,6 +652,22 @@ func (o *Organizer) Organize(ctx context.Context, cmd OrganizeCmd) (*OrganizeRes
 
 	// Dry-run: return early with planned result (no filesystem changes).
 	if cmd.DryRun {
+		return &OrganizeResult{
+			OriginalPath:           plan.SourcePath,
+			NewPath:                plan.TargetPath,
+			FolderPath:             plan.TargetDir,
+			FileName:               plan.TargetFile,
+			Moved:                  false,
+			Warnings:               dupWarnings,
+			ShouldGenerateMetadata: true,
+		}, nil
+	}
+
+	// Authorized intra-batch duplicate (#240 finding A): demoted to a
+	// persisted warning above, it must NOT execute — pre-priming both sources
+	// raced onto the same destination with lock order deciding the surviving
+	// bytes. Skipping guarantees only the deterministic winner publishes.
+	if dupSkip {
 		return &OrganizeResult{
 			OriginalPath:           plan.SourcePath,
 			NewPath:                plan.TargetPath,

--- a/internal/organizer/subtitle_phase_e_test.go
+++ b/internal/organizer/subtitle_phase_e_test.go
@@ -1,0 +1,125 @@
+package organizer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+)
+
+// subtitleEntryFixture builds an organizer with subtitle handling enabled and
+// a source video + subtitle pair.
+func subtitleEntryFixture(t *testing.T) (*Organizer, afero.Fs) {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	cfg := &Config{
+		FolderFormat:       "<ID>",
+		FileFormat:         "<ID>",
+		RenameFile:         true,
+		OperationMode:      operationmode.OperationModeOrganize,
+		MoveSubtitles:      true,
+		SubtitleExtensions: []string{".srt"},
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	require.NoError(t, fs.MkdirAll("/in", 0755))
+	require.NoError(t, afero.WriteFile(fs, "/in/ABC-123.mkv", []byte("video"), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/in/ABC-123.srt", []byte("sub-source"), 0644))
+	return org, fs
+}
+
+func subtitleEntryCmd(moveFiles, force bool) OrganizeCmd {
+	return OrganizeCmd{
+		Match:       models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/ABC-123.mkv", Name: "ABC-123.mkv", Extension: ".mkv"},
+		Movie:       &models.Movie{ID: "ABC-123"},
+		DestDir:     "/dest",
+		MoveFiles:   moveFiles,
+		LinkMode:    LinkModeNone,
+		ForceUpdate: force,
+	}
+}
+
+func TestOrganize_Subtitles_ModeAwareResultsAndSkipOnExists(t *testing.T) {
+	entryPoints := []struct {
+		name      string
+		moveFiles bool
+		wantMoved bool
+		wantCopy  bool
+	}{
+		{"move entry point", true, true, false},
+		{"copy entry point", false, false, true},
+	}
+	for _, ep := range entryPoints {
+		t.Run(ep.name+" install", func(t *testing.T) {
+			org, fs := subtitleEntryFixture(t)
+			result, err := org.Organize(context.Background(), subtitleEntryCmd(ep.moveFiles, false))
+			require.NoError(t, err)
+			require.Len(t, result.Subtitles, 1)
+			sr := result.Subtitles[0]
+			assert.Equal(t, ep.wantMoved, sr.Moved)
+			assert.Equal(t, ep.wantCopy, sr.Copied)
+			assert.False(t, sr.Skipped)
+			destSub := "/dest/ABC-123/ABC-123.srt"
+			content, readErr := afero.ReadFile(fs, destSub)
+			require.NoError(t, readErr)
+			assert.Equal(t, []byte("sub-source"), content)
+			_, srcErr := fs.Stat("/in/ABC-123.srt")
+			if ep.moveFiles {
+				assert.Error(t, srcErr, "move install relocates the source subtitle")
+			} else {
+				assert.NoError(t, srcErr, "copy install retains the source subtitle")
+			}
+		})
+
+		t.Run(ep.name+" skip-on-exists is race-hardened", func(t *testing.T) {
+			org, fs := subtitleEntryFixture(t)
+			require.NoError(t, fs.MkdirAll("/dest/ABC-123", 0755))
+			require.NoError(t, afero.WriteFile(fs, "/dest/ABC-123/ABC-123.srt", []byte("foreign"), 0644))
+			result, err := org.Organize(context.Background(), subtitleEntryCmd(ep.moveFiles, false))
+			require.NoError(t, err, "subtitle skip-on-exists never fails the organize")
+			require.Len(t, result.Subtitles, 1)
+			sr := result.Subtitles[0]
+			assert.True(t, sr.Skipped, "occupied subtitle destination skips through the guarded primitive")
+			assert.False(t, sr.Moved)
+			assert.False(t, sr.Copied)
+			content, readErr := afero.ReadFile(fs, "/dest/ABC-123/ABC-123.srt")
+			require.NoError(t, readErr)
+			assert.Equal(t, []byte("foreign"), content, "the foreign subtitle is byte-preserved")
+			srcContent, readErr := afero.ReadFile(fs, "/in/ABC-123.srt")
+			require.NoError(t, readErr)
+			assert.Equal(t, []byte("sub-source"), srcContent, "the skipped source subtitle is retained at its origin")
+		})
+
+		t.Run(ep.name+" authorization never reaches subtitle destinations", func(t *testing.T) {
+			org, fs := subtitleEntryFixture(t)
+			require.NoError(t, fs.MkdirAll("/dest/ABC-123", 0755))
+			require.NoError(t, afero.WriteFile(fs, "/dest/ABC-123/ABC-123.srt", []byte("foreign"), 0644))
+			require.NoError(t, afero.WriteFile(fs, "/dest/ABC-123/ABC-123.mkv", []byte("foreign-video"), 0644))
+			result, err := org.Organize(context.Background(), subtitleEntryCmd(ep.moveFiles, true))
+			require.NoError(t, err, "authorization replaces the video but not the subtitle")
+			require.Len(t, result.Subtitles, 1)
+			assert.True(t, result.Subtitles[0].Skipped, "ForceUpdate must not authorize-over a subtitle destination")
+			content, readErr := afero.ReadFile(fs, "/dest/ABC-123/ABC-123.srt")
+			require.NoError(t, readErr)
+			assert.Equal(t, []byte("foreign"), content)
+		})
+	}
+}
+
+func TestOrganize_Subtitles_PlanOnlyInstallIsPlanned(t *testing.T) {
+	org, _ := subtitleEntryFixture(t)
+	plan, err := org.plan(
+		models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/ABC-123.mkv", Name: "ABC-123.mkv", Extension: ".mkv"},
+		&models.Movie{ID: "ABC-123"}, "/dest", false, "")
+	require.NoError(t, err)
+	result := &OrganizeResult{}
+	org.handleSubtitles(plan, result, subtitleInstall{})
+	require.Len(t, result.Subtitles, 1)
+	assert.True(t, result.Subtitles[0].Planned)
+	assert.False(t, result.Subtitles[0].Moved)
+	assert.False(t, result.Subtitles[0].Copied)
+}

--- a/internal/organizer/subtitles.go
+++ b/internal/organizer/subtitles.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/javinizer/javinizer-go/internal/config"
-	"github.com/javinizer/javinizer-go/internal/fsutil"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/spf13/afero"
@@ -139,46 +137,6 @@ func (sh *subtitleHandler) FindSubtitles(videoFile models.FileMatchInfo) []subti
 	}
 
 	return matches
-}
-
-// MoveSubtitles moves subtitle files to the target directory with the video file
-func (sh *subtitleHandler) MoveSubtitles(subtitles []subtitleMatch, targetDir, videoFileName string, dryRun bool) error {
-	if len(subtitles) == 0 {
-		return nil
-	}
-
-	// Create target directory if it doesn't exist
-	if !dryRun {
-		if err := sh.fs.MkdirAll(targetDir, config.DirPerm); err != nil {
-			return fmt.Errorf("failed to create target directory: %w", err)
-		}
-	}
-
-	videoNameWithoutExt := strings.TrimSuffix(videoFileName, filepath.Ext(videoFileName))
-
-	for _, subtitle := range subtitles {
-		// Generate new subtitle filename
-		newFileName := sh.generateSubtitleFileName(videoNameWithoutExt, subtitle.Language, subtitle.Extension)
-		newPath := filepath.Join(targetDir, newFileName)
-
-		if dryRun {
-			logging.Debugf("Would move subtitle: %s -> %s", subtitle.OriginalPath, newPath)
-			continue
-		}
-
-		if _, err := sh.fs.Stat(newPath); err == nil {
-			logging.Infof("Subtitle already exists, skipping: %s", newPath)
-			continue
-		}
-
-		if err := fsutil.MoveFileFs(sh.fs, subtitle.OriginalPath, newPath); err != nil {
-			return fmt.Errorf("failed to move subtitle %s to %s: %w", subtitle.OriginalPath, newPath, err)
-		}
-
-		logging.Infof("Moved subtitle: %s -> %s", subtitle.OriginalPath, newPath)
-	}
-
-	return nil
 }
 
 // isSubtitleFile checks if a filename has a subtitle extension

--- a/internal/organizer/subtitles_test.go
+++ b/internal/organizer/subtitles_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/javinizer/javinizer-go/internal/models"
 )
@@ -154,90 +153,6 @@ func TestSubtitleHandler_FindSubtitles_CaseInsensitive(t *testing.T) {
 			t.Errorf("Expected subtitle file not found: %s", expectedFile)
 		} else if actualLang != expectedLang {
 			t.Errorf("File %s: expected language %q, got %q", expectedFile, expectedLang, actualLang)
-		}
-	}
-}
-
-func TestSubtitleHandler_MoveSubtitles(t *testing.T) {
-	cfg := &Config{
-		SubtitleExtensions: []string{".srt", ".ass"},
-	}
-
-	handler := newSubtitleHandler(afero.NewOsFs(), cfg.SubtitleExtensions)
-
-	// Create temporary directory structure
-	sourceDir := t.TempDir()
-	targetDir := filepath.Join(sourceDir, "organized")
-
-	// Create video file
-	videoPath := filepath.Join(sourceDir, "IPX-535.mp4")
-	if err := os.WriteFile(videoPath, []byte("fake video"), 0644); err != nil {
-		t.Fatalf("Failed to create video file: %v", err)
-	}
-
-	// Create subtitle files
-	subtitles := []subtitleMatch{
-		{
-			OriginalPath: filepath.Join(sourceDir, "IPX-535.srt"),
-			Language:     "",
-			Extension:    ".srt",
-		},
-		{
-			OriginalPath: filepath.Join(sourceDir, "IPX-535.eng.srt"),
-			Language:     "english",
-			Extension:    ".srt",
-		},
-		{
-			OriginalPath: filepath.Join(sourceDir, "IPX-535.jpn.ass"),
-			Language:     "japanese",
-			Extension:    ".ass",
-		},
-	}
-
-	// Create the actual subtitle files
-	for _, subtitle := range subtitles {
-		if err := os.WriteFile(subtitle.OriginalPath, []byte("fake subtitle"), 0644); err != nil {
-			t.Fatalf("Failed to create subtitle file %s: %v", subtitle.OriginalPath, err)
-		}
-	}
-
-	// Test dry run
-	err := handler.MoveSubtitles(subtitles, targetDir, "IPX-535.mp4", true)
-	if err != nil {
-		t.Errorf("MoveSubtitles dry run failed: %v", err)
-	}
-
-	// Files should still be in original location for dry run
-	for _, subtitle := range subtitles {
-		if _, err := os.Stat(subtitle.OriginalPath); os.IsNotExist(err) {
-			t.Errorf("Subtitle file was moved during dry run: %s", subtitle.OriginalPath)
-		}
-	}
-
-	// Test actual move
-	err = handler.MoveSubtitles(subtitles, targetDir, "IPX-535.mp4", false)
-	if err != nil {
-		t.Errorf("MoveSubtitles actual move failed: %v", err)
-	}
-
-	// Verify files were moved
-	expectedFiles := []string{
-		"IPX-535.srt",     // No language code
-		"IPX-535.eng.srt", // English
-		"IPX-535.jpn.ass", // Japanese (code conversion)
-	}
-
-	for _, expectedFile := range expectedFiles {
-		expectedPath := filepath.Join(targetDir, expectedFile)
-		if _, err := os.Stat(expectedPath); os.IsNotExist(err) {
-			t.Errorf("Expected subtitle file not found: %s", expectedPath)
-		}
-	}
-
-	// Verify original files are gone
-	for _, subtitle := range subtitles {
-		if _, err := os.Stat(subtitle.OriginalPath); !os.IsNotExist(err) {
-			t.Errorf("Original subtitle file still exists: %s", subtitle.OriginalPath)
 		}
 	}
 }
@@ -422,56 +337,4 @@ func TestSubtitleHandler_FindSubtitles_EmptyExtensions(t *testing.T) {
 	if len(matches) != 0 {
 		t.Errorf("Expected 0 matches when no extensions configured, got %d", len(matches))
 	}
-}
-
-func TestSubtitleHandler_MoveSubtitles_DryRun(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	handler := newSubtitleHandler(fs, []string{".srt", ".ass"})
-
-	subtitles := []subtitleMatch{
-		{OriginalPath: "/src/IPX-535.eng.srt", Language: "eng", Extension: ".srt"},
-	}
-
-	err := handler.MoveSubtitles(subtitles, "/target", "IPX-535.mp4", true)
-	assert.NoError(t, err, "Dry run should not error")
-}
-
-func TestSubtitleHandler_MoveSubtitles_SkipsExisting(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	handler := newSubtitleHandler(fs, []string{".srt", ".ass"})
-
-	// Create target directory and existing subtitle
-	_ = fs.MkdirAll("/target", 0755)
-	_ = afero.WriteFile(fs, "/target/IPX-535.eng.srt", []byte("existing"), 0644)
-
-	subtitles := []subtitleMatch{
-		{OriginalPath: "/src/IPX-535.eng.srt", Language: "eng", Extension: ".srt"},
-	}
-
-	err := handler.MoveSubtitles(subtitles, "/target", "IPX-535.mp4", false)
-	assert.NoError(t, err, "Should skip existing subtitle without error")
-}
-
-func TestSubtitleHandler_MoveSubtitles_MoveFails(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	handler := newSubtitleHandler(fs, []string{".srt", ".ass"})
-
-	// Target dir exists, but source file does not — MoveFileFs will fail
-	_ = fs.MkdirAll("/target", 0755)
-
-	subtitles := []subtitleMatch{
-		{OriginalPath: "/src/nonexistent.srt", Language: "eng", Extension: ".srt"},
-	}
-
-	err := handler.MoveSubtitles(subtitles, "/target", "IPX-535.mp4", false)
-	assert.Error(t, err, "Should error when source file does not exist")
-	assert.Contains(t, err.Error(), "failed to move subtitle")
-}
-
-func TestSubtitleHandler_MoveSubtitles_EmptyList(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	handler := newSubtitleHandler(fs, []string{".srt"})
-
-	err := handler.MoveSubtitles(nil, "/target", "IPX-535.mp4", false)
-	assert.NoError(t, err, "Empty list should return nil")
 }

--- a/internal/worker/apply_interpret_cov_test.go
+++ b/internal/worker/apply_interpret_cov_test.go
@@ -52,7 +52,14 @@ func TestApplyFileBaselineFreezeAgainstWorkflowMutation(t *testing.T) {
 	movie := &models.Movie{ID: "BZ-1", DisplayTitle: "orig"}
 	stored, gErr := store.GetMovieResult("/f/a.mp4")
 	require.NoError(t, gErr)
-	outcome := applyFile(context.Background(), wfm, "/f/a.mp4", stored, movie, inputs, ApplyPhaseConfig{})
+	// Mirror the production pre-fan-out preparation: baseline frozen first,
+	// then the command built once.
+	baseline := movie.Clone()
+	cfg := ApplyPhaseConfig{}
+	cmd, afc, shouldExecute := buildApplyCmd("/f/a.mp4", movie, stored, inputs, cfg, context.Background())
+	require.True(t, shouldExecute)
+	outcome := applyFile(context.Background(), wfm, "/f/a.mp4", stored, movie,
+		&preparedApplyFile{cmd: cmd, afc: afc, baseline: baseline, execute: shouldExecute}, inputs, cfg)
 	_ = outcome
 	final, err := store.GetMovieResult("/f/a.mp4")
 	require.NoError(t, err)

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -14,6 +14,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/downloader"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
 	"github.com/javinizer/javinizer-go/internal/panicutil"
 	"github.com/javinizer/javinizer-go/internal/progress"
 	"github.com/javinizer/javinizer-go/internal/worker/fanout"
@@ -139,6 +140,11 @@ func (p *applyPhase) Run(ctx context.Context, inputs applyPhaseInputs, cfg Apply
 	var processed int64
 	inputs.Dedup = &sync.Map{}
 	downloader.PrimeDownloadOwners(inputs.Dedup, owners)
+	// One intra-batch duplicate preflight registry per apply run (#224 phase
+	// E): every file's plan registers its proven-equal canonical destination
+	// key so same-batch target collisions surface as plan conflicts — or, when
+	// overwrite is authorized, as persisted per-file warnings.
+	cfg.OrganizeOptions.DuplicateTracker = organizer.NewDuplicateTracker()
 	outcomes := fanout.BoundedFanOut(ctx, inputs.Concurrency.MaxWorkers, items,
 		func(egCtx context.Context, item applyItem) applyFileOutcome {
 			outcome := applyFile(egCtx, wf, item.filePath, item.fileResult, item.movie, inputs, cfg)

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -34,6 +34,56 @@ func NewApplyPhase() ApplyPhase {
 	return &applyPhase{}
 }
 
+// applyItem is one file selected for this apply iteration.
+type applyItem struct {
+	filePath   string
+	fileResult *resultstore.MovieResult
+	movie      *models.Movie
+}
+
+// preparedApplyFile is the per-item command material the apply phase builds
+// ONCE per item, in sorted order, before worker fan-out (#240 finding A):
+// the duplicate preflight's owner priming derives from the same commands the
+// workers later execute, so PreApply-hook mutations reach both, and every
+// hook still runs exactly once per file. baseline is the phase-entry movie
+// clone (codex r51), frozen before the hook could mutate the live pointer.
+type preparedApplyFile struct {
+	cmd      workflow.ApplyCmd
+	afc      *ApplyFileContext
+	baseline *models.Movie
+	execute  bool
+}
+
+// primeDuplicateClaims runs the batch's ONE planning pass when the workflow
+// exposes the read-only planning seam: each prepared item's organize target
+// registers against the run's duplicate tracker in sorted order,
+// pre-assigning every canonical key's winner before any apply worker starts
+// (#240 finding A). Items whose PreApply hook declined execution or whose
+// plan fails register nothing — their workers skip execution or fail with
+// the identical plan error, so priming can never claim a file that cannot
+// run. Without the seam (or on a nil workflow) the tracker stays unprimed,
+// preserving first-come observation for single-file callers.
+func primeDuplicateClaims(ctx context.Context, wf workflow.WorkflowInterface, tracker *organizer.DuplicateTracker, items []applyItem, prepared map[string]*preparedApplyFile) {
+	planner, ok := wf.(workflow.DuplicatePrimingPlanner)
+	if !ok {
+		return
+	}
+	primings := make([]organizer.DuplicatePriming, 0, len(items))
+	for _, item := range items {
+		p := prepared[item.filePath]
+		if !p.execute {
+			continue
+		}
+		priming, err := planner.PlanDuplicatePriming(ctx, p.cmd)
+		if err != nil {
+			logging.Warnf("[Apply] duplicate preflight planning skipped %s: %v", item.filePath, err)
+			continue
+		}
+		primings = append(primings, priming)
+	}
+	tracker.PrimeBatch(primings)
+}
+
 // applyFileOutcome captures the result of applying a single file.
 // Collected by the errgroup goroutine, then aggregated by trackApplyResults.
 type applyFileOutcome struct {
@@ -89,11 +139,6 @@ func (p *applyPhase) Run(ctx context.Context, inputs applyPhaseInputs, cfg Apply
 	// exclusion) during apply go through the live tracker via inputs.Updater
 	// but do not affect which files this apply iteration processes. This
 	// prevents concurrent-modification bugs during iteration.
-	type applyItem struct {
-		filePath   string
-		fileResult *resultstore.MovieResult
-		movie      *models.Movie
-	}
 	retryPaths := make(map[string]struct{}, len(cfg.RetryFilePaths))
 	for _, filePath := range cfg.RetryFilePaths {
 		retryPaths[filePath] = struct{}{}
@@ -143,11 +188,23 @@ func (p *applyPhase) Run(ctx context.Context, inputs applyPhaseInputs, cfg Apply
 	// One intra-batch duplicate preflight registry per apply run (#224 phase
 	// E): every file's plan registers its proven-equal canonical destination
 	// key so same-batch target collisions surface as plan conflicts — or, when
-	// overwrite is authorized, as persisted per-file warnings.
-	cfg.OrganizeOptions.DuplicateTracker = organizer.NewDuplicateTracker()
+	// overwrite is authorized, as persisted per-file warnings. Dry runs
+	// construct the non-probing variant so key derivation never writes probe
+	// artifacts (#240 finding B).
+	cfg.OrganizeOptions.DuplicateTracker = organizer.NewDuplicateTracker(cfg.DryRun)
+	// Prepare every item's ApplyCmd ONCE, in sorted order, before fan-out
+	// (#240 finding A): priming and execution share identical commands, and
+	// PreApply hooks keep their once-per-file contract.
+	prepared := make(map[string]*preparedApplyFile, len(items))
+	for _, item := range items {
+		baseline := item.movie.Clone()
+		applyCmd, afc, shouldExecute := buildApplyCmd(item.filePath, item.movie, item.fileResult, inputs, cfg, ctx)
+		prepared[item.filePath] = &preparedApplyFile{cmd: applyCmd, afc: afc, baseline: baseline, execute: shouldExecute}
+	}
+	primeDuplicateClaims(ctx, wf, cfg.OrganizeOptions.DuplicateTracker, items, prepared)
 	outcomes := fanout.BoundedFanOut(ctx, inputs.Concurrency.MaxWorkers, items,
 		func(egCtx context.Context, item applyItem) applyFileOutcome {
-			outcome := applyFile(egCtx, wf, item.filePath, item.fileResult, item.movie, inputs, cfg)
+			outcome := applyFile(egCtx, wf, item.filePath, item.fileResult, item.movie, prepared[item.filePath], inputs, cfg)
 			// Report per-file progress so the frontend bar advances 0→100 across
 			// files instead of jumping straight to 100 on OnPhaseComplete. A file
 			// counts as processed whether it succeeded or failed — the bar tracks
@@ -280,7 +337,7 @@ func buildApplyCmd(
 	fileResult *resultstore.MovieResult,
 	inputs applyPhaseInputs,
 	cfg ApplyPhaseConfig,
-	taskCtx context.Context,
+	ctx context.Context,
 ) (workflow.ApplyCmd, *ApplyFileContext, bool) {
 	sourceDir := filepath.Dir(filePath)
 	match := fileResult.FileMatchInfo
@@ -332,7 +389,7 @@ func buildApplyCmd(
 	}
 
 	if cfg.PreApplyFunc != nil {
-		if err := cfg.PreApplyFunc(taskCtx, afc); err != nil {
+		if err := cfg.PreApplyFunc(ctx, afc); err != nil {
 			logging.Warnf("PreApply hook skipped %s: %v", filePath, err)
 			return applyCmd, afc, false // false = skip execution
 		}
@@ -546,14 +603,17 @@ func interpretApplyResult(
 	return outcome
 }
 
-// applyFile handles the per-file apply logic: build ApplyCmd, execute workflow.Apply,
-// interpret result. Error handling, panic recovery, and result tracking are performed here.
+// applyFile handles the per-file apply logic: consume the prepared ApplyCmd,
+// execute workflow.Apply, interpret result. Error handling, panic recovery,
+// and result tracking are performed here. The command itself was built once
+// per item, in sorted order, before fan-out (#240 finding A).
 func applyFile(
 	egCtx context.Context,
 	wf workflow.WorkflowInterface,
 	filePath string,
 	fileResult *resultstore.MovieResult,
 	movie *models.Movie,
+	prepared *preparedApplyFile,
 	inputs applyPhaseInputs,
 	cfg ApplyPhaseConfig,
 ) (outcome applyFileOutcome) {
@@ -613,17 +673,12 @@ func applyFile(
 		defer taskCancel()
 	}
 
-	// codex r51 P2c: freeze the phase-entry baseline BEFORE the workflow
-	// sees the pointer — stepDisplayTitle & friends mutate cmd.Movie/afc.Movie
-	// (= the same movie), and a mutated "baseline" misclassifies merges as
-	// concurrent review edits, restoring stale fields over the computed ones.
-	frozenBaseline := movie.Clone()
-
-	// Step 1: Build the ApplyCmd.
-	applyCmd, afc, shouldExecute := buildApplyCmd(filePath, movie, fileResult, inputs, cfg, taskCtx)
-	if !shouldExecute {
+	// Step 1: Consume the prepared ApplyCmd (built pre-fan-out with the
+	// phase-entry baseline frozen before any hook mutation, codex r51 P2c).
+	if !prepared.execute {
 		return outcome
 	}
+	applyCmd, afc := prepared.cmd, prepared.afc
 
 	// Step 2: Execute the workflow.Apply.
 	reporter := makeProgressReporter(inputs.Broadcaster, inputs.JobID, movie.ID, jobEventPhaseApply)
@@ -636,7 +691,7 @@ func applyFile(
 
 	// Step 3: Interpret the result against the FROZEN baseline (workflow
 	// permutations may have rewritten fields on the live pointer mid-apply).
-	return interpretApplyResult(filePath, frozenBaseline, startTime, applyTimeout, inputs, cfg, taskCtx, afc, result, applyErr)
+	return interpretApplyResult(filePath, prepared.baseline, startTime, applyTimeout, inputs, cfg, taskCtx, afc, result, applyErr)
 }
 
 // trackApplyResults processes collected applyFileOutcomes: increments counters

--- a/internal/worker/apply_phase_miss_test.go
+++ b/internal/worker/apply_phase_miss_test.go
@@ -128,11 +128,15 @@ func TestApplyFile_PreApplySkipReleasesPrimedOwnerClaim(t *testing.T) {
 		Movie:         &models.Movie{ID: "IPX-778"},
 	}
 
-	_ = applyFile(context.Background(), wf, filePath, fileResult, fileResult.Movie, inputs, ApplyPhaseConfig{
+	cfg := ApplyPhaseConfig{
 		PreApplyFunc: func(_ context.Context, _ *ApplyFileContext) error {
 			return fmt.Errorf("skip this file")
 		},
-	})
+	}
+	cmd, afc, shouldExecute := buildApplyCmd(filePath, fileResult.Movie, fileResult, inputs, cfg, context.Background())
+	require.False(t, shouldExecute, "the hook declined the item during pre-fan-out preparation")
+	_ = applyFile(context.Background(), wf, filePath, fileResult, fileResult.Movie,
+		&preparedApplyFile{cmd: cmd, afc: afc, baseline: fileResult.Movie.Clone(), execute: shouldExecute}, inputs, cfg)
 
 	_, stillClaimed := inputs.Dedup.Load("\x00poster-owner:ipx-778")
 	assert.False(t, stillClaimed, "an item skipped before poster work must release its owner claim")

--- a/internal/worker/apply_phase_priming_test.go
+++ b/internal/worker/apply_phase_priming_test.go
@@ -1,0 +1,206 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/fsutil"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// primingStubWorkflow extends stubApplyWorkflow with the optional
+// workflow.DuplicatePrimingPlanner seam, recording priming attempts in call
+// order and any Apply dispatched before every priming completed.
+type primingStubWorkflow struct {
+	stubApplyWorkflow
+	planErrOn map[string]bool
+
+	mu         sync.Mutex
+	primeCalls []string
+	applyCmds  []workflow.ApplyCmd
+	earlyApply []string
+	total      int
+}
+
+func (s *primingStubWorkflow) PlanDuplicatePriming(_ context.Context, cmd workflow.ApplyCmd) (organizer.DuplicatePriming, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	src := cmd.Match.Path
+	s.primeCalls = append(s.primeCalls, src)
+	if s.planErrOn[src] {
+		return organizer.DuplicatePriming{}, fmt.Errorf("plan boom for %s", src)
+	}
+	return organizer.DuplicatePriming{
+		SourcePath: src,
+		TargetPath: filepath.Join(cmd.DestPath, strings.ToLower(cmd.Match.MovieID)+".mkv"),
+		WillMove:   true,
+	}, nil
+}
+
+func (s *primingStubWorkflow) Apply(ctx context.Context, cmd workflow.ApplyCmd) (*workflow.ApplyResult, error) {
+	s.mu.Lock()
+	if len(s.primeCalls) < s.total {
+		s.earlyApply = append(s.earlyApply, cmd.Match.Path)
+	}
+	s.applyCmds = append(s.applyCmds, cmd)
+	s.mu.Unlock()
+	return s.stubApplyWorkflow.Apply(ctx, cmd)
+}
+
+func (s *primingStubWorkflow) snapshot() (primeCalls []string, applyCmds []workflow.ApplyCmd, early []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.primeCalls...), append([]workflow.ApplyCmd(nil), s.applyCmds...), append([]string(nil), s.earlyApply...)
+}
+
+// TestApplyPhase_Run_PrimesDuplicateOwnersInSortedOrder pins #240 finding A:
+// the apply phase plans every sorted item exactly once BEFORE any worker
+// starts and primes the batch's shared tracker in that sorted order.
+func TestApplyPhase_Run_PrimesDuplicateOwnersInSortedOrder(t *testing.T) {
+	wf := &primingStubWorkflow{total: 3}
+	wf.applyResult = &workflow.ApplyResult{Movie: &models.Movie{ID: "M-100"}}
+	inputs := makeApplyInputs(wf)
+	inputs.Concurrency = concurrencyConfig{MaxWorkers: 4, WorkerTimeout: 0}
+	for _, p := range []string{"/source/m-3.mp4", "/source/a-1.mp4", "/source/z-2.mp4"} {
+		inputs.Results[p] = &resultstore.MovieResult{
+			FileMatchInfo: models.FileMatchInfo{Path: p, MovieID: "M-100"},
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "M-100", Title: "Shared Destination"},
+		}
+	}
+
+	NewApplyPhase().Run(context.Background(), inputs, ApplyPhaseConfig{
+		OrganizeOptions: workflow.OrganizeOptions{MoveFiles: true},
+		Destination:     "/output",
+	})
+
+	primeCalls, applyCmds, early := wf.snapshot()
+	assert.Equal(t, []string{"/source/a-1.mp4", "/source/m-3.mp4", "/source/z-2.mp4"}, primeCalls,
+		"every item is planned exactly once per run, before fan-out, in sorted order")
+	assert.Empty(t, early, "no worker Apply may start before every claim is primed")
+	require.Len(t, applyCmds, 3)
+	for _, cmd := range applyCmds {
+		require.NotNil(t, cmd.Organize.DuplicateTracker)
+		assert.Same(t, applyCmds[0].Organize.DuplicateTracker, cmd.Organize.DuplicateTracker,
+			"primed tracker is shared by every file")
+	}
+}
+
+// TestApplyPhase_Run_PrimingSkipsUnexecutableAndUnplannableItems pins the two
+// priming skip legs: a PreApply-declined item registers no claim (and never
+// applies), while a planning failure only forfeits priming — the item still
+// applies and fails through its own identical plan error.
+func TestApplyPhase_Run_PrimingSkipsUnexecutableAndUnplannableItems(t *testing.T) {
+	wf := &primingStubWorkflow{total: 2, planErrOn: map[string]bool{"/source/bad.mp4": true}}
+	wf.applyResult = &workflow.ApplyResult{Movie: &models.Movie{ID: "M-100"}}
+	inputs := makeApplyInputs(wf)
+	inputs.Concurrency = concurrencyConfig{MaxWorkers: 2, WorkerTimeout: 0}
+	for _, p := range []string{"/source/skip.mp4", "/source/bad.mp4", "/source/good.mp4"} {
+		inputs.Results[p] = &resultstore.MovieResult{
+			FileMatchInfo: models.FileMatchInfo{Path: p, MovieID: "M-100"},
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "M-100"},
+		}
+	}
+
+	NewApplyPhase().Run(context.Background(), inputs, ApplyPhaseConfig{
+		OrganizeOptions: workflow.OrganizeOptions{MoveFiles: true},
+		Destination:     "/output",
+		PreApplyFunc: func(_ context.Context, afc *ApplyFileContext) error {
+			if afc.FilePath == "/source/skip.mp4" {
+				return fmt.Errorf("skip this file")
+			}
+			return nil
+		},
+	})
+
+	primeCalls, applyCmds, _ := wf.snapshot()
+	assert.Equal(t, []string{"/source/bad.mp4", "/source/good.mp4"}, primeCalls,
+		"sorted priming attempts skip hook-declined items and continue past plan failures")
+	appliedPaths := make([]string, 0, len(applyCmds))
+	for _, cmd := range applyCmds {
+		appliedPaths = append(appliedPaths, cmd.Match.Path)
+	}
+	assert.ElementsMatch(t, []string{"/source/bad.mp4", "/source/good.mp4"}, appliedPaths,
+		"a plan failure forfeits priming but never drops the item from apply")
+}
+
+// TestApplyPhase_Run_DuplicatePreflightProbePolicy pins #240 finding B at the
+// batch boundary: dry runs construct the non-probing tracker (zero probes,
+// zero probe artifacts), while live runs probe exactly once per root, exactly
+// as before.
+func TestApplyPhase_Run_DuplicatePreflightProbePolicy(t *testing.T) {
+	snapshotTree := func(t *testing.T, root string) map[string]bool {
+		t.Helper()
+		entries := map[string]bool{}
+		require.NoError(t, filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			entries[path] = d.IsDir()
+			return nil
+		}))
+		return entries
+	}
+
+	runBatch := func(t *testing.T, dryRun bool) (dest string, caseCalls, normCalls int) {
+		t.Helper()
+		fsutil.ResetCaseSensitivityCache()
+		fsutil.ResetNormalizationCache()
+		cc, nc := 0, 0
+		prevCase, prevNorm := fsutil.CaseSensitiveProbe, fsutil.NormalizationProbe
+		fsutil.CaseSensitiveProbe = func(string) (bool, error) { cc++; return false, nil }
+		fsutil.NormalizationProbe = func(string) (bool, error) { nc++; return true, nil }
+		defer func() {
+			fsutil.CaseSensitiveProbe = prevCase
+			fsutil.NormalizationProbe = prevNorm
+			fsutil.ResetCaseSensitivityCache()
+			fsutil.ResetNormalizationCache()
+		}()
+
+		dest = t.TempDir()
+		before := snapshotTree(t, dest)
+
+		wf := &primingStubWorkflow{total: 2}
+		wf.applyResult = &workflow.ApplyResult{Movie: &models.Movie{ID: "M-100"}}
+		inputs := makeApplyInputs(wf)
+		for _, p := range []string{"/source/a-1.mp4", "/source/z-2.mp4"} {
+			inputs.Results[p] = &resultstore.MovieResult{
+				FileMatchInfo: models.FileMatchInfo{Path: p, MovieID: "M-100"},
+				Status:        models.JobStatusCompleted,
+				Movie:         &models.Movie{ID: "M-100"},
+			}
+		}
+		NewApplyPhase().Run(context.Background(), inputs, ApplyPhaseConfig{
+			DryRun:          dryRun,
+			OrganizeOptions: workflow.OrganizeOptions{MoveFiles: true},
+			Destination:     dest,
+		})
+
+		assert.Equal(t, before, snapshotTree(t, dest),
+			"no probe artifacts may survive the run (the duplicate preflight adds no disk writes)")
+		return dest, cc, nc
+	}
+
+	t.Run("dry run performs zero probe writes", func(t *testing.T) {
+		_, cc, nc := runBatch(t, true)
+		assert.Equal(t, 0, cc, "dry runs never run the writing case probe")
+		assert.Equal(t, 0, nc, "dry runs never run the writing normalization probe")
+	})
+
+	t.Run("live run probing is unchanged", func(t *testing.T) {
+		_, cc, nc := runBatch(t, false)
+		assert.Equal(t, 1, cc, "live runs keep one case probe per root per process")
+		assert.Equal(t, 1, nc, "live runs keep one normalization probe per root per process")
+	})
+}

--- a/internal/worker/apply_phase_test.go
+++ b/internal/worker/apply_phase_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
 	"github.com/javinizer/javinizer-go/internal/scrape"
 	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
 	"github.com/javinizer/javinizer-go/internal/workflow"
@@ -777,4 +778,48 @@ func TestCountRemainingApplyFailures_TracksLiveWritebackAndOutcomes(t *testing.T
 	// Only the live Completed row is cleared. A workflow success whose write-back
 	// was skipped must remain retryable, while nil-movie scrape failures stay out.
 	assert.Equal(t, int64(3), countRemainingApplyFailures(inputs, outcomes))
+}
+
+// TestApplyPhase_Run_SharesOneDuplicateTrackerAcrossFiles pins the #224 phase
+// E wiring: the apply phase allocates ONE intra-batch duplicate preflight
+// registry per run and threads it through every file's ApplyCmd.
+func TestApplyPhase_Run_SharesOneDuplicateTrackerAcrossFiles(t *testing.T) {
+	wf := &captureApplyWorkflow{}
+	wf.applyResult = &workflow.ApplyResult{Movie: &models.Movie{ID: "IPX-777"}}
+	inputs := makeApplyInputs(wf)
+	inputs.Concurrency = concurrencyConfig{MaxWorkers: 4, WorkerTimeout: 0}
+	for _, p := range []string{"/source/IPX-777-a.mp4", "/source/IPX-777-b.mp4"} {
+		inputs.Results[p] = &resultstore.MovieResult{
+			FileMatchInfo: models.FileMatchInfo{Path: p, MovieID: "IPX-777"},
+			Status:        models.JobStatusCompleted,
+			Movie:         &models.Movie{ID: "IPX-777", Title: "Test Movie"},
+		}
+	}
+
+	NewApplyPhase().Run(context.Background(), inputs, ApplyPhaseConfig{
+		OrganizeOptions: workflow.OrganizeOptions{MoveFiles: true},
+		MergeOptions:    workflow.MergeOptions{ForceOverwrite: true},
+		Destination:     "/output",
+	})
+
+	cmds := wf.commands()
+	require.Len(t, cmds, 2)
+	require.NotNil(t, cmds[0].Organize.DuplicateTracker)
+	assert.Same(t, cmds[0].Organize.DuplicateTracker, cmds[1].Organize.DuplicateTracker,
+		"one tracker per apply run, shared by every file")
+}
+
+func TestOrganizeMetadataIncludesWarnings(t *testing.T) {
+	result := &workflow.ApplyResult{
+		OrganizeResult: &organizer.OrganizeResult{
+			NewPath:  "/dest/lib/ABC-123.mkv",
+			Warnings: []string{"duplicate destination within batch: /dest/lib/ABC-123.mkv already claimed by /in/A.mkv (overwrite authorized)"},
+		},
+	}
+	meta := organizeMetadata("organize", result)
+	assert.Contains(t, meta, "warnings")
+	assert.Contains(t, meta, "duplicate destination within batch")
+
+	plain := organizeMetadata("organize", &workflow.ApplyResult{OrganizeResult: &organizer.OrganizeResult{NewPath: "/dest/lib/ABC-123.mkv"}})
+	assert.NotContains(t, plain, "warnings", "no warnings key without warning payload")
 }

--- a/internal/worker/history_writer.go
+++ b/internal/worker/history_writer.go
@@ -49,6 +49,9 @@ func organizeMetadata(mode string, result *workflow.ApplyResult) string {
 		"operation_mode": mode,
 		"steps":          json.RawMessage(steps),
 	}
+	if result != nil && result.OrganizeResult != nil && len(result.OrganizeResult.Warnings) > 0 {
+		m["warnings"] = result.OrganizeResult.Warnings
+	}
 	b, err := json.Marshal(m)
 	if err != nil {
 		return "{}"

--- a/internal/workflow/apply_orchestrator.go
+++ b/internal/workflow/apply_orchestrator.go
@@ -19,6 +19,10 @@ import (
 // Unexported — only the composition root (Workflow) uses it.
 type applyOrchestrator interface {
 	Execute(ctx context.Context, cmd ApplyCmd) (*ApplyResult, error)
+	// planDuplicatePriming runs ONLY the organize step's planning half
+	// (read-only) so the apply phase can prime each sorted batch item's
+	// duplicate claim before worker fan-out (#240 finding A).
+	planDuplicatePriming(ctx context.Context, cmd ApplyCmd) (organizer.DuplicatePriming, error)
 }
 
 // applyOrchImpl owns the 6-step Apply sequence: revert begin, organize, merge, DisplayTitle,
@@ -264,6 +268,42 @@ func (o *applyOrchImpl) Execute(ctx context.Context, cmd ApplyCmd) (*ApplyResult
 		Merged:         state.merged,
 		OperationID:    opID,
 		Steps:          steps,
+	}, nil
+}
+
+// planDuplicatePriming computes the organize plan for cmd WITHOUT executing
+// it, mirroring stepOrganize's command assembly. Plans that cannot register
+// a claim — organize skipped, plan error, or an organizer lacking the
+// read-only planning seam — yield no priming; the item's worker then skips
+// execution or fails with the identical plan error.
+func (o *applyOrchImpl) planDuplicatePriming(ctx context.Context, cmd ApplyCmd) (organizer.DuplicatePriming, error) {
+	if cmd.Organize.Skip {
+		return organizer.DuplicatePriming{}, nil
+	}
+	planner, ok := o.organizer.(interface {
+		PlanOrganize(context.Context, organizer.OrganizeCmd) (*organizer.OrganizePlan, error)
+	})
+	if !ok {
+		return organizer.DuplicatePriming{}, nil
+	}
+	plan, err := planner.PlanOrganize(ctx, organizer.OrganizeCmd{
+		Match:           cmd.Match,
+		Movie:           cmd.Movie,
+		DestDir:         cmd.DestPath,
+		ForceUpdate:     cmd.Organize.ForceUpdate,
+		MoveFiles:       cmd.Organize.MoveFiles,
+		LinkMode:        cmd.Organize.LinkMode,
+		DryRun:          cmd.DryRun,
+		OperationMode:   cmd.OperationMode,
+		ForceRenameFile: cmd.Organize.ForceRenameFile,
+	})
+	if err != nil {
+		return organizer.DuplicatePriming{}, err
+	}
+	return organizer.DuplicatePriming{
+		SourcePath: plan.SourcePath,
+		TargetPath: plan.TargetPath,
+		WillMove:   plan.WillMove,
 	}, nil
 }
 
@@ -555,4 +595,8 @@ var _ applyOrchestrator = (*noOpApplyOrchestrator)(nil)
 
 func (noOpApplyOrchestrator) Execute(_ context.Context, _ ApplyCmd) (*ApplyResult, error) {
 	return nil, fmt.Errorf("apply not configured")
+}
+
+func (noOpApplyOrchestrator) planDuplicatePriming(context.Context, ApplyCmd) (organizer.DuplicatePriming, error) {
+	return organizer.DuplicatePriming{}, nil
 }

--- a/internal/workflow/apply_orchestrator.go
+++ b/internal/workflow/apply_orchestrator.go
@@ -270,15 +270,16 @@ func (o *applyOrchImpl) Execute(ctx context.Context, cmd ApplyCmd) (*ApplyResult
 // stepOrganize executes the organize step: move/link files to destination.
 func (o *applyOrchImpl) stepOrganize(ctx context.Context, cmd ApplyCmd, state *applyPipelineState, steps *stepCompletion) error {
 	organizeCmd := organizer.OrganizeCmd{
-		Match:           cmd.Match,
-		Movie:           state.movie,
-		DestDir:         cmd.DestPath,
-		ForceUpdate:     cmd.Organize.ForceUpdate,
-		MoveFiles:       cmd.Organize.MoveFiles,
-		LinkMode:        cmd.Organize.LinkMode,
-		DryRun:          cmd.DryRun,
-		OperationMode:   cmd.OperationMode,
-		ForceRenameFile: cmd.Organize.ForceRenameFile,
+		Match:            cmd.Match,
+		Movie:            state.movie,
+		DestDir:          cmd.DestPath,
+		ForceUpdate:      cmd.Organize.ForceUpdate,
+		MoveFiles:        cmd.Organize.MoveFiles,
+		LinkMode:         cmd.Organize.LinkMode,
+		DryRun:           cmd.DryRun,
+		OperationMode:    cmd.OperationMode,
+		ForceRenameFile:  cmd.Organize.ForceRenameFile,
+		DuplicateTracker: cmd.Organize.DuplicateTracker,
 	}
 	var organizeErr error
 	state.organizeResult, organizeErr = o.organizer.Organize(ctx, organizeCmd)

--- a/internal/workflow/apply_priming_test.go
+++ b/internal/workflow/apply_priming_test.go
@@ -1,0 +1,127 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// primingStubOrganizer implements organizer.OrganizerInterface plus the
+// read-only PlanOrganize seam the workflow's planning leg asserts on.
+type primingStubOrganizer struct {
+	plan    *organizer.OrganizePlan
+	planErr error
+	gotCmd  organizer.OrganizeCmd
+}
+
+func (p *primingStubOrganizer) Organize(context.Context, organizer.OrganizeCmd) (*organizer.OrganizeResult, error) {
+	return &organizer.OrganizeResult{}, nil
+}
+
+func (p *primingStubOrganizer) PlanOrganize(_ context.Context, cmd organizer.OrganizeCmd) (*organizer.OrganizePlan, error) {
+	p.gotCmd = cmd
+	return p.plan, p.planErr
+}
+
+// recordingPrimingOrch is an applyOrchestrator fake recording priming calls.
+type recordingPrimingOrch struct {
+	prim  organizer.DuplicatePriming
+	err   error
+	calls int
+}
+
+func (r *recordingPrimingOrch) Execute(context.Context, ApplyCmd) (*ApplyResult, error) {
+	return &ApplyResult{}, nil
+}
+
+func (r *recordingPrimingOrch) planDuplicatePriming(context.Context, ApplyCmd) (organizer.DuplicatePriming, error) {
+	r.calls++
+	return r.prim, r.err
+}
+
+func TestNoOpApplyOrchestrator_PlanDuplicatePriming(t *testing.T) {
+	prim, err := noOpApplyOrchestrator{}.planDuplicatePriming(context.Background(), ApplyCmd{})
+	assert.NoError(t, err)
+	assert.Equal(t, organizer.DuplicatePriming{}, prim, "an unconfigured apply registers no claims")
+}
+
+func TestApplyOrch_PlanDuplicatePriming(t *testing.T) {
+	ctx := context.Background()
+	cmd := ApplyCmd{
+		Movie:    &models.Movie{ID: "ABC-123"},
+		Match:    models.FileMatchInfo{Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv", MovieID: "ABC-123"},
+		DestPath: "/dest",
+		Organize: OrganizeOptions{MoveFiles: true, ForceUpdate: true, LinkMode: organizer.LinkModeHard, ForceRenameFile: true},
+		DryRun:   true,
+	}
+
+	newOrch := func(org organizer.OrganizerInterface) *applyOrchImpl {
+		return newApplyOrchestrator(afero.NewMemMapFs(), org, nil, nil, nil, ApplyConfig{}, nil, nil, nil, nil)
+	}
+
+	t.Run("skipped organize registers no claim and never plans", func(t *testing.T) {
+		org := &primingStubOrganizer{planErr: errors.New("must not be called")}
+		prim, err := newOrch(org).planDuplicatePriming(ctx, ApplyCmd{Organize: OrganizeOptions{Skip: true}})
+		assert.NoError(t, err)
+		assert.Equal(t, organizer.DuplicatePriming{}, prim)
+		assert.Equal(t, organizer.OrganizeCmd{}, org.gotCmd, "the planner is untouched for skipped runs")
+	})
+
+	t.Run("an organizer without the planning seam registers no claim", func(t *testing.T) {
+		prim, err := newOrch(&stubOrganizer{}).planDuplicatePriming(ctx, cmd)
+		assert.NoError(t, err)
+		assert.Equal(t, organizer.DuplicatePriming{}, prim)
+	})
+
+	t.Run("plan errors propagate", func(t *testing.T) {
+		planErr := errors.New("template boom")
+		_, err := newOrch(&primingStubOrganizer{planErr: planErr}).planDuplicatePriming(ctx, cmd)
+		assert.ErrorIs(t, err, planErr)
+	})
+
+	t.Run("successful planning maps the claim and the mirrored command", func(t *testing.T) {
+		org := &primingStubOrganizer{plan: &organizer.OrganizePlan{
+			SourcePath: "/in/A.mkv", TargetPath: "/dest/ABC-123/ABC-123.mkv", WillMove: true,
+		}}
+		prim, err := newOrch(org).planDuplicatePriming(ctx, cmd)
+		require.NoError(t, err)
+		assert.Equal(t, organizer.DuplicatePriming{
+			SourcePath: "/in/A.mkv",
+			TargetPath: "/dest/ABC-123/ABC-123.mkv",
+			WillMove:   true,
+		}, prim)
+		// The planning command mirrors stepOrganize's assembly — minus the
+		// duplicate tracker itself, which only execution registers against.
+		assert.Equal(t, "/dest", org.gotCmd.DestDir)
+		assert.Equal(t, "/in/A.mkv", org.gotCmd.Match.Path)
+		assert.True(t, org.gotCmd.ForceUpdate)
+		assert.True(t, org.gotCmd.MoveFiles)
+		assert.True(t, org.gotCmd.DryRun)
+		assert.True(t, org.gotCmd.ForceRenameFile)
+		assert.Equal(t, organizer.LinkModeHard, org.gotCmd.LinkMode)
+		assert.Nil(t, org.gotCmd.DuplicateTracker, "planning must not observe against the run's tracker")
+	})
+}
+
+// TestWorkflow_PlanDuplicatePriming_Delegates pins the Workflow composition
+// root routing of the optional priming seam (#240 finding A).
+func TestWorkflow_PlanDuplicatePriming_Delegates(t *testing.T) {
+	rec := &recordingPrimingOrch{
+		prim: organizer.DuplicatePriming{SourcePath: "/in/A.mkv", TargetPath: "/dest/x.mkv", WillMove: true},
+	}
+	w := &Workflow{apply: rec}
+	prim, err := w.PlanDuplicatePriming(context.Background(), ApplyCmd{})
+	require.NoError(t, err)
+	assert.Equal(t, rec.prim, prim)
+	assert.Equal(t, 1, rec.calls, "exactly one delegated planning call")
+
+	rec.err = errors.New("plan boom")
+	_, err = w.PlanDuplicatePriming(context.Background(), ApplyCmd{})
+	assert.ErrorIs(t, err, rec.err)
+}

--- a/internal/workflow/coverage_uncovered_test.go
+++ b/internal/workflow/coverage_uncovered_test.go
@@ -1461,3 +1461,38 @@ func TestCompareOrchImpl_Construction(t *testing.T) {
 	assert.Equal(t, orch.merger, orch.merger)
 	assert.Equal(t, orch.scraper, orch.scraper)
 }
+
+func TestBuildGeneratedFilesJSON_SubtitleCopiedGoesToDelete(t *testing.T) {
+	// #224 phase E mode distinction: a copy-installed subtitle retains its
+	// source, so the revert artifact is the installed copy (Delete), never a
+	// MoveBack that would clobber the retained source.
+	subtitles := []models.SubtitleMove{
+		{OriginalPath: "/source/sub1.srt", NewPath: "/dest/sub1.srt", Copied: true},
+	}
+	result := buildGeneratedFilesJSON(logging.GlobalLogger(), "", subtitles, nil)
+	require.NotEmpty(t, result)
+	gf, err := models.ParseGeneratedFiles(result)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/dest/sub1.srt"}, gf.Delete)
+	assert.Empty(t, gf.MoveBack)
+}
+
+func TestBuildGeneratedFilesJSON_SubtitleCopiedEmptyNewPath(t *testing.T) {
+	subtitles := []models.SubtitleMove{{OriginalPath: "/source/sub1.srt", NewPath: "", Copied: true}}
+	result := buildGeneratedFilesJSON(logging.GlobalLogger(), "", subtitles, nil)
+	assert.Empty(t, result, "copied subtitle without a destination has no revert artifact")
+}
+
+func TestBuildGeneratedFilesJSON_SubtitleCopiedAndMovedMix(t *testing.T) {
+	subtitles := []models.SubtitleMove{
+		{OriginalPath: "/source/m.srt", NewPath: "/dest/m.srt", Moved: true},
+		{OriginalPath: "/source/c.srt", NewPath: "/dest/c.srt", Copied: true},
+	}
+	result := buildGeneratedFilesJSON(logging.GlobalLogger(), "", subtitles, nil)
+	require.NotEmpty(t, result)
+	gf, err := models.ParseGeneratedFiles(result)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/dest/c.srt"}, gf.Delete)
+	require.Len(t, gf.MoveBack, 1)
+	assert.Equal(t, models.FileMove{OriginalPath: "/source/m.srt", NewPath: "/dest/m.srt"}, gf.MoveBack[0])
+}

--- a/internal/workflow/interfaces.go
+++ b/internal/workflow/interfaces.go
@@ -23,7 +23,9 @@ type OrganizeOptions struct {
 	ForceRenameFile bool
 	// DuplicateTracker carries the batch run's intra-batch duplicate
 	// preflight registry into every file's plan (#224 phase E). The apply
-	// phase allocates one per run; nil disables detection.
+	// phase allocates one per run (non-probing for dry runs, #240 finding B),
+	// primes it in sorted order before fan-out (#240 finding A); nil disables
+	// detection.
 	DuplicateTracker *organizer.DuplicateTracker
 }
 
@@ -128,6 +130,17 @@ type PreviewResult struct {
 	TrailerPath     string
 	SourcePath      string
 	OperationMode   operationmode.OperationMode
+}
+
+// DuplicatePrimingPlanner is the OPTIONAL workflow capability the apply
+// phase discovers by type assertion to pre-assign deterministic intra-batch
+// duplicate owners (#240 finding A): for each sorted batch item the phase
+// calls PlanDuplicatePriming exactly once BEFORE worker fan-out and primes
+// the run's duplicate tracker with the returned claims in that sorted order.
+// Workflows that do not implement it keep first-come duplicate observation
+// (single-item or otherwise unprimed runs only).
+type DuplicatePrimingPlanner interface {
+	PlanDuplicatePriming(ctx context.Context, cmd ApplyCmd) (organizer.DuplicatePriming, error)
 }
 
 // WorkflowInterface exposes the high-level scrape, apply, preview, compare, and scan workflows.

--- a/internal/workflow/interfaces.go
+++ b/internal/workflow/interfaces.go
@@ -21,6 +21,10 @@ type OrganizeOptions struct {
 	LinkMode        organizer.LinkMode // resolved at factory boundary, not inside orchestrator
 	ForceUpdate     bool
 	ForceRenameFile bool
+	// DuplicateTracker carries the batch run's intra-batch duplicate
+	// preflight registry into every file's plan (#224 phase E). The apply
+	// phase allocates one per run; nil disables detection.
+	DuplicateTracker *organizer.DuplicateTracker
 }
 
 // MergeOptions controls the NFO merge step within Apply.

--- a/internal/workflow/revert_log.go
+++ b/internal/workflow/revert_log.go
@@ -326,7 +326,13 @@ func buildGeneratedFilesJSON(logger logging.Logger, nfoPath string, subtitleMove
 	if len(subtitleMoves) > 0 {
 		moveBackList := make([]models.FileMove, 0, len(subtitleMoves))
 		for _, sr := range subtitleMoves {
-			if sr.Moved && sr.OriginalPath != "" && sr.NewPath != "" {
+			switch {
+			// #224 phase E mode distinction: a copy-installed subtitle retains
+			// its source, so the revert artifact is the installed copy (delete
+			// it); only a move-installed subtitle moves back.
+			case sr.Copied && sr.NewPath != "":
+				gf.Delete = append(gf.Delete, sr.NewPath)
+			case sr.Moved && sr.OriginalPath != "" && sr.NewPath != "":
 				moveBackList = append(moveBackList, models.FileMove{OriginalPath: sr.OriginalPath, NewPath: sr.NewPath})
 			}
 		}
@@ -590,7 +596,7 @@ func (l *dbRevertLog) Complete(ctx context.Context, opID OperationID, result *Ap
 		newPath = result.OrganizeResult.NewPath
 		inPlaceRenamed = result.OrganizeResult.InPlaceRenamed
 		for _, sr := range result.OrganizeResult.Subtitles {
-			if sr.Moved {
+			if sr.Moved || sr.Copied {
 				subtitles = append(subtitles, sr.SubtitleMove)
 			}
 		}
@@ -677,7 +683,7 @@ func (l *dbRevertLog) CompleteFailed(ctx context.Context, opID OperationID, resu
 		newPath = result.OrganizeResult.NewPath
 		inPlaceRenamed = result.OrganizeResult.InPlaceRenamed
 		for _, sr := range result.OrganizeResult.Subtitles {
-			if sr.Moved {
+			if sr.Moved || sr.Copied {
 				subtitles = append(subtitles, sr.SubtitleMove)
 			}
 		}

--- a/internal/workflow/revert_log_complete_journal_w9_test.go
+++ b/internal/workflow/revert_log_complete_journal_w9_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/mocks"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -312,4 +313,76 @@ func TestW9CompleteThenCompleteFailedKeepsFailedStatus(t *testing.T) {
 	require.Equal(t, "/dst/flip/poster.jpg", gf.Replacements[0].Destination)
 	require.Contains(t, gf.Roots, "/dst/flip", "the completed root survives")
 	require.Contains(t, gf.Delete, "/dst/flip/final.nfo", "the latest payload merges against the fresh row")
+}
+
+// TestW9CompleteJournalsCopiedSubtitlesAsDelete pins the #224 phase E
+// copy/move distinction at the Complete journal boundary: copy-installed
+// subtitles join Delete (their source was retained), move-installed join
+// MoveBack, skipped/planned entries journal nothing.
+func TestW9CompleteJournalsCopiedSubtitlesAsDelete(t *testing.T) {
+	repo := mocks.NewMockBatchFileOperationRepositoryInterface(t)
+	log := NewDBRevertLog(repo, nil, "job-w9", nil, nil, nil, nil)
+
+	var txPersisted string
+	repo.On("FindByID", mock.Anything, uint(11)).Return(&models.BatchFileOperation{
+		ID: 11, BatchJobID: "job-w9", MovieID: "W9-011",
+		RevertStatus: models.RevertStatusApplied,
+	}, nil)
+	runFnMock(repo, 11, &models.BatchFileOperation{ID: 11, RevertStatus: models.RevertStatusApplied}, &txPersisted)
+	repo.On("UpdateNonJournalFields", mock.Anything, mock.AnythingOfType("*models.BatchFileOperation")).Return(nil)
+
+	err := log.Complete(context.Background(), "11", &ApplyResult{
+		Movie: &models.Movie{ID: "W9-011"},
+		OrganizeResult: &organizer.OrganizeResult{
+			NewPath:    "/dst/w9-011.mp4",
+			FolderPath: "/dst/lib",
+			Subtitles: []organizer.SubtitleResult{
+				{SubtitleMove: models.SubtitleMove{OriginalPath: "/src/m.srt", NewPath: "/dst/lib/m.srt", Moved: true}},
+				{SubtitleMove: models.SubtitleMove{OriginalPath: "/src/c.srt", NewPath: "/dst/lib/c.srt", Copied: true}},
+				{SubtitleMove: models.SubtitleMove{OriginalPath: "/src/s.srt", NewPath: "/dst/lib/s.srt"}, Skipped: true},
+				{SubtitleMove: models.SubtitleMove{OriginalPath: "/src/p.srt", NewPath: "/dst/lib/p.srt"}, Planned: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	gf, perr := models.ParseGeneratedFiles(txPersisted)
+	require.NoError(t, perr)
+	assert.Equal(t, []string{"/dst/lib/c.srt"}, gf.Delete)
+	require.Len(t, gf.MoveBack, 1)
+	assert.Equal(t, models.FileMove{OriginalPath: "/src/m.srt", NewPath: "/dst/lib/m.srt"}, gf.MoveBack[0])
+}
+
+// TestW9CompleteFailedJournalsCopiedSubtitlesAsDelete is the CompleteFailed
+// twin of the #224 phase E journal boundary.
+func TestW9CompleteFailedJournalsCopiedSubtitlesAsDelete(t *testing.T) {
+	repo := mocks.NewMockBatchFileOperationRepositoryInterface(t)
+	log := NewDBRevertLog(repo, nil, "job-w9", nil, nil, nil, nil)
+
+	var txPersisted string
+	var saved models.BatchFileOperation
+	repo.On("FindByID", mock.Anything, uint(12)).Return(&models.BatchFileOperation{
+		ID: 12, BatchJobID: "job-w9", MovieID: "W9-012",
+		RevertStatus: models.RevertStatusApplied,
+	}, nil)
+	runFnMock(repo, 12, &models.BatchFileOperation{ID: 12, RevertStatus: models.RevertStatusApplied}, &txPersisted)
+	repo.On("UpdateNonJournalFields", mock.Anything, mock.AnythingOfType("*models.BatchFileOperation")).
+		Run(func(args mock.Arguments) { saved = *args.Get(1).(*models.BatchFileOperation) }).Return(nil)
+
+	err := log.CompleteFailed(context.Background(), "12", &ApplyResult{
+		Movie: &models.Movie{ID: "W9-012"},
+		OrganizeResult: &organizer.OrganizeResult{
+			NewPath: "/dst/w9-012.mp4",
+			Subtitles: []organizer.SubtitleResult{
+				{SubtitleMove: models.SubtitleMove{OriginalPath: "/src/c.srt", NewPath: "/dst/lib/c.srt", Copied: true}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	gf, perr := models.ParseGeneratedFiles(txPersisted)
+	require.NoError(t, perr)
+	assert.Equal(t, []string{"/dst/lib/c.srt"}, gf.Delete)
+	assert.Empty(t, gf.MoveBack)
+	assert.Equal(t, models.RevertStatusFailed, saved.RevertStatus)
 }

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 
+	"github.com/javinizer/javinizer-go/internal/organizer"
 	"github.com/javinizer/javinizer-go/internal/scrape"
 )
 
@@ -29,6 +30,15 @@ func (w *Workflow) Scrape(ctx context.Context, cmd scrape.ScrapeCmd) (*scrape.Sc
 func (w *Workflow) Apply(ctx context.Context, cmd ApplyCmd) (*ApplyResult, error) {
 	return w.apply.Execute(ctx, cmd)
 }
+
+// PlanDuplicatePriming delegates to the apply orchestrator's read-only
+// organizing-plan leg so the apply phase can pre-assign deterministic
+// duplicate winners before fan-out (#240 finding A).
+func (w *Workflow) PlanDuplicatePriming(ctx context.Context, cmd ApplyCmd) (organizer.DuplicatePriming, error) {
+	return w.apply.planDuplicatePriming(ctx, cmd)
+}
+
+var _ DuplicatePrimingPlanner = (*Workflow)(nil)
 
 // Compare delegates to the internal compareOrchestrator which owns the compare pipeline:
 // parse NFO, scrape fresh, merge.


### PR DESCRIPTION
## Summary

Issue #224 phase E — dry-run intra-batch duplicate preflight + subtitle result-mode semantics. **Stacked on #239 (`feat/organize-phase-d`); will retarget to `main` once that merges.**

**Duplicate preflight (plan-only, planner side):**
- `DuplicateTracker` (batch-scoped) groups plans by **proven-equal** canonical destination keys via `fsutil.DestKeyResolver` — same folded-key discipline as `SharedDestLocks`; per-root case-sensitivity postures frozen per run; casefold/multipart-cdN/spelling-variant grouping pinned.
- New reserved `ConflictDuplicate` kind: unauthorized duplicates append `PlanConflict{Kind: ConflictDuplicate}` and short-circuit through the **identical** failure pipeline (conflict error strings byte-identical to occupied-destination failures — pinned). Authorized (force) duplicates demote to `OrganizeResult.Warnings`.
- Threaded one tracker per apply run through `worker.ApplyPhase.Run` → CLI sort/update dry-run and API batch alike.
- Persistence reuses existing plumbing: warnings ride per-file history row `Metadata` JSON; each warning emits a `SeverityWarn` eventlog audit entry in the existing post-apply lane. No new tables/columns, no API contract change (dry-run renders via the existing conflict surface).

**Subtitle semantics:**
- Skip-on-exists race-hardening pinned for **both** entry points: move leg (`MoveFileNoReplace`) and copy leg (`CopyFileNoReplace`) each skip-on-exists; `ForceUpdate` never authorizes over subtitle destinations (6-way matrix test).
- Mode-aware results: `models.SubtitleMove.Copied` / `SubtitleResult`; revert journal now routes copied subtitles to `Delete` instead of `MoveBack`, fixing a latent clobber-on-revert of the retained source.
- Removed dead `subtitleHandler.MoveSubtitles` (test-only seam).

**Scoped out**: CLI console rendering of these warnings; cross-movie duplicates on the per-movie preview endpoint; legacy test-only `o.execute()` seam.

Advances #224 (phase E; remaining #224 item is multipart-detection hardening, blocked on reporter samples).

## Test plan
- [x] Duplicate grouping (casefold postures, variants, cdN, idempotence, third-claim, 64-goroutine concurrency); conflict-equivalence + authorized-warning persistence + audit tests
- [x] `go test ./internal/organizer/ ./internal/fsutil/ ./internal/worker/ ./internal/workflow/ ./internal/api/batch/` + `-race` (organizer/worker) — green; `go test -short ./...` full repo green
- [x] All new/changed statements at 100% function-block coverage