### PR TITLE
feat(cli): persist batch skip warnings to history

### DIFF
--- a/internal/commandutil/batch_audit_id_w248_test.go
+++ b/internal/commandutil/batch_audit_id_w248_test.go
@@ -1,0 +1,178 @@
+package commandutil
+
+// Regression pins for #248 codex P2 (R2): the console must never print a
+// queryable-looking "Batch Job: <id>" for a run whose jobs row does not
+// exist — `history list --batch <id>` would answer 'batch job not found'.
+// 30ac1625 fixed the dry-run header (preview label); this file pins the
+// remaining LIVE legs: the scan early-exits (zero files / zero matched IDs)
+// render the identical no-audit sentence dry runs use, while a normal live
+// run prints its identity strictly AFTER the runtime persisted the jobs row.
+//
+// All paths are built with filepath.Join / t.TempDir (never POSIX literals)
+// so the tests stay Windows-safe.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupLiveBatchConfig writes an offline-live batch config plus empty
+// source/destination trees. Mirrors batch_history_w244's setupDuplicateBatch
+// config minus the fixture files, so each test plants exactly the files its
+// leg needs. Downloads are disabled — e2emock media URLs are non-resolvable.
+func setupLiveBatchConfig(t *testing.T) (configPath, src, dest, dbPath string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	src = filepath.Join(tmpDir, "src")
+	dest = filepath.Join(tmpDir, "dest")
+	require.NoError(t, os.MkdirAll(src, 0o700))
+	require.NoError(t, os.MkdirAll(dest, 0o700))
+
+	dbPath = filepath.Join(tmpDir, "javinizer.db")
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.Database.DSN = dbPath
+	cfg.Database.LogLevel = "silent"
+	cfg.Matching.Extensions = []string{".mp4"}
+	cfg.Matching.MinSizeMB = 0
+	cfg.Output.Template.FolderFormat = "<ID>"
+	cfg.Output.Template.SubfolderFormat = []string{}
+	cfg.Output.Template.FileFormat = "<ID>"
+	cfg.Output.Operation.RenameFile = true
+	cfg.Output.Download.DownloadCover = false
+	cfg.Output.Download.DownloadPoster = false
+	cfg.Output.Download.DownloadExtrafanart = false
+	cfg.Output.Download.DownloadTrailer = false
+	cfg.Output.Download.DownloadActress = false
+
+	configPath = filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, config.Save(cfg, configPath))
+	return configPath, src, dest, dbPath
+}
+
+// runLiveBatch drives RunBatchCommand in LIVE mode against the fixture with
+// the default (real) presenter so the console surface under test is real.
+func runLiveBatch(t *testing.T, configPath, src, dest string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:        configPath,
+		SourcePath:        src,
+		Destination:       dest,
+		Recursive:         true,
+		CommandLabel:      "Javinizer Sort",
+		ActionVerb:        "Processing files",
+		CompletionMessage: "Sort complete!",
+		Resolved:          &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err)
+	return buf.String()
+}
+
+// assertNoJobsRow re-opens the run database and proves nothing persisted a
+// jobs row — the other half of the 'no audit ID offered' contract.
+func assertNoJobsRow(t *testing.T, dbPath string) {
+	t.Helper()
+	db := openAssertionDB(t, dbPath)
+	jobs, err := db.Repositories().JobRepo.List(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, jobs, "a scan early-exit persist no jobs row")
+}
+
+// TestRunBatchCommand_LiveZeroFiles_PrintsNoBatchJobToken — leg (a): a live
+// run whose scan finds no video files exits before the runtime exists; the
+// console must offer NO 'Batch Job:' token and instead render the identical
+// no-audit sentence the dry-run header prints.
+func TestRunBatchCommand_LiveZeroFiles_PrintsNoBatchJobToken(t *testing.T) {
+	configPath, src, dest, dbPath := setupLiveBatchConfig(t)
+
+	out := runLiveBatch(t, configPath, src, dest)
+
+	assert.NotContains(t, out, "Batch Job:", "zero-file live runs offer no queryable audit id\n%s", out)
+	assert.Contains(t, out, "Preview (not persisted; no audit ID)",
+		"the early-exit note matches the dry-run variant exactly\n%s", out)
+	assert.Contains(t, out, "No files to process", "sanity: the zero-file leg ran\n%s", out)
+	assert.NotContains(t, out, "Processing files", "the runtime leg never started\n%s", out)
+	assertNoJobsRow(t, dbPath)
+}
+
+// TestRunBatchCommand_LiveUnmatchedFiles_PrintsNoBatchJobToken — leg (b): a
+// live run whose scan finds video files but matches NO content IDs exits
+// before the runtime exists; same no-audit contract as leg (a).
+func TestRunBatchCommand_LiveUnmatchedFiles_PrintsNoBatchJobToken(t *testing.T) {
+	configPath, src, dest, dbPath := setupLiveBatchConfig(t)
+
+	// A video file whose name matches no ID pattern: scanned, never matched.
+	require.NoError(t, os.WriteFile(filepath.Join(src, "family-recital.mp4"), []byte("fake video"), 0o600))
+
+	out := runLiveBatch(t, configPath, src, dest)
+
+	assert.NotContains(t, out, "Batch Job:", "unmatched live runs offer no queryable audit id\n%s", out)
+	assert.Contains(t, out, "Preview (not persisted; no audit ID)",
+		"the early-exit note matches the dry-run variant exactly\n%s", out)
+	assert.NotContains(t, out, "Processing files", "the runtime leg never started\n%s", out)
+	assertNoJobsRow(t, dbPath)
+}
+
+// TestRunBatchCommand_LiveRun_PrintsIDAfterPersist — leg (c): a normal live
+// run still prints its batch identity, and the ordering evidence holds —
+// the printed token resolves to a jobs row on disk under that exact id
+// (post-persist console placement: the identity renders after processing
+// started, i.e. after runtime construction wrote the row).
+func TestRunBatchCommand_LiveRun_PrintsIDAfterPersist(t *testing.T) {
+	// One matchable file on the e2emock scraper seam (offline) — the
+	// batch_update_mode_w248 fixture.
+	configPath, src, dest, dbPath := setupSingleFileBatch(t, "GOOD-700")
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:        configPath,
+		SourcePath:        src,
+		Destination:       dest,
+		Recursive:         true,
+		MoveFiles:         true,
+		GenerateNFO:       true,
+		CommandLabel:      "Javinizer Sort",
+		ActionVerb:        "Processing files",
+		CompletionMessage: "Sort complete!",
+		Resolved:          &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+
+	// The printed identity parses and post-dates the processing banner —
+	// console evidence the id is rendered only within the persisted leg.
+	batchID := batchIDFromOutput(t, out)
+	idxProcessing := strings.Index(out, "Processing files")
+	idxBatchID := strings.Index(out, "Batch Job: ")
+	require.GreaterOrEqual(t, idxProcessing, 0, "the processing banner printed\n%s", out)
+	assert.Greater(t, idxBatchID, idxProcessing,
+		"the audit id renders strictly after runtime construction (post-persist)\n%s", out)
+
+	// The jobs row exists on disk under the printed id — the token is
+	// queryable via `history list --batch <id>`, never dangling.
+	db := openAssertionDB(t, dbPath)
+	job, err := db.Repositories().JobRepo.FindByID(context.Background(), batchID)
+	require.NoError(t, err, "the printed id must resolve to a persisted jobs row")
+	require.NotNil(t, job)
+	assert.Equal(t, batchID, job.ID)
+}
+
+// TestSilentBatchCommandPresenter_OnAuditID pins the silent seam for the new
+// presenter lifecycle hook (W-5: no stdout side effects in tests).
+func TestSilentBatchCommandPresenter_OnAuditID(t *testing.T) {
+	p := &SilentBatchCommandPresenter{}
+	var buf bytes.Buffer
+	p.OnAuditID(&buf, BatchCommandOptions{BatchJobID: "job-1"}, true)
+	p.OnAuditID(&buf, BatchCommandOptions{}, false)
+	assert.Empty(t, buf.String())
+}

--- a/internal/commandutil/batch_command.go
+++ b/internal/commandutil/batch_command.go
@@ -3,6 +3,7 @@ package commandutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -25,6 +26,16 @@ import (
 // render the IDENTICAL line so `history list --batch <id>` can never be
 // pointed at an id that would answer 'batch job not found'.
 const noAuditIDLine = "Preview (not persisted; no audit ID)"
+
+// ErrJobPersistenceFailed marks failure of the initial jobs-row persist that
+// binds a live batch's audit identity (#248 codex P2). The store itself keeps
+// best-effort swallow-and-log semantics for the API path (in-flight jobs must
+// not die on a transient persist failure — a later persist self-heals and
+// persist_error rides the job status payload), but a one-shot CLI batch turns
+// the failure into a batch STARTUP error: RunBatchCommand returns non-nil,
+// the console lands on the NOT-persisted audit line, and no unqueryable
+// `history list --batch <id>` pointer is advertised. Match via errors.Is.
+var ErrJobPersistenceFailed = errors.New("batch job audit persistence failed")
 
 // BatchCommandPresenter abstracts CLI presentation for batch commands.
 // Per W-5: extracted from RunBatchCommand so that the orchestration logic is
@@ -328,6 +339,19 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 	batchCfg := BatchJobConfigFromAppConfig(cfg)
 	rt, err := newCLIBatchRuntimeFn(bs, cfg, opts, batchCfg, filePaths)
 	if err != nil {
+		if errors.Is(err, ErrJobPersistenceFailed) {
+			// #248 codex P2: the initial jobs-row persist failed, so the
+			// pre-generated BatchJobID names NOTHING durable — land on the
+			// NOT-persisted branch (never advertise the unqueryable id) and
+			// say setup failed instead of printing a normal per-file summary.
+			// Live runs only print the audit line: a dry run persists nothing
+			// BY DESIGN (NoopJobPersistence) and the header already carried
+			// the preview label.
+			if !opts.DryRun {
+				presenter.OnAuditID(w, opts, false)
+			}
+			fmt.Fprintf(w, "\n❌ Batch setup failed: %v\n", err)
+		}
 		return fmt.Errorf("failed to create batch job runtime: %w", err)
 	}
 	job := rt.job
@@ -483,9 +507,16 @@ func newCLIBatchRuntime(bs *bootstrapResult, cfg *config.Config, opts BatchComma
 		return nil, err
 	}
 	repos := bs.DB.Repositories()
+	// #248 codex P2: observe the create-time jobs-row persist failure the
+	// store otherwise only LOGS (its best-effort semantics stand for the API
+	// path — in-flight jobs must not die on a transient persist failure), so
+	// the post-create check below converts it into an ErrJobPersistenceFailed
+	// startup error rather than advertising an unqueryable batch id.
+	var initialPersistErr error
 	storeOpts := []worker.JobStoreOption{
 		worker.WithHistoryRepo(repos.HistoryRepo),
 		worker.WithSkipStartupRecovery(),
+		worker.WithInitialPersistErrorReporter(func(err error) { initialPersistErr = err }),
 	}
 	if opts.DryRun {
 		// A dry run previews work: no jobs row and no envelope persists (the
@@ -509,6 +540,14 @@ func newCLIBatchRuntime(bs *bootstrapResult, cfg *config.Config, opts BatchComma
 		Update:                persistUpdate,
 		WF:                    jobWF,
 	})
+	// #248 codex P2: fail startup on the initial jobs-row persist failure —
+	// pre-fix, the store only logged it while OnAuditID(..., true) advertised
+	// the never-persisted id and the batch pressed into phases whose audit
+	// trail could never land. A dry run's NoopJobPersistence never fails, so
+	// previews keep their not-persisted-BY-DESIGN handling.
+	if initialPersistErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrJobPersistenceFailed, initialPersistErr)
+	}
 	return &cliBatchRuntime{job: job, factory: factory, emitter: emitter}, nil
 }
 

