### PR TITLE
fix(workflow): skip revert journaling in dry-run + dedupe duplicate-path message

### DIFF
--- a/internal/organizer/conflict.go
+++ b/internal/organizer/conflict.go
@@ -103,13 +103,32 @@ func refuseIfUnsuppressibleAuthorizedDestination(fs afero.Fs, src, dst string) (
 	return false, false, fmt.Errorf("cannot authorize-over a %s destination (refusing to replace): %s", c.Conflict.kindName(), c.Conflict.Path)
 }
 
-// joinPlanConflictPaths joins conflict paths with "; " matching today's plan
-// rendering (bare paths, in order). PlanConflict.String() renders a bare
-// path; conflict semantics live in Kind.
-func joinPlanConflictPaths(cs []PlanConflict) string {
-	paths := make([]string, 0, len(cs))
+// distinctConflictRenders returns each conflict's rendered form exactly once,
+// first occurrence kept, zero/all/one surviving untouched. #246: an
+// unauthorized intra-batch duplicate of an on-disk-OCCUPIED destination
+// records TWO conflicts whose bare-path renders are identical (the
+// destination-occupation PlanConflict plus the appended ConflictDuplicate),
+// and composing both into the failure message printed the destination twice.
+// Semantics of every distinct conflict stay on the Kind list — only the
+// message render dedupes, so a genuinely twice-relevant destination still
+// blocks through plan.Conflicts exactly as before.
+func distinctConflictRenders(cs []PlanConflict) []string {
+	seen := make(map[string]struct{}, len(cs))
+	out := make([]string, 0, len(cs))
 	for _, c := range cs {
-		paths = append(paths, c.String())
+		s := c.String()
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
 	}
-	return strings.Join(paths, "; ")
+	return out
+}
+
+// joinPlanConflictPaths joins conflict paths with "; " matching today's plan
+// rendering (bare paths, in order, deduplicated per #246). PlanConflict.String()
+// renders a bare path; conflict semantics live in Kind.
+func joinPlanConflictPaths(cs []PlanConflict) string {
+	return strings.Join(distinctConflictRenders(cs), "; ")
 }

--- a/internal/organizer/conflict_render_w246_test.go
+++ b/internal/organizer/conflict_render_w246_test.go
@@ -1,0 +1,118 @@
+package organizer
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+// Issue #246: an unauthorized duplicate of an on-disk-OCCUPIED destination
+// composed two identical bare-path renders into the failure message (the
+// destination-occupation PlanConflict + the appended ConflictDuplicate), e.g.
+// "organization validation failed: [/dest/X/Y.mp4 /dest/X/Y.mp4]". The render
+// dedupes at composition level; every conflict's semantics stay unchanged.
+
+const w246Dest = "/dest/ABC-123/ABC-123.mkv"
+
+func TestDistinctConflictRenders_DedupesIdenticalPaths(t *testing.T) {
+	t.Run("identical renders collapse once, order stable", func(t *testing.T) {
+		cs := []PlanConflict{
+			{Path: w246Dest, Kind: ConflictFile},
+			{Path: w246Dest, Kind: ConflictDuplicate},
+			{Path: "/dest/other.mkv", Kind: ConflictFile},
+		}
+		assert.Equal(t, []string{w246Dest, "/dest/other.mkv"}, distinctConflictRenders(cs))
+	})
+
+	t.Run("empty and singleton pass through", func(t *testing.T) {
+		assert.Empty(t, distinctConflictRenders(nil))
+		assert.Equal(t, []string{w246Dest}, distinctConflictRenders([]PlanConflict{{Path: w246Dest, Kind: ConflictSymlink}}))
+	})
+
+	t.Run("joinPlanConflictPaths renders a doubled path once", func(t *testing.T) {
+		cs := []PlanConflict{
+			{Path: w246Dest, Kind: ConflictFile},
+			{Path: w246Dest, Kind: ConflictDuplicate},
+		}
+		assert.Equal(t, w246Dest, joinPlanConflictPaths(cs))
+	})
+}
+
+func TestValidatePlan_DedupesIdenticalConflictPaths(t *testing.T) {
+	org, _ := dupBatchFixture(t)
+	plan := &OrganizePlan{
+		SourcePath: "/in/B.mkv",
+		TargetDir:  "/dest/ABC-123",
+		TargetFile: "ABC-123.mkv",
+		TargetPath: w246Dest,
+		WillMove:   true,
+		Conflicts: []PlanConflict{
+			{Path: w246Dest, Kind: ConflictFile},
+			{Path: w246Dest, Kind: ConflictDuplicate},
+		},
+	}
+	assert.Equal(t, []string{w246Dest}, org.validatePlan(plan), "the doubled render collapses to one issue line")
+}
+
+// Pin the dup-only conflict render: exact full message, destination once.
+func TestOrganize_UnauthorizedDuplicateConflictRendersDestinationOnce(t *testing.T) {
+	forceCasePosture(t, true)
+	org, _ := dupBatchFixture(t)
+	tracker := NewDuplicateTracker(true)
+
+	_, err := org.Organize(context.Background(), dupBatchCmd(
+		models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}, tracker, false, true))
+	require.NoError(t, err)
+
+	_, dupErr := org.Organize(context.Background(), dupBatchCmd(
+		models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, tracker, false, true))
+	require.Error(t, dupErr)
+	assert.Equal(t, "organization validation failed: ["+w246Dest+"]", dupErr.Error())
+	assert.Equal(t, 1, strings.Count(dupErr.Error(), w246Dest))
+}
+
+// Pin the occupied-dest conflict render: exact full message, destination once.
+func TestOrganize_OccupiedDestinationConflictRendersDestinationOnce(t *testing.T) {
+	forceCasePosture(t, true)
+	org, fs := dupBatchFixture(t)
+	require.NoError(t, fs.MkdirAll("/dest/ABC-123", 0o755))
+	require.NoError(t, afero.WriteFile(fs, w246Dest, []byte("foreign"), 0o644))
+
+	_, occErr := org.Organize(context.Background(), dupBatchCmd(
+		models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, NewDuplicateTracker(true), false, true))
+	require.Error(t, occErr)
+	assert.Equal(t, "organization validation failed: ["+w246Dest+"]", occErr.Error())
+	assert.Equal(t, 1, strings.Count(occErr.Error(), w246Dest))
+}
+
+// The #246 reproduction: destination occupied on disk AND batch-claimed. The
+// unauthorized loser carries BOTH PlanConflicts (occupation + duplicate) with
+// identical renders — the composed message must still print the path once.
+func TestOrganize_DuplicateOfOccupiedDestinationRendersDestinationOnce(t *testing.T) {
+	forceCasePosture(t, true)
+	org, fs := dupBatchFixture(t)
+	require.NoError(t, fs.MkdirAll("/dest/ABC-123", 0o755))
+	require.NoError(t, afero.WriteFile(fs, w246Dest, []byte("foreign"), 0o644))
+	tracker := NewDuplicateTracker(true)
+
+	// A claims the destination key with overwrite authorization (its
+	// ConflictFile is suppressed), settling the claim on the occupied target.
+	_, err := org.Organize(context.Background(), dupBatchCmd(
+		models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}, tracker, true, true))
+	require.NoError(t, err)
+
+	// B is unauthorized AND disk-occupied: pre-fix this rendered the doubled
+	// "organization validation failed: ["+dest+" "+dest+"]".
+	_, combErr := org.Organize(context.Background(), dupBatchCmd(
+		models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, tracker, false, true))
+	require.Error(t, combErr)
+	assert.Equal(t, "organization validation failed: ["+w246Dest+"]", combErr.Error())
+	assert.Equal(t, 1, strings.Count(combErr.Error(), w246Dest),
+		"occupation + duplicate conflicts render the destination once")
+}

