### PR TITLE
fix(cli): carry multipart part-suffix into sort planning

### DIFF
--- a/internal/commandutil/batch_command.go
+++ b/internal/commandutil/batch_command.go
@@ -207,13 +207,22 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 		return nil
 	}
 
-	// Extract file paths with matched IDs
+	// Extract file paths with matched IDs, keeping the per-file match metadata.
+	// ScanAndMatch derives IsMultiPart / PartNumber / PartSuffix from the
+	// directory listing; the scrape + apply phases plan part-suffixed targets
+	// (<PARTSUFFIX> / multipart NFO + media layout) from FileMatchInfo, so the
+	// map must reach the job below — discarding it collapses every part of a
+	// multi-part file onto the same destination. Mirrors the API organize
+	// usecase, which seeds ScrapePhaseConfig.FileMatchInfo from
+	// discoverSiblingPartsWithMetadata (internal/api/batch/usecases.go).
 	filePaths := make([]string, 0)
 	uniqueIDs := make(map[string]bool)
+	matchInfo := make(map[string]models.FileMatchInfo, len(scanResult.Files))
 	for _, fmi := range scanResult.Files {
 		if fmi.MovieID != "" {
 			filePaths = append(filePaths, fmi.Path)
 			uniqueIDs[fmi.MovieID] = true
+			matchInfo[fmi.Path] = fmi
 		}
 	}
 	if len(filePaths) == 0 {
@@ -263,8 +272,14 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 			ArrayStrategy:  opts.Resolved.ArrayStrategy,
 		},
 	}
+	scrapeCfg := factory.NewScrapeConfig(opts.ScraperPriority, false, opts.ForceRefresh)
+	// Carry the scan/match metadata into the job: StartScrape seeds the
+	// result store from ScrapePhaseConfig.FileMatchInfo, and buildApplyCmd
+	// reads PartSuffix/PartNumber/IsMultiPart back out of the per-file result
+	// when planning organize destinations.
+	scrapeCfg.FileMatchInfo = matchInfo
 	job.SetRunOptions(
-		factory.NewScrapeConfig(opts.ScraperPriority, false, opts.ForceRefresh),
+		scrapeCfg,
 		applyOpts.ToApplyPhaseConfig(),
 	)
 