--- a/internal/commandutil/batch_command.go
+++ b/internal/commandutil/batch_command.go
@@ -44,7 +44,18 @@ func (p *defaultBatchCommandPresenter) OnHeader(w io.Writer, opts BatchCommandOp
 	fmt.Fprintf(w, "Destination: %s\n", opts.Destination)
 	fmt.Fprintf(w, "Mode: %s\n", map[bool]string{true: "DRY RUN", false: "LIVE"}[opts.DryRun])
 	if opts.BatchJobID != "" {
-		fmt.Fprintf(w, "Batch Job: %s\n", opts.BatchJobID)
+		if opts.DryRun {
+			// Truthful rendering (#248 codex P2): a dry run intentionally
+			// persists no jobs row (NoopJobPersistence — #245's invariant
+			// stands), so the pre-generated id is NOT queryable:
+			// `history list --batch <id>` 404s with 'batch job not found'.
+			// Print a preview label instead of a queryable-looking audit
+			// ID; dry-run history rows stay reachable via plain
+			// `history list` under its Dry Run marker.
+			fmt.Fprintln(w, "Preview (not persisted; no audit ID)")
+		} else {
+			fmt.Fprintf(w, "Batch Job: %s\n", opts.BatchJobID)
+		}
 	}
 	if opts.OperationLabel != "" {
 		fmt.Fprintf(w, "Operation: %s\n", opts.OperationLabel)
@@ -127,9 +138,11 @@ type BatchCommandOptions struct {
 	// Resolved seam strings (caller must resolve before calling)
 	Resolved *workflow.ResolvedSeamStrings
 
-	// BatchJobID is populated by RunBatchCommand before presentation: it
-	// identifies the persisted batch (audit rows, jobs row) so
-	// `javinizer history list --batch <id>` can drill into the run.
+	// BatchJobID is populated by RunBatchCommand before presentation. A
+	// live run's id identifies the persisted batch (audit rows, jobs row)
+	// so `javinizer history list --batch <id>` can drill into the run; a
+	// dry run persists no jobs row, so the presenter prints a
+	// non-queryable preview label instead of the id (#248 codex P2).
 	// Callers must leave it empty.
 	BatchJobID string
 

--- a/internal/commandutil/batch_command.go
+++ b/internal/commandutil/batch_command.go
@@ -301,12 +301,14 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 	// when planning organize destinations.
 	scrapeCfg.FileMatchInfo = matchInfo
 	applyCfg := applyOpts.ToApplyPhaseConfig()
-	// Audit hook (#244): persist per-file organize events (incl. authorized
-	// duplicate-skip warnings) to the eventlog and print skip warnings to the
-	// console, keeping CLI output in sync with the persisted audit truth.
+	// Audit hook (#244): persist per-file organize/update events (incl.
+	// authorized duplicate-skip warnings) to the eventlog and print skip
+	// warnings to the console, keeping CLI output in sync with the persisted
+	// audit truth. opts.SkipOrganize selects the update-mode event taxonomy
+	// (#248 codex P2, F3).
 	skipCount := &atomic.Int64{}
 	printMu := &sync.Mutex{}
-	applyCfg.PostApplyFunc = cliBatchPostApply(rt.emitter, w, opts.BatchJobID, opts.DryRun, skipCount, printMu)
+	applyCfg.PostApplyFunc = cliBatchPostApply(rt.emitter, w, opts.BatchJobID, opts.DryRun, opts.SkipOrganize, skipCount, printMu)
 	job.SetRunOptions(scrapeCfg, applyCfg)
 
 	// Subscribe to events for progress printing
@@ -430,15 +432,21 @@ func newCLIBatchRuntime(bs *bootstrapResult, cfg *config.Config, opts BatchComma
 }
 
 // cliBatchPostApply returns the apply-phase per-file hook for CLI batches. It
-// mirrors the API organize resolver's audit emission
-// (internal/api/batch/apply_config_builder.go): both flows persist an
-// "Organized"/"Organize failed" event plus one warning event per
-// OrganizeResult.Warnings entry — authorized duplicate skips land there and
-// were previously invisible from the CLI because no emitter existed (#244).
+// mirrors the API resolvers' audit emission
+// (internal/api/batch/apply_config_builder.go): organize flows persist an
+// "Organized"/"Organize failed" event (source file_move) plus one warning
+// event per OrganizeResult.Warnings entry — authorized duplicate skips land
+// there and were previously invisible from the CLI because no emitter
+// existed (#244). updateMode (javinizer update: files stay in place) takes
+// the API update resolver's taxonomy instead (#248 codex P2, F3): the
+// nfo_gen source with "Updated"/"Update failed" vocabulary, and NO file_move
+// events — an in-place metadata refresh is not a file move, and the previous
+// file_move/"Organized <id>" success event carried an empty new_path that
+// misrepresented the audit trail.
 // Warning text is also printed to the console so CLI output tells the same
 // truth as the persisted audit rows. Event emission is skipped for dry runs:
 // previews are not operations.
-func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string, dryRun bool, skipCount *atomic.Int64, printMu *sync.Mutex) func(context.Context, *worker.ApplyFileContext, *worker.ApplyFileResult) {
+func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string, dryRun, updateMode bool, skipCount *atomic.Int64, printMu *sync.Mutex) func(context.Context, *worker.ApplyFileContext, *worker.ApplyFileResult) {
 	return func(ctx context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
 		// Guard matches the API resolver: never deref a nil payload; the hook
 		// must not mask the original apply outcome with a panic.
@@ -448,8 +456,20 @@ func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string,
 		if dryRun {
 			return
 		}
+		// Event taxonomy by operation mode (see the doc comment): file_move
+		// organize vocabulary vs nfo_gen update vocabulary.
+		source := "file_move"
+		failureVerb := "Organize failed"
+		successVerb := "Organized"
+		warningVerb := "Organize warning"
+		if updateMode {
+			source = "nfo_gen"
+			failureVerb = "Update failed"
+			successVerb = "Updated"
+			warningVerb = "Update warning"
+		}
 		if afr.Err != nil {
-			_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organize failed for %s", afc.Movie.ID), models.SeverityError, map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "error": afr.Err.Error()})
+			_ = emitter.EmitOrganizeEvent(ctx, source, fmt.Sprintf("%s for %s", failureVerb, afc.Movie.ID), models.SeverityError, map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "error": afr.Err.Error()})
 			return
 		}
 		var newPath string
@@ -461,9 +481,17 @@ func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string,
 				skipCount.Add(1)
 			}
 		}
-		_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organized %s", afc.Movie.ID), models.SeverityInfo, map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath})
+		eventCtx := map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "file": afc.FilePath}
+		if !updateMode {
+			eventCtx["new_path"] = newPath
+		}
+		_ = emitter.EmitOrganizeEvent(ctx, source, fmt.Sprintf("%s %s", successVerb, afc.Movie.ID), models.SeverityInfo, eventCtx)
 		for _, warning := range warnings {
-			_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning})
+			warnCtx := map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "file": afc.FilePath, "warning": warning}
+			if !updateMode {
+				warnCtx["new_path"] = newPath
+			}
+			_ = emitter.EmitOrganizeEvent(ctx, source, fmt.Sprintf("%s for %s: %s", warningVerb, afc.Movie.ID, warning), models.SeverityWarn, warnCtx)
 		}
 		if len(warnings) > 0 {
 			printMu.Lock()
@@ -489,6 +517,20 @@ func defaultEventHandler(w io.Writer, event worker.JobEvent) {
 // defaultSummaryPrinter prints the standard summary for a batch command.
 func defaultSummaryPrinter(w io.Writer, opts BatchCommandOptions, result BatchCommandResult) {
 	successCount := result.SuccessCount
+	// PR #248 codex P2 (F2): a completed authorized duplicate skip lands
+	// JobStatusCompleted but moves NO bytes (the loser's row finalizes
+	// completed-noop), so organize/NFO success totals must exclude skips —
+	// completed minus SkippedDuplicates. Subtraction lives ONLY here at the
+	// summary aggregation site: "Metadata found" keeps counting every
+	// completed file (the loser WAS scraped and matched), while organize/output
+	// claims match the real file movement (1 winner moved must never read
+	// "Organized 2 file(s)"). Skips are organize-mode only, so the update-mode
+	// lines (driven by len(Movies) above and this subtraction being zero when
+	// no skips occurred) are unchanged.
+	organizedCount := successCount - result.SkippedDuplicates
+	if organizedCount < 0 {
+		organizedCount = 0
+	}
 
 	if opts.SkipOrganize {
 		// Update-style summary
@@ -496,9 +538,9 @@ func defaultSummaryPrinter(w io.Writer, opts BatchCommandOptions, result BatchCo
 	} else {
 		// Sort-style summary
 		if opts.DryRun {
-			fmt.Fprintf(w, "\n   Would organize %d file(s)\n", successCount)
+			fmt.Fprintf(w, "\n   Would organize %d file(s)\n", organizedCount)
 		} else {
-			fmt.Fprintf(w, "\n   Organized %d file(s)\n", successCount)
+			fmt.Fprintf(w, "\n   Organized %d file(s)\n", organizedCount)
 		}
 	}
 
@@ -508,10 +550,10 @@ func defaultSummaryPrinter(w io.Writer, opts BatchCommandOptions, result BatchCo
 	fmt.Fprintf(w, "IDs matched: %d\n", result.MatchedCount)
 	fmt.Fprintf(w, "Metadata found: %d\n", successCount)
 	if opts.GenerateNFO {
-		fmt.Fprintf(w, "NFOs generated: %s\n", map[bool]string{true: fmt.Sprintf("%d (dry-run)", successCount), false: fmt.Sprintf("%d", successCount)}[opts.DryRun])
+		fmt.Fprintf(w, "NFOs generated: %s\n", map[bool]string{true: fmt.Sprintf("%d (dry-run)", organizedCount), false: fmt.Sprintf("%d", organizedCount)}[opts.DryRun])
 	}
 	if !opts.SkipOrganize {
-		fmt.Fprintf(w, "Files organized: %s\n", map[bool]string{true: fmt.Sprintf("%d (dry-run)", successCount), false: fmt.Sprintf("%d", successCount)}[opts.DryRun])
+		fmt.Fprintf(w, "Files organized: %s\n", map[bool]string{true: fmt.Sprintf("%d (dry-run)", organizedCount), false: fmt.Sprintf("%d", organizedCount)}[opts.DryRun])
 	}
 	if result.SkippedDuplicates > 0 {
 		// An authorized intra-batch duplicate applies as a successful skip —

--- a/internal/commandutil/batch_command.go
+++ b/internal/commandutil/batch_command.go
@@ -18,13 +18,31 @@ import (
 	"github.com/javinizer/javinizer-go/internal/workflow"
 )
 
+// noAuditIDLine is the single console sentence for runs with NO persisted
+// jobs row (#248 codex P2, R2): dry runs (a preview persists no queryable
+// batch identity) and live runs that exit during scan (zero files / zero
+// matched IDs) before the runtime ever persists a jobs row. Both branches
+// render the IDENTICAL line so `history list --batch <id>` can never be
+// pointed at an id that would answer 'batch job not found'.
+const noAuditIDLine = "Preview (not persisted; no audit ID)"
+
 // BatchCommandPresenter abstracts CLI presentation for batch commands.
 // Per W-5: extracted from RunBatchCommand so that the orchestration logic is
 // decoupled from presentation. Default presenter prints to stdout;
 // tests can use a silent presenter.
 type BatchCommandPresenter interface {
 	// OnHeader prints the command header (source, destination, mode, etc.).
+	// The header renders NO audit identity: at header time (pre-scan) whether
+	// a jobs row will exist is still unknown (#248 codex P2, R2) —
+	// OnAuditID owns every audit-identity sentence.
 	OnHeader(w io.Writer, opts BatchCommandOptions)
+	// OnAuditID prints the run's audit-trail identity line, called only once
+	// the persistence truth is known (#248 codex P2, R2): persisted=true
+	// renders the queryable batch id for live runs, strictly AFTER the
+	// runtime persisted the jobs row; persisted=false renders the 'no audit
+	// trail' sentence for runs that exit before anything was persisted (live
+	// early-exit during scan), identical to the dry-run header preview label.
+	OnAuditID(w io.Writer, opts BatchCommandOptions, persisted bool)
 	// OnScanStart prints the scan-started message.
 	OnScanStart(w io.Writer)
 	// OnNoFiles prints the no-files-found message.
@@ -43,19 +61,19 @@ func (p *defaultBatchCommandPresenter) OnHeader(w io.Writer, opts BatchCommandOp
 	fmt.Fprintf(w, "Source: %s\n", opts.SourcePath)
 	fmt.Fprintf(w, "Destination: %s\n", opts.Destination)
 	fmt.Fprintf(w, "Mode: %s\n", map[bool]string{true: "DRY RUN", false: "LIVE"}[opts.DryRun])
-	if opts.BatchJobID != "" {
-		if opts.DryRun {
-			// Truthful rendering (#248 codex P2): a dry run intentionally
-			// persists no jobs row (NoopJobPersistence — #245's invariant
-			// stands), so the pre-generated id is NOT queryable:
-			// `history list --batch <id>` 404s with 'batch job not found'.
-			// Print a preview label instead of a queryable-looking audit
-			// ID; dry-run history rows stay reachable via plain
-			// `history list` under its Dry Run marker.
-			fmt.Fprintln(w, "Preview (not persisted; no audit ID)")
-		} else {
-			fmt.Fprintf(w, "Batch Job: %s\n", opts.BatchJobID)
-		}
+	if opts.BatchJobID != "" && opts.DryRun {
+		// Truthful rendering (#248 codex P2): a dry run intentionally
+		// persists no jobs row (NoopJobPersistence — #245's invariant
+		// stands), so the pre-generated id is NOT queryable:
+		// `history list --batch <id>` 404s with 'batch job not found'.
+		// Print a preview label instead of a queryable-looking audit
+		// ID; dry-run history rows stay reachable via plain
+		// `history list` under its Dry Run marker.
+		// A LIVE header prints no identity at all (#248 codex P2, R2):
+		// whether a jobs row will exist is only known once the runtime is
+		// constructed post-scan (the early-exit scan legs persist nothing),
+		// so the identity line defers to OnAuditID.
+		fmt.Fprintln(w, noAuditIDLine)
 	}
 	if opts.OperationLabel != "" {
 		fmt.Fprintf(w, "Operation: %s\n", opts.OperationLabel)
@@ -64,6 +82,19 @@ func (p *defaultBatchCommandPresenter) OnHeader(w io.Writer, opts BatchCommandOp
 		fmt.Fprintf(w, "Generate NFO: %v\n", opts.GenerateNFO)
 	}
 	fmt.Fprintf(w, "Download Media: %v\n\n", opts.DownloadMedia)
+}
+
+// OnAuditID renders the audit identity once persistence is known (see the
+// interface contract): live runs get the queryable id strictly post-persist;
+// every unpersisted branch (live scan early-exit) gets the identical
+// dry-run no-audit sentence, so no console output ever names a batch id
+// whose jobs row does not exist.
+func (p *defaultBatchCommandPresenter) OnAuditID(w io.Writer, opts BatchCommandOptions, persisted bool) {
+	if persisted && opts.BatchJobID != "" {
+		fmt.Fprintf(w, "Batch Job: %s\n", opts.BatchJobID)
+		return
+	}
+	fmt.Fprintln(w, noAuditIDLine)
 }
 
 func (p *defaultBatchCommandPresenter) OnScanStart(w io.Writer) {
@@ -88,6 +119,9 @@ type SilentBatchCommandPresenter struct{}
 
 // OnHeader implements BatchCommandPresenter.OnHeader as a no-op.
 func (p *SilentBatchCommandPresenter) OnHeader(_ io.Writer, _ BatchCommandOptions) {}
+
+// OnAuditID implements BatchCommandPresenter.OnAuditID as a no-op.
+func (p *SilentBatchCommandPresenter) OnAuditID(_ io.Writer, _ BatchCommandOptions, _ bool) {}
 
 // OnScanStart implements BatchCommandPresenter.OnScanStart as a no-op.
 func (p *SilentBatchCommandPresenter) OnScanStart(_ io.Writer) {}
@@ -140,10 +174,11 @@ type BatchCommandOptions struct {
 
 	// BatchJobID is populated by RunBatchCommand before presentation. A
 	// live run's id identifies the persisted batch (audit rows, jobs row)
-	// so `javinizer history list --batch <id>` can drill into the run; a
-	// dry run persists no jobs row, so the presenter prints a
-	// non-queryable preview label instead of the id (#248 codex P2).
-	// Callers must leave it empty.
+	// so `javinizer history list --batch <id>` can drill into the run —
+	// printed via OnAuditID strictly AFTER the runtime persisted the jobs
+	// row; dry runs and live scan early-exits persist nothing, so the
+	// presenter renders the non-queryable no-audit sentence instead of the
+	// id (#248 codex P2, R2). Callers must leave it empty.
 	BatchJobID string
 
 	// Header label printed at the start (e.g., "Javinizer Sort" or "Javinizer Update")
@@ -243,6 +278,14 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 
 	if len(scanResult.Files) == 0 {
 		presenter.OnNoFiles(w)
+		// Live early-exit (#248 codex P2, R2): the runtime is never
+		// constructed and NO jobs row exists, so offer no queryable batch id
+		// (the pre-scan header printed none) — print the identical no-audit
+		// sentence dry runs use. Dry runs already labelled the preview in
+		// the header; do not repeat it.
+		if !opts.DryRun {
+			presenter.OnAuditID(w, opts, false)
+		}
 		return nil
 	}
 
@@ -265,6 +308,12 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 		}
 	}
 	if len(filePaths) == 0 {
+		// Same live early-exit leg: scan found video files but no matched
+		// IDs, nothing was persisted — no queryable audit id is offered
+		// (#248 codex P2, R2).
+		if !opts.DryRun {
+			presenter.OnAuditID(w, opts, false)
+		}
 		return nil
 	}
 
@@ -283,6 +332,16 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 	}
 	job := rt.job
 	factory := rt.factory
+
+	// Print the queryable batch identity ONLY post-persist (#248 codex P2,
+	// R2): CreatePersistentStandaloneJob writes the jobs row at creation,
+	// so from here on `history list --batch <id>` resolves — printing it
+	// any earlier named an id the scan early-exit legs never persisted.
+	// Dry runs persist nothing (NoopJobPersistence) and keep the header's
+	// preview label instead.
+	if !opts.DryRun {
+		presenter.OnAuditID(w, opts, true)
+	}
 
 	// Validate the resolved seam strings before dereferencing them below; a
 	// missing resolution step would otherwise panic when building applyOpts.

--- a/internal/commandutil/batch_command.go
+++ b/internal/commandutil/batch_command.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/javinizer/javinizer-go/internal/config"
 	"github.com/javinizer/javinizer-go/internal/eventlog"
@@ -423,10 +424,18 @@ func newCLIBatchRuntime(bs *bootstrapResult, cfg *config.Config, opts BatchComma
 	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, nil, nil, storeOpts...)
 	emitter := eventlog.NewEmitter(repos.EventRepo)
 	factory := worker.NewBatchJobFactory(jobStore, jobWF, bs.Matcher, bs.PosterGen, batchCfg, emitter)
+	// Persisted job identity at creation (#248 codex P2, F1): mirror the API
+	// StartScrapeUseCase wiring so a CLI update batch's jobs row classifies as
+	// update (update=true + metadata-artwork) instead of organize. StartApply
+	// re-commits the same mapping from ApplyPhaseConfig — persistedJobMode is
+	// the single mapping source.
+	persistUpdate, persistMode := persistedJobMode(opts.SkipOrganize)
 	job := factory.CreatePersistentStandaloneJob(filePaths, worker.BatchJobOptions{
-		ID:          opts.BatchJobID,
-		Destination: opts.Destination,
-		WF:          jobWF,
+		ID:                    opts.BatchJobID,
+		Destination:           opts.Destination,
+		OperationModeOverride: persistMode,
+		Update:                persistUpdate,
+		WF:                    jobWF,
 	})
 	return &cliBatchRuntime{job: job, factory: factory, emitter: emitter}, nil
 }
@@ -446,8 +455,18 @@ func newCLIBatchRuntime(bs *bootstrapResult, cfg *config.Config, opts BatchComma
 // Warning text is also printed to the console so CLI output tells the same
 // truth as the persisted audit rows. Event emission is skipped for dry runs:
 // previews are not operations.
+//
+// Audit emission is deliberately DETACHED from the per-file task ctx
+// (#248 codex P2, F2): when apply exhausts WorkerTimeout, interpretApplyResult
+// invokes this hook with the task ctx ALREADY canceled, and the eventlog
+// emitter drops events on a canceled ctx (eventlog.emit checks ctx.Err()) —
+// the timeout failure previously never landed in the CLI eventlog, while the
+// worker's history writer still recorded it because it audits with a fresh
+// bounded ctx (worker/history_writer.go historyAuditContext). Mirror that
+// pattern here, and log loudly if emission STILL fails instead of discarding
+// the error.
 func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string, dryRun, updateMode bool, skipCount *atomic.Int64, printMu *sync.Mutex) func(context.Context, *worker.ApplyFileContext, *worker.ApplyFileResult) {
-	return func(ctx context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
+	return func(_ context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
 		// Guard matches the API resolver: never deref a nil payload; the hook
 		// must not mask the original apply outcome with a panic.
 		if afc == nil || afc.Movie == nil || afr == nil {
@@ -455,6 +474,13 @@ func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string,
 		}
 		if dryRun {
 			return
+		}
+		auditCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		emit := func(source, message string, severity models.EventSeverity, eventCtx map[string]any) {
+			if err := emitter.EmitOrganizeEvent(auditCtx, source, message, severity, eventCtx); err != nil {
+				logging.Warnf("[cli batch %s] eventlog audit emission failed (source=%s, severity=%s, message=%q): %v", jobID, source, severity, message, err)
+			}
 		}
 		// Event taxonomy by operation mode (see the doc comment): file_move
 		// organize vocabulary vs nfo_gen update vocabulary.
@@ -469,7 +495,7 @@ func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string,
 			warningVerb = "Update warning"
 		}
 		if afr.Err != nil {
-			_ = emitter.EmitOrganizeEvent(ctx, source, fmt.Sprintf("%s for %s", failureVerb, afc.Movie.ID), models.SeverityError, map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "error": afr.Err.Error()})
+			emit(source, fmt.Sprintf("%s for %s", failureVerb, afc.Movie.ID), models.SeverityError, map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "error": afr.Err.Error()})
 			return
 		}
 		var newPath string
@@ -485,13 +511,13 @@ func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string,
 		if !updateMode {
 			eventCtx["new_path"] = newPath
 		}
-		_ = emitter.EmitOrganizeEvent(ctx, source, fmt.Sprintf("%s %s", successVerb, afc.Movie.ID), models.SeverityInfo, eventCtx)
+		emit(source, fmt.Sprintf("%s %s", successVerb, afc.Movie.ID), models.SeverityInfo, eventCtx)
 		for _, warning := range warnings {
 			warnCtx := map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "file": afc.FilePath, "warning": warning}
 			if !updateMode {
 				warnCtx["new_path"] = newPath
 			}
-			_ = emitter.EmitOrganizeEvent(ctx, source, fmt.Sprintf("%s for %s: %s", warningVerb, afc.Movie.ID, warning), models.SeverityWarn, warnCtx)
+			emit(source, fmt.Sprintf("%s for %s: %s", warningVerb, afc.Movie.ID, warning), models.SeverityWarn, warnCtx)
 		}
 		if len(warnings) > 0 {
 			printMu.Lock()

--- a/internal/commandutil/batch_command.go
+++ b/internal/commandutil/batch_command.go
@@ -5,8 +5,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
 
 	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/eventlog"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/worker"
@@ -38,6 +42,9 @@ func (p *defaultBatchCommandPresenter) OnHeader(w io.Writer, opts BatchCommandOp
 	fmt.Fprintf(w, "Source: %s\n", opts.SourcePath)
 	fmt.Fprintf(w, "Destination: %s\n", opts.Destination)
 	fmt.Fprintf(w, "Mode: %s\n", map[bool]string{true: "DRY RUN", false: "LIVE"}[opts.DryRun])
+	if opts.BatchJobID != "" {
+		fmt.Fprintf(w, "Batch Job: %s\n", opts.BatchJobID)
+	}
 	if opts.OperationLabel != "" {
 		fmt.Fprintf(w, "Operation: %s\n", opts.OperationLabel)
 	}
@@ -119,6 +126,12 @@ type BatchCommandOptions struct {
 	// Resolved seam strings (caller must resolve before calling)
 	Resolved *workflow.ResolvedSeamStrings
 
+	// BatchJobID is populated by RunBatchCommand before presentation: it
+	// identifies the persisted batch (audit rows, jobs row) so
+	// `javinizer history list --batch <id>` can drill into the run.
+	// Callers must leave it empty.
+	BatchJobID string
+
 	// Header label printed at the start (e.g., "Javinizer Sort" or "Javinizer Update")
 	CommandLabel string
 	// Operation label for the header (e.g., "COPY", "MOVE", "HARDLINK")
@@ -151,6 +164,10 @@ type BatchCommandResult struct {
 	Movies       map[string]*models.Movie
 	SuccessCount int
 	FailedCount  int
+	// SkippedDuplicates counts files whose apply succeeded as an authorized
+	// intra-batch duplicate skip (no bytes moved). Reported separately so the
+	// console summary tells the same truth as the persisted audit rows.
+	SkippedDuplicates int
 }
 
 // RunBatchCommand executes the shared scaffold: config load → prepare → bootstrap →
@@ -182,6 +199,14 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 	if _, err := config.Prepare(cfg); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
+
+	// Pre-generate the batch job ID up front (mirrors the API organize
+	// usecase): it binds the per-job workflow's revert ledger, the persisted
+	// jobs row, and every history/eventlog audit row to ONE identity.
+	// Previously the CLI ran with no persisted identity, so
+	// batch_file_operations rows landed under "" and no history/event rows
+	// were written at all (#244).
+	opts.BatchJobID = models.NewJobID().String()
 
 	bs, err := Bootstrap(cfg)
 	if err != nil {
@@ -238,15 +263,12 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 	// Per NEW-1: the factory owns infrastructure deps (WF, Matcher, PosterGen, BatchCfg)
 	// so the CLI only provides per-call varying fields.
 	batchCfg := BatchJobConfigFromAppConfig(cfg)
-	factory := worker.NewBatchJobFactory(
-		nil, // no JobStore — CLI doesn't need persistence
-		bs.Workflow,
-		bs.Matcher,
-		bs.PosterGen,
-		batchCfg,
-		nil, // no emitter for CLI
-	)
-	job := factory.CreateStandaloneJob(filePaths, worker.BatchJobOptions{})
+	rt, err := newCLIBatchRuntimeFn(bs, cfg, opts, batchCfg, filePaths)
+	if err != nil {
+		return fmt.Errorf("failed to create batch job runtime: %w", err)
+	}
+	job := rt.job
+	factory := rt.factory
 
 	// Validate the resolved seam strings before dereferencing them below; a
 	// missing resolution step would otherwise panic when building applyOpts.
@@ -278,10 +300,14 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 	// reads PartSuffix/PartNumber/IsMultiPart back out of the per-file result
 	// when planning organize destinations.
 	scrapeCfg.FileMatchInfo = matchInfo
-	job.SetRunOptions(
-		scrapeCfg,
-		applyOpts.ToApplyPhaseConfig(),
-	)
+	applyCfg := applyOpts.ToApplyPhaseConfig()
+	// Audit hook (#244): persist per-file organize events (incl. authorized
+	// duplicate-skip warnings) to the eventlog and print skip warnings to the
+	// console, keeping CLI output in sync with the persisted audit truth.
+	skipCount := &atomic.Int64{}
+	printMu := &sync.Mutex{}
+	applyCfg.PostApplyFunc = cliBatchPostApply(rt.emitter, w, opts.BatchJobID, opts.DryRun, skipCount, printMu)
+	job.SetRunOptions(scrapeCfg, applyCfg)
 
 	// Subscribe to events for progress printing
 	subscriber := job.Subscribe()
@@ -297,7 +323,11 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 		defer close(doneReading)
 		for event := range subscriber.Events() {
 			if event.Message != "" {
+				// Serialize with PostApplyFunc warning prints (worker goroutines)
+				// so console lines never interleave mid-line.
+				printMu.Lock()
 				eventHandler(w, event)
+				printMu.Unlock()
 			}
 		}
 	}()
@@ -331,13 +361,14 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 	}
 
 	batchResult := BatchCommandResult{
-		ScanResult:   scanResult,
-		FilePaths:    filePaths,
-		MatchedCount: matchedCount,
-		UniqueIDs:    uniqueIDs,
-		Movies:       movies,
-		SuccessCount: successCount,
-		FailedCount:  failedCount,
+		ScanResult:        scanResult,
+		FilePaths:         filePaths,
+		MatchedCount:      matchedCount,
+		UniqueIDs:         uniqueIDs,
+		Movies:            movies,
+		SuccessCount:      successCount,
+		FailedCount:       failedCount,
+		SkippedDuplicates: int(skipCount.Load()),
 	}
 
 	// Print summary — backward-compatible: if SummaryPrinter is set, use it;
@@ -349,6 +380,99 @@ func RunBatchCommand(ctx context.Context, w io.Writer, opts BatchCommandOptions)
 	}
 
 	return nil
+}
+
+// cliBatchRuntime bundles the per-run batch infrastructure for sort/update:
+// the DB-backed job store (jobs row + phase envelope persists), the eventlog
+// emitter (audit entries), the shared BatchJobFactory seam, and the runnable
+// job itself.
+type cliBatchRuntime struct {
+	job     worker.StandaloneJob
+	factory worker.BatchJobFactoryInterface
+	emitter eventlog.EventEmitter
+}
+
+// newCLIBatchRuntimeFn is the seam RunBatchCommand uses to build the batch
+// runtime; tests replace it to exercise the runtime-construction error branch.
+var newCLIBatchRuntimeFn = newCLIBatchRuntime
+
+// newCLIBatchRuntime constructs the CLI batch runtime with API-parity audit
+// persistence (#244): a real JobStore over the app database (startup recovery
+// skipped — a one-shot CLI process must not reconcile jobs a live server may
+// own), the eventlog emitter, a per-job workflow whose revert ledger binds
+// the pre-generated batch job ID, and the runnable job built through the
+// shared factory seam.
+func newCLIBatchRuntime(bs *bootstrapResult, cfg *config.Config, opts BatchCommandOptions, batchCfg worker.BatchJobConfig, filePaths []string) (*cliBatchRuntime, error) {
+	jobWF, err := bs.NewJobWorkflow(opts.BatchJobID)
+	if err != nil {
+		return nil, err
+	}
+	repos := bs.DB.Repositories()
+	storeOpts := []worker.JobStoreOption{
+		worker.WithHistoryRepo(repos.HistoryRepo),
+		worker.WithSkipStartupRecovery(),
+	}
+	if opts.DryRun {
+		// A dry run previews work: no jobs row and no envelope persists (the
+		// apply ledger already skips dry run) — while history rows still land
+		// with their dry_run flag so previews remain visible in the audit.
+		storeOpts = append(storeOpts, worker.WithPersistence(worker.NewNoopJobPersistence()))
+	}
+	jobStore := worker.NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, cfg.System.TempDir, nil, nil, storeOpts...)
+	emitter := eventlog.NewEmitter(repos.EventRepo)
+	factory := worker.NewBatchJobFactory(jobStore, jobWF, bs.Matcher, bs.PosterGen, batchCfg, emitter)
+	job := factory.CreatePersistentStandaloneJob(filePaths, worker.BatchJobOptions{
+		ID:          opts.BatchJobID,
+		Destination: opts.Destination,
+		WF:          jobWF,
+	})
+	return &cliBatchRuntime{job: job, factory: factory, emitter: emitter}, nil
+}
+
+// cliBatchPostApply returns the apply-phase per-file hook for CLI batches. It
+// mirrors the API organize resolver's audit emission
+// (internal/api/batch/apply_config_builder.go): both flows persist an
+// "Organized"/"Organize failed" event plus one warning event per
+// OrganizeResult.Warnings entry — authorized duplicate skips land there and
+// were previously invisible from the CLI because no emitter existed (#244).
+// Warning text is also printed to the console so CLI output tells the same
+// truth as the persisted audit rows. Event emission is skipped for dry runs:
+// previews are not operations.
+func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string, dryRun bool, skipCount *atomic.Int64, printMu *sync.Mutex) func(context.Context, *worker.ApplyFileContext, *worker.ApplyFileResult) {
+	return func(ctx context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
+		// Guard matches the API resolver: never deref a nil payload; the hook
+		// must not mask the original apply outcome with a panic.
+		if afc == nil || afc.Movie == nil || afr == nil {
+			return
+		}
+		if dryRun {
+			return
+		}
+		if afr.Err != nil {
+			_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organize failed for %s", afc.Movie.ID), models.SeverityError, map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "error": afr.Err.Error()})
+			return
+		}
+		var newPath string
+		var warnings []string
+		if afr.Result != nil && afr.Result.OrganizeResult != nil {
+			newPath = afr.Result.OrganizeResult.NewPath
+			warnings = afr.Result.OrganizeResult.Warnings
+			if afr.Result.OrganizeResult.DuplicateSkipped {
+				skipCount.Add(1)
+			}
+		}
+		_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organized %s", afc.Movie.ID), models.SeverityInfo, map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath})
+		for _, warning := range warnings {
+			_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning})
+		}
+		if len(warnings) > 0 {
+			printMu.Lock()
+			defer printMu.Unlock()
+			for _, warning := range warnings {
+				fmt.Fprintf(w, "   ⚠️  %s: %s\n", filepath.Base(afc.FilePath), warning)
+			}
+		}
+	}
 }
 
 // defaultEventHandler prints ❌ for failures and ✅ for completions.
@@ -388,6 +512,12 @@ func defaultSummaryPrinter(w io.Writer, opts BatchCommandOptions, result BatchCo
 	}
 	if !opts.SkipOrganize {
 		fmt.Fprintf(w, "Files organized: %s\n", map[bool]string{true: fmt.Sprintf("%d (dry-run)", successCount), false: fmt.Sprintf("%d", successCount)}[opts.DryRun])
+	}
+	if result.SkippedDuplicates > 0 {
+		// An authorized intra-batch duplicate applies as a successful skip —
+		// the console says so explicitly instead of counting the file as
+		// organized, matching its persisted noop audit row (#244).
+		fmt.Fprintf(w, "Skipped (authorized duplicates): %d\n", result.SkippedDuplicates)
 	}
 	if opts.ModeLine != "" {
 		fmt.Fprintf(w, "Mode: %s\n", opts.ModeLine)

--- a/internal/commandutil/batch_command.go
+++ b/internal/commandutil/batch_command.go
@@ -453,8 +453,14 @@ func newCLIBatchRuntime(bs *bootstrapResult, cfg *config.Config, opts BatchComma
 // file_move/"Organized <id>" success event carried an empty new_path that
 // misrepresented the audit trail.
 // Warning text is also printed to the console so CLI output tells the same
-// truth as the persisted audit rows. Event emission is skipped for dry runs:
-// previews are not operations.
+// truth as the persisted audit rows. Skip accounting + that console warning
+// surface run for DRY RUNS identically to live (#248 codex P2 dry-run leg):
+// the organizer's dry-run skip result carries DuplicateSkipped exactly like
+// the live leg, so the summary's organized totals reuse the live arithmetic
+// (completed minus SkippedDuplicates) and the authorized duplicate warning is
+// the ONLY place a preview tells the operator a file would be skipped —
+// previews persist nothing, but they must SAY it. Eventlog emission stays
+// skipped for dry runs: previews are not operations.
 //
 // Audit emission is deliberately DETACHED from the per-file task ctx
 // (#248 codex P2, F2): when apply exhausts WorkerTimeout, interpretApplyResult
@@ -471,6 +477,25 @@ func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string,
 		// must not mask the original apply outcome with a panic.
 		if afc == nil || afc.Movie == nil || afr == nil {
 			return
+		}
+		// Skip accounting + warning print run before the dry-run gate (see
+		// the doc comment); a failed apply keeps failures' single surface —
+		// no warning double-print on the error path.
+		var warnings []string
+		if afr.Err == nil && afr.Result != nil && afr.Result.OrganizeResult != nil {
+			warnings = afr.Result.OrganizeResult.Warnings
+			if afr.Result.OrganizeResult.DuplicateSkipped {
+				skipCount.Add(1)
+			}
+		}
+		if len(warnings) > 0 {
+			// Serialize with the event-handler prints (worker goroutines) so
+			// console lines never interleave mid-line.
+			printMu.Lock()
+			for _, warning := range warnings {
+				fmt.Fprintf(w, "   ⚠️  %s: %s\n", filepath.Base(afc.FilePath), warning)
+			}
+			printMu.Unlock()
 		}
 		if dryRun {
 			return
@@ -499,13 +524,8 @@ func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string,
 			return
 		}
 		var newPath string
-		var warnings []string
 		if afr.Result != nil && afr.Result.OrganizeResult != nil {
 			newPath = afr.Result.OrganizeResult.NewPath
-			warnings = afr.Result.OrganizeResult.Warnings
-			if afr.Result.OrganizeResult.DuplicateSkipped {
-				skipCount.Add(1)
-			}
 		}
 		eventCtx := map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "file": afc.FilePath}
 		if !updateMode {
@@ -518,13 +538,6 @@ func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string,
 				warnCtx["new_path"] = newPath
 			}
 			emit(source, fmt.Sprintf("%s for %s: %s", warningVerb, afc.Movie.ID, warning), models.SeverityWarn, warnCtx)
-		}
-		if len(warnings) > 0 {
-			printMu.Lock()
-			defer printMu.Unlock()
-			for _, warning := range warnings {
-				fmt.Fprintf(w, "   ⚠️  %s: %s\n", filepath.Base(afc.FilePath), warning)
-			}
 		}
 	}
 }

--- a/internal/commandutil/batch_config.go
+++ b/internal/commandutil/batch_config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
 	"github.com/javinizer/javinizer-go/internal/organizer"
 	"github.com/javinizer/javinizer-go/internal/worker"
 	"github.com/javinizer/javinizer-go/internal/workflow"
@@ -37,6 +38,29 @@ type CLIApplyOptions struct {
 	MergeOptions           workflow.MergeOptions
 }
 
+// persistedJobMode maps the CLI's update/organize toggle onto the persisted
+// job identity fields, mirroring the API job-creation mapping in
+// StartScrapeUseCase (internal/api/batch/usecases.go): the update flow's
+// leave-in-place operation projects to update=true + operation_mode=
+// metadata-artwork (applyplan.Project and the frontend's projectLegacyPlan
+// agree on that pairing, and resolveUpdateApplyConfig runs with
+// OrganizeOptions.Skip=true). Without this the CLI persisted update batches
+// as update=false + empty mode, and API/history consumers read them as
+// organize (#248 codex P2, F1).
+//
+// Organize runs (skipOrganize=false) keep an EMPTY mode override: the CLI
+// resolves seam strings without an operation-mode input, so stamping the
+// default ("organize") would additionally feed the organizer's per-command
+// strategy override and rewrite the user's configured operation mode — while
+// every consumer already infers organize from update=false + empty mode.
+func persistedJobMode(skipOrganize bool) (update *bool, mode operationmode.OperationMode) {
+	u := skipOrganize
+	if skipOrganize {
+		return &u, operationmode.OperationModeMetadataArtwork
+	}
+	return &u, ""
+}
+
 // ToApplyPhaseConfig converts CLIApplyOptions to a worker.ApplyPhaseConfig.
 func (o CLIApplyOptions) ToApplyPhaseConfig() worker.ApplyPhaseConfig {
 	// The --extrafanart flag is a force-enable: only emit a non-nil override
@@ -49,6 +73,10 @@ func (o CLIApplyOptions) ToApplyPhaseConfig() worker.ApplyPhaseConfig {
 		t := true
 		downloadExtrafanart = &t
 	}
+	// Persisted job identity (#248 codex P2, F1): committed onto the job by
+	// jobController.StartApply and mirrored at job creation (newCLIBatchRuntime)
+	// so a CLI update batch's jobs row classifies as update, not organize.
+	updateMode, modeOverride := persistedJobMode(o.SkipOrganize)
 	return worker.ApplyPhaseConfig{
 		OrganizeOptions: workflow.OrganizeOptions{
 			Skip:        o.SkipOrganize,
@@ -63,5 +91,7 @@ func (o CLIApplyOptions) ToApplyPhaseConfig() worker.ApplyPhaseConfig {
 		Download:               o.Download,
 		DownloadExtrafanart:    downloadExtrafanart,
 		OverwriteExistingMedia: o.OverwriteExistingMedia,
+		Update:                 updateMode,
+		OperationModeOverride:  modeOverride,
 	}
 }

--- a/internal/commandutil/batch_dryrun_dups_w248_test.go
+++ b/internal/commandutil/batch_dryrun_dups_w248_test.go
@@ -1,0 +1,180 @@
+package commandutil
+
+// Regression pins for #248 codex P2 — the dry-run leg of the authorized
+// intra-batch duplicate skip. The organizer's dry-run branch returned
+// OrganizeResult.Warnings WITHOUT setting DuplicateSkipped (the live leg sets
+// it), so the CLI dry-run summary silently reported "Would organize N"
+// counting BOTH winner and loser, the skip line never appeared, and the
+// duplicate warning text never printed (the post-apply hook gated ALL of it
+// behind the dry-run early return instead of gating just the eventlog
+// emission). Post-fix the dry-run skip result mirrors the live shape and the
+// summary reuses the live arithmetic (completed minus SkippedDuplicates).
+//
+// Fixtures follow batch_history_w244_test.go conventions: the
+// JAVINIZER_E2E_SCRAPERS seam substitutes the offline e2emock scraper, and all
+// paths are built with filepath.Join/t.TempDir (never POSIX literals) so the
+// tests stay Windows-safe.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupResidentMoverDryRunBatch writes the codex P2 dry-run fixture: a
+// RESIDENT already parked at its computed destination plus a MOVER planning
+// onto the identical destination, both below the scanned root (the batch's
+// Destination lives inside the scan tree so the resident IS a batch input).
+// With ForceUpdate the mover is an AUTHORIZED duplicate (warning + skip);
+// without it the mover loses through the ordinary conflict pipeline.
+func setupResidentMoverDryRunBatch(t *testing.T) (configPath, scan, moverSrc, residentPath string) {
+	t.Helper()
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+
+	tmpDir := t.TempDir()
+	scan = filepath.Join(tmpDir, "scan")
+	dest := filepath.Join(scan, "dest")
+	require.NoError(t, os.MkdirAll(filepath.Join(scan, "in"), 0o700))
+	residentDir := filepath.Join(dest, "GOOD-700")
+	require.NoError(t, os.MkdirAll(residentDir, 0o700))
+	moverSrc = filepath.Join(scan, "in", "GOOD-700.mp4")
+	residentPath = filepath.Join(residentDir, "GOOD-700.mp4")
+	require.NoError(t, os.WriteFile(moverSrc, []byte("mover bytes"), 0o600))
+	require.NoError(t, os.WriteFile(residentPath, []byte("resident bytes"), 0o600))
+
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.Database.DSN = filepath.Join(tmpDir, "javinizer.db")
+	cfg.Database.LogLevel = "silent"
+	cfg.Matching.Extensions = []string{".mp4"}
+	cfg.Matching.MinSizeMB = 0
+	cfg.Output.Template.FolderFormat = "<ID>"
+	cfg.Output.Template.SubfolderFormat = []string{}
+	cfg.Output.Template.FileFormat = "<ID>"
+	cfg.Output.Operation.RenameFile = true
+	// e2emock media URLs are non-resolvable; downloads are irrelevant here.
+	cfg.Output.Download.DownloadCover = false
+	cfg.Output.Download.DownloadPoster = false
+	cfg.Output.Download.DownloadExtrafanart = false
+	cfg.Output.Download.DownloadTrailer = false
+	cfg.Output.Download.DownloadActress = false
+
+	configPath = filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, config.Save(cfg, configPath))
+	return configPath, scan, moverSrc, residentPath
+}
+
+// assertDryRunStateUnchanged pins the preview contract on the filesystem: the
+// mover never left its source, the resident's bytes stand, no second video
+// landed at the destination, and no NFO was generated.
+func assertDryRunStateUnchanged(t *testing.T, scan, moverSrc, residentPath string) {
+	t.Helper()
+	assert.FileExists(t, moverSrc, "the mover's source must stay put in dry-run")
+	assert.FileExists(t, residentPath, "the resident's bytes must stand in dry-run")
+	count := 0
+	walkErr := filepath.Walk(scan, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		switch filepath.Ext(p) {
+		case ".mp4":
+			count++
+		case ".nfo":
+			t.Errorf("dry-run generated an NFO at %s", p)
+		}
+		return nil
+	})
+	require.NoError(t, walkErr)
+	assert.Equal(t, 2, count, "exactly the original two videos exist — no copy/move happened")
+}
+
+// TestRunBatchCommand_DryRun_AuthorizedDuplicateSkip_CountsWarnsUnchanged is
+// the core pin: a dry run over the resident+mover duplicate fixture with -f
+// must report the skip EXACTLY like live — winner/losers excluded from the
+// organize totals via the live arithmetic, the skip line counted, and the
+// warning text printed — while nothing on disk changes.
+func TestRunBatchCommand_DryRun_AuthorizedDuplicateSkip_CountsWarnsUnchanged(t *testing.T) {
+	configPath, scan, moverSrc, residentPath := setupResidentMoverDryRunBatch(t)
+	dest := filepath.Join(scan, "dest")
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   scan,
+		Destination:  dest,
+		Recursive:    true,
+		DryRun:       true,
+		MoveFiles:    true,
+		ForceUpdate:  true, // -f authorizes the intra-batch duplicate
+		GenerateNFO:  true,
+		CommandLabel: "Javinizer Sort",
+		ActionVerb:   "Processing files",
+		Resolved:     &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+
+	// Summary truth: the live arithmetic (completed minus skipped) drives the
+	// preview — pre-fix this read "Would organize 2 file(s)" with no skip line.
+	assert.NotContains(t, out, "Apply failed", "an authorized duplicate dry-run never fails\n%s", out)
+	assert.Contains(t, out, "Would organize 1 file(s)", "the skipped loser must not count as would-organize\n%s", out)
+	assert.Contains(t, out, "Skipped (authorized duplicates): 1", "the summary must count the dry-run skip\n%s", out)
+	assert.Contains(t, out, "Metadata found: 2", "both files scraped and matched\n%s", out)
+	assert.Contains(t, out, "Files organized: 1 (dry-run)", "summary totals reuse the live subtraction\n%s", out)
+	assert.Contains(t, out, "NFOs generated: 1 (dry-run)", "NFO totals exclude the skipped duplicate\n%s", out)
+
+	// The warning text prints to the console identically to live — pre-fix the
+	// dry-run gate swallowed it before the print.
+	assert.Contains(t, out, "⚠️", "the duplicate warning must print in dry-run\n%s", out)
+	assert.Contains(t, out, "duplicate destination within batch", "warning text must survive to the dry-run console\n%s", out)
+	assert.Contains(t, out, "already claimed by")
+	assert.Contains(t, out, "overwrite authorized")
+
+	assertDryRunStateUnchanged(t, scan, moverSrc, residentPath)
+}
+
+// TestRunBatchCommand_DryRun_UnauthorizedDuplicate_StillConflicts pins the
+// unchanged non-force leg: the same fixture WITHOUT -f keeps demoting the
+// mover through the ordinary conflict pipeline (a failed apply, no skip
+// accounting, no warning print) — exactly the pre-existing dry-run behavior.
+func TestRunBatchCommand_DryRun_UnauthorizedDuplicate_StillConflicts(t *testing.T) {
+	configPath, scan, moverSrc, residentPath := setupResidentMoverDryRunBatch(t)
+	dest := filepath.Join(scan, "dest")
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   scan,
+		Destination:  dest,
+		Recursive:    true,
+		DryRun:       true,
+		MoveFiles:    true,
+		ForceUpdate:  false,
+		CommandLabel: "Javinizer Sort",
+		ActionVerb:   "Processing files",
+		Resolved:     &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err, "per-file failures print but never fail the batch run")
+	out := buf.String()
+
+	// The mover fails through the validation pipeline; only the resident
+	// completes, so the preview counts exactly the resident.
+	assert.Contains(t, out, "Apply failed", "the unauthorized duplicate must surface as a failure\n%s", out)
+	assert.Contains(t, out, "organization validation failed")
+	assert.Contains(t, out, "Would organize 1 file(s)")
+	assert.Contains(t, out, "Metadata found: 1")
+	assert.NotContains(t, out, "Skipped (authorized duplicates)", "no authorization, no skip line")
+	assert.False(t, strings.Contains(out, "⚠️"), "no warning print without an authorized skip\n%s", out)
+
+	assertDryRunStateUnchanged(t, scan, moverSrc, residentPath)
+}