--- a/internal/organizer/conflict_render_w246_test.go
+++ b/internal/organizer/conflict_render_w246_test.go
@@ -2,6 +2,7 @@ package organizer
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -19,6 +20,11 @@ import (
 // dedupes at composition level; every conflict's semantics stay unchanged.
 
 const w246Dest = "/dest/ABC-123/ABC-123.mkv"
+
+// w246Slash slash-normalizes produced paths/messages so assertions against the
+// "/dest/..." literals stay separator-portable: on Windows the planner's
+// filepath.Join renders the destination with '\'.
+func w246Slash(s string) string { return filepath.ToSlash(s) }
 
 func TestDistinctConflictRenders_DedupesIdenticalPaths(t *testing.T) {
 	t.Run("identical renders collapse once, order stable", func(t *testing.T) {
@@ -73,8 +79,8 @@ func TestOrganize_UnauthorizedDuplicateConflictRendersDestinationOnce(t *testing
 	_, dupErr := org.Organize(context.Background(), dupBatchCmd(
 		models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, tracker, false, true))
 	require.Error(t, dupErr)
-	assert.Equal(t, "organization validation failed: ["+w246Dest+"]", dupErr.Error())
-	assert.Equal(t, 1, strings.Count(dupErr.Error(), w246Dest))
+	assert.Equal(t, "organization validation failed: ["+w246Dest+"]", w246Slash(dupErr.Error()))
+	assert.Equal(t, 1, strings.Count(w246Slash(dupErr.Error()), w246Dest))
 }
 
 // Pin the occupied-dest conflict render: exact full message, destination once.
@@ -87,8 +93,8 @@ func TestOrganize_OccupiedDestinationConflictRendersDestinationOnce(t *testing.T
 	_, occErr := org.Organize(context.Background(), dupBatchCmd(
 		models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, NewDuplicateTracker(true), false, true))
 	require.Error(t, occErr)
-	assert.Equal(t, "organization validation failed: ["+w246Dest+"]", occErr.Error())
-	assert.Equal(t, 1, strings.Count(occErr.Error(), w246Dest))
+	assert.Equal(t, "organization validation failed: ["+w246Dest+"]", w246Slash(occErr.Error()))
+	assert.Equal(t, 1, strings.Count(w246Slash(occErr.Error()), w246Dest))
 }
 
 // The #246 reproduction: destination occupied on disk AND batch-claimed. The
@@ -112,7 +118,7 @@ func TestOrganize_DuplicateOfOccupiedDestinationRendersDestinationOnce(t *testin
 	_, combErr := org.Organize(context.Background(), dupBatchCmd(
 		models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, tracker, false, true))
 	require.Error(t, combErr)
-	assert.Equal(t, "organization validation failed: ["+w246Dest+"]", combErr.Error())
-	assert.Equal(t, 1, strings.Count(combErr.Error(), w246Dest),
+	assert.Equal(t, "organization validation failed: ["+w246Dest+"]", w246Slash(combErr.Error()))
+	assert.Equal(t, 1, strings.Count(w246Slash(combErr.Error()), w246Dest),
 		"occupation + duplicate conflicts render the destination once")
 }

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -859,10 +859,11 @@ func (o *Organizer) Organize(ctx context.Context, cmd OrganizeCmd) (*OrganizeRes
 func (o *Organizer) validatePlan(plan *OrganizePlan) []string {
 	issues := make([]string, 0)
 
-	// Check for conflicts
-	for _, c := range plan.Conflicts {
-		issues = append(issues, c.String()) // String() = bare path
-	}
+	// Check for conflicts — #246: a duplicated occupied destination surfaces
+	// its path ONCE (occupation conflict + ConflictDuplicate render the same
+	// bare path); distinctConflictRenders dedupes only the render, never the
+	// underlying conflict list the execution gate reads.
+	issues = append(issues, distinctConflictRenders(plan.Conflicts)...)
 
 	// Check source exists
 	if _, err := o.fs.Stat(plan.SourcePath); os.IsNotExist(err) {

--- a/internal/workflow/apply_orchestrator.go
+++ b/internal/workflow/apply_orchestrator.go
@@ -628,18 +628,23 @@ func replacementRecorder(rl RevertLog) downloader.ReplacementRecorder {
 // Returns an empty OperationID with no error when revert logging is disabled.
 // A configured logger's failed Begin is fatal for destructive apply work: no
 // filesystem step may run without a committed inverse in the ledger.
+//
+// #245: dry-run never starts journal writing at all — a dry-run plan mutates
+// nothing, so Begin's pre-record would sit in the real revert ledger as an
+// 'applied' phantom row for a planned-but-unexecuted organize. Returning the
+// empty OperationID rides the existing downstream guards instead of needing
+// dry-run branches there: Complete and completeRevertLogWithState are gated
+// on opID != "", no database row exists for CaptureSnapshot to fetch, and the
+// downloader's seedRoot/RecordReplacement lanes are unreachable with output
+// steps disabled. dbRevertLog's Complete/CompleteFailed additionally treat an
+// empty or unparsable OperationID as a nil-error no-op, so a skipped Begin
+// can never make a later completion throw.
 func (o *applyOrchImpl) beginRevertLog(ctx context.Context, cmd ApplyCmd) (OperationID, error) {
-	if o.revertLog == nil {
+	if o.revertLog == nil || cmd.DryRun {
 		return "", nil
 	}
 	opID, beginErr := o.revertLog.Begin(ctx, cmd)
 	if beginErr != nil {
-		if cmd.DryRun {
-			// Dry-run performs no destructive filesystem work, so a ledger is
-			// not required to preview the pipeline.
-			resolveLogger(o.logger).Warnf("[workflow] RevertLog.Begin failed for %s: %v", cmd.Movie.ID, beginErr)
-			return opID, nil
-		}
 		resolveLogger(o.logger).Errorf("[workflow] RevertLog.Begin failed for %s: %v — aborting before destructive steps", cmd.Movie.ID, beginErr)
 		return opID, fmt.Errorf("revert log begin failed: %w", beginErr)
 	}

--- a/internal/workflow/apply_orchestrator_coverage_test.go
+++ b/internal/workflow/apply_orchestrator_coverage_test.go
@@ -971,10 +971,10 @@ func TestApplyOrchImpl_Execute_RevertLogBeginError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// applyOrchImpl.Execute — revertLog begin error (dry run)
+// applyOrchImpl.Execute — dry-run never touches the revert journal (#245)
 // ---------------------------------------------------------------------------
 
-func TestApplyOrchImpl_Execute_RevertLogBeginError_DryRun(t *testing.T) {
+func TestApplyOrchImpl_Execute_DryRunSkipsRevertJournal(t *testing.T) {
 	rl := &recordingRevertLog{beginErr: errors.New("begin failed")}
 	impl := &applyOrchImpl{
 		fs:        afero.NewMemMapFs(),
@@ -989,6 +989,35 @@ func TestApplyOrchImpl_Execute_RevertLogBeginError_DryRun(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	require.NotNil(t, result)
+	// #245: dry-run starts NO journal writes — Begin is skipped outright (a
+	// begin failure is moot: no ledger is needed to preview) and the empty
+	// OperationID keeps Complete from running, leaving zero phantom rows.
+	assert.Zero(t, rl.beginCalls, "dry-run must skip RevertLog.Begin")
+	assert.Zero(t, rl.completeCalls, "dry-run must skip RevertLog.Complete")
+	assert.Empty(t, result.OperationID)
+}
+
+// A dry-run step failure rides completeRevertLogWithState with the skipped-Begin
+// empty OperationID: completion must no-op rather than throw (#245).
+func TestApplyOrchImpl_Execute_DryRunFailureSkipsCompleteFailed(t *testing.T) {
+	rl := &recordingRevertLog{}
+	impl := &applyOrchImpl{
+		fs:        afero.NewMemMapFs(),
+		organizer: &stubOrganizer{err: errors.New("organize boom")},
+		nfo:       &applyStubNFO{},
+		revertLog: rl,
+	}
+	result, err := impl.Execute(context.Background(), ApplyCmd{
+		Movie:    &models.Movie{ID: "TEST-001", Title: "Test"},
+		Match:    defaultMatch(),
+		Organize: OrganizeOptions{MoveFiles: true},
+		DryRun:   true,
+	})
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "organize", result.FailedStep)
+	assert.Zero(t, rl.beginCalls)
+	assert.Zero(t, rl.completeCalls, "CompleteFailed must no-op when Begin was skipped")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/workflow/apply_orchestrator_dryrun_journal_w245_test.go
+++ b/internal/workflow/apply_orchestrator_dryrun_journal_w245_test.go
@@ -1,0 +1,92 @@
+package workflow
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+)
+
+// Issue #245: a dry-run apply must leave the revert journal AND the
+// batch_file_operations table completely empty — no 'applied' phantom rows
+// for planned-but-unexecuted organizes — while a later real apply on the same
+// ledger keeps journaling exactly as before.
+func TestApply_DryRunLeavesRevertLedgerEmpty_W245(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := database.New(&database.Config{Type: "sqlite", DSN: filepath.Join(t.TempDir(), "revert-w245.db"), LogLevel: "error"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.RunMigrationsOnStartup(ctx))
+	repo := database.NewBatchFileOperationRepository(db)
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/in", 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("a-bytes"), 0o644))
+
+	const jobID = "job-dryrun-w245"
+	rl := NewDBRevertLog(repo, NewRevertLogConfig(true, nil), jobID, fs, nil, nil, nil)
+	org := organizer.NewOrganizer(fs, &organizer.Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}, nil, nil)
+	orch := &applyOrchImpl{fs: fs, organizer: org, revertLog: rl}
+
+	cmdFor := func(movieID, src, name string, dryRun bool) ApplyCmd {
+		return ApplyCmd{
+			Movie:    &models.Movie{ID: movieID, Title: "W245 Movie"},
+			Match:    models.FileMatchInfo{MovieID: movieID, Path: src, Name: name, Extension: ".mkv"},
+			DestPath: "/dest",
+			DryRun:   dryRun,
+			Organize: OrganizeOptions{MoveFiles: true},
+		}
+	}
+
+	// Dry-run: the plan computes (the fixture's whole point) but NOTHING may
+	// reach the ledger — Begin is skipped before repo.Create can journal a
+	// phantom 'applied' row, and the empty OperationID suppresses Complete.
+	dryRes, err := orch.Execute(ctx, cmdFor("DRY-001", "/in/A.mkv", "A.mkv", true))
+	require.NoError(t, err)
+	require.NotNil(t, dryRes)
+	require.NotNil(t, dryRes.OrganizeResult, "dry-run still surfaces the plan")
+	assert.Empty(t, dryRes.OperationID, "dry-run carries no ledger correlation")
+
+	srcExists, err := afero.Exists(fs, "/in/A.mkv")
+	require.NoError(t, err)
+	assert.True(t, srcExists, "dry-run moved no bytes")
+	destExists, err := afero.Exists(fs, "/dest/DRY-001/DRY-001.mkv")
+	require.NoError(t, err)
+	assert.False(t, destExists)
+
+	dryCount, err := repo.CountByBatchJobID(ctx, jobID)
+	require.NoError(t, err)
+	assert.Zero(t, dryCount, "batch_file_operations stays empty after a dry-run sort")
+	ledgerRows, err := repo.FindOperationsWithLedger(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, ledgerRows, "no journaled ledger content survives a dry-run")
+
+	// Later real op on the SAME ledger instance: rows journal normally.
+	liveRes, err := orch.Execute(ctx, cmdFor("DRY-001", "/in/A.mkv", "A.mkv", false))
+	require.NoError(t, err)
+	require.NotNil(t, liveRes)
+	assert.NotEmpty(t, liveRes.OperationID, "real apply still correlates with its revert row")
+
+	rows, err := repo.FindByBatchJobID(ctx, jobID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "exactly the real apply's row exists")
+	assert.Equal(t, models.RevertStatusApplied, rows[0].RevertStatus)
+	assert.Equal(t, "/dest/DRY-001/DRY-001.mkv", filepath.ToSlash(rows[0].NewPath))
+	movedBytes, err := afero.ReadFile(fs, "/dest/DRY-001/DRY-001.mkv")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("a-bytes"), movedBytes, "the subsequent real move is unaffected")
+}


### PR DESCRIPTION
## Summary

Two small hygiene fixes found by the #224 smoke verification:

**Closes #245 — dry-run phantom revert rows.** `beginRevertLog` no-ops under `DryRun` before `Begin`/`CaptureSnapshot`; downstream `Complete`/`CompleteFailed`/`seedRoot` were already conditioned on a non-empty opID. Preview batches no longer leave phantom `applied` rows in the revert ledger, `batch_file_operations` stays empty, and subsequent real ops journal exactly once.

**Closes #246 — doubled destination path.** Unauthorized duplicate failures printed the destination twice inside one bracketed list (destination-occupation conflict and appended duplicate conflict stringified identically). `joinPlanConflictPaths` now dedupes by rendered message in stable order; conflict kinds, ordering, and gating semantics untouched — only the message render changes.

## Test plan
- [x] Real sqlite + revert-log dry-run test: zero rows + no byte movement; follow-up real apply lands exactly one `applied` row with correct paths
- [x] Message render pinned separately for duplicate-only vs plain occupied-destination conflicts
- [x] `go test -short ./...` green; `-race` organizer/workflow/worker/history/api green; `make coverage-patch-strict` PASSED 100%