--- a/internal/commandutil/multipart_partsuffix_test.go
+++ b/internal/commandutil/multipart_partsuffix_test.go
@@ -1,0 +1,138 @@
+package commandutil
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression pins for the CLI multipart part-suffix drop.
+//
+// Bug: RunBatchCommand discarded the per-file match metadata that
+// ScanAndMatch produced (IsMultiPart / PartNumber / PartSuffix) and never
+// seeded ScrapePhaseConfig.FileMatchInfo — unlike the API organize usecase
+// (internal/api/batch/usecases.go). The apply phase therefore planned every
+// part of a multi-part library onto the SAME destination
+// (dest/GOOD-701/GOOD-701.mp4 for GOOD-701-cd1/2/3), and parts cd2/cd3 hit
+// "organization validation failed" conflicts even though the matcher had
+// detected the explicit -cdN parts correctly.
+//
+// Fix being pinned: the scan/match metadata map now flows into the batch job
+// via ScrapePhaseConfig.FileMatchInfo, so the sort pipeline honors part info
+// exactly like batch apply does.
+//
+// The JAVINIZER_E2E_SCRAPERS seam (Bootstrap substitutes the offline
+// e2emock scraper for GOOD-* IDs) keeps these tests deterministic and
+// network-free, exercising the real scan → match → scrape → apply chain.
+func setupMultipartPartSuffixChain(t *testing.T) (configPath, src, dest string) {
+	t.Helper()
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+
+	tmpDir := t.TempDir()
+	src = filepath.Join(tmpDir, "lib")
+	dest = filepath.Join(tmpDir, "dest")
+	require.NoError(t, os.MkdirAll(src, 0o700))
+	require.NoError(t, os.MkdirAll(dest, 0o700))
+	for _, part := range []string{"cd1", "cd2", "cd3"} {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(src, "GOOD-701-"+part+".mp4"), []byte("fake video"), 0o600))
+	}
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.Database.DSN = filepath.Join(tmpDir, "javinizer.db")
+	cfg.Matching.Extensions = []string{".mp4"}
+	cfg.Matching.MinSizeMB = 0
+	cfg.Output.Template.FolderFormat = "<ID>"
+	cfg.Output.Template.SubfolderFormat = []string{}
+	cfg.Output.Template.FileFormat = "<ID><PARTSUFFIX>"
+	cfg.Output.Operation.RenameFile = true
+	// e2emock media URLs are non-resolvable (e2e.invalid); downloads are
+	// irrelevant to the plan/drop being pinned, so turn them all off.
+	cfg.Output.Download.DownloadCover = false
+	cfg.Output.Download.DownloadPoster = false
+	cfg.Output.Download.DownloadExtrafanart = false
+	cfg.Output.Download.DownloadTrailer = false
+	cfg.Output.Download.DownloadActress = false
+
+	configPath = filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, config.Save(cfg, configPath))
+	return configPath, src, dest
+}
+
+// TestRunBatchCommand_MultipartPartSuffix_DryRunPlansDistinctTargets pins the
+// dry-run plan leg: all three parts must plan cleanly to distinct targets, so
+// the plan render shows zero conflicts and "Would organize 3 file(s)".
+func TestRunBatchCommand_MultipartPartSuffix_DryRunPlansDistinctTargets(t *testing.T) {
+	configPath, src, dest := setupMultipartPartSuffixChain(t)
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   src,
+		Destination:  dest,
+		DryRun:       true,
+		MoveFiles:    true,
+		GenerateNFO:  false,
+		CommandLabel: "Javinizer Sort",
+		ActionVerb:   "Processing files",
+		Resolved:     &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+
+	// Pre-fix this printed two conflict lines because cd2/cd3 re-planned onto
+	// the bare dest/GOOD-701/GOOD-701.mp4 that cd1 claimed.
+	assert.NotContains(t, out, "Apply failed",
+		"no part may conflict on the planned destination\n%s", out)
+	assert.Contains(t, out, "Would organize 3 file(s)",
+		"all three -cdN parts must plan\n%s", out)
+
+	// Dry-run is a preview: nothing moved, nothing created at the destination.
+	for _, part := range []string{"cd1", "cd2", "cd3"} {
+		assert.FileExists(t, filepath.Join(src, "GOOD-701-"+part+".mp4"))
+	}
+	entries, err := os.ReadDir(dest)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "dry-run must not create organized output")
+}
+
+// TestRunBatchCommand_MultipartPartSuffix_LiveMovesToDistinctTargets pins the
+// apply leg: each part lands at its own <ID><PARTSUFFIX> target and the
+// sources are consumed by the move.
+func TestRunBatchCommand_MultipartPartSuffix_LiveMovesToDistinctTargets(t *testing.T) {
+	configPath, src, dest := setupMultipartPartSuffixChain(t)
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   src,
+		Destination:  dest,
+		DryRun:       false,
+		MoveFiles:    true,
+		GenerateNFO:  false,
+		CommandLabel: "Javinizer Sort",
+		ActionVerb:   "Processing files",
+		Resolved:     &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+
+	assert.NotContains(t, out, "Apply failed", "no part may conflict on apply\n%s", out)
+	assert.Contains(t, out, "Organized 3 file(s)",
+		"all three -cdN parts must apply\n%s", out)
+
+	for _, part := range []string{"cd1", "cd2", "cd3"} {
+		assert.FileExists(t, filepath.Join(dest, "GOOD-701", "GOOD-701-"+part+".mp4"),
+			"part %s must land at its part-suffixed target\n%s", part, out)
+	}
+	entries, err := os.ReadDir(src)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "--move consumed the sources")
+}

--- a/test/e2e/cli/cli_e2e_test.go
+++ b/test/e2e/cli/cli_e2e_test.go
@@ -243,6 +243,109 @@ func TestCLI_Sort_Multipart(t *testing.T) {
 	assert.Contains(t, string(nfo), "E2E Movie MULTI-001", "NFO carries scraped title\n%s", nfo)
 }
 