--- a/internal/commandutil/batch_history_w244_test.go
+++ b/internal/commandutil/batch_history_w244_test.go
@@ -1,0 +1,435 @@
+package commandutil
+
+// Regression pins for #244: the CLI batch runtime (sort/update) must persist
+// batch history with API parity — a persisted jobs row, batch_file_operations
+// revert-ledger rows (incl. the authorized duplicate-skip noop row), history
+// rows whose organize metadata carries the skip warning text, and eventlog
+// audit entries — instead of reporting "Applied ✓" while every audit trail
+// the API batches get vanishes.
+//
+// Fixtures build on the multipart_partsuffix_test.go pattern: the
+// JAVINIZER_E2E_SCRAPERS seam substitutes the offline e2emock scraper, and all
+// paths are built with filepath.Join/t.TempDir (never POSIX literals) so the
+// tests stay Windows-safe.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupDuplicateBatch writes a two-file intra-batch duplicate fixture: both
+// files scrape to GOOD-700 and plan onto the SAME destination
+// (<dest>/GOOD-700/GOOD-700.mp4) because file_format carries no PARTSUFFIX.
+// With ForceUpdate (-f) the second claimant is an AUTHORIZED duplicate:
+// demoted to a warning + skip (only the winner's bytes move).
+func setupDuplicateBatch(t *testing.T) (configPath, src, dest, dbPath string) {
+	t.Helper()
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+
+	tmpDir := t.TempDir()
+	src = filepath.Join(tmpDir, "src")
+	dest = filepath.Join(tmpDir, "dest")
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "a"), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "b"), 0o700))
+	require.NoError(t, os.MkdirAll(dest, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "a", "GOOD-700.mp4"), []byte("fake video a"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "b", "GOOD-700.mp4"), []byte("fake video b"), 0o600))
+
+	dbPath = filepath.Join(tmpDir, "javinizer.db")
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.Database.DSN = dbPath
+	cfg.Database.LogLevel = "silent"
+	cfg.Matching.Extensions = []string{".mp4"}
+	cfg.Matching.MinSizeMB = 0
+	cfg.Output.Template.FolderFormat = "<ID>"
+	cfg.Output.Template.SubfolderFormat = []string{}
+	cfg.Output.Template.FileFormat = "<ID>"
+	cfg.Output.Operation.RenameFile = true
+	// e2emock media URLs are non-resolvable; downloads are irrelevant here.
+	cfg.Output.Download.DownloadCover = false
+	cfg.Output.Download.DownloadPoster = false
+	cfg.Output.Download.DownloadExtrafanart = false
+	cfg.Output.Download.DownloadTrailer = false
+	cfg.Output.Download.DownloadActress = false
+
+	configPath = filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, config.Save(cfg, configPath))
+	return configPath, src, dest, dbPath
+}
+
+// batchIDFromOutput extracts the batch job UUID the presenter header prints.
+func batchIDFromOutput(t *testing.T, out string) string {
+	t.Helper()
+	m := regexp.MustCompile(`Batch Job: ([0-9a-f-]{36})`).FindStringSubmatch(out)
+	require.Len(t, m, 2, "header must print the batch job id\n%s", out)
+	return m[1]
+}
+
+// openAssertionDB re-opens the run's sqlite database read/write for
+// assertions. RunBatchCommand closes its own handle, so tests must not share it.
+func openAssertionDB(t *testing.T, dbPath string) *database.DB {
+	t.Helper()
+	db, err := database.New(&database.Config{Type: "sqlite", DSN: dbPath, LogLevel: "silent"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestRunBatchCommand_DuplicateSkip_PersistsAuditRows is the #244 core pin:
+// after a live 2-file authorized duplicate batch with -f, every audit surface
+// the API batches get must be populated for the CLI flow too.
+func TestRunBatchCommand_DuplicateSkip_PersistsAuditRows(t *testing.T) {
+	configPath, src, dest, dbPath := setupDuplicateBatch(t)
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   src,
+		Destination:  dest,
+		Recursive:    true,
+		MoveFiles:    true,
+		ForceUpdate:  true, // -f authorizes the intra-batch duplicate
+		GenerateNFO:  true,
+		CommandLabel: "Javinizer Sort",
+		ActionVerb:   "Processing files",
+		Resolved:     &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+
+	// Console truth: the skip is reported, not hidden behind a bare "Applied ✓".
+	batchID := batchIDFromOutput(t, out)
+	assert.Contains(t, out, "⚠️", "skip warning must print to the console\n%s", out)
+	assert.Contains(t, out, "duplicate destination within batch", "warning text must survive to the console\n%s", out)
+	assert.Contains(t, out, "Skipped (authorized duplicates): 1", "summary must count the skip\n%s", out)
+
+	ctx := context.Background()
+	db := openAssertionDB(t, dbPath)
+	repos := db.Repositories()
+
+	// (i) jobs row: the CLI batch is queryable via `history list --batch`.
+	job, err := repos.JobRepo.FindByID(ctx, batchID)
+	require.NoError(t, err, "jobs row for the CLI batch must persist")
+	require.NotNil(t, job)
+	assert.Equal(t, models.JobStatusOrganized, job.Status)
+	assert.NotNil(t, job.OrganizedAt)
+
+	// (i) batch_file_operations: winner applied, loser finalized noop with no
+	// NewPath (its display path would name the winner's destination).
+	ops, err := repos.BatchFileOpRepo.FindByBatchJobID(ctx, batchID)
+	require.NoError(t, err)
+	require.Len(t, ops, 2, "both files must journal an operation row. ops=%v", ops)
+	var noopOps, appliedOps []models.BatchFileOperation
+	for _, op := range ops {
+		switch op.RevertStatus {
+		case models.RevertStatusNoOp:
+			noopOps = append(noopOps, op)
+		case models.RevertStatusApplied:
+			appliedOps = append(appliedOps, op)
+		}
+	}
+	require.Len(t, noopOps, 1, "the authorized duplicate skip must finalize completed-noop")
+	require.Len(t, appliedOps, 1, "the batch winner's move row stays applied")
+	assert.Empty(t, noopOps[0].NewPath, "noop row must not arm revert against the winner's destination")
+	assert.Equal(t,
+		filepath.Join(dest, "GOOD-700", "GOOD-700.mp4"),
+		appliedOps[0].NewPath,
+		"the winner row names its real destination")
+
+	// (i) history rows: scrape + organize per file, and the loser's organize
+	// metadata carries the skip warning text (the text that previously vanished).
+	rows, err := repos.HistoryRepo.FindByBatchJobID(ctx, batchID)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(rows), 4, "scrape+organize rows for both files")
+	warningRows := 0
+	for _, h := range rows {
+		if h.Operation == models.HistoryOpOrganize && h.Status == models.HistoryStatusSuccess {
+			if h.Metadata != "" && strings.Contains(h.Metadata, "duplicate destination within batch") {
+				warningRows++
+			}
+		}
+	}
+	assert.Equal(t, 1, warningRows, "exactly one organize history row carries the skip warning metadata")
+
+	// (ii) eventlog: one organize warning audit entry per skip warning.
+	events, err := repos.EventRepo.FindFiltered(ctx, database.EventFilter{
+		EventType: models.EventCategoryOrganize,
+		Severity:  models.SeverityWarn,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, events, "the skip warning must land in the eventlog")
+	assert.Contains(t, events[0].Message, "duplicate destination within batch")
+}
+
+// TestRunBatchCommand_DryRun_WritesNoOperationalRows pins the preview
+// semantics: dry runs write NO revert-ledger rows (a preview never moves the
+// bytes a revert would target), no jobs row, and no eventlog entries — while
+// history rows still land with their dry_run flag so previews stay auditable.
+func TestRunBatchCommand_DryRun_WritesNoOperationalRows(t *testing.T) {
+	configPath, src, dest, dbPath := setupDuplicateBatch(t)
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   src,
+		Destination:  dest,
+		Recursive:    true,
+		MoveFiles:    true,
+		ForceUpdate:  true,
+		GenerateNFO:  true,
+		DryRun:       true,
+		CommandLabel: "Javinizer Sort",
+		ActionVerb:   "Processing files",
+		Resolved:     &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	batchID := batchIDFromOutput(t, out) // a preview still names its run identity
+
+	ctx := context.Background()
+	db := openAssertionDB(t, dbPath)
+	repos := db.Repositories()
+
+	jobs, err := repos.JobRepo.List(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, jobs, "dry run persists no jobs row")
+
+	opCount, err := repos.BatchFileOpRepo.CountByBatchJobID(ctx, batchID)
+	require.NoError(t, err)
+	assert.Zero(t, opCount, "dry run writes no batch_file_operations rows (revert ledger)")
+
+	eventCount, err := repos.EventRepo.Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, eventCount, "dry run emits no audit events — previews are not operations")
+
+	historyCount, err := repos.HistoryRepo.Count(ctx)
+	require.NoError(t, err)
+	assert.Greater(t, historyCount, int64(0), "dry-run history rows remain visible")
+	rows, err := repos.HistoryRepo.FindByOperation(ctx, models.HistoryOpOrganize, 50)
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+	for _, h := range rows {
+		assert.True(t, h.DryRun, "organize history from a preview must carry the dry_run flag")
+	}
+}
+
+// TestRunBatchCommand_RuntimeConstructionError covers the error branch where
+// the batch runtime cannot be constructed (seam replaced by a failing stub).
+func TestRunBatchCommand_RuntimeConstructionError(t *testing.T) {
+	configPath, src, dest, _ := setupDuplicateBatch(t)
+
+	orig := newCLIBatchRuntimeFn
+	t.Cleanup(func() { newCLIBatchRuntimeFn = orig })
+	newCLIBatchRuntimeFn = func(_ *bootstrapResult, _ *config.Config, _ BatchCommandOptions, _ worker.BatchJobConfig, _ []string) (*cliBatchRuntime, error) {
+		return nil, fmt.Errorf("simulated runtime failure")
+	}
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   src,
+		Destination:  dest,
+		Recursive:    true,
+		CommandLabel: "Javinizer Sort",
+		ActionVerb:   "Processing files",
+		Presenter:    &SilentBatchCommandPresenter{},
+		Resolved:     &workflow.ResolvedSeamStrings{},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create batch job runtime")
+	assert.Contains(t, err.Error(), "simulated runtime failure")
+}
+
+// TestNewCLIBatchRuntime_NilWorkflowFactory covers the defensive error branch
+// for a bootstrapResult constructed without a workflow factory.
+func TestNewCLIBatchRuntime_NilWorkflowFactory(t *testing.T) {
+	rt, err := newCLIBatchRuntime(&bootstrapResult{}, config.DefaultConfig(nil, nil), BatchCommandOptions{BatchJobID: "job-x"}, BatchJobConfigFromAppConfig(config.DefaultConfig(nil, nil)), nil)
+	require.Error(t, err)
+	assert.Nil(t, rt)
+	assert.Contains(t, err.Error(), "workflow factory unavailable")
+}
+
+// TestDefaultPresenter_HeaderPrintsBatchJobID pins the presenter surface the
+// e2e suite parses: the run's persisted batch identity is printed once.
+func TestDefaultPresenter_HeaderPrintsBatchJobID(t *testing.T) {
+	var buf bytes.Buffer
+	p := &defaultBatchCommandPresenter{}
+	p.OnHeader(&buf, BatchCommandOptions{
+		CommandLabel: "Javinizer Sort",
+		SourcePath:   "src",
+		Destination:  "dest",
+		BatchJobID:   "job-123",
+	})
+	assert.Contains(t, buf.String(), "Batch Job: job-123")
+
+	// Empty id (tests that never reach the batch stage) prints nothing.
+	buf.Reset()
+	p.OnHeader(&buf, BatchCommandOptions{CommandLabel: "Javinizer Sort"})
+	assert.NotContains(t, buf.String(), "Batch Job:")
+}
+
+// TestDefaultSummaryPrinter_SkippedDuplicatesLine pins the summary truth:
+// authorized duplicate skips are counted separately from organized files.
+func TestDefaultSummaryPrinter_SkippedDuplicatesLine(t *testing.T) {
+	var buf bytes.Buffer
+	defaultSummaryPrinter(&buf, BatchCommandOptions{}, BatchCommandResult{
+		ScanResult:        &workflow.ScanAndMatchResult{},
+		SuccessCount:      2,
+		SkippedDuplicates: 1,
+	})
+	assert.Contains(t, buf.String(), "Skipped (authorized duplicates): 1")
+
+	// Zero skips keep the summary unchanged.
+	buf.Reset()
+	defaultSummaryPrinter(&buf, BatchCommandOptions{}, BatchCommandResult{ScanResult: &workflow.ScanAndMatchResult{}})
+	assert.NotContains(t, buf.String(), "Skipped (authorized duplicates)")
+}
+
+// ---------------------------------------------------------------------------
+// cliBatchPostApply unit pins
+// ---------------------------------------------------------------------------
+
+// recordingEmitter captures emitted organize events without a database.
+type recordingEmitter struct {
+	mu     sync.Mutex
+	events []models.Event
+}
+
+func (e *recordingEmitter) record(sev models.EventSeverity, message string, ctx map[string]any) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.events = append(e.events, models.Event{EventType: models.EventCategoryOrganize, Severity: sev, Message: message})
+}
+
+func (e *recordingEmitter) EmitScraperEvent(_ context.Context, source string, message string, severity models.EventSeverity, eventCtx map[string]any) error {
+	e.record(severity, message, eventCtx)
+	return nil
+}
+
+func (e *recordingEmitter) EmitOrganizeEvent(_ context.Context, source string, message string, severity models.EventSeverity, eventCtx map[string]any) error {
+	e.record(severity, message, eventCtx)
+	return nil
+}
+
+func (e *recordingEmitter) EmitSystemEvent(_ context.Context, source string, message string, severity models.EventSeverity, eventCtx map[string]any) error {
+	e.record(severity, message, eventCtx)
+	return nil
+}
+
+func (e *recordingEmitter) Stats() (int64, int64) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return int64(len(e.events)), 0
+}
+
+func (e *recordingEmitter) snapshot() []models.Event {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]models.Event(nil), e.events...)
+}
+
+func TestCliBatchPostApply_SuccessWithDuplicateSkipWarning(t *testing.T) {
+	var (
+		emitter   = &recordingEmitter{}
+		buf       bytes.Buffer
+		skipCount = &atomic.Int64{}
+		printMu   = &sync.Mutex{}
+	)
+	hook := cliBatchPostApply(emitter, &buf, "job-1", false, skipCount, printMu)
+
+	hook(context.Background(),
+		&worker.ApplyFileContext{FilePath: filepath.Join("src", "GOOD-700.mp4"), Movie: &models.Movie{ID: "GOOD-700"}},
+		&worker.ApplyFileResult{Result: &workflow.ApplyResult{
+			OrganizeResult: &organizer.OrganizeResult{
+				NewPath:          filepath.Join("dest", "GOOD-700", "GOOD-700.mp4"),
+				Warnings:         []string{"duplicate destination within batch: ... already claimed by /src/a/GOOD-700.mp4 (overwrite authorized)"},
+				DuplicateSkipped: true,
+			},
+		}},
+	)
+
+	events := emitter.snapshot()
+	require.Len(t, events, 2, "info event + warning event")
+	assert.Equal(t, models.SeverityInfo, events[0].Severity)
+	assert.Equal(t, models.SeverityWarn, events[1].Severity)
+	assert.Contains(t, events[1].Message, "duplicate destination within batch")
+	assert.Equal(t, int64(1), skipCount.Load(), "skip counted for the summary")
+	assert.Contains(t, buf.String(), "⚠️")
+	assert.Contains(t, buf.String(), "duplicate destination within batch")
+}
+
+func TestCliBatchPostApply_ApplyError_EmitsErrorEvent(t *testing.T) {
+	var (
+		emitter   = &recordingEmitter{}
+		buf       bytes.Buffer
+		skipCount = &atomic.Int64{}
+	)
+	hook := cliBatchPostApply(emitter, &buf, "job-1", false, skipCount, &sync.Mutex{})
+
+	hook(context.Background(),
+		&worker.ApplyFileContext{FilePath: "x", Movie: &models.Movie{ID: "GOOD-700"}},
+		&worker.ApplyFileResult{Err: fmt.Errorf("disk full")},
+	)
+
+	events := emitter.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, models.SeverityError, events[0].Severity)
+	assert.Contains(t, events[0].Message, "Organize failed for GOOD-700")
+	assert.Empty(t, buf.String(), "failures surface via the event handler, not warning prints")
+}
+
+func TestCliBatchPostApply_DryRunEmitsNothing(t *testing.T) {
+	var (
+		emitter   = &recordingEmitter{}
+		buf       bytes.Buffer
+		skipCount = &atomic.Int64{}
+	)
+	hook := cliBatchPostApply(emitter, &buf, "job-1", true, skipCount, &sync.Mutex{})
+
+	hook(context.Background(),
+		&worker.ApplyFileContext{FilePath: "x", Movie: &models.Movie{ID: "GOOD-700"}},
+		&worker.ApplyFileResult{Result: &workflow.ApplyResult{OrganizeResult: &organizer.OrganizeResult{
+			Warnings:         []string{"w"},
+			DuplicateSkipped: true,
+		}}},
+	)
+
+	assert.Empty(t, emitter.snapshot())
+	assert.Empty(t, buf.String())
+}
+
+func TestCliBatchPostApply_NilPayloads(t *testing.T) {
+	hook := cliBatchPostApply(&recordingEmitter{}, &bytes.Buffer{}, "job-1", false, &atomic.Int64{}, &sync.Mutex{})
+	movie := &models.Movie{ID: "GOOD-700"}
+	afc := &worker.ApplyFileContext{FilePath: "x", Movie: movie}
+	afr := &worker.ApplyFileResult{}
+
+	hook(context.Background(), nil, afr)                                     // nil context
+	hook(context.Background(), &worker.ApplyFileContext{FilePath: "x"}, afr) // nil movie
+	hook(context.Background(), afc, nil)                                     // nil result
+
+	// Success with NO OrganizeResult (result nil) still emits the info event.
+	emitter := &recordingEmitter{}
+	hook = cliBatchPostApply(emitter, &bytes.Buffer{}, "job-1", false, &atomic.Int64{}, &sync.Mutex{})
+	hook(context.Background(), afc, &worker.ApplyFileResult{})
+	events := emitter.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, models.SeverityInfo, events[0].Severity)
+}

--- a/internal/commandutil/batch_history_w244_test.go
+++ b/internal/commandutil/batch_history_w244_test.go
@@ -308,9 +308,14 @@ func TestNewCLIBatchRuntime_NilWorkflowFactory(t *testing.T) {
 	assert.Contains(t, err.Error(), "workflow factory unavailable")
 }
 