+// writePartSuffixConfig mirrors writeConfig but uses file_format
+// "<ID><PARTSUFFIX>" and leaves the custom regex off (regex_enabled: false) so
+// the built-in matcher + cd-suffix detection own the match — the exact shape
+// of the reported bug's library (GOOD-701-cd1/2/3 planned onto the same
+// destination).
+func writePartSuffixConfig(t *testing.T, dir string) string {
+	t.Helper()
+	cfg := `config_version: 3
+
+file_matching:
+    extensions:
+        - .mp4
+        - .mkv
+    regex_enabled: false
+
+output:
+    folder_format: "<ID>"
+    subfolder_format: []
+    file_format: "<ID><PARTSUFFIX>"
+    rename_file: true
+    download_cover: false
+    download_poster: false
+    download_extrafanart: false
+    download_trailer: false
+    download_actress: false
+    download_timeout: 5
+
+metadata:
+    nfo:
+        feature:
+            enabled: true
+        format:
+            filename_template: <ID><PARTSUFFIX>.nfo
+
+database:
+    type: sqlite
+    dsn: ` + filepath.Join(dir, "javinizer.db") + `
+    log_level: silent
+
+logging:
+    level: error
+`
+	p := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(cfg), 0o600))
+	return p
+}
+
+// TestCLI_Sort_Multipart_PartSuffixTargets pins the fix for the CLI
+// part-suffix drop (fix/cli-part-suffix-drop): RunBatchCommand must carry the
+// ScanAndMatch per-file metadata (IsMultiPart / PartNumber / PartSuffix) into
+// the batch job so the apply phase plans <PARTSUFFIX>-suffixed destinations.
+// Pre-fix, all of GOOD-701-cd1/2/3 planned onto dest/GOOD-701/GOOD-701.mp4 —
+// cd1 applied, cd2/cd3 conflicted as "organization validation failed".
+//
+// Both legs are asserted:
+//   - dry-run: zero "Apply failed" conflicts, "Would organize 3 file(s)",
+//     and nothing is moved or created;
+//   - live: all three parts land at distinct GOOD-701-cdN targets.
+func TestCLI_Sort_Multipart_PartSuffixTargets(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writePartSuffixConfig(t, dir)
+	src := filepath.Join(dir, "lib")
+	dest := filepath.Join(dir, "dest")
+	require.NoError(t, os.MkdirAll(src, 0o700))
+	require.NoError(t, os.MkdirAll(dest, 0o700))
+	for _, part := range []string{"cd1", "cd2", "cd3"} {
+		writeFile(t, filepath.Join(src, "GOOD-701-"+part+".mp4"))
+	}
+
+	t.Run("dry-run plans distinct targets", func(t *testing.T) {
+		out, code := run(t, cfgPath, "sort", "--dry-run", "--move", src, "--dest", dest)
+		require.Equal(t, 0, code, "dry-run sort exited %d\n%s", code, out)
+		assert.NotContains(t, out, "Apply failed",
+			"no part may conflict on the planned destination\n%s", out)
+		assert.Contains(t, out, "Would organize 3 file(s)",
+			"all three -cdN parts must plan\n%s", out)
+		for _, part := range []string{"cd1", "cd2", "cd3"} {
+			assert.FileExists(t, filepath.Join(src, "GOOD-701-"+part+".mp4"),
+				"dry-run must not move sources\n%s", out)
+		}
+		entries, err := os.ReadDir(dest)
+		require.NoError(t, err)
+		assert.Empty(t, entries, "dry-run must not create organized output\n%s", out)
+	})
+
+	t.Run("live moves to part-suffixed targets", func(t *testing.T) {
+		out, code := run(t, cfgPath, "sort", "--move", src, "--dest", dest)
+		require.Equal(t, 0, code, "live sort exited %d\n%s", code, out)
+		assert.Contains(t, out, "Sort complete!")
+		assert.NotContains(t, out, "Apply failed", "no part may conflict on apply\n%s", out)
+		assert.Contains(t, out, "Organized 3 file(s)",
+			"all three -cdN parts must apply\n%s", out)
+		for _, part := range []string{"cd1", "cd2", "cd3"} {
+			assert.FileExists(t,
+				filepath.Join(dest, "GOOD-701", "GOOD-701-"+part+".mp4"),
+				"part %s must land at its part-suffixed target\n%s", part, out)
+		}
+		entries, err := os.ReadDir(src)
+		require.NoError(t, err)
+		assert.Empty(t, entries, "--move consumed the sources\n%s", out)
+	})
+}
+
 // TestCLI_DryRun confirms --dry-run previews the operation without moving
 // files or writing an NFO. Guards against a regression where dry-run silently
 // mutates the filesystem.


### PR DESCRIPTION
## Summary

Smoke-testing the merged #224 work (`main` @ `537906464`) with the real CLI over the offline `e2emock` scrapers surfaced a functional gap: **CLI `sort` on multi-part files loses the part info before planning**, so every part of a multi-part movie renders the same destination (`<ID>.mp4`) — parts 2..N then conflict onto part 1's target and fail loudly instead of organizing.

Root cause (`internal/commandutil/batch_command.go`): `RunBatchCommand` uses `ScanAndMatch` results only for the file list; the batch job config never receives the `FileMatchInfo` map (unlike the API batch, which seeds it at `internal/api/batch/usecases.go:263`). The scrape phase's zero-value fallback then re-derives IDs via `Matcher.MatchString` — an ID-only call with no part granularity.

Fix: build `matchInfo[path] = fmi` from `scanResult.Files` and seed `scrapeCfg.FileMatchInfo` before `SetRunOptions` — parity with the API seam.

## Behavior

Before: `GOOD-701-cd1.mp4`, `GOOD-701-cd2.mp4`, `GOOD-701-cd3.mp4` → one applied to `dest/GOOD-701/GOOD-701.mp4`, two conflicts.

After: `GOOD-701-cd1.mp4` → `-cd1.mp4`, `…-cd2.mp4`, `…-cd3.mp4` — all three apply, zero conflicts, NFO per family semantics unchanged.

## Test plan
- [x] `internal/commandutil/multipart_partsuffix_test.go` — drives the real scan→match→mock-scrape→apply chain (dry-run asserts no conflicts + nothing moved; live asserts three distinct part-suffixed targets); verified red on main.
- [x] `test/e2e/cli`: `TestCLI_Sort_Multipart_PartSuffixTargets` — real binary, dry-run + live legs.
- [x] `go test -short ./...` + `-race` on matcher/scanner/worker/workflow — green; `make coverage-patch-strict` PASSED (100%).

Found by the #224 smoke verification; follow-up for the remaining smoke findings (CLI warning persistence, dry-run ledger rows) is split across dedicated issues.