-// TestDefaultPresenter_HeaderPrintsBatchJobID pins the presenter surface the
-// e2e suite parses: the run's persisted batch identity is printed once.
-func TestDefaultPresenter_HeaderPrintsBatchJobID(t *testing.T) {
+// TestDefaultPresenter_HeaderDefersAuditID pins the #248 codex P2 (R2)
+// restructure: at header time (pre-scan) the persistence state is UNKNOWN —
+// a live jobs row only exists once the runtime is constructed post-scan, and
+// the scan early-exit legs never persist one — so the header renders NO
+// batch identity in any mode. OnAuditID owns the identity line: the live id
+// prints strictly post-persist, early exits get the no-audit sentence, and
+// the unqueryable id never leaks.
+func TestDefaultPresenter_HeaderDefersAuditID(t *testing.T) {
 	var buf bytes.Buffer
 	p := &defaultBatchCommandPresenter{}
 	p.OnHeader(&buf, BatchCommandOptions{
@@ -319,19 +324,38 @@ func TestDefaultPresenter_HeaderPrintsBatchJobID(t *testing.T) {
 		Destination:  "dest",
 		BatchJobID:   "job-123",
 	})
+	out := buf.String()
+	assert.NotContains(t, out, "Batch Job:", "live header defers the identity to post-persist\n%s", out)
+	assert.NotContains(t, out, "job-123", "the not-yet-persisted id must not leak from the pre-scan header\n%s", out)
+
+	// Post-persist (live): the queryable identity prints verbatim — the
+	// console surface the e2e suite parses.
+	buf.Reset()
+	p.OnAuditID(&buf, BatchCommandOptions{BatchJobID: "job-123"}, true)
 	assert.Contains(t, buf.String(), "Batch Job: job-123")
 
-	// Empty id (tests that never reach the batch stage) prints nothing.
+	// Early-exit (nothing persisted): the no-audit sentence, never the id.
 	buf.Reset()
-	p.OnHeader(&buf, BatchCommandOptions{CommandLabel: "Javinizer Sort"})
+	p.OnAuditID(&buf, BatchCommandOptions{BatchJobID: "job-123"}, false)
+	out = buf.String()
+	assert.NotContains(t, out, "Batch Job:")
+	assert.Contains(t, out, "Preview (not persisted; no audit ID)")
+	assert.NotContains(t, out, "job-123")
+
+	// Degenerate guard: persisted claimed with no id available still prints
+	// no empty 'Batch Job: ' token.
+	buf.Reset()
+	p.OnAuditID(&buf, BatchCommandOptions{}, true)
 	assert.NotContains(t, buf.String(), "Batch Job:")
+	assert.Contains(t, buf.String(), "Preview (not persisted; no audit ID)")
 }
 
 // TestDefaultPresenter_HeaderDryRunPrintsNoQueryableID pins the #248 codex P2
 // truthful-rendering leg on the presenter directly: a dry run persists no
 // jobs row, so the header must not print a queryable-looking 'Batch Job: <id>'
 // (history list --batch <id> answers 'batch job not found'); it labels the
-// run a preview instead. Live runs keep printing the persisted identity.
+// run a preview instead. Live runs keep printing the persisted identity —
+// deferred to OnAuditID after the jobs row exists (#248 codex P2, R2).
 func TestDefaultPresenter_HeaderDryRunPrintsNoQueryableID(t *testing.T) {
 	var buf bytes.Buffer
 	p := &defaultBatchCommandPresenter{}
@@ -347,7 +371,9 @@ func TestDefaultPresenter_HeaderDryRunPrintsNoQueryableID(t *testing.T) {
 	assert.Contains(t, out, "Preview (not persisted; no audit ID)")
 	assert.NotContains(t, out, "job-123", "the unqueryable id must not leak into the header\n%s", out)
 
-	// Live regression: the persisted batch identity still prints verbatim.
+	// Live flow (#248 codex P2, R2): the pre-scan header prints NO identity
+	// (persistence state unknown), and the persisted batch identity prints
+	// verbatim post-persist via OnAuditID.
 	buf.Reset()
 	p.OnHeader(&buf, BatchCommandOptions{
 		CommandLabel: "Javinizer Sort",
@@ -355,6 +381,9 @@ func TestDefaultPresenter_HeaderDryRunPrintsNoQueryableID(t *testing.T) {
 		Destination:  "dest",
 		BatchJobID:   "job-123",
 	})
+	assert.NotContains(t, buf.String(), "Batch Job:", "live header carries no identity pre-scan\n%s", buf.String())
+	buf.Reset()
+	p.OnAuditID(&buf, BatchCommandOptions{BatchJobID: "job-123"}, true)
 	assert.Contains(t, buf.String(), "Batch Job: job-123")
 }
 

--- a/internal/commandutil/batch_history_w244_test.go
+++ b/internal/commandutil/batch_history_w244_test.go
@@ -206,6 +206,11 @@ func TestRunBatchCommand_DuplicateSkip_PersistsAuditRows(t *testing.T) {
 // semantics: dry runs write NO revert-ledger rows (a preview never moves the
 // bytes a revert would target), no jobs row, and no eventlog entries — while
 // history rows still land with their dry_run flag so previews stay auditable.
+// Console side (#248 codex P2): because no jobs row persists, the header must
+// NOT print a queryable-looking "Batch Job: <id>" token (`history list --batch
+// <id>` would answer 'batch job not found'); it labels the run a preview.
+// The run identity for the ledger assertions below is read back from the
+// dry-run history rows' batch_job_id, not from the console.
 func TestRunBatchCommand_DryRun_WritesNoOperationalRows(t *testing.T) {
 	configPath, src, dest, dbPath := setupDuplicateBatch(t)
 
@@ -225,7 +230,13 @@ func TestRunBatchCommand_DryRun_WritesNoOperationalRows(t *testing.T) {
 	})
 	require.NoError(t, err)
 	out := buf.String()
-	batchID := batchIDFromOutput(t, out) // a preview still names its run identity
+
+	// Truthful rendering (#248 codex P2): the console advertises NO queryable
+	// batch identity for a preview — nothing here parses as `history list
+	// --batch <id>` input, and the header says why there is no audit ID.
+	assert.NotContains(t, out, "Batch Job:", "a preview must not print a queryable audit ID\n%s", out)
+	assert.Contains(t, out, "Preview (not persisted; no audit ID)",
+		"the dry-run header states the run is not persisted\n%s", out)
 
 	ctx := context.Background()
 	db := openAssertionDB(t, dbPath)
@@ -234,10 +245,6 @@ func TestRunBatchCommand_DryRun_WritesNoOperationalRows(t *testing.T) {
 	jobs, err := repos.JobRepo.List(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, jobs, "dry run persists no jobs row")
-
-	opCount, err := repos.BatchFileOpRepo.CountByBatchJobID(ctx, batchID)
-	require.NoError(t, err)
-	assert.Zero(t, opCount, "dry run writes no batch_file_operations rows (revert ledger)")
 
 	eventCount, err := repos.EventRepo.Count(ctx)
 	require.NoError(t, err)
@@ -249,9 +256,20 @@ func TestRunBatchCommand_DryRun_WritesNoOperationalRows(t *testing.T) {
 	rows, err := repos.HistoryRepo.FindByOperation(ctx, models.HistoryOpOrganize, 50)
 	require.NoError(t, err)
 	require.NotEmpty(t, rows)
+	var batchID string
 	for _, h := range rows {
 		assert.True(t, h.DryRun, "organize history from a preview must carry the dry_run flag")
+		if h.BatchJobID != nil && *h.BatchJobID != "" {
+			batchID = *h.BatchJobID
+		}
 	}
+	require.NotEmpty(t, batchID, "dry-run history rows still bind the run identity internally")
+
+	// The preview's run identity must have NO revert-ledger rows under it —
+	// read back from the history rows since the console no longer names it.
+	opCount, err := repos.BatchFileOpRepo.CountByBatchJobID(ctx, batchID)
+	require.NoError(t, err)
+	assert.Zero(t, opCount, "dry run writes no batch_file_operations rows (revert ledger)")
 }
 
 // TestRunBatchCommand_RuntimeConstructionError covers the error branch where
@@ -307,6 +325,37 @@ func TestDefaultPresenter_HeaderPrintsBatchJobID(t *testing.T) {
 	buf.Reset()
 	p.OnHeader(&buf, BatchCommandOptions{CommandLabel: "Javinizer Sort"})
 	assert.NotContains(t, buf.String(), "Batch Job:")
+}
+
+// TestDefaultPresenter_HeaderDryRunPrintsNoQueryableID pins the #248 codex P2
+// truthful-rendering leg on the presenter directly: a dry run persists no
+// jobs row, so the header must not print a queryable-looking 'Batch Job: <id>'
+// (history list --batch <id> answers 'batch job not found'); it labels the
+// run a preview instead. Live runs keep printing the persisted identity.
+func TestDefaultPresenter_HeaderDryRunPrintsNoQueryableID(t *testing.T) {
+	var buf bytes.Buffer
+	p := &defaultBatchCommandPresenter{}
+	p.OnHeader(&buf, BatchCommandOptions{
+		CommandLabel: "Javinizer Sort",
+		SourcePath:   "src",
+		Destination:  "dest",
+		DryRun:       true,
+		BatchJobID:   "job-123",
+	})
+	out := buf.String()
+	assert.NotContains(t, out, "Batch Job:", "a preview prints no queryable audit ID\n%s", out)
+	assert.Contains(t, out, "Preview (not persisted; no audit ID)")
+	assert.NotContains(t, out, "job-123", "the unqueryable id must not leak into the header\n%s", out)
+
+	// Live regression: the persisted batch identity still prints verbatim.
+	buf.Reset()
+	p.OnHeader(&buf, BatchCommandOptions{
+		CommandLabel: "Javinizer Sort",
+		SourcePath:   "src",
+		Destination:  "dest",
+		BatchJobID:   "job-123",
+	})
+	assert.Contains(t, buf.String(), "Batch Job: job-123")
 }
 
 // TestDefaultSummaryPrinter_SkippedDuplicatesLine pins the summary truth:

--- a/internal/commandutil/batch_history_w244_test.go
+++ b/internal/commandutil/batch_history_w244_test.go
@@ -120,6 +120,30 @@ func TestRunBatchCommand_DuplicateSkip_PersistsAuditRows(t *testing.T) {
 	assert.Contains(t, out, "duplicate destination within batch", "warning text must survive to the console\n%s", out)
 	assert.Contains(t, out, "Skipped (authorized duplicates): 1", "summary must count the skip\n%s", out)
 
+	// #248 codex P2 (F2): the visible counts must match the real file
+	// movement — ONE winner moved, the authorized duplicate loser stayed put.
+	// Completed-minus-skips keeps "Metadata found" intact (both files scraped)
+	// while organize/NFO totals count only files whose bytes landed.
+	assert.Contains(t, out, "Organized 1 file(s)", "organize headline counts only real moves\n%s", out)
+	assert.Contains(t, out, "Metadata found: 2", "metadata-found counts both scraped files\n%s", out)
+	assert.Contains(t, out, "NFOs generated: 1", "NFO totals exclude the skipped duplicate\n%s", out)
+	assert.Contains(t, out, "Files organized: 1", "summary organized total excludes the skipped duplicate\n%s", out)
+	countVideos := func(root string) int {
+		t.Helper()
+		count := 0
+		walkErr := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+			if err == nil && !info.IsDir() && filepath.Ext(p) == ".mp4" {
+				count++
+			}
+			return err
+		})
+		require.NoError(t, walkErr)
+		return count
+	}
+	assert.Equal(t, 1, countVideos(dest), "exactly one winner's bytes landed at the destination")
+	assert.FileExists(t, filepath.Join(dest, "GOOD-700", "GOOD-700.mp4"))
+	assert.Equal(t, 1, countVideos(src), "the authorized duplicate loser never moved")
+
 	ctx := context.Background()
 	db := openAssertionDB(t, dbPath)
 	repos := db.Repositories()
@@ -302,6 +326,63 @@ func TestDefaultSummaryPrinter_SkippedDuplicatesLine(t *testing.T) {
 	assert.NotContains(t, buf.String(), "Skipped (authorized duplicates)")
 }
 
+// TestDefaultSummaryPrinter_SkipAdjustedOrganizeTotals pins #248 codex P2
+// (F2): organize/output success totals are completed MINUS skipped duplicates
+// (subtraction at this summary aggregation site only), while metadata-found
+// counting stays intact.
+func TestDefaultSummaryPrinter_SkipAdjustedOrganizeTotals(t *testing.T) {
+	newResult := func(skips int) BatchCommandResult {
+		return BatchCommandResult{
+			ScanResult:        &workflow.ScanAndMatchResult{},
+			SuccessCount:      2,
+			SkippedDuplicates: skips,
+		}
+	}
+
+	// Live sort: 2 completed, 1 authorized skip → exactly 1 file actually moved.
+	var buf bytes.Buffer
+	defaultSummaryPrinter(&buf, BatchCommandOptions{GenerateNFO: true}, newResult(1))
+	out := buf.String()
+	assert.Contains(t, out, "Organized 1 file(s)", "completed minus skips")
+	assert.Contains(t, out, "Metadata found: 2", "metadata-found keeps counting every completed file")
+	assert.Contains(t, out, "NFOs generated: 1")
+	assert.Contains(t, out, "Files organized: 1")
+
+	// Dry run inherits the same subtraction discipline.
+	buf.Reset()
+	defaultSummaryPrinter(&buf, BatchCommandOptions{DryRun: true, GenerateNFO: true}, newResult(1))
+	out = buf.String()
+	assert.Contains(t, out, "Would organize 1 file(s)")
+	assert.Contains(t, out, "NFOs generated: 1 (dry-run)")
+	assert.Contains(t, out, "Files organized: 1 (dry-run)")
+
+	// A pathological skip surplus clamps at zero rather than printing a
+	// negative count.
+	buf.Reset()
+	defaultSummaryPrinter(&buf, BatchCommandOptions{GenerateNFO: true}, BatchCommandResult{
+		ScanResult:        &workflow.ScanAndMatchResult{},
+		SuccessCount:      1,
+		SkippedDuplicates: 2,
+	})
+	out = buf.String()
+	assert.Contains(t, out, "Organized 0 file(s)")
+	assert.Contains(t, out, "Files organized: 0")
+
+	// Update-mode lines are driven by len(Movies) and stay untouched; the skip
+	// line still reports truthfully if a skip somehow occurred.
+	buf.Reset()
+	defaultSummaryPrinter(&buf, BatchCommandOptions{SkipOrganize: true}, BatchCommandResult{
+		ScanResult:        &workflow.ScanAndMatchResult{},
+		SuccessCount:      2,
+		SkippedDuplicates: 1,
+		FailedCount:       0,
+		Movies:            map[string]*models.Movie{"GOOD-700": {}},
+	})
+	out = buf.String()
+	assert.Contains(t, out, "Updated: 1, Failed: 0")
+	assert.Contains(t, out, "Skipped (authorized duplicates): 1")
+}
+
 // ---------------------------------------------------------------------------
 // cliBatchPostApply unit pins
 // ---------------------------------------------------------------------------
@@ -312,24 +393,24 @@ type recordingEmitter struct {
 	events []models.Event
 }
 
-func (e *recordingEmitter) record(sev models.EventSeverity, message string, ctx map[string]any) {
+func (e *recordingEmitter) record(source string, sev models.EventSeverity, message string, ctx map[string]any) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.events = append(e.events, models.Event{EventType: models.EventCategoryOrganize, Severity: sev, Message: message})
+	e.events = append(e.events, models.Event{EventType: models.EventCategoryOrganize, Source: source, Severity: sev, Message: message})
 }
 
 func (e *recordingEmitter) EmitScraperEvent(_ context.Context, source string, message string, severity models.EventSeverity, eventCtx map[string]any) error {
-	e.record(severity, message, eventCtx)
+	e.record(source, severity, message, eventCtx)
 	return nil
 }
 
 func (e *recordingEmitter) EmitOrganizeEvent(_ context.Context, source string, message string, severity models.EventSeverity, eventCtx map[string]any) error {
-	e.record(severity, message, eventCtx)
+	e.record(source, severity, message, eventCtx)
 	return nil
 }
 
 func (e *recordingEmitter) EmitSystemEvent(_ context.Context, source string, message string, severity models.EventSeverity, eventCtx map[string]any) error {
-	e.record(severity, message, eventCtx)
+	e.record(source, severity, message, eventCtx)
 	return nil
 }
 
@@ -352,7 +433,7 @@ func TestCliBatchPostApply_SuccessWithDuplicateSkipWarning(t *testing.T) {
 		skipCount = &atomic.Int64{}
 		printMu   = &sync.Mutex{}
 	)
-	hook := cliBatchPostApply(emitter, &buf, "job-1", false, skipCount, printMu)
+	hook := cliBatchPostApply(emitter, &buf, "job-1", false, false, skipCount, printMu)
 
 	hook(context.Background(),
 		&worker.ApplyFileContext{FilePath: filepath.Join("src", "GOOD-700.mp4"), Movie: &models.Movie{ID: "GOOD-700"}},
@@ -368,7 +449,10 @@ func TestCliBatchPostApply_SuccessWithDuplicateSkipWarning(t *testing.T) {
 	events := emitter.snapshot()
 	require.Len(t, events, 2, "info event + warning event")
 	assert.Equal(t, models.SeverityInfo, events[0].Severity)
+	assert.Equal(t, "file_move", events[0].Source, "organize mode keeps the file_move taxonomy")
+	assert.Equal(t, "Organized GOOD-700", events[0].Message)
 	assert.Equal(t, models.SeverityWarn, events[1].Severity)
+	assert.Equal(t, "file_move", events[1].Source)
 	assert.Contains(t, events[1].Message, "duplicate destination within batch")
 	assert.Equal(t, int64(1), skipCount.Load(), "skip counted for the summary")
 	assert.Contains(t, buf.String(), "⚠️")
@@ -381,7 +465,7 @@ func TestCliBatchPostApply_ApplyError_EmitsErrorEvent(t *testing.T) {
 		buf       bytes.Buffer
 		skipCount = &atomic.Int64{}
 	)
-	hook := cliBatchPostApply(emitter, &buf, "job-1", false, skipCount, &sync.Mutex{})
+	hook := cliBatchPostApply(emitter, &buf, "job-1", false, false, skipCount, &sync.Mutex{})
 
 	hook(context.Background(),
 		&worker.ApplyFileContext{FilePath: "x", Movie: &models.Movie{ID: "GOOD-700"}},
@@ -391,6 +475,7 @@ func TestCliBatchPostApply_ApplyError_EmitsErrorEvent(t *testing.T) {
 	events := emitter.snapshot()
 	require.Len(t, events, 1)
 	assert.Equal(t, models.SeverityError, events[0].Severity)
+	assert.Equal(t, "file_move", events[0].Source)
 	assert.Contains(t, events[0].Message, "Organize failed for GOOD-700")
 	assert.Empty(t, buf.String(), "failures surface via the event handler, not warning prints")
 }
@@ -401,7 +486,7 @@ func TestCliBatchPostApply_DryRunEmitsNothing(t *testing.T) {
 		buf       bytes.Buffer
 		skipCount = &atomic.Int64{}
 	)
-	hook := cliBatchPostApply(emitter, &buf, "job-1", true, skipCount, &sync.Mutex{})
+	hook := cliBatchPostApply(emitter, &buf, "job-1", true, false, skipCount, &sync.Mutex{})
 
 	hook(context.Background(),
 		&worker.ApplyFileContext{FilePath: "x", Movie: &models.Movie{ID: "GOOD-700"}},
@@ -416,7 +501,7 @@ func TestCliBatchPostApply_DryRunEmitsNothing(t *testing.T) {
 }
 
 func TestCliBatchPostApply_NilPayloads(t *testing.T) {
-	hook := cliBatchPostApply(&recordingEmitter{}, &bytes.Buffer{}, "job-1", false, &atomic.Int64{}, &sync.Mutex{})
+	hook := cliBatchPostApply(&recordingEmitter{}, &bytes.Buffer{}, "job-1", false, false, &atomic.Int64{}, &sync.Mutex{})
 	movie := &models.Movie{ID: "GOOD-700"}
 	afc := &worker.ApplyFileContext{FilePath: "x", Movie: movie}
 	afr := &worker.ApplyFileResult{}
@@ -427,9 +512,72 @@ func TestCliBatchPostApply_NilPayloads(t *testing.T) {
 
 	// Success with NO OrganizeResult (result nil) still emits the info event.
 	emitter := &recordingEmitter{}
-	hook = cliBatchPostApply(emitter, &bytes.Buffer{}, "job-1", false, &atomic.Int64{}, &sync.Mutex{})
+	hook = cliBatchPostApply(emitter, &bytes.Buffer{}, "job-1", false, false, &atomic.Int64{}, &sync.Mutex{})
 	hook(context.Background(), afc, &worker.ApplyFileResult{})
 	events := emitter.snapshot()
 	require.Len(t, events, 1)
 	assert.Equal(t, models.SeverityInfo, events[0].Severity)
+}
+
+// ---------------------------------------------------------------------------
+// Update-mode event taxonomy pins (#248 codex P2, F3): javinizer update runs
+// (SkipOrganize) must speak the API update resolver's nfo_gen vocabulary and
+// emit NO file_move success events — an in-place metadata refresh is not a
+// file move.
+// ---------------------------------------------------------------------------
+
+// updateModeEvents runs the hook in update mode against the given result and
+// returns the recorded events.
+func updateModeEvents(t *testing.T, emitter *recordingEmitter, afr *worker.ApplyFileResult) []models.Event {
+	t.Helper()
+	var buf bytes.Buffer
+	hook := cliBatchPostApply(emitter, &buf, "job-1", false, true, &atomic.Int64{}, &sync.Mutex{})
+	hook(context.Background(),
+		&worker.ApplyFileContext{FilePath: filepath.Join("src", "GOOD-700.mp4"), Movie: &models.Movie{ID: "GOOD-700"}},
+		afr,
+	)
+	return emitter.snapshot()
+}
+
+// assertNoFileMoveEvents fails when any recorded event uses the organize-mode
+// file_move source.
+func assertNoFileMoveEvents(t *testing.T, events []models.Event) {
+	t.Helper()
+	for _, ev := range events {
+		assert.NotEqual(t, "file_move", ev.Source, "update mode must never emit file_move events: %q", ev.Message)
+	}
+}
+
+func TestCliBatchPostApply_UpdateMode_Success_NfoGenTaxonomy(t *testing.T) {
+	emitter := &recordingEmitter{}
+	events := updateModeEvents(t, emitter, &worker.ApplyFileResult{Result: &workflow.ApplyResult{}})
+	require.Len(t, events, 1)
+	assert.Equal(t, models.SeverityInfo, events[0].Severity)
+	assert.Equal(t, "nfo_gen", events[0].Source, "update-mode success rides the API update path's nfo_gen taxonomy")
+	assert.Equal(t, "Updated GOOD-700", events[0].Message)
+	assertNoFileMoveEvents(t, events)
+}
+
+func TestCliBatchPostApply_UpdateMode_SuccessWithWarning(t *testing.T) {
+	emitter := &recordingEmitter{}
+	events := updateModeEvents(t, emitter, &worker.ApplyFileResult{Result: &workflow.ApplyResult{
+		OrganizeResult: &organizer.OrganizeResult{Warnings: []string{"nfo merged partial"}},
+	}})
+	require.Len(t, events, 2)
+	assert.Equal(t, "nfo_gen", events[0].Source)
+	assert.Equal(t, "Updated GOOD-700", events[0].Message)
+	assert.Equal(t, models.SeverityWarn, events[1].Severity)
+	assert.Equal(t, "nfo_gen", events[1].Source)
+	assert.Equal(t, "Update warning for GOOD-700: nfo merged partial", events[1].Message)
+	assertNoFileMoveEvents(t, events)
+}
+
+func TestCliBatchPostApply_UpdateMode_ApplyError(t *testing.T) {
+	emitter := &recordingEmitter{}
+	events := updateModeEvents(t, emitter, &worker.ApplyFileResult{Err: fmt.Errorf("read only")})
+	require.Len(t, events, 1)
+	assert.Equal(t, models.SeverityError, events[0].Severity)
+	assert.Equal(t, "nfo_gen", events[0].Source, "update-mode failure parity with the API update resolver")
+	assert.Equal(t, "Update failed for GOOD-700", events[0].Message)
+	assertNoFileMoveEvents(t, events)
 }

--- a/internal/commandutil/batch_history_w244_test.go
+++ b/internal/commandutil/batch_history_w244_test.go
@@ -480,7 +480,12 @@ func TestCliBatchPostApply_ApplyError_EmitsErrorEvent(t *testing.T) {
 	assert.Empty(t, buf.String(), "failures surface via the event handler, not warning prints")
 }
 
-func TestCliBatchPostApply_DryRunEmitsNothing(t *testing.T) {
+// TestCliBatchPostApply_DryRunCountsSkipsAndWarnsWithoutAuditing pins the
+// #248 codex P2 dry-run leg: a preview persists NOTHING (no eventlog audit)
+// but must still account the authorized duplicate skip and print its warning
+// — pre-fix both vanished behind the dry-run gate, so a dry-run summary
+// silently counted the loser as organized and never showed the warning.
+func TestCliBatchPostApply_DryRunCountsSkipsAndWarnsWithoutAuditing(t *testing.T) {
 	var (
 		emitter   = &recordingEmitter{}
 		buf       bytes.Buffer
@@ -489,15 +494,17 @@ func TestCliBatchPostApply_DryRunEmitsNothing(t *testing.T) {
 	hook := cliBatchPostApply(emitter, &buf, "job-1", true, false, skipCount, &sync.Mutex{})
 
 	hook(context.Background(),
-		&worker.ApplyFileContext{FilePath: "x", Movie: &models.Movie{ID: "GOOD-700"}},
+		&worker.ApplyFileContext{FilePath: filepath.Join("src", "GOOD-700.mp4"), Movie: &models.Movie{ID: "GOOD-700"}},
 		&worker.ApplyFileResult{Result: &workflow.ApplyResult{OrganizeResult: &organizer.OrganizeResult{
 			Warnings:         []string{"w"},
 			DuplicateSkipped: true,
 		}}},
 	)
 
-	assert.Empty(t, emitter.snapshot())
-	assert.Empty(t, buf.String())
+	assert.Empty(t, emitter.snapshot(), "previews are not operations — no eventlog audit in dry-run")
+	assert.Equal(t, int64(1), skipCount.Load(), "the dry-run skip counts identically to live")
+	assert.Contains(t, buf.String(), "⚠️")
+	assert.Contains(t, buf.String(), "w", "the dry-run warning prints to the console identically to live")
 }
 
 func TestCliBatchPostApply_NilPayloads(t *testing.T) {

--- a/internal/commandutil/batch_persist_startup_w248_test.go
+++ b/internal/commandutil/batch_persist_startup_w248_test.go
@@ -1,0 +1,204 @@
+package commandutil
+
+// Regression pins for #248 codex P2: when the initial jobs-row persist fails
+// inside JobStore.createJob (shallow disk-full / locked database AFTER
+// bootstrap succeeded), the CLI batch must report a real STARTUP failure —
+// RunBatchCommand returns a non-nil, ErrJobPersistenceFailed-matching error,
+// the console lands on the NOT-persisted audit branch (never advertising the
+// unqueryable pre-generated id) and says setup failed, and `history list
+// --batch <id>` answers 'batch job not found' consistently with that message.
+//
+// Fixtures build on the batch_history_w244_test.go pattern (the e2emock
+// scraper seam, filepath.Join/t.TempDir paths) so the tests stay
+// Windows-safe.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunBatchCommand_InitialPersistFailure_NotPersistedBranchAndSetupFailure
+// injects the failing persist seed through the runtime-construction seam and
+// pins the end-to-end contract: error propagation, the NOT-persisted console
+// branch, the setup-failed statement, and history-lookup 'not found'
+// consistency for the never-persisted id.
+func TestRunBatchCommand_InitialPersistFailure_NotPersistedBranchAndSetupFailure(t *testing.T) {
+	configPath, src, dest, dbPath := setupDuplicateBatch(t)
+
+	// Failing persist seed: the runtime constructor reports the jobs-row
+	// persist failure exactly like newCLIBatchRuntime does against a real
+	// failing store (sentinel-wrapped so RunBatchCommand's errors.Is branch
+	// triggers), and captures the pre-generated batch id for the history
+	// consistency assertions below.
+	var seededID string
+	orig := newCLIBatchRuntimeFn
+	t.Cleanup(func() { newCLIBatchRuntimeFn = orig })
+	newCLIBatchRuntimeFn = func(_ *bootstrapResult, _ *config.Config, o BatchCommandOptions, _ worker.BatchJobConfig, _ []string) (*cliBatchRuntime, error) {
+		seededID = o.BatchJobID
+		return nil, fmt.Errorf("%w: upsert failed: simulated disk full", ErrJobPersistenceFailed)
+	}
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   src,
+		Destination:  dest,
+		Recursive:    true,
+		CommandLabel: "Javinizer Sort",
+		ActionVerb:   "Processing files",
+		Resolved:     &workflow.ResolvedSeamStrings{},
+	})
+
+	// Error propagation: non-nil, sentinel-visible through both wraps, and
+	// carrying the underlying failure detail.
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrJobPersistenceFailed)
+	assert.Contains(t, err.Error(), "simulated disk full")
+	require.NotEmpty(t, seededID, "the failing seed observed the pre-generated batch id")
+
+	out := buf.String()
+	// NOT-persisted branch: the presenter never prints the queryable id; the
+	// no-audit sentence and the setup-failed statement carry the run's truth.
+	assert.NotContains(t, out, "Batch Job: "+seededID, "the unqueryable id must not be advertised\n%s", out)
+	assert.NotContains(t, out, "Batch Job:", "no persisted identity line at all on the failure branch\n%s", out)
+	assert.Contains(t, out, "Preview (not persisted; no audit ID)", "the NOT-persisted audit line prints\n%s", out)
+	assert.Contains(t, out, "Batch setup failed", "the summary states the setup failure\n%s", out)
+	assert.Contains(t, out, ErrJobPersistenceFailed.Error(), "the failure statement names the cause class\n%s", out)
+
+	// History lookup consistency: the id the console deliberately did NOT
+	// advertise answers 'batch job not found' exactly like the messaging
+	// claims — no jobs row, no history rows, no revert-ledger rows.
+	ctx := context.Background()
+	db := openAssertionDB(t, dbPath)
+	repos := db.Repositories()
+	_, findErr := repos.JobRepo.FindByID(ctx, seededID)
+	assert.True(t, database.IsNotFound(findErr),
+		"history list --batch %s must answer 'batch job not found', got: %v", seededID, findErr)
+	hist, histErr := repos.HistoryRepo.FindByBatchJobID(ctx, seededID)
+	require.NoError(t, histErr)
+	assert.Empty(t, hist, "no history rows bind the never-persisted batch id")
+	opCount, opErr := repos.BatchFileOpRepo.CountByBatchJobID(ctx, seededID)
+	require.NoError(t, opErr)
+	assert.Zero(t, opCount, "no revert-ledger rows bind the never-persisted batch id")
+}
+
+// TestRunBatchCommand_InitialPersistFailure_DryRunSkipsAuditLine pins the
+// dry-run leg of the error branch: a dry run persists nothing BY DESIGN and
+// the header already carried the preview label, so the failure surface prints
+// only the setup-failed statement — no duplicate no-audit sentence.
+func TestRunBatchCommand_InitialPersistFailure_DryRunSkipsAuditLine(t *testing.T) {
+	configPath, src, dest, _ := setupDuplicateBatch(t)
+
+	orig := newCLIBatchRuntimeFn
+	t.Cleanup(func() { newCLIBatchRuntimeFn = orig })
+	newCLIBatchRuntimeFn = func(_ *bootstrapResult, _ *config.Config, _ BatchCommandOptions, _ worker.BatchJobConfig, _ []string) (*cliBatchRuntime, error) {
+		return nil, fmt.Errorf("%w: upsert failed: simulated disk full", ErrJobPersistenceFailed)
+	}
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   src,
+		Destination:  dest,
+		Recursive:    true,
+		DryRun:       true,
+		CommandLabel: "Javinizer Sort",
+		ActionVerb:   "Processing files",
+		Resolved:     &workflow.ResolvedSeamStrings{},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrJobPersistenceFailed)
+
+	out := buf.String()
+	assert.Equal(t, 1, bytes.Count([]byte(out), []byte("Preview (not persisted; no audit ID)")),
+		"only the header's preview label prints — the failure branch adds no second no-audit sentence\n%s", out)
+	assert.Contains(t, out, "Batch setup failed")
+}
+
+// TestNewCLIBatchRuntime_InitialPersistFailure_ReturnsSentinel drives the
+// REAL runtime constructor against a real-but-closed jobs database — the
+// shallow post-bootstrap failure class from the finding (disk full / locked):
+// every jobs-row upsert now fails, so the constructor must surface
+// ErrJobPersistenceFailed instead of returning a live job whose id the CLI
+// would advertise. The dry-run noop-persistence path stays silent (previews
+// persist nothing by design), proving the good dry path is unchanged.
+func TestNewCLIBatchRuntime_InitialPersistFailure_ReturnsSentinel(t *testing.T) {
+	configPath, _, _, _ := setupDuplicateBatch(t)
+
+	cfg, err := config.LoadOrCreate(configPath)
+	require.NoError(t, err)
+	config.ApplyEnvironmentOverrides(cfg)
+	_, err = config.Prepare(cfg)
+	require.NoError(t, err)
+
+	bs, err := Bootstrap(cfg)
+	require.NoError(t, err)
+
+	// The jobs database went away AFTER bootstrap: every jobs-row upsert now
+	// fails with 'sql: database is closed' (deterministic on every platform,
+	// including Windows — a closed database/sql pool never reopens).
+	require.NoError(t, bs.Close())
+
+	files := []string{filepath.Join("src", "GOOD-700.mp4")}
+	rt, err := newCLIBatchRuntime(bs, cfg,
+		BatchCommandOptions{BatchJobID: models.NewJobID().String()},
+		BatchJobConfigFromAppConfig(cfg), files)
+	require.Error(t, err, "a failed initial jobs-row persist must become a startup error")
+	assert.Nil(t, rt)
+	assert.ErrorIs(t, err, ErrJobPersistenceFailed)
+
+	// Dry-run parity: NoopJobPersistence previews persist nothing by design,
+	// so the dead database handle produces NO sentinel and the runtime still
+	// constructs — the good dry path is byte-identical to pre-fix behavior.
+	rt, err = newCLIBatchRuntime(bs, cfg,
+		BatchCommandOptions{BatchJobID: models.NewJobID().String(), DryRun: true},
+		BatchJobConfigFromAppConfig(cfg), files)
+	assert.NoError(t, err, "dry-run previews never persist, so a dead DB cannot fail them")
+	assert.NotNil(t, rt)
+}
+
+// TestRunBatchCommand_UnrelatedRuntimeError_UnchangedSurface pins the
+// non-persist runtime error branch: a plain construction failure (no sentinel)
+// keeps its pre-fix surface — wrapped error, NO audit line, NO setup-failed
+// print (the persist-failure presentation is gated on errors.Is).
+func TestRunBatchCommand_UnrelatedRuntimeError_UnchangedSurface(t *testing.T) {
+	configPath, src, dest, _ := setupDuplicateBatch(t)
+
+	var seededID string
+	orig := newCLIBatchRuntimeFn
+	t.Cleanup(func() { newCLIBatchRuntimeFn = orig })
+	newCLIBatchRuntimeFn = func(_ *bootstrapResult, _ *config.Config, o BatchCommandOptions, _ worker.BatchJobConfig, _ []string) (*cliBatchRuntime, error) {
+		seededID = o.BatchJobID
+		return nil, fmt.Errorf("simulated runtime failure")
+	}
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   src,
+		Destination:  dest,
+		Recursive:    true,
+		CommandLabel: "Javinizer Sort",
+		ActionVerb:   "Processing files",
+		Resolved:     &workflow.ResolvedSeamStrings{},
+	})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrJobPersistenceFailed)
+	assert.Contains(t, err.Error(), "failed to create batch job runtime")
+	assert.Contains(t, err.Error(), "simulated runtime failure")
+
+	out := buf.String()
+	assert.NotContains(t, out, "Batch setup failed", "generic runtime errors keep the pre-fix silent-console surface\n%s", out)
+	assert.NotContains(t, out, "Batch Job: "+seededID, "no audit identity ever prints on the unconstructed runtime\n%s", out)
+}

--- a/internal/commandutil/batch_update_mode_w248_test.go
+++ b/internal/commandutil/batch_update_mode_w248_test.go
@@ -1,38 +1,58 @@
 package commandutil
 
-// End-to-end pin for #248 codex P2 (F3): a javinizer UPDATE run through the
-// real CLI scaffold (RunBatchCommand with SkipOrganize) must report its
-// apply-phase audit with the API update path's nfo_gen taxonomy — never a
-// file_move/"Organized <id>" success event with an empty new_path.
+// Regression pins for #248 codex P2 (F1 + F2):
+//
+// F1 — persisted CLI update jobs misclassified as organize: a non-dry-run
+// `update` run must persist the API's update identity on the jobs row
+// (update=true + operation_mode=metadata-artwork, the same projection the
+// API's leave-in-place plan commits) instead of update=false + empty mode.
+// F2 — audit writes with an expired per-file ctx dropped silently: the
+// post-apply hook must emit to the eventlog with a context detached from the
+// WorkerTimeout deadline so timeout failures still land, and log (not
+// discard) if emission still fails.
+//
+// Fixtures follow batch_history_w244_test.go conventions: the
+// JAVINIZER_E2E_SCRAPERS seam substitutes the offline e2emock scraper, and
+// all paths are built with filepath.Join/t.TempDir (never POSIX literals) so
+// the tests stay Windows-safe.
 
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/config"
 	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/eventlog"
+	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/worker"
 	"github.com/javinizer/javinizer-go/internal/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestRunBatchCommand_UpdateMode_EventTaxonomy runs a single-file in-place
-// metadata update and asserts the persisted eventlog speaks the update
-// vocabulary: nfo_gen info event per updated file, zero file_move events.
-func TestRunBatchCommand_UpdateMode_EventTaxonomy(t *testing.T) {
+// setupSingleFileBatch writes a one-file fixture: src/<ID>.mp4 matched by the
+// e2emock scraper. The update run leaves the video in place; the sort control
+// copies it into a separate dest root.
+func setupSingleFileBatch(t *testing.T, id string) (configPath, src, dest, dbPath string) {
+	t.Helper()
 	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
 
 	tmpDir := t.TempDir()
-	src := filepath.Join(tmpDir, "src")
-	require.NoError(t, os.MkdirAll(filepath.Join(src, "lib"), 0o700))
-	videoPath := filepath.Join(src, "lib", "GOOD-700.mp4")
-	require.NoError(t, os.WriteFile(videoPath, []byte("fake video"), 0o600))
+	src = filepath.Join(tmpDir, "src")
+	dest = filepath.Join(tmpDir, "dest")
+	require.NoError(t, os.MkdirAll(src, 0o700))
+	require.NoError(t, os.MkdirAll(dest, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(src, id+".mp4"), []byte("fake video"), 0o600))
 
-	dbPath := filepath.Join(tmpDir, "javinizer.db")
+	dbPath = filepath.Join(tmpDir, "javinizer.db")
 	cfg := config.DefaultConfig(nil, nil)
 	cfg.Database.DSN = dbPath
 	cfg.Database.LogLevel = "silent"
@@ -41,61 +61,286 @@ func TestRunBatchCommand_UpdateMode_EventTaxonomy(t *testing.T) {
 	cfg.Output.Template.FolderFormat = "<ID>"
 	cfg.Output.Template.SubfolderFormat = []string{}
 	cfg.Output.Template.FileFormat = "<ID>"
+	cfg.Output.Operation.RenameFile = true
+	// e2emock media URLs are non-resolvable; downloads are irrelevant here.
 	cfg.Output.Download.DownloadCover = false
 	cfg.Output.Download.DownloadPoster = false
 	cfg.Output.Download.DownloadExtrafanart = false
 	cfg.Output.Download.DownloadTrailer = false
 	cfg.Output.Download.DownloadActress = false
-	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configPath = filepath.Join(tmpDir, "config.yaml")
 	require.NoError(t, config.Save(cfg, configPath))
+	return configPath, src, dest, dbPath
+}
+
+// ---------------------------------------------------------------------------
+// F1: persisted job identity pins
+// ---------------------------------------------------------------------------
+
+// TestCLIApplyOptions_ToApplyPhaseConfig_UpdateModeJobIdentity pins the
+// ApplyPhaseConfig-side mapping an update-mode apply commits onto the job at
+// apply entry: the same identity an API leave-in-place batch carries.
+func TestCLIApplyOptions_ToApplyPhaseConfig_UpdateModeJobIdentity(t *testing.T) {
+	upd := CLIApplyOptions{SkipOrganize: true}.ToApplyPhaseConfig()
+	require.NotNil(t, upd.Update, "update mode must commit an explicit update=true")
+	assert.True(t, *upd.Update)
+	assert.Equal(t, operationmode.OperationModeMetadataArtwork, upd.OperationModeOverride,
+		"CLI update (leave-in-place) must persist the API update path's mode")
+
+	org := CLIApplyOptions{}.ToApplyPhaseConfig()
+	require.NotNil(t, org.Update, "organize mode must commit an explicit update=false")
+	assert.False(t, *org.Update)
+	assert.Equal(t, operationmode.OperationMode(""), org.OperationModeOverride,
+		"organize runs keep an empty mode override so the organizer's configured mode still governs planning")
+}
+
+// TestRunBatchCommand_UpdateMode_PersistsUpdateJobIdentity is the F1 core
+// pin: a live CLI update run must persist a jobs row reading update=true +
+// mode metadata-artwork (NOT misclassified as organize), and its eventlog
+// audit must carry the update taxonomy (nfo_gen "Updated <id>", zero
+// file_move events) with the video left in place.
+func TestRunBatchCommand_UpdateMode_PersistsUpdateJobIdentity(t *testing.T) {
+	configPath, src, _, dbPath := setupSingleFileBatch(t, "GOOD-701")
+
+	resolved, err := workflow.ResolveSeamStrings(workflow.SeamStringsInput{})
+	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
-		ConfigFile:        configPath,
-		SourcePath:        src,
-		Destination:       src, // update mode: files remain in place
-		Recursive:         true,
-		GenerateNFO:       true,
-		SkipOrganize:      true, // javinizer update: never move files
-		CommandLabel:      "Javinizer Update",
-		ActionVerb:        "Updating metadata",
-		CompletionMessage: "Update complete!",
-		ModeLine:          "Update (metadata & artwork, files remain in place)",
-		Resolved:          &workflow.ResolvedSeamStrings{},
+	runErr := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   src,
+		Destination:  src, // update mode: files stay in place (mirrors the update command)
+		Recursive:    true,
+		SkipOrganize: true,
+		GenerateNFO:  true,
+		CommandLabel: "Javinizer Update",
+		ActionVerb:   "Updating metadata",
+		Resolved:     resolved,
 	})
-	require.NoError(t, err)
-	out := buf.String()
-	batchID := batchIDFromOutput(t, out)
-	assert.Contains(t, out, "Updated: 1, Failed: 0", "the update summary reports the in-place refresh\n%s", out)
-	assert.FileExists(t, videoPath, "update mode never moves the source")
+	require.NoError(t, runErr)
+	batchID := batchIDFromOutput(t, buf.String())
 
 	ctx := context.Background()
 	db := openAssertionDB(t, dbPath)
 	repos := db.Repositories()
 
-	events, err := repos.EventRepo.FindFiltered(ctx, database.EventFilter{EventType: models.EventCategoryOrganize}, 50, 0)
-	require.NoError(t, err)
-	require.NotEmpty(t, events, "the update run must journal per-file audit events")
-	fileMoveEvents := 0
-	nfoGenInfoEvents := 0
-	for _, ev := range events {
-		if ev.Source == "file_move" {
-			fileMoveEvents++
-		}
-		if ev.Source == "nfo_gen" && ev.Severity == models.SeverityInfo && ev.Message == "Updated GOOD-700" {
-			nfoGenInfoEvents++
-		}
-	}
-	assert.Zero(t, fileMoveEvents, "update mode must emit NO file_move events (in-place refresh is not a file move)")
-	assert.Equal(t, 1, nfoGenInfoEvents, "exactly one nfo_gen update-success event per updated file")
-
-	// The jobs row and the per-file operation row persist under the same batch
-	// identity (the op row journals the in-place update operation type).
+	// (i) jobs row: update identity persisted, not organize-misclassified.
 	job, err := repos.JobRepo.FindByID(ctx, batchID)
+	require.NoError(t, err, "jobs row for the CLI update batch must persist")
+	require.NotNil(t, job)
+	assert.True(t, job.Update, "update run must persist update=true, not the default false")
+	assert.Equal(t, operationmode.OperationModeMetadataArtwork, job.OperationModeOverride,
+		"update run must persist the API leave-in-place mode, not the empty/organize default")
+
+	// (ii) eventlog: update taxonomy — an nfo_gen "Updated" info event and
+	// NO file_move events (an in-place metadata refresh is not a file move).
+	updateEvents, err := repos.EventRepo.FindFiltered(ctx, database.EventFilter{
+		EventType: models.EventCategoryOrganize,
+		Source:    "nfo_gen",
+	}, 50, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, updateEvents, "update run must emit nfo_gen audit events")
+	assert.Equal(t, "Updated GOOD-701", updateEvents[0].Message)
+	assert.Equal(t, models.SeverityInfo, updateEvents[0].Severity)
+
+	fileMoveEvents, err := repos.EventRepo.FindFiltered(ctx, database.EventFilter{
+		EventType: models.EventCategoryOrganize,
+		Source:    "file_move",
+	}, 50, 0)
+	require.NoError(t, err)
+	assert.Empty(t, fileMoveEvents, "update run must never emit file_move events")
+
+	// (iii) update semantics: the video stayed in place and the metadata
+	// refresh still produced its NFO next to the removed-nowhere source.
+	assert.FileExists(t, filepath.Join(src, "GOOD-701.mp4"))
+	assert.FileExists(t, filepath.Join(src, "GOOD-701.nfo"))
+	assert.NoDirExists(t, filepath.Join(src, "GOOD-701"),
+		"update mode must not organize the video into a folder")
+}
+
+// TestRunBatchCommand_OrganizeMode_PersistsUpdateFalseJobIdentity is the F1
+// control: a live sort run keeps update=false so update batches and sort
+// batches classify disjointly.
+func TestRunBatchCommand_OrganizeMode_PersistsUpdateFalseJobIdentity(t *testing.T) {
+	configPath, src, dest, dbPath := setupSingleFileBatch(t, "GOOD-702")
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:   configPath,
+		SourcePath:   src,
+		Destination:  dest,
+		Recursive:    true,
+		GenerateNFO:  true,
+		CommandLabel: "Javinizer Sort",
+		ActionVerb:   "Processing files",
+		Resolved:     &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err)
+	batchID := batchIDFromOutput(t, buf.String())
+
+	ctx := context.Background()
+	db := openAssertionDB(t, dbPath)
+	job, err := db.Repositories().JobRepo.FindByID(ctx, batchID)
 	require.NoError(t, err)
 	require.NotNil(t, job)
-	ops, err := repos.BatchFileOpRepo.FindByBatchJobID(ctx, batchID)
+	assert.False(t, job.Update, "sort must persist update=false")
+	assert.Empty(t, string(job.OperationModeOverride),
+		"sort persists no mode override — consumers read it as organize, unchanged")
+	assert.Equal(t, models.JobStatusOrganized, job.Status)
+}
+
+// ---------------------------------------------------------------------------
+// F2: detached-ctx audit emission pins
+// ---------------------------------------------------------------------------
+
+// newMigratedEventDB opens a fresh sqlite database and runs startup
+// migrations so the eventlog repos tables exist (unlike openAssertionDB,
+// which re-opens a DB Bootstrap already migrated).
+func newMigratedEventDB(t *testing.T) *database.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "javinizer.db")
+	db, err := database.New(&database.Config{Type: "sqlite", DSN: dbPath, LogLevel: "silent"})
 	require.NoError(t, err)
-	require.Len(t, ops, 1)
-	assert.Equal(t, models.OperationTypeUpdate, ops[0].OperationType, "the op row journals an in-place update, not a move")
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.RunMigrationsOnStartup(context.Background()))
+	return db
+}
+
+// TestCliBatchPostApply_TimeoutExpiredCtx_StillAudits reproduces the F2 drop:
+// a WorkerTimeout-exhausted apply hands the post-apply hook an ALREADY
+// canceled task ctx together with the deadline-exceeded error, and the
+// eventlog emitter refuses canceled contexts — pre-fix the timeout failure
+// event vanished from the CLI eventlog while the history writer (fresh ctx)
+// still recorded it. The hook must detach from the worker deadline so the
+// audit lands: real emitter + real sqlite readback.
+func TestCliBatchPostApply_TimeoutExpiredCtx_StillAudits(t *testing.T) {
+	db := newMigratedEventDB(t)
+	repos := db.Repositories()
+	emitter := eventlog.NewEmitter(repos.EventRepo)
+
+	expired, cancel := context.WithCancel(context.Background())
+	cancel()                                // the WorkerTimeout-exhausted per-file task ctx
+	deadlineErr := context.DeadlineExceeded // what wf.Apply returns on timeout
+
+	afc := &worker.ApplyFileContext{
+		FilePath: filepath.Join("src", "GOOD-703.mp4"),
+		Movie:    &models.Movie{ID: "GOOD-703"},
+	}
+	afr := &worker.ApplyFileResult{Err: deadlineErr}
+
+	// Pre-fix sanity: emitting with the expired ctx IS dropped by the real
+	// emitter, proving this test pins the hook's detached-ctx behavior and
+	// not the emitter's.
+	preFixCount, err := repos.EventRepo.Count(context.Background())
+	require.NoError(t, err)
+	require.Error(t, emitter.EmitOrganizeEvent(expired, "file_move", "probe", models.SeverityError, nil))
+	postProbeCount, err := repos.EventRepo.Count(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, preFixCount, postProbeCount, "the emitter drops canceled-ctx events — this is the F2 mechanism")
+
+	// The hook as interpretApplyResult invokes it at timeout: detached
+	// emission must land the timeout failure with valid severity/message.
+	hook := cliBatchPostApply(emitter, nopWriter{}, "job-timeout-248", false, false, &atomic.Int64{}, &sync.Mutex{})
+	hook(expired, afc, afr)
+
+	events, err := repos.EventRepo.FindFiltered(context.Background(), database.EventFilter{
+		EventType: models.EventCategoryOrganize,
+		Severity:  models.SeverityError,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Len(t, events, 1, "the timeout failure event must land in the CLI eventlog — no silent drop")
+	assert.Equal(t, "file_move", events[0].Source)
+	assert.Equal(t, "Organize failed for GOOD-703", events[0].Message)
+	assert.Contains(t, events[0].Context, `"error":"context deadline exceeded"`, "audit context carries the timeout cause")
+	assert.Contains(t, events[0].Context, `"job_id":"job-timeout-248"`)
+
+	// The update taxonomy also survives the expired ctx — same detached budget.
+	hookUpdate := cliBatchPostApply(emitter, nopWriter{}, "job-timeout-248", false, true, &atomic.Int64{}, &sync.Mutex{})
+	hookUpdate(expired, afc, afr)
+
+	updateEvents, err := repos.EventRepo.FindFiltered(context.Background(), database.EventFilter{
+		EventType: models.EventCategoryOrganize,
+		Source:    "nfo_gen",
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Len(t, updateEvents, 1)
+	assert.Equal(t, "Update failed for GOOD-703", updateEvents[0].Message)
+	assert.Equal(t, models.SeverityError, updateEvents[0].Severity)
+}
+
+// nopWriter discards console side output without pulling in io.Discard's
+// wrapper import surface — the hook's console prints are orthogonal here.
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// TestCliBatchPostApply_SuccessWithExpiredCtx_StillAudits pins the symmetric
+// case: an organized-success audit emitted after the task ctx expired (the
+// runner's final accounting window) still reaches the eventlog.
+func TestCliBatchPostApply_SuccessWithExpiredCtx_StillAudits(t *testing.T) {
+	db := newMigratedEventDB(t)
+	repos := db.Repositories()
+	emitter := eventlog.NewEmitter(repos.EventRepo)
+
+	expired, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	hook := cliBatchPostApply(emitter, nopWriter{}, "job-success-248", false, false, &atomic.Int64{}, &sync.Mutex{})
+	hook(expired,
+		&worker.ApplyFileContext{
+			FilePath: filepath.Join("src", "GOOD-704.mp4"),
+			Movie:    &models.Movie{ID: "GOOD-704"},
+		},
+		&worker.ApplyFileResult{Result: &workflow.ApplyResult{}},
+	)
+
+	events, err := repos.EventRepo.FindFiltered(context.Background(), database.EventFilter{
+		EventType: models.EventCategoryOrganize,
+		Severity:  models.SeverityInfo,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "Organized GOOD-704", events[0].Message)
+}
+
+// failingEmitter always fails emission so the hook's log-and-continue path
+// (F2: log, not discard) is exercised.
+type failingEmitter struct{}
+
+func (failingEmitter) EmitScraperEvent(context.Context, string, string, models.EventSeverity, map[string]any) error {
+	return fmt.Errorf("simulated eventlog outage")
+}
+func (failingEmitter) EmitOrganizeEvent(context.Context, string, string, models.EventSeverity, map[string]any) error {
+	return fmt.Errorf("simulated eventlog outage")
+}
+func (failingEmitter) EmitSystemEvent(context.Context, string, string, models.EventSeverity, map[string]any) error {
+	return fmt.Errorf("simulated eventlog outage")
+}
+func (failingEmitter) Stats() (int64, int64) { return 0, 0 }
+
+// TestCliBatchPostApply_EmissionFailure_LogsNotDiscards pins the F2 contract
+// that an emission error is never silently discarded: the warning lands in
+// the log carrying the batch identity, event detail, and underlying error.
+func TestCliBatchPostApply_EmissionFailure_LogsNotDiscards(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "cli.log")
+	require.NoError(t, logging.InitLogger(&logging.Config{Level: "debug", Format: "text", Output: logPath}))
+	t.Cleanup(func() { _ = logging.InitLogger(nil) })
+
+	hook := cliBatchPostApply(failingEmitter{}, nopWriter{}, "job-log-248", false, false, &atomic.Int64{}, &sync.Mutex{})
+	hook(context.Background(),
+		&worker.ApplyFileContext{
+			FilePath: filepath.Join("src", "GOOD-705.mp4"),
+			Movie:    &models.Movie{ID: "GOOD-705"},
+		},
+		&worker.ApplyFileResult{Result: &workflow.ApplyResult{}},
+	)
+
+	content, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	logged := string(content)
+	assert.Contains(t, logged, "eventlog audit emission failed")
+	assert.Contains(t, logged, "job-log-248")
+	assert.Contains(t, logged, "Organized GOOD-705")
+	assert.Contains(t, logged, "simulated eventlog outage")
 }

--- a/internal/commandutil/batch_update_mode_w248_test.go
+++ b/internal/commandutil/batch_update_mode_w248_test.go
@@ -1,0 +1,101 @@
+package commandutil
+
+// End-to-end pin for #248 codex P2 (F3): a javinizer UPDATE run through the
+// real CLI scaffold (RunBatchCommand with SkipOrganize) must report its
+// apply-phase audit with the API update path's nfo_gen taxonomy — never a
+// file_move/"Organized <id>" success event with an empty new_path.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunBatchCommand_UpdateMode_EventTaxonomy runs a single-file in-place
+// metadata update and asserts the persisted eventlog speaks the update
+// vocabulary: nfo_gen info event per updated file, zero file_move events.
+func TestRunBatchCommand_UpdateMode_EventTaxonomy(t *testing.T) {
+	t.Setenv("JAVINIZER_E2E_SCRAPERS", "true")
+
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "src")
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "lib"), 0o700))
+	videoPath := filepath.Join(src, "lib", "GOOD-700.mp4")
+	require.NoError(t, os.WriteFile(videoPath, []byte("fake video"), 0o600))
+
+	dbPath := filepath.Join(tmpDir, "javinizer.db")
+	cfg := config.DefaultConfig(nil, nil)
+	cfg.Database.DSN = dbPath
+	cfg.Database.LogLevel = "silent"
+	cfg.Matching.Extensions = []string{".mp4"}
+	cfg.Matching.MinSizeMB = 0
+	cfg.Output.Template.FolderFormat = "<ID>"
+	cfg.Output.Template.SubfolderFormat = []string{}
+	cfg.Output.Template.FileFormat = "<ID>"
+	cfg.Output.Download.DownloadCover = false
+	cfg.Output.Download.DownloadPoster = false
+	cfg.Output.Download.DownloadExtrafanart = false
+	cfg.Output.Download.DownloadTrailer = false
+	cfg.Output.Download.DownloadActress = false
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, config.Save(cfg, configPath))
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:        configPath,
+		SourcePath:        src,
+		Destination:       src, // update mode: files remain in place
+		Recursive:         true,
+		GenerateNFO:       true,
+		SkipOrganize:      true, // javinizer update: never move files
+		CommandLabel:      "Javinizer Update",
+		ActionVerb:        "Updating metadata",
+		CompletionMessage: "Update complete!",
+		ModeLine:          "Update (metadata & artwork, files remain in place)",
+		Resolved:          &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	batchID := batchIDFromOutput(t, out)
+	assert.Contains(t, out, "Updated: 1, Failed: 0", "the update summary reports the in-place refresh\n%s", out)
+	assert.FileExists(t, videoPath, "update mode never moves the source")
+
+	ctx := context.Background()
+	db := openAssertionDB(t, dbPath)
+	repos := db.Repositories()
+
+	events, err := repos.EventRepo.FindFiltered(ctx, database.EventFilter{EventType: models.EventCategoryOrganize}, 50, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, events, "the update run must journal per-file audit events")
+	fileMoveEvents := 0
+	nfoGenInfoEvents := 0
+	for _, ev := range events {
+		if ev.Source == "file_move" {
+			fileMoveEvents++
+		}
+		if ev.Source == "nfo_gen" && ev.Severity == models.SeverityInfo && ev.Message == "Updated GOOD-700" {
+			nfoGenInfoEvents++
+		}
+	}
+	assert.Zero(t, fileMoveEvents, "update mode must emit NO file_move events (in-place refresh is not a file move)")
+	assert.Equal(t, 1, nfoGenInfoEvents, "exactly one nfo_gen update-success event per updated file")
+
+	// The jobs row and the per-file operation row persist under the same batch
+	// identity (the op row journals the in-place update operation type).
+	job, err := repos.JobRepo.FindByID(ctx, batchID)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	ops, err := repos.BatchFileOpRepo.FindByBatchJobID(ctx, batchID)
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.Equal(t, models.OperationTypeUpdate, ops[0].OperationType, "the op row journals an in-place update, not a move")
+}

--- a/internal/commandutil/dependencies.go
+++ b/internal/commandutil/dependencies.go
@@ -413,6 +413,22 @@ func (d *CoreDeps) ReplaceR18DevDumpCloser(newCloser io.Closer) io.Closer {
 type bootstrapResult struct {
 	*CoreDeps
 	*workflow.WorkflowComponents
+	// workflowFactory is the cached factory all Workflow accessors mint from.
+	// Held so batch commands can build a per-job workflow whose apply-phase
+	// revert ledger is bound to a concrete batch job ID (Workflow above is the
+	// bootstrap-time "" instance used for scan/match).
+	workflowFactory *workflow.WorkflowFactory
+}
+
+// NewJobWorkflow constructs a full Workflow whose apply-phase revert ledger is
+// bound to jobID, so batch_file_operations rows land under the caller's batch
+// job rather than the bootstrap-time "" placeholder. The factory's cached
+// sub-graph is shared with Workflow; only the per-job revert log differs.
+func (b *bootstrapResult) NewJobWorkflow(jobID string) (workflow.WorkflowInterface, error) {
+	if b.workflowFactory == nil {
+		return nil, fmt.Errorf("commandutil: workflow factory unavailable — cannot construct per-job workflow for %q", jobID)
+	}
+	return b.workflowFactory.NewWorkflow(jobID)
 }
 
 // bootstrapMode selects which workflow construction path the factory uses.
@@ -454,12 +470,16 @@ func bootstrapWorkflow(cfg *config.Config, mode bootstrapMode) (*bootstrapResult
 		return nil, err
 	}
 
-	return &bootstrapResult{CoreDeps: deps, WorkflowComponents: &workflow.WorkflowComponents{
-		Workflow:  wf,
-		Matcher:   factory.Matcher(),
-		Scanner:   factory.Scanner(),
-		PosterGen: factory.PosterGen(),
-	}}, nil
+	return &bootstrapResult{
+		CoreDeps: deps,
+		WorkflowComponents: &workflow.WorkflowComponents{
+			Workflow:  wf,
+			Matcher:   factory.Matcher(),
+			Scanner:   factory.Scanner(),
+			PosterGen: factory.PosterGen(),
+		},
+		workflowFactory: factory,
+	}, nil
 }
 
 // Bootstrap initializes the full dependency stack from a config:

--- a/internal/database/batch_file_operation_repo.go
+++ b/internal/database/batch_file_operation_repo.go
@@ -35,31 +35,50 @@ func NewBatchFileOperationRepository(db *DB) *BatchFileOperationRepository {
 }
 
 // Create inserts a single batch file operation record.
+//
+// The prune-fence check runs BEFORE the autocommit insert, not inside a
+// deferred transaction around it: under WAL a read-then-write transaction
+// upgrade dies with SQLITE_BUSY_SNAPSHOT (surfaced as "database is locked")
+// when a concurrent apply worker commits between the read and the write —
+// the pool busy timeout does not cover snapshot conflicts. The bare INSERT
+// acquires the writer lock directly, so concurrent per-worker Begin calls
+// (each apply-file goroutine opens its operation row before any filesystem
+// mutation) wait on the busy timeout instead of deadlocking; retryOnLocked
+// additionally rides out any residual transient locked error (same seam as
+// JobRepository.CommitEnvelope).
 func (r *BatchFileOperationRepository) Create(ctx context.Context, op *models.BatchFileOperation) error {
-	err := r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := ensureJobWritable(tx, op.BatchJobID); err != nil {
-			return err
-		}
-		return tx.Create(op).Error
+	label := fmt.Sprintf("batch file operation %d", op.ID)
+	if err := ensureJobWritable(r.GetDB().WithContext(ctx), op.BatchJobID); err != nil {
+		return wrapDBErr("create", label, err)
+	}
+	err := retryOnLocked(func() error {
+		return r.GetDB().WithContext(ctx).Create(op).Error
 	})
 	if err != nil {
-		return wrapDBErr("create", fmt.Sprintf("batch file operation %d", op.ID), err)
+		return wrapDBErr("create", label, err)
 	}
 	return nil
 }
 
 // CreateBatch inserts multiple batch file operation records in a single transaction.
+// Same fence placement as Create: checks run before the write-only transaction
+// (no reads inside, so the upgrade-to-write cannot hit SQLITE_BUSY_SNAPSHOT),
+// with retryOnLocked absorbing residual transient lock errors.
 func (r *BatchFileOperationRepository) CreateBatch(ctx context.Context, ops []*models.BatchFileOperation) error {
-	return r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		for _, op := range ops {
-			if err := ensureJobWritable(tx, op.BatchJobID); err != nil {
-				return err
-			}
-			if err := tx.Create(op).Error; err != nil {
-				return wrapDBErr("create", fmt.Sprintf("batch file operation %d", op.ID), err)
-			}
+	for _, op := range ops {
+		if err := ensureJobWritable(r.GetDB().WithContext(ctx), op.BatchJobID); err != nil {
+			return wrapDBErr("create", fmt.Sprintf("batch file operation %d", op.ID), err)
 		}
-		return nil
+	}
+	return retryOnLocked(func() error {
+		return r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			for _, op := range ops {
+				if err := tx.Create(op).Error; err != nil {
+					return wrapDBErr("create", fmt.Sprintf("batch file operation %d", op.ID), err)
+				}
+			}
+			return nil
+		})
 	})
 }
 
@@ -234,14 +253,16 @@ func (r *BatchFileOperationRepository) UpdateJournalInTx(ctx context.Context, id
 // completion writes go through UpdateNonJournalFields (wave-10 codex
 // follow-up).
 func (r *BatchFileOperationRepository) Update(ctx context.Context, op *models.BatchFileOperation) error {
-	err := r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := ensureJobWritable(tx, op.BatchJobID); err != nil {
-			return err
-		}
-		return tx.Save(op).Error
+	label := fmt.Sprintf("batch file operation %d", op.ID)
+	// Fence outside the (read-then-write) deferred transaction — see Create.
+	if err := ensureJobWritable(r.GetDB().WithContext(ctx), op.BatchJobID); err != nil {
+		return wrapDBErr("update", label, err)
+	}
+	err := retryOnLocked(func() error {
+		return r.GetDB().WithContext(ctx).Save(op).Error
 	})
 	if err != nil {
-		return wrapDBErr("update", fmt.Sprintf("batch file operation %d", op.ID), err)
+		return wrapDBErr("update", label, err)
 	}
 	return nil
 }

--- a/internal/database/batch_file_operation_repo.go
+++ b/internal/database/batch_file_operation_repo.go
@@ -314,25 +314,91 @@ func (r *BatchFileOperationRepository) UpdateJournalInTx(ctx context.Context, id
 	return wrapDBErr("update journal", label, commitErr)
 }
 
+// updateSQL is the write-atomic prune fence for Update (PR #248 codex P2),
+// binding the SAME claim probe createInsertSQL rides INSIDE the statement the
+// row write executes under. The replaced shape was probe-then-Save: the
+// ensureJobWritable status read ran as a separate statement, so a retention
+// claim (DeleteOrganizedOlderThan's status flip + snapshot, committed inside
+// one transaction) landing BETWEEN probe and Save was invisible — GORM Save's
+// UPDATE then affected zero rows and its INSERT fallback RESURRECTED the
+// operation row after the sweep had already snapshotted, cleanup-backed-up,
+// and deleted it (an orphaned ledger row: SQLite FK enforcement is off per
+// the repository DSN, so nothing rejected the dangling batch_job_id), or
+// claimed success for a row the already-snapshotted sweep deleted a moment
+// later. With the probe inside the WHERE, the claim either committed before
+// this statement starts — NOT EXISTS observes pruningJobStatus, zero rows are
+// affected, and the caller is classified below — or it must wait out the
+// write lock this statement holds, in which case its post-claim snapshot
+// necessarily observes the committed update. The GORM Save insert fallback
+// stays OUT of this path entirely: zero affected rows is an explicit
+// decision, never an implicit re-create.
+//
+// The statement mirrors the GORM Save update it replaces: every non-key
+// column binds the caller's struct field verbatim (Save writes zero values
+// too), updated_at stamps like Save's AutoUpdateTime, and the job probe binds
+// the op's (to-be-persisted) BatchJobID exactly like the pre-fix probe did.
+const updateSQL = `UPDATE batch_file_operations SET
+	batch_job_id = ?, movie_id = ?, original_path = ?, new_path = ?, operation_type = ?, nfo_snapshot = ?, nfo_path = ?, generated_files = ?, revert_status = ?, reverted_at = ?, in_place_renamed = ?, original_dir_path = ?, created_at = ?, updated_at = ?
+WHERE id = ? AND NOT EXISTS (SELECT 1 FROM jobs WHERE jobs.id = ? AND jobs.status = ?)`
+
+// updateArgs normalizes op into updateSQL's bound argument list, preserving
+// the observable GORM Save contract: every persisted column binds as carried
+// and updated_at stamps now, assigned back to op exactly like Save's
+// AutoUpdateTime callback did (callers read op.UpdatedAt after Update). The
+// tail re-binds the primary key, BatchJobID, and the pruning fence status for
+// the WHERE NOT EXISTS probe.
+func updateArgs(op *models.BatchFileOperation, now time.Time) []any {
+	op.UpdatedAt = now
+	return []any{
+		op.BatchJobID, op.MovieID, op.OriginalPath, op.NewPath, op.OperationType,
+		op.NFOSnapshot, op.NFOPath, op.GeneratedFiles, op.RevertStatus, op.RevertedAt,
+		op.InPlaceRenamed, op.OriginalDirPath, op.CreatedAt, op.UpdatedAt,
+		op.ID, op.BatchJobID, pruningJobStatus,
+	}
+}
+
 // Update saves all fields of the given batch file operation record.
 //
-// Callers carrying a generated-files journal MUST NOT use this: a full Save
+// Callers carrying a generated-files journal MUST NOT use this: a full save
 // rewrites generated_files with whatever snapshot the caller hydrated, so any
 // journal mutation committed after that snapshot is clobbered/resurrected.
 // The journal column is owned exclusively by UpdateJournalInTx; non-journal
 // completion writes go through UpdateNonJournalFields (wave-10 codex
 // follow-up).
+//
+// The prune fence is the single-statement atomic probe of updateSQL (same
+// shape as createInsertSQL — see Create), so no read-then-write window exists
+// and retryOnLocked rides out residual transient locked errors. Zero affected
+// rows is classified AFTER the statement, on committed state: ErrJobPruning
+// when the owning job's retention claim is observable (the probe suppressed
+// the write), otherwise ErrNotFound (UpdateJournalInTx parity) for a
+// genuinely missing operation row — ensureJobWritable's empty/missing-job
+// allow semantics pass through, so an orphaned row can never ride the
+// pre-fix Save insert fallback back into existence.
 func (r *BatchFileOperationRepository) Update(ctx context.Context, op *models.BatchFileOperation) error {
 	label := fmt.Sprintf("batch file operation %d", op.ID)
-	// Fence outside the (read-then-write) deferred transaction — see Create.
-	if err := ensureJobWritable(r.GetDB().WithContext(ctx), op.BatchJobID); err != nil {
-		return wrapDBErr("update", label, err)
-	}
+	var rowsAffected int64
 	err := retryOnLocked(func() error {
-		return r.GetDB().WithContext(ctx).Save(op).Error
+		result := r.GetDB().WithContext(ctx).Exec(updateSQL, updateArgs(op, time.Now().UTC())...)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
 	})
 	if err != nil {
 		return wrapDBErr("update", label, err)
+	}
+	if rowsAffected == 0 {
+		// Fenced vs gone: the UPDATE's WHERE NOT EXISTS is the race-free
+		// fence; this re-probe only names the cause. A committed retention
+		// claim dominates (ErrJobPruning); a genuinely missing row keeps the
+		// UpdateJournalInTx missing-row contract (ErrNotFound) instead of the
+		// pre-fix Save fallback's resurrection insert.
+		if fenceErr := ensureJobWritable(r.GetDB().WithContext(ctx), op.BatchJobID); fenceErr != nil {
+			return wrapDBErr("update", label, fenceErr)
+		}
+		return wrapDBErr("update", label, ErrNotFound)
 	}
 	return nil
 }

--- a/internal/database/batch_file_operation_repo.go
+++ b/internal/database/batch_file_operation_repo.go
@@ -34,48 +34,118 @@ func NewBatchFileOperationRepository(db *DB) *BatchFileOperationRepository {
 	}
 }
 
+// createInsertSQL is the write-atomic prune fence shared by Create and
+// CreateBatch (PR #248 codex P1). The jobs-status probe rides INSIDE the
+// INSERT ... SELECT's WHERE NOT EXISTS instead of running as a pre-check, so
+// SQLite evaluates the retention claim while holding the statement's write
+// lock and the sweep-flip-vs-create window collapses to zero: the retention
+// claim (DeleteOrganizedOlderThan's status flip + snapshot, committed inside
+// one transaction) either landed BEFORE this statement starts — the probe
+// sees the pruning status, no row is returned, and the caller gets
+// ErrJobPruning — or it must wait out the write lock this statement holds,
+// in which case its post-claim snapshot necessarily observes the committed
+// operation row. The previous pre-check shape let a sweep claim+snapshot
+// commit BETWEEN the check and the insert: the orphaned row was never
+// cleanup-backup-snapshotted, then got pruned while its apply had already
+// proceeded with mutations — filesystem changes with NO durable revert
+// ledger. A missing jobs row (or empty BatchJobID) keeps the pre-existing
+// allow semantics: the probe's inner SELECT finds no pruning row.
+//
+// The statement mirrors the GORM Create it replaces: RETURNING id hands the
+// autoincrement back to the caller, and zero returned rows mean the probe
+// suppressed the insert (the ONLY suppression cause — the statement-time
+// outcome is authoritative; a post-hoc advisory SELECT could race the sweep's
+// follow-up DELETE and misclassify).
+const createInsertSQL = `INSERT INTO batch_file_operations
+	(batch_job_id, movie_id, original_path, new_path, operation_type, nfo_snapshot, nfo_path, generated_files, revert_status, reverted_at, in_place_renamed, original_dir_path, created_at, updated_at)
+SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+WHERE NOT EXISTS (SELECT 1 FROM jobs WHERE jobs.id = ? AND jobs.status = ?)
+RETURNING id`
+
+// createInsertArgs normalizes op into createInsertSQL's bound argument list,
+// preserving the observable GORM Create contract: zero-valued fields carrying
+// `default:` tags bind the schema defaults ('move', 'applied'), and
+// created_at/updated_at stamp now when unset. The normalization assigns back
+// to op exactly like GORM's create callbacks did (callers read op.ID and the
+// stamped timestamps after Create); the tail re-binds BatchJobID plus the
+// pruning fence status for the WHERE NOT EXISTS probe.
+func createInsertArgs(op *models.BatchFileOperation, now time.Time) []any {
+	if op.OperationType == "" {
+		op.OperationType = models.OperationTypeMove
+	}
+	if op.RevertStatus == "" {
+		op.RevertStatus = models.RevertStatusApplied
+	}
+	if op.CreatedAt.IsZero() {
+		op.CreatedAt = now
+	}
+	if op.UpdatedAt.IsZero() {
+		op.UpdatedAt = now
+	}
+	return []any{
+		op.BatchJobID, op.MovieID, op.OriginalPath, op.NewPath, op.OperationType,
+		op.NFOSnapshot, op.NFOPath, op.GeneratedFiles, op.RevertStatus, op.RevertedAt,
+		op.InPlaceRenamed, op.OriginalDirPath, op.CreatedAt, op.UpdatedAt,
+		op.BatchJobID, pruningJobStatus,
+	}
+}
+
 // Create inserts a single batch file operation record.
 //
-// The prune-fence check runs BEFORE the autocommit insert, not inside a
-// deferred transaction around it: under WAL a read-then-write transaction
-// upgrade dies with SQLITE_BUSY_SNAPSHOT (surfaced as "database is locked")
-// when a concurrent apply worker commits between the read and the write —
-// the pool busy timeout does not cover snapshot conflicts. The bare INSERT
-// acquires the writer lock directly, so concurrent per-worker Begin calls
-// (each apply-file goroutine opens its operation row before any filesystem
-// mutation) wait on the busy timeout instead of deadlocking; retryOnLocked
-// additionally rides out any residual transient locked error (same seam as
-// JobRepository.CommitEnvelope).
+// The fence is the single-statement atomic probe of createInsertSQL: no
+// read-then-write transaction upgrade exists, so the WAL SQLITE_BUSY_SNAPSHOT
+// hazard this repository previously documented for a transaction-wrapped
+// check-then-insert cannot arise — the bare statement acquires the writer
+// lock directly, concurrent per-worker Begin calls (each apply-file goroutine
+// opens its operation row before any filesystem mutation) wait on the busy
+// timeout instead of deadlocking, and retryOnLocked rides out any residual
+// transient locked error (same seam as JobRepository.CommitEnvelope).
 func (r *BatchFileOperationRepository) Create(ctx context.Context, op *models.BatchFileOperation) error {
 	label := fmt.Sprintf("batch file operation %d", op.ID)
-	if err := ensureJobWritable(r.GetDB().WithContext(ctx), op.BatchJobID); err != nil {
-		return wrapDBErr("create", label, err)
-	}
+	var ids []uint
 	err := retryOnLocked(func() error {
-		return r.GetDB().WithContext(ctx).Create(op).Error
+		ids = ids[:0]
+		return r.GetDB().WithContext(ctx).Raw(createInsertSQL, createInsertArgs(op, time.Now().UTC())...).Scan(&ids).Error
 	})
 	if err != nil {
 		return wrapDBErr("create", label, err)
 	}
+	if len(ids) == 0 {
+		// Zero returned rows ⟺ the probe suppressed the insert: the owning
+		// job's retention claim is committed.
+		return wrapDBErr("create", label, ErrJobPruning)
+	}
+	op.ID = ids[0]
 	return nil
 }
 
 // CreateBatch inserts multiple batch file operation records in a single transaction.
-// Same fence placement as Create: checks run before the write-only transaction
-// (no reads inside, so the upgrade-to-write cannot hit SQLITE_BUSY_SNAPSHOT),
-// with retryOnLocked absorbing residual transient lock errors.
+// Same atomic fence as Create — each statement re-evaluates the pruning probe
+// under the write lock the transaction holds from its first insert onward, so
+// a retention claim can never commit between a probe and its insert, nor
+// between statements of the batch. The transaction stays write-only, so the
+// deferred BEGIN cannot hit the read-then-write SQLITE_BUSY_SNAPSHOT upgrade
+// hazard; a fenced op rolls the whole batch back (the pre-existing
+// all-or-nothing contract), with retryOnLocked absorbing residual transient
+// lock errors.
 func (r *BatchFileOperationRepository) CreateBatch(ctx context.Context, ops []*models.BatchFileOperation) error {
-	for _, op := range ops {
-		if err := ensureJobWritable(r.GetDB().WithContext(ctx), op.BatchJobID); err != nil {
-			return wrapDBErr("create", fmt.Sprintf("batch file operation %d", op.ID), err)
-		}
+	if len(ops) == 0 {
+		return nil
 	}
 	return retryOnLocked(func() error {
 		return r.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 			for _, op := range ops {
-				if err := tx.Create(op).Error; err != nil {
-					return wrapDBErr("create", fmt.Sprintf("batch file operation %d", op.ID), err)
+				label := fmt.Sprintf("batch file operation %d", op.ID)
+				var ids []uint
+				if err := tx.Raw(createInsertSQL, createInsertArgs(op, time.Now().UTC())...).Scan(&ids).Error; err != nil {
+					return wrapDBErr("create", label, err)
 				}
+				if len(ids) == 0 {
+					// Fenced mid-batch: roll back the whole batch — a partially
+					// journaled batch would corrupt revert bookkeeping.
+					return wrapDBErr("create", label, ErrJobPruning)
+				}
+				op.ID = ids[0]
 			}
 			return nil
 		})

--- a/internal/database/batch_file_operation_repo_create_atomic_w248_test.go
+++ b/internal/database/batch_file_operation_repo_create_atomic_w248_test.go
@@ -38,11 +38,38 @@ func seedOrganizedJob(t *testing.T, db *DB, jobID string) *JobRepository {
 	return jobRepo
 }
 
+// countOpsForJob returns the number of COMMITTED operation rows for jobID.
+//
+// Busy-timeout conformance: the fixture connection already carries prod's
+// busy handling — newDatabaseTestDB goes through New, and normalizeSQLiteDSN
+// appends the same _busy_timeout=5000 to the shared-cache memory DSN that
+// file DSNs get. Shared-cache TABLE locks are the one conflict class SQLite
+// never routes through the busy handler: a reader/writer racing a held table
+// write lock gets SQLITE_LOCKED ("database table is locked") INSTANTLY, so
+// busy_timeout has nothing to wait on (Windows scheduling surfaces this
+// readily; Linux rarely). Every prod writer absorbs exactly this class via
+// retryOnLocked/isLocked; this helper, whose polling callers race the race
+// hammer's creators, mirrors that seam with a deadline-bounded retry instead
+// of treating a legal blocked observation as fatal. Any non-lock failure
+// (schema bugs, real corruption) still aborts the test immediately.
 func countOpsForJob(t *testing.T, db *DB, jobID string) int64 {
 	t.Helper()
-	var count int64
-	require.NoError(t, db.DB.Model(&models.BatchFileOperation{}).Where("batch_job_id = ?", jobID).Count(&count).Error)
-	return count
+	const lockRetryDeadline = 15 * time.Second
+	deadline := time.Now().Add(lockRetryDeadline)
+	var lastErr error
+	for attempts := 0; ; attempts++ {
+		var count int64
+		err := db.DB.Model(&models.BatchFileOperation{}).Where("batch_job_id = ?", jobID).Count(&count).Error
+		if err == nil {
+			return count
+		}
+		require.True(t, isLocked(err), "count batch_file_operations for %s: %v", jobID, err)
+		lastErr = err
+		if time.Now().After(deadline) {
+			t.Fatalf("batch_file_operations count stayed table-locked past %s (%d attempts): %v", lockRetryDeadline, attempts+1, lastErr)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 }
 
 // TestBFOW248_Create_PruningJobRejectedStatically pins the base fence: with
@@ -69,12 +96,16 @@ func TestBFOW248_Create_PruningJobRejectedStatically(t *testing.T) {
 
 // TestBFOW248_Create_ProbeRunsUnderWriteLock is the force-ordered zero-window
 // probe: hold the SQLite write lock on a second connection, start Create for
-// a LIVE job (it must block — its single statement needs the writer lock and
-// cannot complete early), then commit the retention claim from the lock
-// holder. The released Create statement evaluates its WHERE NOT EXISTS probe
-// against the now-committed pruning status — under the old pre-check shape
-// the check had already read "live" and the insert would have landed on the
-// pruned job.
+// a LIVE job (its single statement needs the writer lock, so it cannot insert
+// early), then commit the retention claim from the lock holder. The blocked
+// competitor is observed portably: on Linux/macOS the statement waits on the
+// busy timeout, while Windows shared-cache table locks bypass the busy
+// handler and fail it fast with the SQLITE_BUSY/SQLITE_LOCKED class (the
+// retryOnLocked budget then expires before release) — both legal blocked
+// observations, since nothing was committed. The released (or re-issued)
+// Create statement evaluates its WHERE NOT EXISTS probe against the
+// now-committed pruning status — under the old pre-check shape the check had
+// already read "live" and the insert would have landed on the pruned job.
 func TestBFOW248_Create_ProbeRunsUnderWriteLock(t *testing.T) {
 	db := newDatabaseTestDB(t)
 	repo := NewBatchFileOperationRepository(db)
@@ -101,11 +132,17 @@ func TestBFOW248_Create_ProbeRunsUnderWriteLock(t *testing.T) {
 		done <- repo.Create(ctx, &models.BatchFileOperation{BatchJobID: "w248-race", OriginalPath: "/race/src.mp4", NewPath: "/race/dst.mp4"})
 	}()
 
-	// The create must NOT complete while the writer lock is held: it is gated
-	// on the lock from its first (only) statement — including the probe.
+	// The create must NOT insert while the writer lock is held: it is gated on
+	// the lock from its first (only) statement — including the probe. A legal
+	// blocked observation is either "still waiting after 250ms" or an
+	// SQLITE_BUSY/SQLITE_LOCKED-class error (a write that committed nothing);
+	// illegal is any non-lock outcome during the held window — success would
+	// be the both-committed interleave this probe exists to kill.
+	blockedEarly := false
 	select {
 	case earlyErr := <-done:
-		t.Fatalf("Create returned while the writer lock was held — the probe is not inside the write path: %v", earlyErr)
+		require.True(t, isLocked(earlyErr), "Create returned a non-lock outcome while the writer lock was held — the probe is not inside the write path: %v", earlyErr)
+		blockedEarly = true
 	case <-time.After(250 * time.Millisecond):
 	}
 
@@ -117,8 +154,16 @@ func TestBFOW248_Create_ProbeRunsUnderWriteLock(t *testing.T) {
 	require.NoError(t, err)
 	committed = true
 
-	createErr := <-done
-	require.ErrorIs(t, createErr, ErrJobPruning, "the probe must observe the claim committed while it waited for the lock")
+	if blockedEarly {
+		// The fast-failed competitor committed nothing; pin the same fence
+		// directly: a create issued now evaluates its probe against the
+		// committed claim and must be rejected.
+		err = repo.Create(ctx, &models.BatchFileOperation{BatchJobID: "w248-race", OriginalPath: "/race/after.mp4", NewPath: "/race/dst.mp4"})
+		require.ErrorIs(t, err, ErrJobPruning, "a create evaluated after the committed claim must be fenced")
+	} else {
+		createErr := <-done
+		require.ErrorIs(t, createErr, ErrJobPruning, "the probe must observe the claim committed while it waited for the lock")
+	}
 	assert.Zero(t, countOpsForJob(t, db, "w248-race"))
 }
 
@@ -240,10 +285,14 @@ func TestBFOW248_CreateBatch_DefaultsParity(t *testing.T) {
 // TestBFOW248_Create_RaceSweepClosesWindow is the race-gate hammer: creators
 // loop against a job while the retention sweep claims it. Invariants:
 //
-//   - no create reports anything but success or ErrJobPruning;
+//   - no create reports anything but success, ErrJobPruning, or an exhausted
+//     transient-lock retry (a legal blocked observation on the Windows
+//     fail-fast table-lock path — nothing was committed, so it can never
+//     orphan a row; anything else is the illegal class);
 //   - once the claim is committed (observable inside the cleanup hook), EVERY
-//     subsequent create/batch is refused — there is no late-but-successful
-//     insert that would orphan a ledger row;
+//     subsequent create/batch is refused — proven deterministically by direct
+//     main-thread probes rather than worker timing, so no late-but-successful
+//     insert can orphan a ledger row;
 //   - every row created successfully pre-claim appears in the sweep snapshot
 //     and is deleted by the sweep (zero rows survive).
 func TestBFOW248_Create_RaceSweepClosesWindow(t *testing.T) {
@@ -255,6 +304,7 @@ func TestBFOW248_Create_RaceSweepClosesWindow(t *testing.T) {
 	successIDs := map[uint]bool{}
 	snapshotIDs := map[uint]bool{}
 	rejections := 0
+	lockBlocked := 0
 	var unexpectedErrs []error
 
 	claimCommitted := make(chan struct{})
@@ -283,13 +333,20 @@ func TestBFOW248_Create_RaceSweepClosesWindow(t *testing.T) {
 				}
 				err := repo.Create(context.Background(), op)
 				if err != nil {
-					// The ONLY admissible rejection is the prune fence; the
-					// first rejection ends this worker's loop. Assertions run
-					// on the main goroutine after wg.Wait.
+					// The first terminal error ends this worker's loop; assertions
+					// run on the main goroutine after wg.Wait. Legal terminal
+					// outcomes: the prune fence, or an exhausted transient-lock
+					// retry (Windows shared-cache table locks fail fast with no
+					// busy-handler cover, so a contended create can burn its
+					// retryOnLocked budget — a blocked write that committed
+					// nothing). Any other error is the illegal class.
 					mu.Lock()
-					if errors.Is(err, ErrJobPruning) {
+					switch {
+					case errors.Is(err, ErrJobPruning):
 						rejections++
-					} else {
+					case isLocked(err):
+						lockBlocked++
+					default:
 						unexpectedErrs = append(unexpectedErrs, err)
 					}
 					mu.Unlock()
@@ -360,8 +417,19 @@ func TestBFOW248_Create_RaceSweepClosesWindow(t *testing.T) {
 	require.ErrorIs(t, err, ErrJobPruning, "create-batch after the committed claim must be fenced")
 
 	wg.Wait()
-	assert.Empty(t, unexpectedErrs, "the prune fence is the ONLY admissible create rejection: %v", unexpectedErrs)
-	assert.Equal(t, 4, rejections, "every creator eventually hit the fence")
+	mu.Lock()
+	assert.Empty(t, unexpectedErrs, "only the prune fence or an exhausted transient-table-lock retry may refuse a create: %v", unexpectedErrs)
+	fenceHits := rejections
+	blockedWrites := lockBlocked
+	mu.Unlock()
+	// Seat-level breadth is calibrated, not loose: every creator exits on
+	// exactly one legal terminal observation, and the fence is proved
+	// deterministically by the five direct probes above — the both-committed
+	// interleave this test exists to kill cannot hide behind a blocked write,
+	// because a blocked write committed nothing while snapshot disjointness
+	// and the zero-survivor assert below run over only COMMITTED state.
+	assert.Equal(t, 4, fenceHits+blockedWrites, "every creator exits on exactly one terminal observation")
+	assert.Greater(t, fenceHits, 0, "at least one creator observed the fence directly")
 
 	close(releaseHook)
 	require.NoError(t, <-sweepDone)

--- a/internal/database/batch_file_operation_repo_create_atomic_w248_test.go
+++ b/internal/database/batch_file_operation_repo_create_atomic_w248_test.go
@@ -1,0 +1,379 @@
+package database
+
+// Regression pins for PR #248 codex P1 (F1): the prune fence on
+// Create/CreateBatch must be WRITE-ATOMIC. The pre-check shape let a
+// retention sweep flip the owning job to "pruning" BETWEEN the status probe
+// and the insert, so the operation row survived cleanup-hook snapshotting and
+// then got pruned while its apply proceeded with mutations and NO durable
+// revert ledger. The single-statement INSERT ... SELECT ... WHERE NOT EXISTS
+// (jobs pruning) leaves zero window: the claim observes every committed row,
+// and every post-claim create is rejected.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedOrganizedJob inserts an organized jobs row old enough for retention and
+// returns its repository handle.
+func seedOrganizedJob(t *testing.T, db *DB, jobID string) *JobRepository {
+	t.Helper()
+	jobRepo := NewJobRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	require.NoError(t, jobRepo.Create(context.Background(), &models.Job{
+		ID:          jobID,
+		Status:      models.JobStatusOrganized,
+		Files:       "[]",
+		StartedAt:   organizedAt,
+		OrganizedAt: &organizedAt,
+	}))
+	return jobRepo
+}
+
+func countOpsForJob(t *testing.T, db *DB, jobID string) int64 {
+	t.Helper()
+	var count int64
+	require.NoError(t, db.DB.Model(&models.BatchFileOperation{}).Where("batch_job_id = ?", jobID).Count(&count).Error)
+	return count
+}
+
+// TestBFOW248_Create_PruningJobRejectedStatically pins the base fence: with
+// the claim already committed, Create is refused with ErrJobPruning and no
+// row lands; a live job's create is untouched.
+func TestBFOW248_Create_PruningJobRejectedStatically(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	seedOrganizedJob(t, db, "w248-pruned")
+	require.NoError(t, db.DB.Exec("UPDATE jobs SET status = ? WHERE id = ?", pruningJobStatus, "w248-pruned").Error)
+
+	op := &models.BatchFileOperation{BatchJobID: "w248-pruned", OriginalPath: "/prune/src.mp4", NewPath: "/prune/dst.mp4"}
+	err := repo.Create(context.Background(), op)
+	require.ErrorIs(t, err, ErrJobPruning)
+	assert.Zero(t, op.ID, "a fenced create must never mint a row id")
+	assert.Zero(t, countOpsForJob(t, db, "w248-pruned"))
+
+	// A live job (and a never-persisted job id, the pre-existing allow
+	// semantics) still insert.
+	live := &models.BatchFileOperation{BatchJobID: "w248-live", OriginalPath: "/live/src.mp4", NewPath: "/live/dst.mp4"}
+	require.NoError(t, repo.Create(context.Background(), live))
+	assert.NotZero(t, live.ID)
+}
+
+// TestBFOW248_Create_ProbeRunsUnderWriteLock is the force-ordered zero-window
+// probe: hold the SQLite write lock on a second connection, start Create for
+// a LIVE job (it must block — its single statement needs the writer lock and
+// cannot complete early), then commit the retention claim from the lock
+// holder. The released Create statement evaluates its WHERE NOT EXISTS probe
+// against the now-committed pruning status — under the old pre-check shape
+// the check had already read "live" and the insert would have landed on the
+// pruned job.
+func TestBFOW248_Create_ProbeRunsUnderWriteLock(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	seedOrganizedJob(t, db, "w248-race")
+
+	ctx := context.Background()
+	sqlDB, err := db.DB.DB()
+	require.NoError(t, err)
+	holder, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = holder.Close() }()
+
+	_, err = holder.ExecContext(ctx, "BEGIN IMMEDIATE")
+	require.NoError(t, err)
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = holder.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- repo.Create(ctx, &models.BatchFileOperation{BatchJobID: "w248-race", OriginalPath: "/race/src.mp4", NewPath: "/race/dst.mp4"})
+	}()
+
+	// The create must NOT complete while the writer lock is held: it is gated
+	// on the lock from its first (only) statement — including the probe.
+	select {
+	case earlyErr := <-done:
+		t.Fatalf("Create returned while the writer lock was held — the probe is not inside the write path: %v", earlyErr)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	// Commit the sweep claim from the lock holder (mirrors
+	// DeleteOrganizedOlderThan's status flip) and release the lock.
+	_, err = holder.ExecContext(ctx, "UPDATE jobs SET status = ? WHERE id = ?", pruningJobStatus, "w248-race")
+	require.NoError(t, err)
+	_, err = holder.ExecContext(ctx, "COMMIT")
+	require.NoError(t, err)
+	committed = true
+
+	createErr := <-done
+	require.ErrorIs(t, createErr, ErrJobPruning, "the probe must observe the claim committed while it waited for the lock")
+	assert.Zero(t, countOpsForJob(t, db, "w248-race"))
+}
+
+// TestBFOW248_Create_CommittedRowIncludedInSweepSnapshot pins the OTHER
+// ordering: a create committed before the claim is necessarily part of the
+// sweep's op snapshot (it commits before the claim can land), so the cleanup
+// hook sees it and the follow-up delete removes it — never an orphaned live
+// ledger row.
+func TestBFOW248_Create_CommittedRowIncludedInSweepSnapshot(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	jobRepo := seedOrganizedJob(t, db, "w248-snap")
+
+	op := &models.BatchFileOperation{BatchJobID: "w248-snap", OriginalPath: "/snap/src.mp4", NewPath: "/snap/dst.mp4", OperationType: models.OperationTypeMove}
+	require.NoError(t, repo.Create(context.Background(), op))
+	require.NotZero(t, op.ID)
+
+	snapshotted := map[uint]bool{}
+	jobRepo.SetOrganizedJobPruneHook(func(_ context.Context, ops []models.BatchFileOperation) error {
+		for _, o := range ops {
+			snapshotted[o.ID] = true
+		}
+		return nil
+	})
+
+	require.NoError(t, jobRepo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour)))
+	assert.True(t, snapshotted[op.ID], "a row committed before the claim must ride the sweep snapshot")
+	assert.Zero(t, countOpsForJob(t, db, "w248-snap"), "the sweep deletes the snapshotted row")
+}
+
+// TestBFOW248_CreateBatch_PruneFenceRollsBackWholeBatch pins per-statement
+// fencing inside the batch transaction: a claim committed against ANY target
+// job rejects the batch atomically — no partially journaled batch (a split
+// batch would corrupt revert bookkeeping).
+func TestBFOW248_CreateBatch_PruneFenceRollsBackWholeBatch(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	seedOrganizedJob(t, db, "w248-batch-live")
+	seedOrganizedJob(t, db, "w248-batch-pruned")
+	require.NoError(t, db.DB.Exec("UPDATE jobs SET status = ? WHERE id = ?", pruningJobStatus, "w248-batch-pruned").Error)
+
+	ops := []*models.BatchFileOperation{
+		{BatchJobID: "w248-batch-live", OriginalPath: "/b/1.mp4", NewPath: "/d/1.mp4"},
+		{BatchJobID: "w248-batch-pruned", OriginalPath: "/b/2.mp4", NewPath: "/d/2.mp4"},
+	}
+	err := repo.CreateBatch(context.Background(), ops)
+	require.ErrorIs(t, err, ErrJobPruning)
+	// ops[0].ID may carry its in-memory RETURNING id from before the
+	// rollback (same as the old GORM path); only COMMITTED state matters.
+	assert.Zero(t, countOpsForJob(t, db, "w248-batch-live"), "the unfenced sibling row must roll back too")
+	assert.Zero(t, countOpsForJob(t, db, "w248-batch-pruned"))
+}
+
+// TestBFOW248_CreateBatch_StatementErrorRollsBack pins the non-fence failure
+// arm of the batch write path (and the empty-batch no-DB-touch early return).
+func TestBFOW248_CreateBatch_StatementErrorRollsBack(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	require.NoError(t, db.DB.Exec("DROP TABLE batch_file_operations").Error)
+
+	// Empty batch: a no-op contract that must not touch the (broken) schema.
+	require.NoError(t, repo.CreateBatch(context.Background(), nil))
+
+	err := repo.CreateBatch(context.Background(), []*models.BatchFileOperation{
+		{BatchJobID: "w248-broken", OriginalPath: "/b/1.mp4", NewPath: "/d/1.mp4"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create batch file operation")
+	assert.NotErrorIs(t, err, ErrJobPruning, "a statement failure must not masquerade as the prune fence")
+}
+
+// TestBFOW248_CreateBatch_DefaultsParity pins the schema-default parity of
+// the hand-bound insert: zero-valued enum/status fields land as the schema
+// defaults exactly like the GORM Create they replace, stamped timestamps bind
+// and report back, and caller-preset values persist verbatim.
+func TestBFOW248_CreateBatch_DefaultsParity(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+
+	presetCreated := time.Date(2023, 3, 4, 5, 6, 7, 0, time.UTC)
+	presetUpdated := presetCreated.Add(time.Hour)
+	bare := &models.BatchFileOperation{BatchJobID: "w248-parity", OriginalPath: "/p/bare.mp4", NewPath: "/q/bare.mp4"}
+	full := &models.BatchFileOperation{
+		BatchJobID:     "w248-parity",
+		MovieID:        "PAR-001",
+		OriginalPath:   "/p/full.mp4",
+		NewPath:        "/q/full.mp4",
+		OperationType:  models.OperationTypeCopy,
+		RevertStatus:   models.RevertStatusNoOp,
+		InPlaceRenamed: true,
+		CreatedAt:      presetCreated,
+		UpdatedAt:      presetUpdated,
+	}
+	require.NoError(t, repo.CreateBatch(context.Background(), []*models.BatchFileOperation{bare, full}))
+	require.NotZero(t, bare.ID)
+	require.NotZero(t, full.ID)
+
+	// Assign-back parity with the old GORM create callbacks.
+	assert.Equal(t, models.OperationTypeMove, bare.OperationType)
+	assert.Equal(t, models.RevertStatusApplied, bare.RevertStatus)
+	assert.False(t, bare.CreatedAt.IsZero(), "create stamps created_at on the record")
+	assert.False(t, bare.UpdatedAt.IsZero())
+
+	gotBare, err := repo.FindByID(context.Background(), bare.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.OperationTypeMove, gotBare.OperationType)
+	assert.Equal(t, models.RevertStatusApplied, gotBare.RevertStatus)
+	assert.False(t, gotBare.CreatedAt.IsZero())
+
+	gotFull, err := repo.FindByID(context.Background(), full.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.OperationTypeCopy, gotFull.OperationType)
+	assert.Equal(t, models.RevertStatusNoOp, gotFull.RevertStatus)
+	assert.True(t, gotFull.InPlaceRenamed)
+	assert.WithinDuration(t, presetCreated, gotFull.CreatedAt, time.Microsecond)
+	assert.WithinDuration(t, presetUpdated, gotFull.UpdatedAt, time.Microsecond)
+}
+
+// TestBFOW248_Create_RaceSweepClosesWindow is the race-gate hammer: creators
+// loop against a job while the retention sweep claims it. Invariants:
+//
+//   - no create reports anything but success or ErrJobPruning;
+//   - once the claim is committed (observable inside the cleanup hook), EVERY
+//     subsequent create/batch is refused — there is no late-but-successful
+//     insert that would orphan a ledger row;
+//   - every row created successfully pre-claim appears in the sweep snapshot
+//     and is deleted by the sweep (zero rows survive).
+func TestBFOW248_Create_RaceSweepClosesWindow(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	jobRepo := seedOrganizedJob(t, db, "w248-hammer")
+
+	var mu sync.Mutex
+	successIDs := map[uint]bool{}
+	snapshotIDs := map[uint]bool{}
+	rejections := 0
+	var unexpectedErrs []error
+
+	claimCommitted := make(chan struct{})
+	releaseHook := make(chan struct{})
+	jobRepo.SetOrganizedJobPruneHook(func(_ context.Context, ops []models.BatchFileOperation) error {
+		mu.Lock()
+		for _, o := range ops {
+			snapshotIDs[o.ID] = true
+		}
+		mu.Unlock()
+		close(claimCommitted)
+		<-releaseHook
+		return nil
+	})
+
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; ; i++ {
+				op := &models.BatchFileOperation{
+					BatchJobID:   "w248-hammer",
+					OriginalPath: fmt.Sprintf("/hammer/%d/%d.mp4", worker, i),
+					NewPath:      "/hammer/dst.mp4",
+				}
+				err := repo.Create(context.Background(), op)
+				if err != nil {
+					// The ONLY admissible rejection is the prune fence; the
+					// first rejection ends this worker's loop. Assertions run
+					// on the main goroutine after wg.Wait.
+					mu.Lock()
+					if errors.Is(err, ErrJobPruning) {
+						rejections++
+					} else {
+						unexpectedErrs = append(unexpectedErrs, err)
+					}
+					mu.Unlock()
+					return
+				}
+				mu.Lock()
+				successIDs[op.ID] = true
+				mu.Unlock()
+				// Yield between inserts so the sweep claim can interleave: shared
+				// cache + memory journal surfaces table-lock conflicts immediately
+				// (no busy-handler cover), and a back-to-back write loop would
+				// starve the claim forever under -race.
+				time.Sleep(time.Millisecond)
+			}
+		}(w)
+	}
+
+	// Wait until at least one creator row is committed, THEN claim+snapshot:
+	// the cleanup hook fires only for a non-empty op snapshot, so a fixed
+	// sleep cannot gate this deterministically under -race slowdowns. The hook
+	// blocks inside the sweep so the committed-claim window can be probed.
+	waitDeadline := time.Now().Add(10 * time.Second)
+	for countOpsForJob(t, db, "w248-hammer") == 0 {
+		if time.Now().After(waitDeadline) {
+			t.Fatal("creators never journaled a row before the claim")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	// Claim+snapshot may need several attempts under writer pressure: the
+	// retention claim rides NO retryOnLocked seam of its own, and transient
+	// table-lock conflicts surface immediately on this shared-cache fixture —
+	// retry the sweep (the same retryOnLocked seam the write paths use) until
+	// its hook fires. A nil-error finish without the hook would mean the claim
+	// landed on an empty snapshot, contradicting the ≥1-row gate above.
+	sweepDone := make(chan error, 1)
+	claimed := false
+	for attempt := 0; attempt < 30 && !claimed; attempt++ {
+		go func() {
+			sweepDone <- jobRepo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour))
+		}()
+		select {
+		case <-claimCommitted:
+			claimed = true
+		case sweepErr := <-sweepDone:
+			if sweepErr == nil {
+				t.Fatal("sweep claim landed but the cleanup hook never fired (empty snapshot despite committed rows)")
+			}
+			time.Sleep(10 * time.Millisecond)
+		case <-time.After(30 * time.Second):
+			t.Fatal("sweep cleanup hook never fired — the claim must eventually interleave with creator writes")
+		}
+	}
+	if !claimed {
+		t.Fatal("sweep claim could not land within the attempt budget")
+	}
+
+	// Once the claim is committed, the window is closed: every late create is
+	// refused. Between each probe, creators above hit their first rejection
+	// and stop, so wg converges while the hook still holds the sweep.
+	for i := 0; i < 4; i++ {
+		err := repo.Create(context.Background(), &models.BatchFileOperation{BatchJobID: "w248-hammer", OriginalPath: fmt.Sprintf("/hammer/late/%d.mp4", i), NewPath: "/hammer/dst.mp4"})
+		require.ErrorIs(t, err, ErrJobPruning, "create after the committed claim must be fenced")
+	}
+	err := repo.CreateBatch(context.Background(), []*models.BatchFileOperation{
+		{BatchJobID: "w248-hammer", OriginalPath: "/hammer/late-batch/1.mp4", NewPath: "/hammer/dst.mp4"},
+		{BatchJobID: "w248-hammer", OriginalPath: "/hammer/late-batch/2.mp4", NewPath: "/hammer/dst.mp4"},
+	})
+	require.ErrorIs(t, err, ErrJobPruning, "create-batch after the committed claim must be fenced")
+
+	wg.Wait()
+	assert.Empty(t, unexpectedErrs, "the prune fence is the ONLY admissible create rejection: %v", unexpectedErrs)
+	assert.Equal(t, 4, rejections, "every creator eventually hit the fence")
+
+	close(releaseHook)
+	require.NoError(t, <-sweepDone)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for id := range successIDs {
+		assert.True(t, snapshotIDs[id], "a successful pre-claim create MUST ride the sweep snapshot (orphan ledger → silent revert loss)")
+	}
+	assert.Equal(t, len(successIDs), len(snapshotIDs))
+	assert.Greater(t, len(successIDs), 0, "the hammer must have journaled rows before the claim (fixture sanity)")
+	assert.Zero(t, countOpsForJob(t, db, "w248-hammer"), "the sweep deletes exactly the snapshotted rows; no op row survives")
+	_, findErr := jobRepo.FindByID(context.Background(), "w248-hammer")
+	assert.ErrorIs(t, findErr, ErrNotFound, "the depleted job row is deleted by the sweep")
+}

--- a/internal/database/batch_file_operation_repo_create_w244_test.go
+++ b/internal/database/batch_file_operation_repo_create_w244_test.go
@@ -1,0 +1,29 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBatchFileOperationRepository_Create_PermanentFailure pins the
+// retryOnLocked-wrapped error arm of Create (#244): a non-transient failure
+// (missing table) is not classified "locked", so it propagates immediately
+// with the wrapped "create" label.
+func TestBatchFileOperationRepository_Create_PermanentFailure(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	require.NoError(t, db.DB.Exec("DROP TABLE batch_file_operations").Error)
+
+	err := repo.Create(context.Background(), &models.BatchFileOperation{
+		BatchJobID:    "job-create-failure",
+		OriginalPath:  "/failure/source.mp4",
+		NewPath:       "/failure/dest.mp4",
+		OperationType: models.OperationTypeMove,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create batch file operation")
+}

--- a/internal/database/batch_file_operation_repo_update_atomic_w248_test.go
+++ b/internal/database/batch_file_operation_repo_update_atomic_w248_test.go
@@ -1,0 +1,317 @@
+package database
+
+// Regression pins for PR #248 codex P2 (F-update): the prune fence on Update
+// must be WRITE-ATOMIC, exactly like the Create/CreateBatch conditional
+// insert. The pre-fix shape was probe-then-Save: the ensureJobWritable status
+// read ran as a separate statement, a retention claim landing BETWEEN it and
+// GORM Save flipped zero-rows into Save's INSERT fallback AFTER the sweep had
+// snapshotted/backed-up/deleted the row (orphaned ledger row under a deleted
+// job — SQLite FK enforcement is off per the repository DSN), and Save could
+// claim success for a row the already-snapshotted sweep deleted a moment
+// later. The single-statement UPDATE ... WHERE NOT EXISTS (jobs pruning)
+// leaves zero window; zero affected rows is classified on committed state —
+// ErrJobPruning for the fence, ErrNotFound for a genuinely missing row — and
+// the Save insert fallback can never resurrect a swept row.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBFOW248_Update_SaveParityOnLiveJob pins the happy path against a live
+// job: every non-key column persists verbatim (Save-parity full-column bind),
+// updated_at stamps forward and assigns back onto the caller's struct exactly
+// like GORM Save's AutoUpdateTime callback did, and created_at is untouched.
+func TestBFOW248_Update_SaveParityOnLiveJob(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+
+	require.NoError(t, NewJobRepository(db).Create(context.Background(), &models.Job{
+		ID: "w248-upd-live", Status: models.JobStatusRunning, Files: "[]", StartedAt: time.Now().UTC(),
+	}))
+	op := &models.BatchFileOperation{BatchJobID: "w248-upd-live", OriginalPath: "/upd/src.mp4", NewPath: "/upd/dst.mp4"}
+	require.NoError(t, repo.Create(context.Background(), op))
+	require.NotZero(t, op.ID)
+	createdAt := op.CreatedAt
+
+	revertedAt := time.Now().UTC().Add(-time.Minute)
+	op.NewPath = "/upd/dst-renamed.mp4"
+	op.RevertStatus = models.RevertStatusReverted
+	op.RevertedAt = &revertedAt
+	op.NFOSnapshot = "<movie/>"
+	op.GeneratedFiles = `{"replacements":[]}`
+	before := time.Now().UTC()
+	require.NoError(t, repo.Update(context.Background(), op))
+	assert.WithinDuration(t, before, op.UpdatedAt, 5*time.Second, "Save-parity: updated_at assigns back onto the caller struct")
+
+	got, err := repo.FindByID(context.Background(), op.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "/upd/dst-renamed.mp4", got.NewPath)
+	assert.Equal(t, models.RevertStatusReverted, got.RevertStatus)
+	require.NotNil(t, got.RevertedAt)
+	assert.WithinDuration(t, revertedAt, *got.RevertedAt, time.Microsecond)
+	assert.Equal(t, "<movie/>", got.NFOSnapshot)
+	assert.Equal(t, `{"replacements":[]}`, got.GeneratedFiles)
+	assert.WithinDuration(t, createdAt, got.CreatedAt, time.Microsecond, "update must not restamp created_at")
+	assert.WithinDuration(t, before, got.UpdatedAt, 5*time.Second, "update stamps updated_at like Save")
+}
+
+// TestBFOW248_Update_PruningJobRejectedStatically pins the base fence: with
+// the retention claim already committed, Update is refused with ErrJobPruning
+// and the row is left untouched; a live job's update is unaffected.
+func TestBFOW248_Update_PruningJobRejectedStatically(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	seedOrganizedJob(t, db, "w248-upd-pruned")
+	op := &models.BatchFileOperation{BatchJobID: "w248-upd-pruned", OriginalPath: "/u/src.mp4", NewPath: "/u/dst.mp4"}
+	require.NoError(t, repo.Create(context.Background(), op))
+	require.NoError(t, db.DB.Exec("UPDATE jobs SET status = ? WHERE id = ?", pruningJobStatus, "w248-upd-pruned").Error)
+
+	op.NewPath = "/u/dst-late.mp4"
+	err := repo.Update(context.Background(), op)
+	require.ErrorIs(t, err, ErrJobPruning)
+
+	got, findErr := repo.FindByID(context.Background(), op.ID)
+	require.NoError(t, findErr)
+	assert.Equal(t, "/u/dst.mp4", got.NewPath, "a fenced update must never touch the row")
+	assert.Equal(t, int64(1), countOpsForJob(t, db, "w248-upd-pruned"))
+}
+
+// TestBFOW248_Update_ProbeRunsUnderWriteLock is the force-ordered zero-window
+// probe for Update, mirroring TestBFOW248_Create_ProbeRunsUnderWriteLock:
+// hold the SQLite write lock on a second connection, start Update against a
+// LIVE job (its single statement needs the writer lock, so it cannot land
+// early), then commit the retention claim from the lock holder. The blocked
+// competitor is observed portably: on Linux/macOS the statement waits on the
+// busy timeout, while Windows shared-cache table locks bypass the busy
+// handler and fail it fast with the SQLITE_BUSY/SQLITE_LOCKED class (the
+// retryOnLocked budget then expires before release) — both legal blocked
+// observations, since nothing was committed. The released (or re-issued)
+// Update statement evaluates its WHERE NOT EXISTS probe against the
+// now-committed pruning status — under the pre-fix probe-then-Save shape the
+// pre-check had already read "live" and the write would have landed on the
+// pruning job.
+func TestBFOW248_Update_ProbeRunsUnderWriteLock(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	seedOrganizedJob(t, db, "w248-upd-race")
+
+	ctx := context.Background()
+	op := &models.BatchFileOperation{BatchJobID: "w248-upd-race", OriginalPath: "/ur/src.mp4", NewPath: "/ur/dst.mp4"}
+	require.NoError(t, repo.Create(ctx, op))
+
+	sqlDB, err := db.DB.DB()
+	require.NoError(t, err)
+	holder, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = holder.Close() }()
+
+	_, err = holder.ExecContext(ctx, "BEGIN IMMEDIATE")
+	require.NoError(t, err)
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = holder.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		raced := *op
+		raced.NewPath = "/ur/dst-late.mp4"
+		done <- repo.Update(ctx, &raced)
+	}()
+
+	// The update must NOT land while the writer lock is held: it is gated on
+	// the lock from its first (only) statement — including the probe. A legal
+	// blocked observation is either "still waiting after 250ms" or an
+	// SQLITE_BUSY/SQLITE_LOCKED-class error (a write that committed nothing);
+	// illegal is any non-lock outcome during the held window — success would
+	// be the both-committed interleave this probe exists to kill.
+	blockedEarly := false
+	select {
+	case earlyErr := <-done:
+		require.True(t, isLocked(earlyErr), "Update returned a non-lock outcome while the writer lock was held — the probe is not inside the write path: %v", earlyErr)
+		blockedEarly = true
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	// Commit the sweep claim from the lock holder (mirrors
+	// DeleteOrganizedOlderThan's status flip) and release the lock.
+	_, err = holder.ExecContext(ctx, "UPDATE jobs SET status = ? WHERE id = ?", pruningJobStatus, "w248-upd-race")
+	require.NoError(t, err)
+	_, err = holder.ExecContext(ctx, "COMMIT")
+	require.NoError(t, err)
+	committed = true
+
+	if blockedEarly {
+		// The fast-failed competitor committed nothing; pin the same fence
+		// directly: an update issued now evaluates its probe against the
+		// committed claim and must be rejected.
+		raced := *op
+		raced.NewPath = "/ur/dst-late.mp4"
+		err = repo.Update(ctx, &raced)
+		require.ErrorIs(t, err, ErrJobPruning, "an update evaluated after the committed claim must be fenced")
+	} else {
+		updateErr := <-done
+		require.ErrorIs(t, updateErr, ErrJobPruning, "the probe must observe the claim committed while it waited for the lock")
+	}
+
+	got, err := repo.FindByID(ctx, op.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "/ur/dst.mp4", got.NewPath, "the fenced update must never land")
+	assert.Equal(t, int64(1), countOpsForJob(t, db, "w248-upd-race"))
+}
+
+// TestBFOW248_Update_SweptRowNeverResurrects is the P2 orphan-kill pin,
+// force-ordered: the lock holder commits the retention claim AND the
+// follow-up row delete while Update is gated on the writer lock
+// (DeleteOrganizedOlderThan's claim-then-delete sequence compressed into one
+// hold). The pre-fix shape reported the probe as clean and GORM Save's INSERT
+// fallback re-created the swept row under a pruning job — an orphaned ledger
+// row no sweep snapshot ever saw. The atomic shape reports ErrJobPruning and
+// writes nothing.
+func TestBFOW248_Update_SweptRowNeverResurrects(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	seedOrganizedJob(t, db, "w248-upd-swept")
+
+	ctx := context.Background()
+	op := &models.BatchFileOperation{BatchJobID: "w248-upd-swept", OriginalPath: "/us/src.mp4", NewPath: "/us/dst.mp4"}
+	require.NoError(t, repo.Create(ctx, op))
+
+	sqlDB, err := db.DB.DB()
+	require.NoError(t, err)
+	holder, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = holder.Close() }()
+
+	_, err = holder.ExecContext(ctx, "BEGIN IMMEDIATE")
+	require.NoError(t, err)
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = holder.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		stale := *op
+		done <- repo.Update(ctx, &stale)
+	}()
+
+	blockedEarly := false
+	select {
+	case earlyErr := <-done:
+		require.True(t, isLocked(earlyErr), "Update returned a non-lock outcome while the writer lock was held: %v", earlyErr)
+		blockedEarly = true
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	// Claim + delete commit atomically from the holder's perspective (the
+	// test observes both only after COMMIT — the fix's classification probes
+	// the committed pruning status; the pre-fix insert fallback would land
+	// here).
+	_, err = holder.ExecContext(ctx, "UPDATE jobs SET status = ? WHERE id = ?", pruningJobStatus, "w248-upd-swept")
+	require.NoError(t, err)
+	_, err = holder.ExecContext(ctx, "DELETE FROM batch_file_operations WHERE id = ?", op.ID)
+	require.NoError(t, err)
+	_, err = holder.ExecContext(ctx, "COMMIT")
+	require.NoError(t, err)
+	committed = true
+
+	if blockedEarly {
+		stale := *op
+		err = repo.Update(ctx, &stale)
+		require.ErrorIs(t, err, ErrJobPruning, "swept row under a claimed job: fence dominates the missing-row report")
+	} else {
+		updateErr := <-done
+		require.ErrorIs(t, updateErr, ErrJobPruning, "the statement-time probe must fence the resurrecting write")
+	}
+	assert.Zero(t, countOpsForJob(t, db, "w248-upd-swept"), "the swept row must never be resurrected by an insert fallback")
+	_, findErr := repo.FindByID(ctx, op.ID)
+	require.ErrorIs(t, findErr, ErrNotFound)
+}
+
+// TestBFOW248_Update_CommittedStateRidesSweepSnapshot pins the OTHER ordering
+// with the REAL sweep: an update committed before the retention claim is
+// necessarily observed by the claim's op snapshot (status flip + snapshot
+// commit inside one transaction), so the cleanup hook sees the UPDATED row
+// and the follow-up delete removes it — never a stale-snapshot cleanup
+// against a row whose real state moved.
+func TestBFOW248_Update_CommittedStateRidesSweepSnapshot(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	jobRepo := seedOrganizedJob(t, db, "w248-upd-snap")
+
+	op := &models.BatchFileOperation{BatchJobID: "w248-upd-snap", OriginalPath: "/usp/src.mp4", NewPath: "/usp/dst.mp4", OperationType: models.OperationTypeMove}
+	require.NoError(t, repo.Create(context.Background(), op))
+	op.NewPath = "/usp/dst-final.mp4"
+	require.NoError(t, repo.Update(context.Background(), op))
+
+	snapshotted := map[uint]string{}
+	jobRepo.SetOrganizedJobPruneHook(func(_ context.Context, ops []models.BatchFileOperation) error {
+		for _, o := range ops {
+			snapshotted[o.ID] = o.NewPath
+		}
+		return nil
+	})
+
+	require.NoError(t, jobRepo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour)))
+	assert.Equal(t, "/usp/dst-final.mp4", snapshotted[op.ID], "a committed pre-claim update MUST ride the sweep snapshot")
+	assert.Zero(t, countOpsForJob(t, db, "w248-upd-snap"), "the sweep deletes the snapshotted row")
+}
+
+// TestBFOW248_Update_AfterJobDeletedReportsNotFound pins the decided contract
+// for a genuinely missing operation row (the Save insert fallback is out of
+// the racy path): once the sweep deleted job AND rows, a caller holding a
+// stale snapshot gets ErrNotFound — never a resurrection insert under a
+// job id nothing owns. The empty/never-persisted job id keeps the
+// pre-existing allow semantics at the fence and still reports ErrNotFound.
+func TestBFOW248_Update_AfterJobDeletedReportsNotFound(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	jobRepo := seedOrganizedJob(t, db, "w248-upd-gone")
+
+	op := &models.BatchFileOperation{BatchJobID: "w248-upd-gone", OriginalPath: "/ug/src.mp4", NewPath: "/ug/dst.mp4", OperationType: models.OperationTypeMove}
+	require.NoError(t, repo.Create(context.Background(), op))
+	require.NoError(t, jobRepo.DeleteOrganizedOlderThan(context.Background(), time.Now().UTC().Add(-24*time.Hour)))
+	_, jerr := jobRepo.FindByID(context.Background(), "w248-upd-gone")
+	require.ErrorIs(t, jerr, ErrNotFound, "fixture sanity: the depleted job row is deleted by the sweep")
+
+	stale := *op // the caller's pre-sweep snapshot
+	err := repo.Update(context.Background(), &stale)
+	require.ErrorIs(t, err, ErrNotFound, "an update for a swept row on a deleted job reports the missing row, not the fence (and never silently resurrects)")
+	assert.Zero(t, countOpsForJob(t, db, "w248-upd-gone"), "no orphaned ledger row lands under the deleted job")
+
+	// Never-existed row on a never-persisted job id: same missing-row report
+	// (the fence's missing-job allow semantics are unchanged).
+	ghost := &models.BatchFileOperation{ID: 424242, BatchJobID: "w248-upd-ghost", OriginalPath: "/gh/src.mp4", NewPath: "/gh/dst.mp4"}
+	require.ErrorIs(t, repo.Update(context.Background(), ghost), ErrNotFound)
+	assert.Zero(t, countOpsForJob(t, db, "w248-upd-ghost"))
+
+	// Empty job id (pre-existing allow semantics) with a missing row.
+	lone := &models.BatchFileOperation{ID: 434343, OriginalPath: "/ln/src.mp4", NewPath: "/ln/dst.mp4"}
+	require.ErrorIs(t, repo.Update(context.Background(), lone), ErrNotFound)
+}
+
+// TestBFOW248_Update_StatementErrorSurfaced pins the non-fence failure arm: a
+// schema breakage surfaces as an update error and never masquerades as the
+// prune fence or a missing row.
+func TestBFOW248_Update_StatementErrorSurfaced(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewBatchFileOperationRepository(db)
+	require.NoError(t, db.DB.Exec("DROP TABLE batch_file_operations").Error)
+
+	err := repo.Update(context.Background(), &models.BatchFileOperation{ID: 1, BatchJobID: "w248-upd-broken", OriginalPath: "/b/src.mp4", NewPath: "/b/dst.mp4"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "update batch file operation")
+	assert.NotErrorIs(t, err, ErrJobPruning, "a statement failure must not masquerade as the prune fence")
+	assert.NotErrorIs(t, err, ErrNotFound, "a statement failure must not masquerade as a missing row")
+}

--- a/internal/organizer/duplicates_test.go
+++ b/internal/organizer/duplicates_test.go
@@ -342,8 +342,9 @@ func TestOrganize_DryRunAuthorizedDuplicate_WarnsPersistably(t *testing.T) {
 	tracker := NewDuplicateTracker(true) // dry runs construct the non-probing variant
 
 	cmdA := dupBatchCmd(models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"}, tracker, true, true)
-	_, err := org.Organize(context.Background(), cmdA)
+	resultA, err := org.Organize(context.Background(), cmdA)
 	require.NoError(t, err)
+	require.False(t, resultA.DuplicateSkipped, "the primed winner is never the skip — dry-run counts reuse live arithmetic")
 
 	cmdB := dupBatchCmd(models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"}, tracker, true, true)
 	resultB, err := org.Organize(context.Background(), cmdB)
@@ -351,6 +352,14 @@ func TestOrganize_DryRunAuthorizedDuplicate_WarnsPersistably(t *testing.T) {
 	require.Len(t, resultB.Warnings, 1)
 	assert.Contains(t, resultB.Warnings[0], "duplicate destination within batch")
 	assert.Contains(t, resultB.Warnings[0], "/in/A.mkv")
+	// #248 codex P2: the dry-run skip result mirrors the live leg byte for
+	// byte — nothing moved, the warning carried, and the DuplicateSkipped
+	// marker present so CLI/API summary accounting reads dry runs with the
+	// live arithmetic (pre-fix the marker was missing and the loser silently
+	// counted as would-be-organized).
+	assert.True(t, resultB.DuplicateSkipped, "dry-run authorized skip carries the no-op marker exactly like the live leg")
+	assert.False(t, resultB.Moved)
+	assert.True(t, resultB.ShouldGenerateMetadata, "the skip keeps the live leg's metadata marker")
 }
 
 func TestOrganize_LiveDuplicatePreflight(t *testing.T) {

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -751,6 +751,11 @@ func (o *Organizer) Organize(ctx context.Context, cmd OrganizeCmd) (*OrganizeRes
 	// Dry-run: return early with planned result (no filesystem changes).
 	// The owner still settles its claim (codex P2, PR #241): the dry-run
 	// outcome is terminal, and waiting claimants must resolve now.
+	// DuplicateSkipped rides the result exactly like the live skip leg below
+	// (#248 codex P2): a dry run moves no bytes either, so an authorized
+	// intra-batch duplicate is a skip in BOTH modes — downstream summary/
+	// skip accounting keys off this marker and must see the dry-run truth,
+	// never "would organize" counts that silently include the loser.
 	if cmd.DryRun {
 		cmd.DuplicateTracker.settle(plan)
 		return &OrganizeResult{
@@ -760,6 +765,7 @@ func (o *Organizer) Organize(ctx context.Context, cmd OrganizeCmd) (*OrganizeRes
 			FileName:               plan.TargetFile,
 			Moved:                  false,
 			Warnings:               dupWarnings,
+			DuplicateSkipped:       dupSkip,
 			ShouldGenerateMetadata: true,
 		}, nil
 	}

--- a/internal/worker/apply_phase_dup_waiters_w241_test.go
+++ b/internal/worker/apply_phase_dup_waiters_w241_test.go
@@ -31,10 +31,23 @@ type organizerBackedWorkflow struct {
 	fs                afero.Fs
 	vanishBeforeApply map[string]bool
 	panicBeforeApply  map[string]bool
-	// sleepBeforeApply delays one file's worker apply leg (codex P2, PR #241
-	// F1 resident-gating tests): with workers ≥ 2 a mover reaches the
-	// resident's pending parked claim WHILE the resident still validates.
-	sleepBeforeApply map[string]time.Duration
+	// Rendezvous seams (windows-ci flake fix, #248): the resident-gate tests
+	// must RELATE the sibling workers' apply legs without sleep margins.
+	// applyReturnSignal[path] closes when path's apply leg RETURNS — i.e.
+	// after vanish/validation and the tracker's settle-or-release all
+	// completed inside its Organize call — while waitForApplyReturn[path]
+	// blocks path's leg at ENTRY until the channel closes. Scheduling order
+	// alone cannot do this: on a coarse-timer loaded runner a concurrent
+	// mover can run its whole plan-before-observe while the resident's leg
+	// still waits to START, planning against a destination the resident's
+	// vanish has not cleared yet — the stale plan-time occupation conflict
+	// then survives the ghost release and fails the promoted mover in normal
+	// mode (the exact CI failure shape: destination left EMPTY after both
+	// legs). The rendezvous also preserves the single-worker deadlock pin:
+	// if residents-first fan-out ordering ever regressed, the blocked leg
+	// deadlocks and the deadline runner fires.
+	applyReturnSignal  map[string]chan struct{}
+	waitForApplyReturn map[string]chan struct{}
 }
 
 func (w *organizerBackedWorkflow) Scrape(context.Context, scrape.ScrapeCmd) (*scrape.ScrapeResult, *workflow.OrchestrationMeta, error) {
@@ -57,8 +70,11 @@ func (w *organizerBackedWorkflow) organizeCmd(cmd workflow.ApplyCmd) organizer.O
 }
 
 func (w *organizerBackedWorkflow) Apply(ctx context.Context, cmd workflow.ApplyCmd) (*workflow.ApplyResult, error) {
-	if d := w.sleepBeforeApply[cmd.Match.Path]; d > 0 {
-		time.Sleep(d)
+	if ch := w.waitForApplyReturn[cmd.Match.Path]; ch != nil {
+		<-ch
+	}
+	if ch := w.applyReturnSignal[cmd.Match.Path]; ch != nil {
+		defer close(ch)
 	}
 	if w.panicBeforeApply[cmd.Match.Path] {
 		panic("owner apply boom")

--- a/internal/worker/apply_phase_resident_gate_w241_test.go
+++ b/internal/worker/apply_phase_resident_gate_w241_test.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -61,20 +60,27 @@ func w241ResidentPhaseFixture(t *testing.T, wf *organizerBackedWorkflow, maxWork
 }
 
 // TestApplyPhase_ResidentGate_ValidResidentKeepsItsBytes pins the F1
-// resident-valid half end to end: with the resident deliberately SLOWER than
-// the mover (multi-worker: the mover reaches observe while the resident
-// still validates; single-worker: residents-first scheduling validates the
-// resident before the mover starts), the mover's duplicate outcome resolves
-// only AFTER the resident's own terminal success — the resident's bytes stay
-// put and the mover duplicates (normal mode: conflict failure; force mode:
-// warning + skip) identically at every worker count.
+// resident-valid half end to end: the mover's apply leg rendezvous-waits on
+// the resident's leg RETURNING (its parked claim settled terminal-success
+// inside Organize — multi-worker the blocked mover resumes against an
+// already-settled claim; single-worker residents-first scheduling has the
+// resident validate before the mover starts), so the mover's duplicate
+// outcome resolves only AFTER the resident's own terminal success — the
+// resident's bytes stay put and the mover duplicates (normal mode: conflict
+// failure; force mode: warning + skip) identically at every worker count.
+// No sleep margin: the verdict the rendezvous meets is terminal-equivalent
+// to the mid-validation blocked-observe verdict by claim construction, and
+// sleeping could never order the mover's plan against the resident's fs
+// state anyway (windows-ci flake fix, #248).
 func TestApplyPhase_ResidentGate_ValidResidentKeepsItsBytes(t *testing.T) {
 	for _, maxWorkers := range []int{1, 2} {
 		for _, force := range []bool{false, true} {
 			t.Run(workerForceName(maxWorkers, force), func(t *testing.T) {
 				wf := &organizerBackedWorkflow{}
 				inputs, cfg, fs, _, residentPath, failed := w241ResidentPhaseFixture(t, wf, maxWorkers, force)
-				wf.sleepBeforeApply = map[string]time.Duration{residentPath: 200 * time.Millisecond}
+				residentReturned := make(chan struct{})
+				wf.applyReturnSignal = map[string]chan struct{}{residentPath: residentReturned}
+				wf.waitForApplyReturn = map[string]chan struct{}{"/in/B.mkv": residentReturned}
 
 				runW241PhaseWithDeadline(t, inputs, cfg)
 
@@ -107,6 +113,23 @@ func TestApplyPhase_ResidentGate_ValidResidentKeepsItsBytes(t *testing.T) {
 // onto the released key, and lands its bytes. Identical at every worker
 // count and in both authorization modes (the resident path sorts AFTER the
 // mover, additionally pinning the residents-first single-worker scheduling).
+//
+// Choreography is rendezvous-based (windows-ci flake fix, #248): the mover's
+// leg waits on the resident's leg RETURNING — vanish, ghost-gate release, and
+// standby promotion all complete inside it — so the mover plans against the
+// destination's POST-release truth. Without the rendezvous nothing ordered
+// the resident's vanish against the mover's plan: a concurrent mover could
+// plan while the destination was still occupied and carry a stale plan-time
+// occupation conflict (normal mode only — ForceUpdate suppresses it,
+// single-worker schedules the resident first) past its own promotion into a
+// fatal "organization validation failed" — the destination left EMPTY behind
+// a promoted mover is exactly the failure this test asserts against, so the
+// plan/execute legs must be deterministic, not sleep-margined. The promotion
+// machinery itself stays fully exercised: priming parks the pending ghost
+// claim with the mover as ordered standby, the ghost release promotes it,
+// and only a released parked claim lets the mover's bytes land (a
+// born-settled claim still verdicts duplicate and fails the destination
+// read below; a never-released one trips the deadline runner).
 func TestApplyPhase_GhostResidentGate_MoverLandsBytes(t *testing.T) {
 	for _, maxWorkers := range []int{1, 2} {
 		for _, force := range []bool{false, true} {
@@ -114,6 +137,9 @@ func TestApplyPhase_GhostResidentGate_MoverLandsBytes(t *testing.T) {
 				wf := &organizerBackedWorkflow{}
 				inputs, cfg, fs, _, residentPath, failed := w241ResidentPhaseFixture(t, wf, maxWorkers, force)
 				wf.vanishBeforeApply = map[string]bool{residentPath: true}
+				residentReturned := make(chan struct{})
+				wf.applyReturnSignal = map[string]chan struct{}{residentPath: residentReturned}
+				wf.waitForApplyReturn = map[string]chan struct{}{"/in/B.mkv": residentReturned}
 
 				runW241PhaseWithDeadline(t, inputs, cfg)
 

--- a/internal/worker/batch_job_factory.go
+++ b/internal/worker/batch_job_factory.go
@@ -73,6 +73,17 @@ type BatchJobFactoryInterface interface {
 	// Use this for CLI/TUI usage where persistence is not needed.
 	CreateStandaloneJob(files []string, opts BatchJobOptions) StandaloneJob
 
+	// CreatePersistentStandaloneJob creates a StandaloneJob registered on the
+	// factory's JobStore: the job row is written at creation and phase state
+	// persists through the store's JobPersistencer, so batch history (jobs row,
+	// batch_file_operations via the per-job workflow, history and events rows)
+	// is durable exactly like an API batch. Keeps the standalone lifecycle
+	// (SetRunOptions/Run with keep-open event broadcaster) for CLI usage.
+	// Falls back to CreateStandaloneJob (no persistence) when the factory's
+	// jobStore is nil — callers passing NewInMemoryJobStore get store
+	// registration with the no-op persistence that store carries.
+	CreatePersistentStandaloneJob(files []string, opts BatchJobOptions) StandaloneJob
+
 	// NewScrapeConfig builds a ScrapePhaseConfig with the factory's defaults filled in.
 	// Callers only provide the narrow per-call parameters.
 	NewScrapeConfig(selectedScrapers []string, strict bool, force bool) ScrapePhaseConfig
@@ -143,6 +154,21 @@ func (f *batchJobFactory) CreateStandaloneJob(files []string, opts BatchJobOptio
 	jobCfg := f.buildJobConfig(opts)
 	memStore := NewInMemoryJobStore()
 	job := memStore.CreateJobBatch(files, jobCfg)
+	return newStandaloneJobFromBatchJob(job)
+}
+
+// CreatePersistentStandaloneJob creates a StandaloneJob routed through the
+// factory's JobStore. Per NEW-2 this still uses JobStore.createJob as the
+// single construction path — the only difference from CreateJob is the
+// returned seam: the standalone adapter (JobRunner + broadcaster lifecycle)
+// CLI callers drive synchronously. When the factory has no JobStore, the
+// in-memory fallback keeps TUI/test callers working unchanged (no jobs row).
+func (f *batchJobFactory) CreatePersistentStandaloneJob(files []string, opts BatchJobOptions) StandaloneJob {
+	store, ok := f.jobStore.(*JobStore)
+	if !ok || store == nil {
+		return f.CreateStandaloneJob(files, opts)
+	}
+	job := store.CreateJobBatch(files, f.buildJobConfig(opts))
 	return newStandaloneJobFromBatchJob(job)
 }
 

--- a/internal/worker/initial_persist_reporter_test.go
+++ b/internal/worker/initial_persist_reporter_test.go
@@ -1,0 +1,76 @@
+package worker
+
+// Regression pins for #248 codex P2: the create-time jobs-row persist failure
+// inside JobStore.createJob (shallow disk-full / locked database after
+// bootstrap) keeps its best-effort swallow-and-log semantics for the API path
+// — the job is constructed, registered, and returned — while a registered
+// WithInitialPersistErrorReporter observes the error so one-shot callers (the
+// CLI batch runtime) can turn it into a batch startup failure instead of
+// advertising an unqueryable batch id.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failingInitialPersist is a JobPersistencer whose PersistJob always fails —
+// injected via the store's documented WithPersistence test seam to mimic the
+// post-bootstrap jobs-row upsert failure class (#248 codex P2) without a
+// sabotaged database handle.
+type failingInitialPersist struct {
+	err error
+}
+
+func (p *failingInitialPersist) PersistJob(*BatchJob) error                     { return p.err }
+func (p *failingInitialPersist) PersistJobByID(string) error                    { return p.err }
+func (p *failingInitialPersist) DeleteJobFromDB(string) error                   { return p.err }
+func (p *failingInitialPersist) LoadJobs(context.Context) ([]models.Job, error) { return nil, nil }
+func (p *failingInitialPersist) UpsertJob(*models.Job) error                    { return p.err }
+
+// TestJobStore_CreateJob_InitialPersistFailure_ReporterHook pins the seam: on
+// create-time persist failure the reporter receives the error, AND the
+// best-effort in-flight semantics stay intact (job constructed + registered).
+func TestJobStore_CreateJob_InitialPersistFailure_ReporterHook(t *testing.T) {
+	boom := errors.New("upsert failed: simulated disk full")
+	var reported []error
+	store := NewInMemoryJobStore(
+		WithPersistence(&failingInitialPersist{err: boom}),
+		WithInitialPersistErrorReporter(func(err error) { reported = append(reported, err) }),
+	)
+
+	job := store.CreateJobBatch([]string{"file1.mp4"})
+	require.NotNil(t, job, "best-effort semantics intact: the job is still constructed and returned")
+	_, ok := store.GetJob(job.ID.String())
+	assert.True(t, ok, "the job still registers in the store map (API-path behavior unchanged)")
+
+	require.Len(t, reported, 1, "the reporter fires exactly once for the create-time persist")
+	assert.ErrorIs(t, reported[0], boom)
+}
+
+// TestJobStore_CreateJob_InitialPersistFailure_NoReporter pins the nil-hook
+// branch: without a reporter the store's historical swallow-and-log behavior
+// is byte-identical (no panic, job returned) — the API path is undisturbed.
+func TestJobStore_CreateJob_InitialPersistFailure_NoReporter(t *testing.T) {
+	boom := errors.New("upsert failed: simulated disk full")
+	store := NewInMemoryJobStore(WithPersistence(&failingInitialPersist{err: boom}))
+
+	job := store.CreateJobBatch([]string{"file1.mp4"})
+	require.NotNil(t, job)
+}
+
+// TestJobStore_CreateJob_SuccessfulPersist_ReporterSilent pins the good path:
+// a successful create-time persist never fires the reporter.
+func TestJobStore_CreateJob_SuccessfulPersist_ReporterSilent(t *testing.T) {
+	called := false
+	store := NewInMemoryJobStore(
+		WithInitialPersistErrorReporter(func(error) { called = true }),
+	)
+	job := store.CreateJobBatch([]string{"file1.mp4"})
+	require.NotNil(t, job)
+	assert.False(t, called)
+}

--- a/internal/worker/job_store.go
+++ b/internal/worker/job_store.go
@@ -51,6 +51,13 @@ type JobStore struct {
 	tempCleaner       *TempDirCleaner // Per P-8: owns CleanupStaleTempDirs and StartStaleTempCleanup
 	tempCleanerOnce   sync.Once       // Guards tempCleaner lazy-init against concurrent RLock callers
 
+	// skipStartupRecovery (WithSkipStartupRecovery) suppresses the server-boot
+	// recovery sweep at NewJobStore time: no rekey-witness reconciliation, no
+	// job reconstruction, no orphan recovery. One-shot CLI processes use this
+	// so a CLI run against a database a LIVE server may own never reconciles
+	// or marks that server's in-flight jobs failed.
+	skipStartupRecovery bool
+
 	// reconstructionDeps are infrastructure dependencies that reconstructed jobs
 	// (loaded from DB on startup) need for apply/rescrape phases. They are set
 	// after JobStore construction via SetReconstructionDeps, once the
@@ -100,6 +107,20 @@ func WithActressRepo(r database.ActressRepositoryInterface) JobStoreOption {
 func WithHistoryRepo(r database.HistoryRepositoryInterface) JobStoreOption {
 	return func(s *JobStore) {
 		s.historyRepo = r
+	}
+}
+
+// WithSkipStartupRecovery suppresses the server-boot recovery sweep at
+// NewJobStore time: rekey-witness reconciliation, loadFromDatabase (job
+// reconstruction), and recoverOrphanedJobs are all skipped. These steps exist
+// so an API server restart reconciles jobs orphaned by the PREVIOUS process —
+// but a one-shot CLI process sharing the database with a LIVE server must not
+// reconstruct its rows (reconstruction clears missing temp posters the live
+// process may still reference) or mark its running jobs failed. Jobs created
+// after construction still persist normally via the store's JobPersistencer.
+func WithSkipStartupRecovery() JobStoreOption {
+	return func(s *JobStore) {
+		s.skipStartupRecovery = true
 	}
 }
 
@@ -176,13 +197,18 @@ func NewJobStore(jobRepo database.JobRepositoryInterface, batchFileOpRepo databa
 	// at the new ID. The periodic stale-cleanup goroutine is not started by
 	// the production bootstrap, so this must not ride on
 	// StartStaleTempCleanup.
-	if n, err := s.tempCleaner.ReconcileRekeyWitnesses(context.Background()); err != nil {
-		logging.Warnf("rekey witness reconciliation failed at startup: %v", err)
-	} else if n > 0 {
-		logging.Infof("reversed %d orphaned poster rekey relocation(s) at startup", n)
-	}
+	// Both steps are skipped for one-shot CLI stores (WithSkipStartupRecovery):
+	// there is no previous CLI process to recover from, and either step could
+	// interfere with a live API server owning the same database.
+	if !s.skipStartupRecovery {
+		if n, err := s.tempCleaner.ReconcileRekeyWitnesses(context.Background()); err != nil {
+			logging.Warnf("rekey witness reconciliation failed at startup: %v", err)
+		} else if n > 0 {
+			logging.Infof("reversed %d orphaned poster rekey relocation(s) at startup", n)
+		}
 
-	s.loadFromDatabase()
+		s.loadFromDatabase()
+	}
 
 	return s
 }

--- a/internal/worker/job_store.go
+++ b/internal/worker/job_store.go
@@ -58,6 +58,16 @@ type JobStore struct {
 	// or marks that server's in-flight jobs failed.
 	skipStartupRecovery bool
 
+	// initialPersistErrFn (WithInitialPersistErrorReporter) observes the
+	// create-time jobs-row persist failure that createJob otherwise only LOGS.
+	// The store keeps its best-effort swallow-and-continue semantics (the API
+	// path: in-flight jobs must not die on a transient persist failure — a
+	// later persist self-heals and persist_error rides the job status
+	// payload); one-shot CLI runtimes register the hook to convert the failure
+	// into a batch STARTUP error instead of advertising an unqueryable batch
+	// id (#248 codex P2).
+	initialPersistErrFn func(err error)
+
 	// reconstructionDeps are infrastructure dependencies that reconstructed jobs
 	// (loaded from DB on startup) need for apply/rescrape phases. They are set
 	// after JobStore construction via SetReconstructionDeps, once the
@@ -121,6 +131,19 @@ func WithHistoryRepo(r database.HistoryRepositoryInterface) JobStoreOption {
 func WithSkipStartupRecovery() JobStoreOption {
 	return func(s *JobStore) {
 		s.skipStartupRecovery = true
+	}
+}
+
+// WithInitialPersistErrorReporter registers fn to receive the error when the
+// create-time jobs-row persist inside createJob fails. The failure keeps its
+// existing in-flight handling regardless (the job is constructed, registered,
+// and returned; the error is logged) — fn is purely an observation seam for
+// one-shot callers (the CLI batch runtime, #248 codex P2) that must turn a
+// missing audit row into a startup failure instead of advertising an
+// unqueryable `history list --batch <id>` pointer. Unset means no report.
+func WithInitialPersistErrorReporter(fn func(err error)) JobStoreOption {
+	return func(s *JobStore) {
+		s.initialPersistErrFn = fn
 	}
 }
 
@@ -619,6 +642,9 @@ func (s *JobStore) createJob(files []string, jobCfg ...*JobConfig) *BatchJob {
 
 	if err := s.persistence.PersistJob(job); err != nil {
 		logging.Warnf("Failed to persist new job %s: %v", job.ID.String(), err)
+		if s.initialPersistErrFn != nil {
+			s.initialPersistErrFn(err)
+		}
 	}
 
 	return job

--- a/internal/worker/persistent_standalone_w244_test.go
+++ b/internal/worker/persistent_standalone_w244_test.go
@@ -1,0 +1,113 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression pins for the #244 CLI batch-runtime wiring: the factory's
+// persistent standalone path must register the job on a real JobStore (jobs
+// row written to the DB), while factories without a store keep the in-memory
+// behavior TUI/tests rely on.
+func TestBatchJobFactory_CreatePersistentStandaloneJob_PersistsJobsRow(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	tempDir := t.TempDir()
+
+	store := NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, tempDir, nil, nil,
+		WithHistoryRepo(repos.HistoryRepo),
+		WithSkipStartupRecovery(),
+	)
+
+	jobID := "cli-batch-" + models.NewJobID().String()
+	factory := NewBatchJobFactory(store, nil, nil, nil, BatchJobConfig{}, nil)
+	job := factory.CreatePersistentStandaloneJob([]string{"/src/GOOD-700.mp4"}, BatchJobOptions{
+		ID:          jobID,
+		Destination: "/dest",
+	})
+	require.NotNil(t, job)
+	assert.Equal(t, jobID, job.GetID())
+
+	// The jobs row is written at creation (the CLI batch becomes queryable via
+	// `javinizer history list --batch <id>` and participates in
+	// batch_file_operations FK scoping).
+	row, err := repos.JobRepo.FindByID(context.Background(), jobID)
+	require.NoError(t, err, "jobs row must persist at creation")
+	require.NotNil(t, row)
+	assert.Equal(t, jobID, row.ID)
+	assert.Equal(t, "/dest", row.Destination)
+
+	// HistoryRepo is wired through the store fallback so worker audit rows
+	// persist for CLI batches too.
+	store.mu.RLock()
+	raw, ok := store.jobs[models.JobID(jobID)]
+	store.mu.RUnlock()
+	require.True(t, ok)
+	raw.mu.RLock()
+	hist := raw.deps.HistoryRepo
+	raw.mu.RUnlock()
+	assert.Equal(t, repos.HistoryRepo, hist, "store fallback wires HistoryRepo into the created job")
+}
+
+func TestBatchJobFactory_CreatePersistentStandaloneJob_NilStoreFallsBackToStandalone(t *testing.T) {
+	factory := NewBatchJobFactory(nil, nil, nil, nil, BatchJobConfig{}, nil)
+	job := factory.CreatePersistentStandaloneJob([]string{"/src/GOOD-700.mp4"}, BatchJobOptions{})
+	require.NotNil(t, job, "nil store must fall back to the in-memory standalone path")
+	assert.NotEmpty(t, job.GetID())
+}
+
+// TestNewJobStore_WithSkipStartupRecovery pins the one-shot CLI store
+// behavior (#244): a CLI store sharing a database with a live server must
+// neither reconstruct that server's jobs nor mark its in-flight jobs failed —
+// while the default (server-boot) construction keeps recovering orphans.
+func TestNewJobStore_WithSkipStartupRecovery(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	// Seed a jobs row stuck in 'running' (a possibly-live server's in-flight
+	// batch sharing the database).
+	seed := NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, tempDir, nil, nil, WithSkipStartupRecovery())
+	seeded := seed.CreateJobBatch([]string{"/src/GOOD-700.mp4"})
+	seeded.lifecycle.mu.Lock()
+	seeded.lifecycle.Status = models.JobStatusRunning
+	seeded.lifecycle.mu.Unlock()
+	require.NoError(t, seed.PersistJob(seeded))
+
+	// Skipped recovery: no reconstruction, no orphan marking.
+	skipped := NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, tempDir, nil, nil, WithSkipStartupRecovery())
+	_, found := skipped.GetJob(seeded.ID.String())
+	assert.False(t, found, "skipped recovery must not reconstruct prior jobs")
+	row, err := repos.JobRepo.FindByID(ctx, seeded.ID.String())
+	require.NoError(t, err)
+	assert.Equal(t, models.JobStatusRunning, row.Status, "skipped recovery must not mark a possibly-live job failed")
+
+	// Default construction (parity control) keeps the server-boot semantics:
+	// the orphaned running job is reconstructed and marked failed.
+	full := NewJobStore(repos.JobRepo, repos.BatchFileOpRepo, repos.MovieRepo, tempDir, nil, nil)
+	snap, found := full.GetJob(seeded.ID.String())
+	require.True(t, found, "default construction must reconstruct prior jobs")
+	require.NotNil(t, snap)
+	assert.Equal(t, models.JobStatusFailed, snap.Status)
+	row, err = repos.JobRepo.FindByID(ctx, seeded.ID.String())
+	require.NoError(t, err)
+	assert.Equal(t, models.JobStatusFailed, row.Status)
+}
+
+func TestBatchJobFactory_CreatePersistentStandaloneJob_InMemoryStore(t *testing.T) {
+	// A *JobStore with no-op persistence (the in-memory constructor) is still a
+	// real store: the job registers on it and survives GetJob, while nothing
+	// database-side exists to assert against.
+	memStore := NewInMemoryJobStore()
+	factory := NewBatchJobFactory(memStore, nil, nil, nil, BatchJobConfig{}, nil)
+	job := factory.CreatePersistentStandaloneJob([]string{"/src/GOOD-700.mp4"}, BatchJobOptions{})
+	require.NotNil(t, job)
+	status, ok := memStore.GetJob(job.GetID())
+	require.True(t, ok, "job must be registered on the in-memory store")
+	require.NotNil(t, status)
+}

--- a/internal/workflow/apply_dryrun_ledger_w244_test.go
+++ b/internal/workflow/apply_dryrun_ledger_w244_test.go
@@ -1,0 +1,79 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+// ---------------------------------------------------------------------------
+// applyOrchImpl.beginRevertLog — dry-run previews journal NOTHING (#244)
+//
+// The revert ledger exists to arm reverts of real filesystem mutations. A
+// dry-run apply mutates nothing, so a preview row would sit in
+// batch_file_operations with revert_status 'applied' — looking revertable for
+// bytes that never moved (and would surface that way in `history list
+// --batch`). Previously every preview journaled a row (under "" for the CLI
+// bootstrap workflow); with CLI batches now persisting under a real job ID,
+// the ledger must skip previews explicitly.
+// ---------------------------------------------------------------------------
+
+// dryRunLedgerOrchestrator builds an applyOrchestrator whose revert log is the
+// REAL DB-backed ledger from newTestDBRevertLog; every potentially-mutating
+// step is disabled so Execute exercises exactly the begin/complete boundary.
+func dryRunLedgerOrchestrator(rl RevertLog) *applyOrchImpl {
+	return &applyOrchImpl{
+		fs:         afero.NewMemMapFs(),
+		downloader: &stubDownloader{},
+		nfo:        &applyStubNFO{},
+		revertLog:  rl,
+	}
+}
+
+func TestApplyOrchImpl_BeginRevertLog_DryRunJournalsNothing(t *testing.T) {
+	rl, db := newTestDBRevertLog(t)
+	impl := dryRunLedgerOrchestrator(rl)
+
+	result, err := impl.Execute(context.Background(), ApplyCmd{
+		Movie:    &models.Movie{ID: "DRY-001", Title: "Preview"},
+		Match:    models.FileMatchInfo{Path: "/src/DRY-001.mp4", MovieID: "DRY-001"},
+		DestPath: "/dest",
+		Organize: OrganizeOptions{Skip: true}, // update-mode shape: no move step
+		DryRun:   true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.OperationID, "dry-run apply must not open a revert-ledger operation")
+
+	repo := database.NewBatchFileOperationRepository(db)
+	n, err := repo.CountByBatchJobID(context.Background(), "test-job")
+	require.NoError(t, err)
+	assert.Zero(t, n, "dry-run apply must journal no batch_file_operations rows")
+}
+
+func TestApplyOrchImpl_BeginRevertLog_LiveJournalsRow(t *testing.T) {
+	// Control leg: the live apply path still journals its operation row.
+	rl, db := newTestDBRevertLog(t)
+	impl := dryRunLedgerOrchestrator(rl)
+
+	result, err := impl.Execute(context.Background(), ApplyCmd{
+		Movie:    &models.Movie{ID: "LIVE-001", Title: "Live"},
+		Match:    models.FileMatchInfo{Path: "/src/LIVE-001.mp4", MovieID: "LIVE-001"},
+		DestPath: "/dest",
+		Organize: OrganizeOptions{Skip: true},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.OperationID, "live apply must journal a revert-ledger operation")
+
+	repo := database.NewBatchFileOperationRepository(db)
+	n, err := repo.CountByBatchJobID(context.Background(), "test-job")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "live apply journals exactly one row")
+}

--- a/internal/workflow/revert_log_prune_fence_w248_test.go
+++ b/internal/workflow/revert_log_prune_fence_w248_test.go
@@ -1,0 +1,81 @@
+package workflow
+
+// PR #248 codex P1 (F1) workflow-level pins: when the repository's
+// write-atomic prune fence rejects the revert-log pre-record (the owning
+// job's retention claim is committed), RevertLog.Begin must surface
+// database.ErrJobPruning with NO OperationID — apply aborts before any
+// filesystem mutation (beginRevertLog), so the failure mode "Apply proceeds
+// with mutations and NO durable revert ledger" can never arise.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+// w248FenceRejectRepo is the force-ordered stub: its Create reports the
+// committed retention claim unconditionally — the sweep-flip-before-insert
+// ordering made deterministic. Every other method delegates to the (nil)
+// embedded interface: Begin touches Create only, so nothing else is
+// reachable.
+type w248FenceRejectRepo struct {
+	database.BatchFileOperationRepositoryInterface
+}
+
+func (w248FenceRejectRepo) Create(context.Context, *models.BatchFileOperation) error {
+	return database.ErrJobPruning
+}
+
+// TestDBRevertLog_Begin_FenceRejectionYieldsNoOperationID pins the contract
+// on the stubbed seam: a fence-rejected pre-record aborts Begin before any
+// operation identity exists.
+func TestDBRevertLog_Begin_FenceRejectionYieldsNoOperationID(t *testing.T) {
+	rl := NewDBRevertLog(w248FenceRejectRepo{}, NewRevertLogConfig(true, nil), "job-w248", afero.NewMemMapFs(), nil, nil, nil)
+	opID, err := rl.Begin(context.Background(), ApplyCmd{
+		Movie:    &models.Movie{ID: "W248-001", Title: "Fence"},
+		Match:    models.FileMatchInfo{Path: "/src/W248-001.mp4", MovieID: "W248-001"},
+		Organize: OrganizeOptions{MoveFiles: true},
+	})
+	require.ErrorIs(t, err, database.ErrJobPruning)
+	assert.Empty(t, opID, "a fenced Begin must mint no operation identity — apply aborts before mutations")
+}
+
+// TestDBRevertLog_Begin_RealRepoPrunedJob drives the same contract through
+// the REAL sqlite-backed repository (newTestDBRevertLog wires jobID
+// "test-job"): with the claim committed, Begin's single-statement
+// fence rejects and zero batch_file_operations rows land.
+func TestDBRevertLog_Begin_RealRepoPrunedJob(t *testing.T) {
+	rl, db := newTestDBRevertLog(t)
+
+	jobRepo := database.NewJobRepository(db)
+	organizedAt := time.Now().UTC().Add(-48 * time.Hour)
+	require.NoError(t, jobRepo.Create(context.Background(), &models.Job{
+		ID:          "test-job",
+		Status:      models.JobStatusOrganized,
+		Files:       "[]",
+		StartedAt:   organizedAt,
+		OrganizedAt: &organizedAt,
+	}))
+	// Commit the retention claim (mirrors DeleteOrganizedOlderThan's flip;
+	// pruningJobStatus is unexported, so bind the durable wire value).
+	require.NoError(t, db.DB.Exec("UPDATE jobs SET status = ? WHERE id = ?", "pruning", "test-job").Error)
+
+	opID, err := rl.Begin(context.Background(), ApplyCmd{
+		Movie:    &models.Movie{ID: "W248-002", Title: "Real Fence"},
+		Match:    models.FileMatchInfo{Path: "/src/W248-002.mp4", MovieID: "W248-002"},
+		Organize: OrganizeOptions{MoveFiles: true},
+	})
+	require.ErrorIs(t, err, database.ErrJobPruning)
+	assert.Empty(t, opID)
+
+	count, countErr := database.NewBatchFileOperationRepository(db).CountByBatchJobID(context.Background(), "test-job")
+	require.NoError(t, countErr)
+	assert.Zero(t, count, "no ledger row may survive a fence-rejected Begin")
+}

--- a/test/e2e/cli/dup_history_w244_test.go
+++ b/test/e2e/cli/dup_history_w244_test.go
@@ -1,0 +1,79 @@
+//go:build e2e
+
+package cli_e2e
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLI_SortDuplicateSkip_PersistsHistoryAndLogs pins issue #244 end-to-end
+// through the real binary: an authorized intra-batch duplicate skip from
+// `javinizer sort -f` must persist the same audit trail an API batch writes —
+// a queryable batch job (history list --batch) carrying the winner's applied
+// row AND the loser's completed-noop row, per-movie history whose organize
+// metadata keeps the skip warning text, and an eventlog warning entry —
+// instead of the console claiming "Applied ✓" with nothing persisted.
+//
+// Two files scrape to GOOD-700 and plan onto the SAME destination because
+// file_format is bare <ID>; the -f flag authorizes overwrite, so the second
+// claimant is demoted to a warning + skip. All assertions are substring-based
+// (never raw produced paths) so the test stays Windows-safe.
+func TestCLI_SortDuplicateSkip_PersistsHistoryAndLogs(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeConfig(t, dir)
+	src := filepath.Join(dir, "src")
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "a"), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "b"), 0o700))
+	writeFile(t, filepath.Join(src, "a", "GOOD-700.mp4"))
+	writeFile(t, filepath.Join(src, "b", "GOOD-700.mp4"))
+
+	out, code := run(t, cfgPath, "sort", "-f", "--move", src)
+	require.Equal(t, 0, code, "sort exited %d\n%s", code, out)
+	assert.Contains(t, out, "Sort complete!")
+
+	// Console truth: the skip is surfaced per file and counted in the summary.
+	assert.Contains(t, out, "duplicate destination within batch",
+		"the skip warning must print\n%s", out)
+	assert.Contains(t, out, "Skipped (authorized duplicates): 1",
+		"the summary must count the skip\n%s", out)
+
+	m := regexp.MustCompile(`Batch Job: ([0-9a-f-]{36})`).FindStringSubmatch(out)
+	require.Len(t, m, 2, "the header must name the persisted batch identity\n%s", out)
+	batchID := m[1]
+
+	// Exactly one file may land: the loser's bytes stay in place.
+	assert.FileExists(t, filepath.Join(src, "GOOD-700", "GOOD-700.mp4"),
+		"the batch winner is organized\n%s", out)
+
+	// (i) `javinizer history list --batch` lists both batch ops: the winner
+	// applied, the loser completed-noop (previously NOTHING persisted for the
+	// CLI flow — the noop row landed under "" and was invisible).
+	histOut, histCode := run(t, cfgPath, "history", "list", "--batch", batchID)
+	require.Equal(t, 0, histCode, "history --batch exited %d\n%s", histCode, histOut)
+	assert.Contains(t, histOut, "noop",
+		"the authorized duplicate skip must be listed as a noop op\n%s", histOut)
+	assert.Contains(t, histOut, "applied",
+		"the batch winner's move op must be listed as applied\n%s", histOut)
+
+	// (i) `javinizer history movie` keeps the skip warning text in the
+	// organize row's metadata (the text that used to vanish).
+	movieOut, movieCode := run(t, cfgPath, "history", "movie", "GOOD-700")
+	require.Equal(t, 0, movieCode, "history movie exited %d\n%s", movieCode, movieOut)
+	assert.Contains(t, movieOut, "duplicate destination within batch",
+		"the organize history metadata must carry the warning text\n%s", movieOut)
+
+	// (ii) `javinizer logs` exposes the eventlog audit entry for the skip.
+	logsOut, logsCode := run(t, cfgPath, "logs", "list", "-t", "organize", "-s", "warn")
+	require.Equal(t, 0, logsCode, "logs exited %d\n%s", logsCode, logsOut)
+	assert.Contains(t, logsOut, "Organize warning for GOOD-700",
+		"the eventlog must carry the organize warning audit entry\n%s", logsOut)
+	// Logs output truncates messages at 60 chars; the full text lives in the
+	// events table and the history metadata (asserted above).
+	assert.Contains(t, logsOut, "duplicate destination with", "\n%s", logsOut)
+}


### PR DESCRIPTION
## Summary

CLI `sort`/`update` batches ran through an in-memory job store with no `HistoryRepo` and a workflow not bound to a real batch ID — so per-file outcomes (incl. **authorized duplicate skips** from the #224 duplicate preflight) printed `Applied ✓` while the warning text, operation rows, and revertability vanished after exit.

**This PR**: the CLI batch runs persist the same audit trail as API batches —
- pre-generated batch job ID flows through the CLI chain (API parity), real persisted jobs row;
- `newCLIBatchRuntime` wires a real sqlite-backed job store + eventlog emitter + per-job workflow bound to that ID (seam var for tests);
- history rows carry the duplicate-skip warning text on organize metadata (`metadata.warnings`) and eventlog entries surface the same; console summary keeps `Skipped duplicates` coherent;
- `javinizer history`/`history revert`/`logs` now work for CLI batches.

Adjacent fixes surfaced while wiring (small, included): `WithSkipStartupRecovery` so a one-shot CLI process never reconstructs/marks in-flight jobs; hoist the `batch_file_operations` prune-fence SELECT out of the deferred txn (was racing concurrent apply workers into `database is locked`); a duplicated dry-run guard from #247 clean-rebased away.

Closes #244.

## Test plan
- [x] In-process: dup batch → row/persistence/noop + warning metadata + eventlog entries; dry-run rows none; presenter/hook pins
- [x] Persistent-store standalone job + startup-skip pin; prune-fence retry seam pin
- [x] Live CLI: sort -f over duplicate pair → history/log surfaces match API; revert works
- [x] go test -short/-race on worker/workflow/history/database green; patch coverage 100%