### PR TITLE
feat(organizer): audit crumb for force-overwrite of occupied destinations

### DIFF
--- a/internal/api/batch/apply_config_builder.go
+++ b/internal/api/batch/apply_config_builder.go
@@ -2,6 +2,7 @@ package batch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -146,11 +147,26 @@ func resolveOrganizeApplyConfig(
 				warnings = afr.Result.OrganizeResult.Warnings
 				newPath = afr.Result.OrganizeResult.NewPath
 			}
-			failCtx := map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)}
-			if len(warnings) > 0 {
-				failCtx["warnings"] = warnings
+			// PR #249 codex P2 (canceled-error lane): context.Canceled is
+			// checked BEFORE any failure emit. The worker classifies a canceled
+			// apply as Cancelled, NOT failed (apply_phase.go interpretApplyResult:
+			// fileStatus = models.JobStatusCancelled and OnFileFailed is
+			// deliberately NOT invoked), so a SeverityError "Organize failed"
+			// row for a canceled file would mislabel the audit trail — consumers
+			// correlate failed events with erasable/retriable files. Skip it;
+			// mirrors auditOrganizeFailure's canceled skip
+			// (worker/history_writer.go) and the CLI hook (cliBatchPostApply).
+			// The buffered warning events STILL emit: they are truthful evidence
+			// (resident bytes destroyed, partial publish) recorded before the
+			// cancellation landed, and the success-history row the worker writes
+			// for a canceled partial move reads the same Warnings slice.
+			if !errors.Is(afr.Err, context.Canceled) {
+				failCtx := map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)}
+				if len(warnings) > 0 {
+					failCtx["warnings"] = warnings
+				}
+				emit("file_move", fmt.Sprintf("Organize failed for %s", afc.Movie.ID), models.SeverityError, failCtx)
 			}
-			emit("file_move", fmt.Sprintf("Organize failed for %s", afc.Movie.ID), models.SeverityError, failCtx)
 			for _, warning := range warnings {
 				emit("file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
 			}
@@ -285,10 +301,15 @@ func resolveUpdateApplyConfig(
 			return
 		}
 		emitter := deps.GetEventEmitter()
-		if afr.Err != nil && emitter != nil {
-			// Same one-ctx-per-invocation shape as the organize lane (update
-			// currently emits a single event, but keep the pattern uniform so
-			// a future per-warning lane inherits the aggregated budget).
+		if afr.Err != nil && emitter != nil && !errors.Is(afr.Err, context.Canceled) {
+			// canceled check BEFORE the failure emit (PR #249 codex P2,
+			// canceled-error lane): the worker records canceled files as
+			// Cancelled, not failed, so a SeverityError "Update failed" row
+			// would mislabel the audit trail — mirror the organize lane above
+			// and the CLI hook. Same one-ctx-per-invocation shape as the
+			// organize lane (update currently emits a single event, but keep
+			// the pattern uniform so a future per-warning lane inherits the
+			// aggregated budget).
 			auditCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			postApplyAuditEmit(auditCtx, emitter, job.GetID())("nfo_gen", fmt.Sprintf("Update failed for %s", afc.Movie.ID), models.SeverityError, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})

--- a/internal/api/batch/apply_config_builder.go
+++ b/internal/api/batch/apply_config_builder.go
@@ -1,20 +1,15 @@
 package batch
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/javinizer/javinizer-go/internal/api/contracts"
 	"github.com/javinizer/javinizer-go/internal/api/core"
 	"github.com/javinizer/javinizer-go/internal/applyplan"
-	"github.com/javinizer/javinizer-go/internal/eventlog"
 	"github.com/javinizer/javinizer-go/internal/logging"
-	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/operationmode"
 	"github.com/javinizer/javinizer-go/internal/websocket"
 	"github.com/javinizer/javinizer-go/internal/worker"
@@ -110,82 +105,7 @@ func resolveOrganizeApplyConfig(
 	applyOpts.OnFileOrganizeStart = makeOrganizeFileStartBroadcaster(job, false /* isUpdate */, sink, applyGenerationRef)
 	applyOpts.OnFileOrganized = makeOrganizeFileOrganizedBroadcaster(job, false /* isUpdate */, sink, applyGenerationRef)
 	applyOpts.OnFileFailed = makeOrganizeFileFailedBroadcaster(job, false /* isUpdate */, sink, applyGenerationRef)
-	applyOpts.PostApplyFunc = func(_ context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
-		// Guard: never dereference a nil payload. If the apply context or
-		// result is missing required fields, skip emitting this secondary
-		// event so the original apply error is preserved instead of being
-		// masked by a nil-panic here.
-		if afc == nil || afc.Movie == nil || afr == nil {
-			return
-		}
-		emitter := deps.GetEventEmitter()
-		if emitter == nil {
-			return
-		}
-		// One detached bounded ctx per PostApplyFunc invocation, REUSED
-		// across the success/failure event + every warning event (PR #249
-		// codex P2): scoping a fresh 5s ctx PER EVENT would let an organize
-		// result with W warnings sit (1+W)×5s worst-case on a worker
-		// goroutine after an apply timeout. Mirror the CLI hook
-		// (cliBatchPostApply) and the worker history writer: budget once per
-		// file, aggregate all of the file's audit rows under it.
-		auditCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		emit := postApplyAuditEmit(auditCtx, emitter, job.GetID())
-		if afr.Err != nil {
-			// PR #249 codex follow-up (F4): the failed lane's result still
-			// carries the displacement crumbs — the link lane binds the
-			// force-overwrite crumb at the destruction (F2) and the partial-
-			// publish/cross-device legs union their evidence into the failed
-			// result (F3) — so the failure event itself carries the warnings,
-			// and each warning additionally gets its own audit entry exactly
-			// like the success lane below. Consumers must not have to
-			// distinguish outcomes to see that resident bytes were destroyed.
-			var warnings []string
-			var newPath string
-			if afr.Result != nil && afr.Result.OrganizeResult != nil {
-				warnings = afr.Result.OrganizeResult.Warnings
-				newPath = afr.Result.OrganizeResult.NewPath
-			}
-			// PR #249 codex P2 (canceled-error lane): context.Canceled is
-			// checked BEFORE any failure emit. The worker classifies a canceled
-			// apply as Cancelled, NOT failed (apply_phase.go interpretApplyResult:
-			// fileStatus = models.JobStatusCancelled and OnFileFailed is
-			// deliberately NOT invoked), so a SeverityError "Organize failed"
-			// row for a canceled file would mislabel the audit trail — consumers
-			// correlate failed events with erasable/retriable files. Skip it;
-			// mirrors auditOrganizeFailure's canceled skip
-			// (worker/history_writer.go) and the CLI hook (cliBatchPostApply).
-			// The buffered warning events STILL emit: they are truthful evidence
-			// (resident bytes destroyed, partial publish) recorded before the
-			// cancellation landed, and the success-history row the worker writes
-			// for a canceled partial move reads the same Warnings slice.
-			if !errors.Is(afr.Err, context.Canceled) {
-				failCtx := map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)}
-				if len(warnings) > 0 {
-					failCtx["warnings"] = warnings
-				}
-				emit("file_move", fmt.Sprintf("Organize failed for %s", afc.Movie.ID), models.SeverityError, failCtx)
-			}
-			for _, warning := range warnings {
-				emit("file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
-			}
-			return
-		}
-		var newPath string
-		if afr.Result != nil && afr.Result.OrganizeResult != nil {
-			newPath = afr.Result.OrganizeResult.NewPath
-		}
-		emit("file_move", fmt.Sprintf("Organized %s", afc.Movie.ID), models.SeverityInfo, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "apply_generation": loadApplyGeneration(applyGenerationRef)})
-		// #224 phase E: authorized intra-batch duplicates are demoted from
-		// conflicts to per-file warnings; each warning gets its own audit
-		// event via the existing eventlog.
-		if afr.Result != nil && afr.Result.OrganizeResult != nil {
-			for _, warning := range afr.Result.OrganizeResult.Warnings {
-				emit("file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning, "apply_generation": loadApplyGeneration(applyGenerationRef)})
-			}
-		}
-	}
+	applyOpts.PostApplyFunc = makeOrganizePostApplyAuditHook(deps, job, applyGenerationRef)
 
 	return applyOpts, nil
 }
@@ -294,27 +214,7 @@ func resolveUpdateApplyConfig(
 	applyOpts.OnFileOrganizeStart = makeOrganizeFileStartBroadcaster(job, true /* isUpdate */, sink, applyGenerationRef)
 	applyOpts.OnFileOrganized = makeOrganizeFileOrganizedBroadcaster(job, true /* isUpdate */, sink, applyGenerationRef)
 	applyOpts.OnFileFailed = makeOrganizeFileFailedBroadcaster(job, true /* isUpdate */, sink, applyGenerationRef)
-	applyOpts.PostApplyFunc = func(_ context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
-		// Guard: never dereference a nil payload; skip the secondary event so
-		// the original apply error is preserved.
-		if afc == nil || afc.Movie == nil || afr == nil {
-			return
-		}
-		emitter := deps.GetEventEmitter()
-		if afr.Err != nil && emitter != nil && !errors.Is(afr.Err, context.Canceled) {
-			// canceled check BEFORE the failure emit (PR #249 codex P2,
-			// canceled-error lane): the worker records canceled files as
-			// Cancelled, not failed, so a SeverityError "Update failed" row
-			// would mislabel the audit trail — mirror the organize lane above
-			// and the CLI hook. Same one-ctx-per-invocation shape as the
-			// organize lane (update currently emits a single event, but keep
-			// the pattern uniform so a future per-warning lane inherits the
-			// aggregated budget).
-			auditCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			postApplyAuditEmit(auditCtx, emitter, job.GetID())("nfo_gen", fmt.Sprintf("Update failed for %s", afc.Movie.ID), models.SeverityError, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
-		}
-	}
+	applyOpts.PostApplyFunc = makeUpdatePostApplyAuditHook(deps, job, applyGenerationRef)
 
 	return applyOpts, nil
 }
@@ -341,35 +241,6 @@ func loadApplyGeneration(generationRef *uint64) uint64 {
 		return 0
 	}
 	return atomic.LoadUint64(generationRef)
-}
-
-// postApplyAuditEmit returns an emit closure that forwards organize audit
-// events to the shared eventlog on the caller-supplied DETACHED, bounded
-// auditCtx. The caller (a PostApplyFunc invocation) allocates that ctx ONCE
-// and reuses it across the file's success/failure event plus every warning
-// event, so a result with W warnings costs ONE 5s budget worst-case, not
-// (1+W) — the same aggregation shape as the worker's history writer
-// (worker/history_writer.go historyAuditContext) and the CLI hook
-// (commandutil/batch_command.go cliBatchPostApply).
-//
-// Detachment is required: the apply phase invokes PostApplyFunc via
-// interpretApplyResult with the per-file task ctx, which is ALREADY expired
-// when apply exhausts WorkerTimeout, and eventlog.emit drops events on a
-// canceled ctx (emitter.go checks ctx.Err()). Routing the passed task ctx
-// through here meant a timed-out apply lost its failure/warning audit rows
-// entirely, while the worker's history writer still recorded the outcome
-// because it audits with a fresh bounded ctx. A 5s background-timeout context
-// keeps the audit writes bounded without blocking the apply pipeline.
-//
-// Emission failures are Warn-logged, not silently discarded (mirroring the
-// CLI hook), so a persist-level outage surfaces in the logs instead of
-// vanishing.
-func postApplyAuditEmit(auditCtx context.Context, emitter eventlog.EventEmitter, jobID string) func(source, message string, severity models.EventSeverity, eventCtx map[string]any) {
-	return func(source, message string, severity models.EventSeverity, eventCtx map[string]any) {
-		if err := emitter.EmitOrganizeEvent(auditCtx, source, message, severity, eventCtx); err != nil {
-			logging.Warnf("[api batch %s] eventlog audit emission failed (source=%s, severity=%s, message=%q): %v", jobID, source, severity, message, err)
-		}
-	}
 }
 
 func stampJobCountsForApply(msg *websocket.ProgressMessage, job worker.BatchJobInterface, generationRef ...*uint64) *websocket.ProgressMessage {

--- a/internal/api/batch/apply_config_builder.go
+++ b/internal/api/batch/apply_config_builder.go
@@ -121,7 +121,16 @@ func resolveOrganizeApplyConfig(
 		if emitter == nil {
 			return
 		}
-		emit := postApplyAuditEmit(emitter, job.GetID())
+		// One detached bounded ctx per PostApplyFunc invocation, REUSED
+		// across the success/failure event + every warning event (PR #249
+		// codex P2): scoping a fresh 5s ctx PER EVENT would let an organize
+		// result with W warnings sit (1+W)×5s worst-case on a worker
+		// goroutine after an apply timeout. Mirror the CLI hook
+		// (cliBatchPostApply) and the worker history writer: budget once per
+		// file, aggregate all of the file's audit rows under it.
+		auditCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		emit := postApplyAuditEmit(auditCtx, emitter, job.GetID())
 		if afr.Err != nil {
 			// PR #249 codex follow-up (F4): the failed lane's result still
 			// carries the displacement crumbs — the link lane binds the
@@ -277,7 +286,12 @@ func resolveUpdateApplyConfig(
 		}
 		emitter := deps.GetEventEmitter()
 		if afr.Err != nil && emitter != nil {
-			postApplyAuditEmit(emitter, job.GetID())("nfo_gen", fmt.Sprintf("Update failed for %s", afc.Movie.ID), models.SeverityError, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
+			// Same one-ctx-per-invocation shape as the organize lane (update
+			// currently emits a single event, but keep the pattern uniform so
+			// a future per-warning lane inherits the aggregated budget).
+			auditCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			postApplyAuditEmit(auditCtx, emitter, job.GetID())("nfo_gen", fmt.Sprintf("Update failed for %s", afc.Movie.ID), models.SeverityError, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
 		}
 	}
 
@@ -308,27 +322,29 @@ func loadApplyGeneration(generationRef *uint64) uint64 {
 	return atomic.LoadUint64(generationRef)
 }
 
-// postApplyAuditEmit returns an emit closure that forwards one organize audit
-// event to the shared eventlog on a DETACHED, bounded context, mirroring the
-// worker's historyAuditContext pattern (worker/history_writer.go) and the CLI
-// hook (commandutil/batch_command.go cliBatchPostApply).
+// postApplyAuditEmit returns an emit closure that forwards organize audit
+// events to the shared eventlog on the caller-supplied DETACHED, bounded
+// auditCtx. The caller (a PostApplyFunc invocation) allocates that ctx ONCE
+// and reuses it across the file's success/failure event plus every warning
+// event, so a result with W warnings costs ONE 5s budget worst-case, not
+// (1+W) — the same aggregation shape as the worker's history writer
+// (worker/history_writer.go historyAuditContext) and the CLI hook
+// (commandutil/batch_command.go cliBatchPostApply).
 //
 // Detachment is required: the apply phase invokes PostApplyFunc via
 // interpretApplyResult with the per-file task ctx, which is ALREADY expired
 // when apply exhausts WorkerTimeout, and eventlog.emit drops events on a
-// canceled ctx (emitter.go checks ctx.Err()). Routing the passed ctx through
-// here meant a timed-out apply lost its failure/warning audit rows entirely,
-// while the worker's history writer still recorded the outcome because it
-// audits with a fresh bounded ctx. A 5s background-timeout context keeps the
-// audit write bounded without blocking the apply pipeline.
+// canceled ctx (emitter.go checks ctx.Err()). Routing the passed task ctx
+// through here meant a timed-out apply lost its failure/warning audit rows
+// entirely, while the worker's history writer still recorded the outcome
+// because it audits with a fresh bounded ctx. A 5s background-timeout context
+// keeps the audit writes bounded without blocking the apply pipeline.
 //
 // Emission failures are Warn-logged, not silently discarded (mirroring the
 // CLI hook), so a persist-level outage surfaces in the logs instead of
 // vanishing.
-func postApplyAuditEmit(emitter eventlog.EventEmitter, jobID string) func(source, message string, severity models.EventSeverity, eventCtx map[string]any) {
+func postApplyAuditEmit(auditCtx context.Context, emitter eventlog.EventEmitter, jobID string) func(source, message string, severity models.EventSeverity, eventCtx map[string]any) {
 	return func(source, message string, severity models.EventSeverity, eventCtx map[string]any) {
-		auditCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
 		if err := emitter.EmitOrganizeEvent(auditCtx, source, message, severity, eventCtx); err != nil {
 			logging.Warnf("[api batch %s] eventlog audit emission failed (source=%s, severity=%s, message=%q): %v", jobID, source, severity, message, err)
 		}

--- a/internal/api/batch/apply_config_builder.go
+++ b/internal/api/batch/apply_config_builder.go
@@ -6,10 +6,12 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/javinizer/javinizer-go/internal/api/contracts"
 	"github.com/javinizer/javinizer-go/internal/api/core"
 	"github.com/javinizer/javinizer-go/internal/applyplan"
+	"github.com/javinizer/javinizer-go/internal/eventlog"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/operationmode"
@@ -107,7 +109,7 @@ func resolveOrganizeApplyConfig(
 	applyOpts.OnFileOrganizeStart = makeOrganizeFileStartBroadcaster(job, false /* isUpdate */, sink, applyGenerationRef)
 	applyOpts.OnFileOrganized = makeOrganizeFileOrganizedBroadcaster(job, false /* isUpdate */, sink, applyGenerationRef)
 	applyOpts.OnFileFailed = makeOrganizeFileFailedBroadcaster(job, false /* isUpdate */, sink, applyGenerationRef)
-	applyOpts.PostApplyFunc = func(ctx context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
+	applyOpts.PostApplyFunc = func(_ context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
 		// Guard: never dereference a nil payload. If the apply context or
 		// result is missing required fields, skip emitting this secondary
 		// event so the original apply error is preserved instead of being
@@ -116,7 +118,11 @@ func resolveOrganizeApplyConfig(
 			return
 		}
 		emitter := deps.GetEventEmitter()
-		if afr.Err != nil && emitter != nil {
+		if emitter == nil {
+			return
+		}
+		emit := postApplyAuditEmit(emitter, job.GetID())
+		if afr.Err != nil {
 			// PR #249 codex follow-up (F4): the failed lane's result still
 			// carries the displacement crumbs — the link lane binds the
 			// force-overwrite crumb at the destruction (F2) and the partial-
@@ -135,23 +141,23 @@ func resolveOrganizeApplyConfig(
 			if len(warnings) > 0 {
 				failCtx["warnings"] = warnings
 			}
-			_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organize failed for %s", afc.Movie.ID), models.SeverityError, failCtx)
+			emit("file_move", fmt.Sprintf("Organize failed for %s", afc.Movie.ID), models.SeverityError, failCtx)
 			for _, warning := range warnings {
-				_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
+				emit("file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
 			}
-		} else if emitter != nil {
-			var newPath string
-			if afr.Result != nil && afr.Result.OrganizeResult != nil {
-				newPath = afr.Result.OrganizeResult.NewPath
-			}
-			_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organized %s", afc.Movie.ID), models.SeverityInfo, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "apply_generation": loadApplyGeneration(applyGenerationRef)})
-			// #224 phase E: authorized intra-batch duplicates are demoted from
-			// conflicts to per-file warnings; each warning gets its own audit
-			// event via the existing eventlog.
-			if afr.Result != nil && afr.Result.OrganizeResult != nil {
-				for _, warning := range afr.Result.OrganizeResult.Warnings {
-					_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning, "apply_generation": loadApplyGeneration(applyGenerationRef)})
-				}
+			return
+		}
+		var newPath string
+		if afr.Result != nil && afr.Result.OrganizeResult != nil {
+			newPath = afr.Result.OrganizeResult.NewPath
+		}
+		emit("file_move", fmt.Sprintf("Organized %s", afc.Movie.ID), models.SeverityInfo, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "apply_generation": loadApplyGeneration(applyGenerationRef)})
+		// #224 phase E: authorized intra-batch duplicates are demoted from
+		// conflicts to per-file warnings; each warning gets its own audit
+		// event via the existing eventlog.
+		if afr.Result != nil && afr.Result.OrganizeResult != nil {
+			for _, warning := range afr.Result.OrganizeResult.Warnings {
+				emit("file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning, "apply_generation": loadApplyGeneration(applyGenerationRef)})
 			}
 		}
 	}
@@ -263,7 +269,7 @@ func resolveUpdateApplyConfig(
 	applyOpts.OnFileOrganizeStart = makeOrganizeFileStartBroadcaster(job, true /* isUpdate */, sink, applyGenerationRef)
 	applyOpts.OnFileOrganized = makeOrganizeFileOrganizedBroadcaster(job, true /* isUpdate */, sink, applyGenerationRef)
 	applyOpts.OnFileFailed = makeOrganizeFileFailedBroadcaster(job, true /* isUpdate */, sink, applyGenerationRef)
-	applyOpts.PostApplyFunc = func(ctx context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
+	applyOpts.PostApplyFunc = func(_ context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
 		// Guard: never dereference a nil payload; skip the secondary event so
 		// the original apply error is preserved.
 		if afc == nil || afc.Movie == nil || afr == nil {
@@ -271,7 +277,7 @@ func resolveUpdateApplyConfig(
 		}
 		emitter := deps.GetEventEmitter()
 		if afr.Err != nil && emitter != nil {
-			_ = emitter.EmitOrganizeEvent(ctx, "nfo_gen", fmt.Sprintf("Update failed for %s", afc.Movie.ID), models.SeverityError, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
+			postApplyAuditEmit(emitter, job.GetID())("nfo_gen", fmt.Sprintf("Update failed for %s", afc.Movie.ID), models.SeverityError, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
 		}
 	}
 
@@ -300,6 +306,33 @@ func loadApplyGeneration(generationRef *uint64) uint64 {
 		return 0
 	}
 	return atomic.LoadUint64(generationRef)
+}
+
+// postApplyAuditEmit returns an emit closure that forwards one organize audit
+// event to the shared eventlog on a DETACHED, bounded context, mirroring the
+// worker's historyAuditContext pattern (worker/history_writer.go) and the CLI
+// hook (commandutil/batch_command.go cliBatchPostApply).
+//
+// Detachment is required: the apply phase invokes PostApplyFunc via
+// interpretApplyResult with the per-file task ctx, which is ALREADY expired
+// when apply exhausts WorkerTimeout, and eventlog.emit drops events on a
+// canceled ctx (emitter.go checks ctx.Err()). Routing the passed ctx through
+// here meant a timed-out apply lost its failure/warning audit rows entirely,
+// while the worker's history writer still recorded the outcome because it
+// audits with a fresh bounded ctx. A 5s background-timeout context keeps the
+// audit write bounded without blocking the apply pipeline.
+//
+// Emission failures are Warn-logged, not silently discarded (mirroring the
+// CLI hook), so a persist-level outage surfaces in the logs instead of
+// vanishing.
+func postApplyAuditEmit(emitter eventlog.EventEmitter, jobID string) func(source, message string, severity models.EventSeverity, eventCtx map[string]any) {
+	return func(source, message string, severity models.EventSeverity, eventCtx map[string]any) {
+		auditCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := emitter.EmitOrganizeEvent(auditCtx, source, message, severity, eventCtx); err != nil {
+			logging.Warnf("[api batch %s] eventlog audit emission failed (source=%s, severity=%s, message=%q): %v", jobID, source, severity, message, err)
+		}
+	}
 }
 
 func stampJobCountsForApply(msg *websocket.ProgressMessage, job worker.BatchJobInterface, generationRef ...*uint64) *websocket.ProgressMessage {

--- a/internal/api/batch/apply_config_builder.go
+++ b/internal/api/batch/apply_config_builder.go
@@ -117,7 +117,28 @@ func resolveOrganizeApplyConfig(
 		}
 		emitter := deps.GetEventEmitter()
 		if afr.Err != nil && emitter != nil {
-			_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organize failed for %s", afc.Movie.ID), models.SeverityError, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
+			// PR #249 codex follow-up (F4): the failed lane's result still
+			// carries the displacement crumbs — the link lane binds the
+			// force-overwrite crumb at the destruction (F2) and the partial-
+			// publish/cross-device legs union their evidence into the failed
+			// result (F3) — so the failure event itself carries the warnings,
+			// and each warning additionally gets its own audit entry exactly
+			// like the success lane below. Consumers must not have to
+			// distinguish outcomes to see that resident bytes were destroyed.
+			var warnings []string
+			var newPath string
+			if afr.Result != nil && afr.Result.OrganizeResult != nil {
+				warnings = afr.Result.OrganizeResult.Warnings
+				newPath = afr.Result.OrganizeResult.NewPath
+			}
+			failCtx := map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)}
+			if len(warnings) > 0 {
+				failCtx["warnings"] = warnings
+			}
+			_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organize failed for %s", afc.Movie.ID), models.SeverityError, failCtx)
+			for _, warning := range warnings {
+				_ = emitter.EmitOrganizeEvent(ctx, "file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
+			}
 		} else if emitter != nil {
 			var newPath string
 			if afr.Result != nil && afr.Result.OrganizeResult != nil {

--- a/internal/api/batch/apply_config_builder_canceled_w249_test.go
+++ b/internal/api/batch/apply_config_builder_canceled_w249_test.go
@@ -1,0 +1,158 @@
+package batch
+
+// PR #249 codex P2 — canceled-error lane. interpretApplyResult
+// (worker/apply_phase.go) classifies an apply error satisfying
+// errors.Is(err, context.Canceled) as Cancelled, NOT failed (fileStatus =
+// models.JobStatusCancelled; OnFileFailed deliberately not invoked). The
+// PostApplyFunc hooks must match that taxonomy: no SeverityError
+// "Organize failed"/"Update failed" event for a canceled file, because the
+// audit trail would mislabel a cancelled item as erasable/retriable whilst
+// the job row says Cancelled. The buffered OrganizeResult.Warnings events
+// STILL emit — they are truthful evidence of work done (bytes destroyed,
+// partial publish) before the cancellation landed, and the success-history
+// row the worker writes for a canceled partial move reads the same slice.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostApplyCanceled_Organize_NoFailureEvent_WarningsStillEmitted pins the
+// organize lane with errors.Is(err, context.Canceled): bare AND wrapped
+// cancellation errors each suppress the "Organize failed" SeverityError event
+// while every buffered warning still lands as its own SeverityWarn audit row.
+func TestPostApplyCanceled_Organize_NoFailureEvent_WarningsStillEmitted(t *testing.T) {
+	emitter := &ctxEnforcingEmitter{}
+	rt := core.NewAPIRuntime(&core.APIDeps{EventEmitter: emitter})
+	snapshot := core.NewSnapshotForTesting(rt, core.APIConfig{})
+	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
+	job := &stubControlledJob{}
+
+	organize, err := resolveOrganizeApplyConfig(snapshot, factory, job, contracts.OrganizeRequest{
+		OperationMode: string(operationmode.OperationModeInPlace),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, organize.PostApplyFunc)
+	require.NotNil(t, organize.ApplyGenerationRef)
+	*organize.ApplyGenerationRef = 55
+
+	warning := "overwrite authorized: replaced existing destination /dest/MOV-55/MOV-55.mp4"
+
+	for _, tc := range []struct {
+		name     string
+		applyErr error
+	}{
+		{name: "bare context.Canceled", applyErr: context.Canceled},
+		{name: "wrapped context.Canceled", applyErr: fmt.Errorf("organization aborted: %w", context.Canceled)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			emitter.calls = nil
+			emitter.drops = nil
+
+			organize.PostApplyFunc(context.Background(), &worker.ApplyFileContext{
+				FilePath: "/source/MOV-55.mp4",
+				Movie:    &models.Movie{ID: "MOV-55"},
+			}, &worker.ApplyFileResult{
+				Err: tc.applyErr,
+				Result: &workflow.ApplyResult{
+					OrganizeResult: &organizer.OrganizeResult{
+						NewPath:  "/dest/MOV-55/MOV-55.mp4",
+						Warnings: []string{warning},
+					},
+				},
+			})
+
+			require.Equal(t, 1, len(emitter.calls), "exactly the warning event — no failure event for a canceled apply")
+			ev := emitter.calls[0]
+			assert.Equal(t, "file_move", ev.source)
+			assert.Equal(t, models.SeverityWarn, ev.severity, "canceled applies never produce SeverityError rows")
+			assert.Equal(t, fmt.Sprintf("Organize warning for MOV-55: %s", warning), ev.message)
+			assert.Equal(t, warning, ev.context["warning"])
+			assert.Equal(t, tc.applyErr.Error(), ev.context["error"], "the warning row still records the cancellation cause verbatim")
+			assert.Equal(t, uint64(55), ev.context["apply_generation"])
+			assert.Empty(t, emitter.drops, "audit events ride the detached ctx even here")
+		})
+	}
+}
+
+// TestPostApplyCanceled_Organize_NoWarnings_NoEvents pins the canceled lane
+// with no buffered crumbs: NOTHING is emitted — no failure event to mislabel
+// the Cancelled file, and no warning loop iterations on an empty slice.
+func TestPostApplyCanceled_Organize_NoWarnings_NoEvents(t *testing.T) {
+	emitter := &ctxEnforcingEmitter{}
+	rt := core.NewAPIRuntime(&core.APIDeps{EventEmitter: emitter})
+	snapshot := core.NewSnapshotForTesting(rt, core.APIConfig{})
+	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
+	job := &stubControlledJob{}
+
+	organize, err := resolveOrganizeApplyConfig(snapshot, factory, job, contracts.OrganizeRequest{
+		OperationMode: string(operationmode.OperationModeInPlace),
+	})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name   string
+		result *workflow.ApplyResult
+	}{
+		{name: "nil result", result: nil},
+		{name: "organize result without warnings", result: &workflow.ApplyResult{OrganizeResult: &organizer.OrganizeResult{NewPath: "/dest/movie.mp4"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			emitter.calls = nil
+			emitter.drops = nil
+
+			organize.PostApplyFunc(context.Background(), &worker.ApplyFileContext{
+				FilePath: "/source/movie.mp4",
+				Movie:    &models.Movie{ID: "MOV-56"},
+			}, &worker.ApplyFileResult{Err: context.Canceled, Result: tc.result})
+
+			assert.Empty(t, emitter.calls, "a canceled apply with no crumbs emits no events at all")
+			assert.Empty(t, emitter.drops)
+		})
+	}
+}
+
+// TestPostApplyCanceled_Update_NoEvents pins the update resolver's nfo_gen
+// lane: errors.Is(err, context.Canceled) suppresses the "Update failed"
+// SeverityError event entirely — the worker records the file Cancelled, so a
+// failure row would mislabel it (update has no warning loop to preserve).
+func TestPostApplyCanceled_Update_NoEvents(t *testing.T) {
+	emitter := &ctxEnforcingEmitter{}
+	rt := core.NewAPIRuntime(&core.APIDeps{EventEmitter: emitter})
+	snapshot := core.NewSnapshotForTesting(rt, core.APIConfig{})
+	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
+	job := &stubControlledJob{}
+
+	update, err := resolveUpdateApplyConfig(snapshot, factory, job, contracts.UpdateRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, update.PostApplyFunc)
+
+	update.PostApplyFunc(context.Background(), &worker.ApplyFileContext{
+		FilePath: "/source/MOV-57.mp4",
+		Movie:    &models.Movie{ID: "MOV-57"},
+	}, &worker.ApplyFileResult{Err: fmt.Errorf("update aborted: %w", context.Canceled)})
+
+	assert.Empty(t, emitter.calls, "a canceled update emits no failure event")
+	assert.Empty(t, emitter.drops)
+
+	// Control: a NON-canceled update failure still lands the failure event —
+	// the canceled predicate does not suppress real failures.
+	update.PostApplyFunc(context.Background(), &worker.ApplyFileContext{
+		FilePath: "/source/MOV-58.mp4",
+		Movie:    &models.Movie{ID: "MOV-58"},
+	}, &worker.ApplyFileResult{Err: fmt.Errorf("update failed: nfo write timed out")})
+	require.Len(t, emitter.calls, 1)
+	assert.Equal(t, models.SeverityError, emitter.calls[0].severity)
+	assert.Contains(t, emitter.calls[0].message, "Update failed for MOV-58")
+}

--- a/internal/api/batch/apply_config_builder_detached_audit_ctx_test.go
+++ b/internal/api/batch/apply_config_builder_detached_audit_ctx_test.go
@@ -1,0 +1,199 @@
+package batch
+
+// PR #249 codex follow-up (F5) — the API PostApplyFunc audit emits must ride a
+// DETACHED bounded ctx, not the per-file task ctx: interpretApplyResult
+// (worker/apply_phase.go) invokes the hook with a ctx that is ALREADY expired
+// when apply exhausts WorkerTimeout, and eventlog.emit drops events on a
+// canceled ctx (eventlog/emitter.go checks ctx.Err()), so the timed-out
+// apply's failure/warning audit rows vanished — the same drop the CLI hook
+// fixed in commandutil/batch_command.go cliBatchPostApply. The pins below
+// mimic the real eventlog's drop-on-canceled-ctx semantics and invoke the
+// hooks with a pre-canceled ctx synchronously; a regression back to the task
+// ctx would drop every event and fail these tests.
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/eventlog"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxEnforcingEmitter mirrors eventlog.emit: an emit on an already-canceled
+// ctx is DROPPED (recorded in drops), exactly like the production emitter —
+// so these pins fail if PostApplyFunc ever forwards the (canceled) task ctx.
+type ctxEnforcingEmitter struct {
+	calls []applyConfigEventCall
+	drops []string
+}
+
+func (e *ctxEnforcingEmitter) EmitScraperEvent(context.Context, string, string, models.EventSeverity, map[string]any) error {
+	return nil
+}
+
+func (e *ctxEnforcingEmitter) EmitOrganizeEvent(ctx context.Context, source, message string, severity models.EventSeverity, eventContext map[string]any) error {
+	if ctx.Err() != nil {
+		e.drops = append(e.drops, message)
+		return fmt.Errorf("event emitter: caller context cancelled: %w", ctx.Err())
+	}
+	e.calls = append(e.calls, applyConfigEventCall{source: source, message: message, severity: severity, context: eventContext})
+	return nil
+}
+
+func (e *ctxEnforcingEmitter) EmitSystemEvent(context.Context, string, string, models.EventSeverity, map[string]any) error {
+	return nil
+}
+
+func (e *ctxEnforcingEmitter) Stats() (emitted, failed int64) {
+	return int64(len(e.calls)), int64(len(e.drops))
+}
+
+var _ eventlog.EventEmitter = (*ctxEnforcingEmitter)(nil)
+
+func preCanceledCtx() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
+
+// TestPostApplyDetachedAuditCtx_Organize pins both organize lanes: invoked
+// with a pre-canceled task ctx (the WorkerTimeout-exhausted shape), the
+// success info + per-warning audit entries AND the failure + per-warning
+// audit entries all still land — detached from the dead ctx.
+func TestPostApplyDetachedAuditCtx_Organize(t *testing.T) {
+	emitter := &ctxEnforcingEmitter{}
+	rt := core.NewAPIRuntime(&core.APIDeps{EventEmitter: emitter})
+	snapshot := core.NewSnapshotForTesting(rt, core.APIConfig{})
+	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
+	job := &stubControlledJob{}
+
+	organize, err := resolveOrganizeApplyConfig(snapshot, factory, job, contracts.OrganizeRequest{
+		OperationMode: string(operationmode.OperationModeInPlace),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, organize.PostApplyFunc)
+	require.NotNil(t, organize.ApplyGenerationRef)
+	*organize.ApplyGenerationRef = 44
+
+	warning := "duplicate destination within batch: /dest/movie.mp4 already claimed (overwrite authorized)"
+
+	// Success lane, pre-canceled task ctx.
+	organize.PostApplyFunc(preCanceledCtx(), &worker.ApplyFileContext{
+		FilePath: "/source/movie.mp4",
+		Movie:    &models.Movie{ID: "MOV-44"},
+	}, &worker.ApplyFileResult{Result: &workflow.ApplyResult{
+		OrganizeResult: &organizer.OrganizeResult{NewPath: "/dest/movie.mp4", Warnings: []string{warning}},
+	}})
+
+	// Failure lane, pre-canceled task ctx.
+	organize.PostApplyFunc(preCanceledCtx(), &worker.ApplyFileContext{
+		FilePath: "/source/other.mp4",
+		Movie:    &models.Movie{ID: "MOV-45"},
+	}, &worker.ApplyFileResult{
+		Err:    fmt.Errorf("organization failed: copy timed out"),
+		Result: &workflow.ApplyResult{OrganizeResult: &organizer.OrganizeResult{NewPath: "/dest/other.mp4", Warnings: []string{warning}}},
+	})
+
+	assert.Empty(t, emitter.drops, "no audit event may be dropped on the canceled task ctx")
+	require.Len(t, emitter.calls, 4, "info + warning on success, failure + warning on failure")
+
+	assert.Equal(t, models.SeverityInfo, emitter.calls[0].severity)
+	assert.Contains(t, emitter.calls[0].message, "Organized MOV-44")
+
+	assert.Equal(t, models.SeverityWarn, emitter.calls[1].severity)
+	assert.Contains(t, emitter.calls[1].message, warning)
+
+	assert.Equal(t, models.SeverityError, emitter.calls[2].severity)
+	assert.Contains(t, emitter.calls[2].message, "Organize failed for MOV-45")
+	assert.Equal(t, []string{warning}, emitter.calls[2].context["warnings"])
+
+	assert.Equal(t, models.SeverityWarn, emitter.calls[3].severity)
+	assert.Equal(t, warning, emitter.calls[3].context["warning"])
+}
+
+// erringEmitter fails every emit so the postApplyAuditEmit failure branch
+// (Warn-logged, not fatal) is exercised.
+type erringEmitter struct {
+	attempts atomic.Int64
+}
+
+func (e *erringEmitter) EmitScraperEvent(context.Context, string, string, models.EventSeverity, map[string]any) error {
+	return nil
+}
+
+func (e *erringEmitter) EmitOrganizeEvent(_ context.Context, _, _ string, _ models.EventSeverity, _ map[string]any) error {
+	e.attempts.Add(1)
+	return fmt.Errorf("event repo write failed")
+}
+
+func (e *erringEmitter) EmitSystemEvent(context.Context, string, string, models.EventSeverity, map[string]any) error {
+	return nil
+}
+
+func (e *erringEmitter) Stats() (emitted, failed int64) {
+	return 0, e.attempts.Load()
+}
+
+var _ eventlog.EventEmitter = (*erringEmitter)(nil)
+
+// TestPostApplyAuditEmitFailure_WarnLoggedNotFatal pins that a persist-level
+// emission failure is Warn-logged and swallowed (mirroring the CLI hook) —
+// the post-apply hook must never mask the original apply outcome.
+func TestPostApplyAuditEmitFailure_WarnLoggedNotFatal(t *testing.T) {
+	emitter := &erringEmitter{}
+	rt := core.NewAPIRuntime(&core.APIDeps{EventEmitter: emitter})
+	snapshot := core.NewSnapshotForTesting(rt, core.APIConfig{})
+	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
+	job := &stubControlledJob{}
+
+	organize, err := resolveOrganizeApplyConfig(snapshot, factory, job, contracts.OrganizeRequest{
+		OperationMode: string(operationmode.OperationModeInPlace),
+	})
+	require.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		organize.PostApplyFunc(context.Background(), &worker.ApplyFileContext{
+			FilePath: "/source/movie.mp4",
+			Movie:    &models.Movie{ID: "MOV-47"},
+		}, &worker.ApplyFileResult{Result: &workflow.ApplyResult{
+			OrganizeResult: &organizer.OrganizeResult{NewPath: "/dest/movie.mp4"},
+		}})
+	})
+	assert.Equal(t, int64(1), emitter.attempts.Load(), "the emit was attempted and its failure absorbed")
+}
+
+// TestPostApplyDetachedAuditCtx_Update pins the update resolver's nfo_gen
+// failure emit: with a pre-canceled task ctx the "Update failed" audit entry
+// must still land on the detached bounded ctx.
+func TestPostApplyDetachedAuditCtx_Update(t *testing.T) {
+	emitter := &ctxEnforcingEmitter{}
+	rt := core.NewAPIRuntime(&core.APIDeps{EventEmitter: emitter})
+	snapshot := core.NewSnapshotForTesting(rt, core.APIConfig{})
+	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
+	job := &stubControlledJob{}
+
+	update, err := resolveUpdateApplyConfig(snapshot, factory, job, contracts.UpdateRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, update.PostApplyFunc)
+
+	update.PostApplyFunc(preCanceledCtx(), &worker.ApplyFileContext{
+		FilePath: "/source/movie.mp4",
+		Movie:    &models.Movie{ID: "MOV-46"},
+	}, &worker.ApplyFileResult{Err: fmt.Errorf("update failed: nfo write timed out")})
+
+	assert.Empty(t, emitter.drops, "no audit event may be dropped on the canceled task ctx")
+	require.Len(t, emitter.calls, 1)
+	assert.Equal(t, "nfo_gen", emitter.calls[0].source)
+	assert.Equal(t, models.SeverityError, emitter.calls[0].severity)
+	assert.Contains(t, emitter.calls[0].message, "Update failed for MOV-46")
+}

--- a/internal/api/batch/apply_config_builder_detached_audit_ctx_test.go
+++ b/internal/api/batch/apply_config_builder_detached_audit_ctx_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/javinizer/javinizer-go/internal/api/contracts"
 	"github.com/javinizer/javinizer-go/internal/api/core"
@@ -170,6 +171,80 @@ func TestPostApplyAuditEmitFailure_WarnLoggedNotFatal(t *testing.T) {
 		}})
 	})
 	assert.Equal(t, int64(1), emitter.attempts.Load(), "the emit was attempted and its failure absorbed")
+}
+
+// deadlineCapturingEmitter records the deadline carried by the ctx on every
+// emit, so tests can assert that all audit events of ONE PostApplyFunc
+// invocation ride a single shared budget (PR #249 codex P2) instead of each
+// event re-scoping its own 5s ctx.
+type deadlineCapturingEmitter struct {
+	deadlines []time.Time
+}
+
+func (e *deadlineCapturingEmitter) EmitScraperEvent(context.Context, string, string, models.EventSeverity, map[string]any) error {
+	return nil
+}
+
+func (e *deadlineCapturingEmitter) EmitOrganizeEvent(ctx context.Context, source, message string, severity models.EventSeverity, eventContext map[string]any) error {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("event emitter: caller context carries no deadline")
+	}
+	e.deadlines = append(e.deadlines, deadline)
+	return nil
+}
+
+func (e *deadlineCapturingEmitter) EmitSystemEvent(context.Context, string, string, models.EventSeverity, map[string]any) error {
+	return nil
+}
+
+func (e *deadlineCapturingEmitter) Stats() (emitted, failed int64) {
+	return int64(len(e.deadlines)), 0
+}
+
+var _ eventlog.EventEmitter = (*deadlineCapturingEmitter)(nil)
+
+// TestPostApplyAuditCtx_SharedDeadlineAcrossWarnings pins the P2 fix: ONE
+// detached bounded ctx per PostApplyFunc invocation, reused across the
+// success event and every warning event. A success lane carrying W>2
+// warnings must present the SAME deadline to the emitter on all 1+W events —
+// a regression back to per-event ctx scoping would create a distinct
+// deadline per event (and re-open the (1+W)×5s worst-case worker delay after
+// an apply timeout).
+func TestPostApplyAuditCtx_SharedDeadlineAcrossWarnings(t *testing.T) {
+	emitter := &deadlineCapturingEmitter{}
+	rt := core.NewAPIRuntime(&core.APIDeps{EventEmitter: emitter})
+	snapshot := core.NewSnapshotForTesting(rt, core.APIConfig{})
+	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
+	job := &stubControlledJob{}
+
+	organize, err := resolveOrganizeApplyConfig(snapshot, factory, job, contracts.OrganizeRequest{
+		OperationMode: string(operationmode.OperationModeInPlace),
+	})
+	require.NoError(t, err)
+
+	warnings := []string{
+		"force-overwrite: existing destination bytes were destroyed",
+		"duplicate destination within batch: /dest/movie.mp4 already claimed (overwrite authorized)",
+		"partial publish: earlier legs completed before failure",
+	}
+
+	start := time.Now()
+	organize.PostApplyFunc(context.Background(), &worker.ApplyFileContext{
+		FilePath: "/source/movie.mp4",
+		Movie:    &models.Movie{ID: "MOV-48"},
+	}, &worker.ApplyFileResult{Result: &workflow.ApplyResult{
+		OrganizeResult: &organizer.OrganizeResult{NewPath: "/dest/movie.mp4", Warnings: warnings},
+	}})
+
+	require.Len(t, emitter.deadlines, 1+len(warnings), "success event + one event per warning")
+	for i, deadline := range emitter.deadlines[1:] {
+		assert.True(t, deadline.Equal(emitter.deadlines[0]),
+			"event %d deadline %v must be identical to the shared deadline %v", i+1, deadline, emitter.deadlines[0])
+	}
+	// Sanity: the shared budget is the 5s detached budget, not unbounded.
+	assert.False(t, emitter.deadlines[0].Before(start.Add(4*time.Second)), "deadline must be at the ~5s budget, not sooner")
+	assert.False(t, emitter.deadlines[0].After(start.Add(6*time.Second)), "deadline must be bounded (~5s), not unbounded")
 }
 
 // TestPostApplyDetachedAuditCtx_Update pins the update resolver's nfo_gen

--- a/internal/api/batch/apply_config_builder_failure_warnings_w249b_test.go
+++ b/internal/api/batch/apply_config_builder_failure_warnings_w249b_test.go
@@ -1,0 +1,126 @@
+package batch
+
+// PR #249 codex follow-up (F4) — the API organize PostApplyFunc must surface
+// an Err!=nil lane's OrganizeResult.Warnings: the failure event carries them
+// in its context AND each warning gets its own audit entry, exactly like the
+// success lane's duplicate-warning loop. The organizer binds the displacement
+// crumb at the destruction (F2) so failed organize results carry warnings the
+// pre-F4 hook discarded behind the `afr.Err != nil` early-emit/return.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostApplyFailureCarriesWarnings pins the F4 failure-lane warning
+// surface deterministically (synchronous direct PostApplyFunc invocation —
+// the same all-or-nothing async-timing hazard the w241 pin retired).
+func TestPostApplyFailureCarriesWarnings(t *testing.T) {
+	emitter := &applyConfigEventEmitter{}
+	rt := core.NewAPIRuntime(&core.APIDeps{EventEmitter: emitter})
+	snapshot := core.NewSnapshotForTesting(rt, core.APIConfig{})
+	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
+	job := &stubControlledJob{}
+
+	organize, err := resolveOrganizeApplyConfig(snapshot, factory, job, contracts.OrganizeRequest{
+		OperationMode: string(operationmode.OperationModeInPlace),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, organize.PostApplyFunc)
+	require.NotNil(t, organize.ApplyGenerationRef)
+	*organize.ApplyGenerationRef = 33
+
+	warnings := []string{
+		"overwrite authorized: replaced existing destination /dest/movie.mp4",
+		"overwrite authorized: replaced existing destination /dest/subtitle.srt",
+	}
+	applyErr := fmt.Errorf("organization failed: failed to create hard link (source and destination must be on the same filesystem)")
+	organize.PostApplyFunc(context.Background(), &worker.ApplyFileContext{
+		FilePath: "/source/movie.mp4",
+		Movie:    &models.Movie{ID: "MOV-33"},
+	}, &worker.ApplyFileResult{
+		Err: applyErr,
+		Result: &workflow.ApplyResult{
+			OrganizeResult: &organizer.OrganizeResult{
+				NewPath:  "/dest/movie.mp4",
+				Warnings: warnings,
+			},
+		},
+	})
+
+	// One error emit carrying the warnings in its context + one audit emit
+	// per warning, in order.
+	require.Len(t, emitter.calls, 3)
+
+	failure := emitter.calls[0]
+	assert.Equal(t, "file_move", failure.source)
+	assert.Equal(t, models.SeverityError, failure.severity)
+	assert.Contains(t, failure.message, "Organize failed for MOV-33")
+	assert.Equal(t, applyErr.Error(), failure.context["error"])
+	assert.Equal(t, warnings, failure.context["warnings"],
+		"the failure event itself carries the crumbs — no correlation needed")
+	assert.Equal(t, uint64(33), failure.context["apply_generation"])
+
+	for i, warning := range warnings {
+		ev := emitter.calls[1+i]
+		assert.Equal(t, "file_move", ev.source, "warning %d source", i)
+		assert.Equal(t, models.SeverityWarn, ev.severity, "warning %d severity", i)
+		assert.Equal(t, ev.message, fmt.Sprintf("Organize warning for MOV-33: %s", warning), "warning %d message", i)
+		assert.Equal(t, "stub-job", ev.context["job_id"], "warning %d job id", i)
+		assert.Equal(t, "MOV-33", ev.context["movie_id"], "warning %d movie id", i)
+		assert.Equal(t, "/source/movie.mp4", ev.context["file"], "warning %d file", i)
+		assert.Equal(t, "/dest/movie.mp4", ev.context["new_path"], "warning %d new path", i)
+		assert.Equal(t, warning, ev.context["warning"], "warning %d audit payload", i)
+		assert.Equal(t, applyErr.Error(), ev.context["error"], "warning %d failure context", i)
+		assert.Equal(t, uint64(33), ev.context["apply_generation"], "warning %d generation", i)
+	}
+}
+
+// TestPostApplyFailureWithoutWarnings_KeepsSingleSurface pins the unchanged
+// failure lane: no OrganizeResult (or an empty Warnings slice) emits exactly
+// the failure event with no warnings key and zero audit entries.
+func TestPostApplyFailureWithoutWarnings_KeepsSingleSurface(t *testing.T) {
+	emitter := &applyConfigEventEmitter{}
+	rt := core.NewAPIRuntime(&core.APIDeps{EventEmitter: emitter})
+	snapshot := core.NewSnapshotForTesting(rt, core.APIConfig{})
+	factory := worker.NewBatchJobFactory(nil, nil, nil, nil, worker.BatchJobConfig{}, nil)
+	job := &stubControlledJob{}
+
+	organize, err := resolveOrganizeApplyConfig(snapshot, factory, job, contracts.OrganizeRequest{
+		OperationMode: string(operationmode.OperationModeInPlace),
+	})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name   string
+		result *workflow.ApplyResult
+	}{
+		{name: "nil result", result: nil},
+		{name: "empty warnings", result: &workflow.ApplyResult{OrganizeResult: &organizer.OrganizeResult{NewPath: "/dest/movie.mp4"}}},
+		{name: "nil organize result", result: &workflow.ApplyResult{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			emitter.calls = nil
+			organize.PostApplyFunc(context.Background(), &worker.ApplyFileContext{
+				FilePath: "/source/movie.mp4",
+				Movie:    &models.Movie{ID: "MOV-34"},
+			}, &worker.ApplyFileResult{Err: fmt.Errorf("organization failed"), Result: tc.result})
+
+			require.Len(t, emitter.calls, 1, "exactly the failure event")
+			failure := emitter.calls[0]
+			assert.Equal(t, models.SeverityError, failure.severity)
+			assert.NotContains(t, failure.context, "warnings")
+		})
+	}
+}

--- a/internal/api/batch/apply_post_apply.go
+++ b/internal/api/batch/apply_post_apply.go
@@ -1,0 +1,162 @@
+package batch
+
+// Post-apply audit emission: the secondary eventlog rows each apply file
+// result produces (success/failure + one row per warning) and the factories
+// that build the PostApplyFunc hooks the apply phase invokes per file.
+// Split out of apply_config_builder.go to keep it under the API file-size
+// cap (scripts/check_api_file_size.sh) — the reviewer-driven audit additions
+// (detached ctx, shared deadline, canceled checks, per-warning rows) grew it
+// over the 700-line limit.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/eventlog"
+	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker"
+)
+
+// makeOrganizePostApplyAuditHook returns the organize lane's PostApplyFunc:
+// it emits the file's audit rows ("Organized" success or "Organize failed"
+// plus one row per OrganizeResult.Warnings entry) under ONE detached, bounded
+// ctx per invocation (see postApplyAuditEmit for why detachment matters).
+func makeOrganizePostApplyAuditHook(deps *core.APIDeps, job worker.BatchJobInterface, applyGenerationRef *uint64) func(ctx context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
+	return func(_ context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
+		// Guard: never dereference a nil payload. If the apply context or
+		// result is missing required fields, skip emitting this secondary
+		// event so the original apply error is preserved instead of being
+		// masked by a nil-panic here.
+		if afc == nil || afc.Movie == nil || afr == nil {
+			return
+		}
+		emitter := deps.GetEventEmitter()
+		if emitter == nil {
+			return
+		}
+		// One detached bounded ctx per PostApplyFunc invocation, REUSED
+		// across the success/failure event + every warning event (PR #249
+		// codex P2): scoping a fresh 5s ctx PER EVENT would let an organize
+		// result with W warnings sit (1+W)×5s worst-case on a worker
+		// goroutine after an apply timeout. Mirror the CLI hook
+		// (cliBatchPostApply) and the worker history writer: budget once per
+		// file, aggregate all of the file's audit rows under it.
+		auditCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		emit := postApplyAuditEmit(auditCtx, emitter, job.GetID())
+		if afr.Err != nil {
+			// PR #249 codex follow-up (F4): the failed lane's result still
+			// carries the displacement crumbs — the link lane binds the
+			// force-overwrite crumb at the destruction (F2) and the partial-
+			// publish/cross-device legs union their evidence into the failed
+			// result (F3) — so the failure event itself carries the warnings,
+			// and each warning additionally gets its own audit entry exactly
+			// like the success lane below. Consumers must not have to
+			// distinguish outcomes to see that resident bytes were destroyed.
+			var warnings []string
+			var newPath string
+			if afr.Result != nil && afr.Result.OrganizeResult != nil {
+				warnings = afr.Result.OrganizeResult.Warnings
+				newPath = afr.Result.OrganizeResult.NewPath
+			}
+			// PR #249 codex P2 (canceled-error lane): context.Canceled is
+			// checked BEFORE any failure emit. The worker classifies a canceled
+			// apply as Cancelled, NOT failed (apply_phase.go interpretApplyResult:
+			// fileStatus = models.JobStatusCancelled and OnFileFailed is
+			// deliberately NOT invoked), so a SeverityError "Organize failed"
+			// row for a canceled file would mislabel the audit trail — consumers
+			// correlate failed events with erasable/retriable files. Skip it;
+			// mirrors auditOrganizeFailure's canceled skip
+			// (worker/history_writer.go) and the CLI hook (cliBatchPostApply).
+			// The buffered warning events STILL emit: they are truthful evidence
+			// (resident bytes destroyed, partial publish) recorded before the
+			// cancellation landed, and the success-history row the worker writes
+			// for a canceled partial move reads the same Warnings slice.
+			if !errors.Is(afr.Err, context.Canceled) {
+				failCtx := map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)}
+				if len(warnings) > 0 {
+					failCtx["warnings"] = warnings
+				}
+				emit("file_move", fmt.Sprintf("Organize failed for %s", afc.Movie.ID), models.SeverityError, failCtx)
+			}
+			for _, warning := range warnings {
+				emit("file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
+			}
+			return
+		}
+		var newPath string
+		if afr.Result != nil && afr.Result.OrganizeResult != nil {
+			newPath = afr.Result.OrganizeResult.NewPath
+		}
+		emit("file_move", fmt.Sprintf("Organized %s", afc.Movie.ID), models.SeverityInfo, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "apply_generation": loadApplyGeneration(applyGenerationRef)})
+		// #224 phase E: authorized intra-batch duplicates are demoted from
+		// conflicts to per-file warnings; each warning gets its own audit
+		// event via the existing eventlog.
+		if afr.Result != nil && afr.Result.OrganizeResult != nil {
+			for _, warning := range afr.Result.OrganizeResult.Warnings {
+				emit("file_move", fmt.Sprintf("Organize warning for %s: %s", afc.Movie.ID, warning), models.SeverityWarn, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "file": afc.FilePath, "new_path": newPath, "warning": warning, "apply_generation": loadApplyGeneration(applyGenerationRef)})
+			}
+		}
+	}
+}
+
+// makeUpdatePostApplyAuditHook returns the update lane's PostApplyFunc: it
+// emits the "Update failed" audit row (skipped for canceled applies) under a
+// single detached, bounded ctx per invocation.
+func makeUpdatePostApplyAuditHook(deps *core.APIDeps, job worker.BatchJobInterface, applyGenerationRef *uint64) func(ctx context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
+	return func(_ context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
+		// Guard: never dereference a nil payload; skip the secondary event so
+		// the original apply error is preserved.
+		if afc == nil || afc.Movie == nil || afr == nil {
+			return
+		}
+		emitter := deps.GetEventEmitter()
+		if afr.Err != nil && emitter != nil && !errors.Is(afr.Err, context.Canceled) {
+			// canceled check BEFORE the failure emit (PR #249 codex P2,
+			// canceled-error lane): the worker records canceled files as
+			// Cancelled, not failed, so a SeverityError "Update failed" row
+			// would mislabel the audit trail — mirror the organize lane
+			// (makeOrganizePostApplyAuditHook)
+			// and the CLI hook. Same one-ctx-per-invocation shape as the
+			// organize lane (update currently emits a single event, but keep
+			// the pattern uniform so a future per-warning lane inherits the
+			// aggregated budget).
+			auditCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			postApplyAuditEmit(auditCtx, emitter, job.GetID())("nfo_gen", fmt.Sprintf("Update failed for %s", afc.Movie.ID), models.SeverityError, map[string]any{"job_id": job.GetID(), "movie_id": afc.Movie.ID, "error": afr.Err.Error(), "apply_generation": loadApplyGeneration(applyGenerationRef)})
+		}
+	}
+}
+
+// postApplyAuditEmit returns an emit closure that forwards organize audit
+// events to the shared eventlog on the caller-supplied DETACHED, bounded
+// auditCtx. The caller (a PostApplyFunc invocation) allocates that ctx ONCE
+// and reuses it across the file's success/failure event plus every warning
+// event, so a result with W warnings costs ONE 5s budget worst-case, not
+// (1+W) — the same aggregation shape as the worker's history writer
+// (worker/history_writer.go historyAuditContext) and the CLI hook
+// (commandutil/batch_command.go cliBatchPostApply).
+//
+// Detachment is required: the apply phase invokes PostApplyFunc via
+// interpretApplyResult with the per-file task ctx, which is ALREADY expired
+// when apply exhausts WorkerTimeout, and eventlog.emit drops events on a
+// canceled ctx (emitter.go checks ctx.Err()). Routing the passed task ctx
+// through here meant a timed-out apply lost its failure/warning audit rows
+// entirely, while the worker's history writer still recorded the outcome
+// because it audits with a fresh bounded ctx. A 5s background-timeout context
+// keeps the audit writes bounded without blocking the apply pipeline.
+//
+// Emission failures are Warn-logged, not silently discarded (mirroring the
+// CLI hook), so a persist-level outage surfaces in the logs instead of
+// vanishing.
+func postApplyAuditEmit(auditCtx context.Context, emitter eventlog.EventEmitter, jobID string) func(source, message string, severity models.EventSeverity, eventCtx map[string]any) {
+	return func(source, message string, severity models.EventSeverity, eventCtx map[string]any) {
+		if err := emitter.EmitOrganizeEvent(auditCtx, source, message, severity, eventCtx); err != nil {
+			logging.Warnf("[api batch %s] eventlog audit emission failed (source=%s, severity=%s, message=%q): %v", jobID, source, severity, message, err)
+		}
+	}
+}

--- a/internal/api/batch/apply_post_apply_nil_guards_test.go
+++ b/internal/api/batch/apply_post_apply_nil_guards_test.go
@@ -1,0 +1,46 @@
+package batch
+
+// Pins the nil-payload guards at the head of both post-apply audit hooks
+// (apply_post_apply.go makeOrganizePostApplyAuditHook /
+// makeUpdatePostApplyAuditHook): a nil ApplyFileContext, a context missing
+// Movie, or a nil ApplyFileResult must return WITHOUT panicking and WITHOUT
+// emitting any audit row, so the original apply error is never masked by a
+// nil-panic in the secondary-event lane. Sibling of the detached-ctx pins in
+// apply_config_builder_detached_audit_ctx_test.go; reuses its recording
+// ctxEnforcingEmitter.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostApplyAuditHook_NilGuards(t *testing.T) {
+	validAFC := &worker.ApplyFileContext{FilePath: "/f.mp4", Movie: &models.Movie{ID: "MOV-1"}}
+	validAFR := &worker.ApplyFileResult{}
+	cases := []struct {
+		name string
+		afc  *worker.ApplyFileContext
+		afr  *worker.ApplyFileResult
+	}{{"nil afc", nil, validAFR}, {"nil movie", &worker.ApplyFileContext{}, validAFR}, {"nil afr", validAFC, nil}}
+	gen := uint64(7)
+	for _, lane := range []string{"organize", "update"} {
+		for _, tc := range cases {
+			t.Run(lane+"/"+tc.name, func(t *testing.T) {
+				emitter := &ctxEnforcingEmitter{}
+				deps := &core.APIDeps{EventEmitter: emitter}
+				hook := makeOrganizePostApplyAuditHook(deps, &stubControlledJob{}, &gen)
+				if lane == "update" {
+					hook = makeUpdatePostApplyAuditHook(deps, &stubControlledJob{}, &gen)
+				}
+				assert.NotPanics(t, func() { hook(context.Background(), tc.afc, tc.afr) })
+				assert.Empty(t, emitter.calls, "nil guard must skip all audit emits")
+				assert.Empty(t, emitter.drops)
+			})
+		}
+	}
+}

--- a/internal/commandutil/batch_canceled_w249_test.go
+++ b/internal/commandutil/batch_canceled_w249_test.go
@@ -1,0 +1,108 @@
+package commandutil
+
+// PR #249 codex P2 — canceled-error lane, CLI equivalent of the API resolvers'
+// suppression (internal/api/batch/apply_config_builder_canceled_w249_test.go).
+// interpretApplyResult (worker/apply_phase.go) records an apply error matching
+// errors.Is(err, context.Canceled) as Cancelled, NOT failed, so the CLI hook
+// must not persist an "Organize failed"/"Update failed" SeverityError row for
+// it — the audit trail would mislabel a cancelled item as a retriable failure.
+// Buffered warnings STILL surface (console AND eventlog): they are truthful
+// evidence of work done before the cancellation landed.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCliBatchPostApply_CanceledApplyError_NoFailureEvent_WarningsStillRecorded
+// pins the organize-mode canceled lane: no failure event, the buffered warning
+// still gets its own audit row, and the console line still prints — the crumb
+// must reach every surface that a real failure would have told.
+func TestCliBatchPostApply_CanceledApplyError_NoFailureEvent_WarningsStillRecorded(t *testing.T) {
+	var (
+		emitter   = &recordingEmitter{}
+		buf       bytes.Buffer
+		skipCount = &atomic.Int64{}
+	)
+	hook := cliBatchPostApply(emitter, &buf, "job-cancel-1", false, false, skipCount, &sync.Mutex{})
+
+	warning := "overwrite authorized: replaced existing destination /dest/GOOD-701/GOOD-701.mp4"
+	hook(context.Background(),
+		&worker.ApplyFileContext{FilePath: filepath.Join("src", "GOOD-701.mp4"), Movie: &models.Movie{ID: "GOOD-701"}},
+		&worker.ApplyFileResult{
+			Err: fmt.Errorf("organization aborted: %w", context.Canceled),
+			Result: &workflow.ApplyResult{OrganizeResult: &organizer.OrganizeResult{
+				NewPath:  filepath.Join("dest", "GOOD-701", "GOOD-701.mp4"),
+				Warnings: []string{warning},
+			}},
+		},
+	)
+
+	events := emitter.snapshot()
+	require.Len(t, events, 1, "exactly the warning event — cancellation suppresses the failure event")
+	assert.Equal(t, models.SeverityWarn, events[0].Severity, "canceled applies never produce SeverityError rows")
+	assert.Equal(t, "file_move", events[0].Source)
+	assert.Contains(t, events[0].Message, warning)
+	assert.Zero(t, skipCount.Load(), "a canceled lane never claimed a duplicate skip")
+	assert.Contains(t, buf.String(), "⚠️")
+	assert.Contains(t, buf.String(), warning, "the console warning surface still fires on the canceled lane")
+}
+
+// TestCliBatchPostApply_CanceledApplyError_NoCrumbs_NoEvents pins the
+// organize-mode canceled lane with no result payload: the hook persists
+// nothing at all — no failure event to mislabel the Cancelled file.
+func TestCliBatchPostApply_CanceledApplyError_NoCrumbs_NoEvents(t *testing.T) {
+	var (
+		emitter = &recordingEmitter{}
+		buf     bytes.Buffer
+	)
+	hook := cliBatchPostApply(emitter, &buf, "job-cancel-2", false, false, &atomic.Int64{}, &sync.Mutex{})
+
+	hook(context.Background(),
+		&worker.ApplyFileContext{FilePath: "x", Movie: &models.Movie{ID: "GOOD-702"}},
+		&worker.ApplyFileResult{Err: context.Canceled},
+	)
+
+	assert.Empty(t, emitter.snapshot(), "a canceled apply with no crumbs persists nothing")
+	assert.Empty(t, buf.String())
+}
+
+// TestCliBatchPostApply_CanceledApplyError_UpdateMode_NoEvents pins the
+// update-mode canceled lane: same taxonomy, nfo_gen vocabulary stays silent —
+// the worker's Cancelled status is the only truth. The control invocation
+// re-asserts that a real update failure still lands its failure event.
+func TestCliBatchPostApply_CanceledApplyError_UpdateMode_NoEvents(t *testing.T) {
+	var (
+		emitter = &recordingEmitter{}
+		buf     bytes.Buffer
+	)
+	hook := cliBatchPostApply(emitter, &buf, "job-cancel-3", false, true, &atomic.Int64{}, &sync.Mutex{})
+
+	hook(context.Background(),
+		&worker.ApplyFileContext{FilePath: "x", Movie: &models.Movie{ID: "GOOD-703"}},
+		&worker.ApplyFileResult{Err: fmt.Errorf("update aborted: %w", context.Canceled)},
+	)
+	assert.Empty(t, emitter.snapshot(), "a canceled update persists no failure row")
+
+	hook(context.Background(),
+		&worker.ApplyFileContext{FilePath: "y", Movie: &models.Movie{ID: "GOOD-704"}},
+		&worker.ApplyFileResult{Err: fmt.Errorf("update failed: nfo write error")},
+	)
+	events := emitter.snapshot()
+	require.Len(t, events, 1, "real update failures still land the failure event")
+	assert.Equal(t, models.SeverityError, events[0].Severity)
+	assert.Equal(t, "nfo_gen", events[0].Source)
+	assert.Contains(t, events[0].Message, "Update failed for GOOD-704")
+}

--- a/internal/commandutil/batch_command.go
+++ b/internal/commandutil/batch_command.go
@@ -589,13 +589,21 @@ func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string,
 		if afc == nil || afc.Movie == nil || afr == nil {
 			return
 		}
-		// Skip accounting + warning print run before the dry-run gate (see
-		// the doc comment); a failed apply keeps failures' single surface —
-		// no warning double-print on the error path.
+		// Warning collection + console print run for BOTH outcomes before the
+		// dry-run gate (see the doc comment): a failed lane's result still
+		// carries the displacement crumbs — the link lane binds the
+		// force-overwrite crumb at the destruction (PR #249 codex follow-up
+		// F2), and the failed OrganizeResult flows through the publish-
+		// completed partial lineage — so the crumb must surface on Err!=nil
+		// lanes too (F4): console print here, per-warning eventlog entries on
+		// the failure branch below, and the worker history metadata (the
+		// failure row's organizeMetadata reads the same Warnings slice). Only
+		// skip ACCOUNTING stays success-gated — a failed lane never claimed a
+		// duplicate skip.
 		var warnings []string
-		if afr.Err == nil && afr.Result != nil && afr.Result.OrganizeResult != nil {
+		if afr.Result != nil && afr.Result.OrganizeResult != nil {
 			warnings = afr.Result.OrganizeResult.Warnings
-			if afr.Result.OrganizeResult.DuplicateSkipped {
+			if afr.Err == nil && afr.Result.OrganizeResult.DuplicateSkipped {
 				skipCount.Add(1)
 			}
 		}
@@ -631,7 +639,18 @@ func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string,
 			warningVerb = "Update warning"
 		}
 		if afr.Err != nil {
-			emit(source, fmt.Sprintf("%s for %s", failureVerb, afc.Movie.ID), models.SeverityError, map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "error": afr.Err.Error()})
+			failCtx := map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "error": afr.Err.Error()}
+			if len(warnings) > 0 {
+				// The failed lane's crumbs ride the failure event's context
+				// too — the eventlog consumer sees the displacement disclosure
+				// without having to correlate the warning events that follow.
+				failCtx["warnings"] = warnings
+			}
+			emit(source, fmt.Sprintf("%s for %s", failureVerb, afc.Movie.ID), models.SeverityError, failCtx)
+			for _, warning := range warnings {
+				warnCtx := map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "file": afc.FilePath, "warning": warning, "error": afr.Err.Error()}
+				emit(source, fmt.Sprintf("%s for %s: %s", warningVerb, afc.Movie.ID, warning), models.SeverityWarn, warnCtx)
+			}
 			return
 		}
 		var newPath string

--- a/internal/commandutil/batch_command.go
+++ b/internal/commandutil/batch_command.go
@@ -582,6 +582,14 @@ func newCLIBatchRuntime(bs *bootstrapResult, cfg *config.Config, opts BatchComma
 // bounded ctx (worker/history_writer.go historyAuditContext). Mirror that
 // pattern here, and log loudly if emission STILL fails instead of discarding
 // the error.
+//
+// Cancellation is NOT a failure (PR #249 codex P2, canceled-error lane): the
+// worker classifies a canceled apply as Cancelled, not failed
+// (worker/apply_phase.go interpretApplyResult), so the failure event is
+// suppressed when errors.Is(err, context.Canceled) — mirroring
+// auditOrganizeFailure's canceled skip (worker/history_writer.go) and the API
+// resolvers' PostApplyFunc. Buffered warning events still emit on the canceled
+// lane: they are truthful evidence of work done before cancellation landed.
 func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string, dryRun, updateMode bool, skipCount *atomic.Int64, printMu *sync.Mutex) func(context.Context, *worker.ApplyFileContext, *worker.ApplyFileResult) {
 	return func(_ context.Context, afc *worker.ApplyFileContext, afr *worker.ApplyFileResult) {
 		// Guard matches the API resolver: never deref a nil payload; the hook
@@ -639,14 +647,21 @@ func cliBatchPostApply(emitter eventlog.EventEmitter, w io.Writer, jobID string,
 			warningVerb = "Update warning"
 		}
 		if afr.Err != nil {
-			failCtx := map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "error": afr.Err.Error()}
-			if len(warnings) > 0 {
-				// The failed lane's crumbs ride the failure event's context
-				// too — the eventlog consumer sees the displacement disclosure
-				// without having to correlate the warning events that follow.
-				failCtx["warnings"] = warnings
+			// Suppress the failure event on cancellation (see the doc
+			// comment) — the canceled check must run BEFORE the failure emit;
+			// the per-warning events below still land because the crumbs are
+			// truthful evidence regardless of whether the apply was completed,
+			// failed, or canceled.
+			if !errors.Is(afr.Err, context.Canceled) {
+				failCtx := map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "error": afr.Err.Error()}
+				if len(warnings) > 0 {
+					// The failed lane's crumbs ride the failure event's context
+					// too — the eventlog consumer sees the displacement disclosure
+					// without having to correlate the warning events that follow.
+					failCtx["warnings"] = warnings
+				}
+				emit(source, fmt.Sprintf("%s for %s", failureVerb, afc.Movie.ID), models.SeverityError, failCtx)
 			}
-			emit(source, fmt.Sprintf("%s for %s", failureVerb, afc.Movie.ID), models.SeverityError, failCtx)
 			for _, warning := range warnings {
 				warnCtx := map[string]any{"job_id": jobID, "movie_id": afc.Movie.ID, "file": afc.FilePath, "warning": warning, "error": afr.Err.Error()}
 				emit(source, fmt.Sprintf("%s for %s: %s", warningVerb, afc.Movie.ID, warning), models.SeverityWarn, warnCtx)

--- a/internal/commandutil/batch_failure_warnings_w249b_test.go
+++ b/internal/commandutil/batch_failure_warnings_w249b_test.go
@@ -1,0 +1,113 @@
+package commandutil
+
+// PR #249 codex follow-up (F4) — the CLI post-apply hook must surface an
+// Err!=nil lane's OrganizeResult.Warnings on EVERY consumer: the console
+// print, one eventlog entry per warning, and the failure event's context.
+// The organizer now binds the force-overwrite displacement crumb at the
+// destruction (F2) so failed organize results carry warnings the pre-F4 hook
+// dropped behind its `afr.Err == nil` gate.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCliBatchPostApply_ApplyErrorWithWarnings_SurfacesEverywhere pins the
+// failure-lane warning surface: a failed apply whose OrganizeResult carries
+// the displacement crumb emits the failure event (with the warnings folded
+// into its context), one warning event per entry, and the console print.
+func TestCliBatchPostApply_ApplyErrorWithWarnings_SurfacesEverywhere(t *testing.T) {
+	var (
+		emitter   = &recordingEmitter{}
+		buf       bytes.Buffer
+		skipCount = &atomic.Int64{}
+	)
+	hook := cliBatchPostApply(emitter, &buf, "job-1", false, false, skipCount, &sync.Mutex{})
+
+	warning := "overwrite authorized: replaced existing destination /dest/GOOD-700/GOOD-700.mp4"
+	hook(context.Background(),
+		&worker.ApplyFileContext{FilePath: filepath.Join("src", "GOOD-700.mp4"), Movie: &models.Movie{ID: "GOOD-700"}},
+		&worker.ApplyFileResult{
+			Err: fmt.Errorf("organization failed: failed to create hard link: cross-device"),
+			Result: &workflow.ApplyResult{
+				OrganizeResult: &organizer.OrganizeResult{
+					NewPath:  filepath.Join("dest", "GOOD-700", "GOOD-700.mp4"),
+					Warnings: []string{warning},
+				},
+			},
+		},
+	)
+
+	events := emitter.snapshot()
+	require.Len(t, events, 2, "failure event + one warning event per crumb entry")
+	assert.Equal(t, models.SeverityError, events[0].Severity)
+	assert.Equal(t, "file_move", events[0].Source)
+	assert.Contains(t, events[0].Message, "Organize failed for GOOD-700")
+	assert.Equal(t, models.SeverityWarn, events[1].Severity)
+	assert.Equal(t, "file_move", events[1].Source)
+	assert.Equal(t, events[1].Message, "Organize warning for GOOD-700: "+warning)
+	assert.Contains(t, buf.String(), "⚠️", "the failed lane's crumb prints to the console too")
+	assert.Contains(t, buf.String(), warning)
+	assert.Zero(t, skipCount.Load(), "a failed lane never claims the duplicate-skip accounting")
+}
+
+// TestCliBatchPostApply_ApplyErrorNilResult_StaysQuiet pins the failure lane
+// that carries NO result: exactly the failure event, no prints, unchanged
+// from the pre-F4 single-surface discipline.
+func TestCliBatchPostApply_ApplyErrorNilResult_StaysQuiet(t *testing.T) {
+	var (
+		emitter = &recordingEmitter{}
+		buf     bytes.Buffer
+	)
+	hook := cliBatchPostApply(emitter, &buf, "job-1", false, false, &atomic.Int64{}, &sync.Mutex{})
+
+	hook(context.Background(),
+		&worker.ApplyFileContext{FilePath: "x", Movie: &models.Movie{ID: "GOOD-700"}},
+		&worker.ApplyFileResult{Err: fmt.Errorf("disk full"), Result: &workflow.ApplyResult{}},
+	)
+
+	events := emitter.snapshot()
+	require.Len(t, events, 1, "a failure without warnings keeps failures' single surface")
+	assert.Equal(t, models.SeverityError, events[0].Severity)
+	assert.Empty(t, buf.String())
+}
+
+// TestCliBatchPostApply_UpdateModeApplyErrorWithWarnings_SurfacesEverywhere
+// pins the update taxonomy on the failure lane: same crumb surfacing with
+// the nfo_gen source + "Update warning" vocabulary.
+func TestCliBatchPostApply_UpdateModeApplyErrorWithWarnings_SurfacesEverywhere(t *testing.T) {
+	var (
+		emitter = &recordingEmitter{}
+		buf     bytes.Buffer
+	)
+	hook := cliBatchPostApply(emitter, &buf, "job-1", false, true, &atomic.Int64{}, &sync.Mutex{})
+
+	warning := "overwrite authorized: replaced existing destination /dest/GOOD-700/GOOD-700.mp4"
+	hook(context.Background(),
+		&worker.ApplyFileContext{FilePath: "x", Movie: &models.Movie{ID: "GOOD-700"}},
+		&worker.ApplyFileResult{
+			Err:    fmt.Errorf("apply timed out"),
+			Result: &workflow.ApplyResult{OrganizeResult: &organizer.OrganizeResult{Warnings: []string{warning}}},
+		},
+	)
+
+	events := emitter.snapshot()
+	require.Len(t, events, 2)
+	assert.Equal(t, "nfo_gen", events[0].Source, "update mode keeps the nfo_gen taxonomy")
+	assert.Contains(t, events[0].Message, "Update failed for GOOD-700")
+	assert.Equal(t, "nfo_gen", events[1].Source)
+	assert.Equal(t, events[1].Message, "Update warning for GOOD-700: "+warning)
+	assert.Contains(t, buf.String(), warning)
+}

--- a/internal/commandutil/sort_force_overwrite_audit_test.go
+++ b/internal/commandutil/sort_force_overwrite_audit_test.go
@@ -1,0 +1,228 @@
+package commandutil
+
+// Force-overwrite audit crumb through the CLI batch seam: `sort -f` moving a
+// file onto a pre-seeded (bytes-bearing) destination must surface the
+// "overwrite authorized: replaced existing destination <path>" warning on
+// EVERY audit surface the authenticated API flow gets — the console per-file
+// warning (same rendering as the dup warnings), one eventlog organize/warn
+// entry, the organize history row's warnings metadata, and the revert ledger
+// keeps naming the real destination. The negative leg pins the authorized
+// intra-batch duplicate SKIP against double-warns: pre-seeding the shared
+// destination gives the loser's plan BOTH warning signals (occupation + dup),
+// yet the skipped loser must carry ONLY the dup demotion.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// forceCrumbPrefix is the audit message stem the organizer composes
+// ("overwrite authorized: replaced existing destination <path>").
+const forceCrumbPrefix = "overwrite authorized: replaced existing destination"
+
+// warningLines collects the per-file warning lines the CLI printed.
+func warningLines(out string) []string {
+	var lines []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "⚠️") {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// TestRunBatchCommand_ForceOverwriteOccupiedDest_PersistsAuditCrumb is the
+// positive pin: sort -f onto a destination already holding resident bytes.
+func TestRunBatchCommand_ForceOverwriteOccupiedDest_PersistsAuditCrumb(t *testing.T) {
+	configPath, src, dest, dbPath := setupSingleFileBatch(t, "GOOD-703")
+
+	// Pre-seed the computed destination with resident bytes; -f authorizes
+	// replacing them, and the replacement must be auditable.
+	targetPath := filepath.Join(dest, "GOOD-703", "GOOD-703.mp4")
+	require.NoError(t, os.MkdirAll(filepath.Dir(targetPath), 0o700))
+	require.NoError(t, os.WriteFile(targetPath, []byte("resident bytes"), 0o600))
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:        configPath,
+		SourcePath:        src,
+		Destination:       dest,
+		Recursive:         true,
+		MoveFiles:         true,
+		ForceUpdate:       true, // -f authorizes the overwrite
+		GenerateNFO:       true,
+		CommandLabel:      "Javinizer Sort",
+		ActionVerb:        "Processing files",
+		CompletionMessage: "Sort complete!",
+		Resolved:          &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	batchID := batchIDFromOutput(t, out)
+
+	// Console: the per-file warning prints exactly like the dup warnings.
+	assert.Contains(t, out, "⚠️", "the overwrite warning must print to the console\n%s", out)
+	assert.Contains(t, out, forceCrumbPrefix, "crumb text must survive to the console\n%s", out)
+	assert.Contains(t, out, targetPath, "the crumb names the replaced destination\n%s", out)
+	assert.NotContains(t, out, "duplicate destination within batch",
+		"a single-file run has no intra-batch duplicate\n%s", out)
+
+	// Journal evidence: the destination now carries the source's bytes; the
+	// source moved; the revert ledger row names the real (replaced) target.
+	content, readErr := os.ReadFile(targetPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "fake video", string(content), "resident bytes were replaced")
+	_, statErr := os.Stat(filepath.Join(src, "GOOD-703.mp4"))
+	assert.True(t, os.IsNotExist(statErr), "the source moved")
+
+	ctx := context.Background()
+	db := openAssertionDB(t, dbPath)
+	repos := db.Repositories()
+
+	ops, err := repos.BatchFileOpRepo.FindByBatchJobID(ctx, batchID)
+	require.NoError(t, err)
+	require.Len(t, ops, 1, "one journaled operation")
+	assert.Equal(t, models.RevertStatusApplied, ops[0].RevertStatus)
+	assert.Equal(t, targetPath, ops[0].NewPath, "the ledger row names the replaced destination")
+
+	// History: the organize row's warnings metadata carries the crumb.
+	rows, err := repos.HistoryRepo.FindByBatchJobID(ctx, batchID)
+	require.NoError(t, err)
+	crumbRows, dupRows := 0, 0
+	for _, h := range rows {
+		if h.Operation == models.HistoryOpOrganize && h.Status == models.HistoryStatusSuccess && h.Metadata != "" {
+			if strings.Contains(h.Metadata, forceCrumbPrefix) {
+				crumbRows++
+			}
+			if strings.Contains(h.Metadata, "duplicate destination within batch") {
+				dupRows++
+			}
+		}
+	}
+	assert.Equal(t, 1, crumbRows, "the organize history row carries the crumb in its warnings metadata")
+	assert.Zero(t, dupRows, "no batch-duplicate warning in a single-file run")
+
+	// Eventlog: one organize/warn audit entry with the force message.
+	events, err := repos.EventRepo.FindFiltered(ctx, database.EventFilter{
+		EventType: models.EventCategoryOrganize,
+		Severity:  models.SeverityWarn,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Len(t, events, 1, "exactly one warn event — the crumb")
+	assert.Contains(t, events[0].Message, forceCrumbPrefix)
+	assert.Contains(t, events[0].Message, targetPath)
+}
+
+// TestRunBatchCommand_ForceDuplicateOntoOccupied_NoDoubleWarn is the
+// negative pin: an AUTHORIZED intra-batch duplicate whose shared destination
+// was ALSO pre-seeded gets both warning signals on its plan — the skipped
+// loser must carry ONLY the dup demotion warning (the overwrite crumb belongs
+// to the winner, whose bytes actually replaced the occupant).
+func TestRunBatchCommand_ForceDuplicateOntoOccupied_NoDoubleWarn(t *testing.T) {
+	configPath, src, dest, dbPath := setupDuplicateBatch(t)
+
+	// Pre-seed the shared destination both files compute (<dest>/GOOD-700/
+	// GOOD-700.mp4): the winner force-replaces it; the loser skips as an
+	// authorized duplicate of the now-occupied destination.
+	targetPath := filepath.Join(dest, "GOOD-700", "GOOD-700.mp4")
+	require.NoError(t, os.MkdirAll(filepath.Dir(targetPath), 0o700))
+	require.NoError(t, os.WriteFile(targetPath, []byte("resident bytes"), 0o600))
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:        configPath,
+		SourcePath:        src,
+		Destination:       dest,
+		Recursive:         true,
+		MoveFiles:         true,
+		ForceUpdate:       true,
+		GenerateNFO:       true,
+		CommandLabel:      "Javinizer Sort",
+		ActionVerb:        "Processing files",
+		CompletionMessage: "Sort complete!",
+		Resolved:          &workflow.ResolvedSeamStrings{},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	batchID := batchIDFromOutput(t, out)
+
+	// Console: exactly two per-file warnings — one crumb (winner), one dup
+	// (loser); no line carries both, and the loser's line warns ONCE.
+	warns := warningLines(out)
+	require.Len(t, warns, 2, "winner crumb + loser dup warning, nothing doubled\n%s", out)
+	var crumbLines, dupLines int
+	for _, line := range warns {
+		hasCrumb := strings.Contains(line, forceCrumbPrefix)
+		hasDup := strings.Contains(line, "duplicate destination within batch")
+		assert.False(t, hasCrumb && hasDup, "no single file carries both warnings: %s", line)
+		if hasCrumb {
+			crumbLines++
+		}
+		if hasDup {
+			dupLines++
+		}
+	}
+	assert.Equal(t, 1, crumbLines, "exactly one overwrite crumb (the winner)")
+	assert.Equal(t, 1, dupLines, "exactly one dup warning (the skipped loser — no double-warn)")
+
+	// The destination carries one of the batch files' bytes, never the
+	// pre-seeded resident's.
+	content, readErr := os.ReadFile(targetPath)
+	require.NoError(t, readErr)
+	assert.Contains(t, []string{"fake video a", "fake video b"}, string(content),
+		"the winner replaced the resident bytes")
+
+	ctx := context.Background()
+	db := openAssertionDB(t, dbPath)
+	repos := db.Repositories()
+
+	// Eventlog: exactly two warn entries — the winner's crumb and the loser's
+	// dup warning; the loser did NOT also emit a crumb.
+	events, err := repos.EventRepo.FindFiltered(ctx, database.EventFilter{
+		EventType: models.EventCategoryOrganize,
+		Severity:  models.SeverityWarn,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Len(t, events, 2, "one warn event per warning, none doubled")
+	var crumbEvents, dupEvents int
+	for _, ev := range events {
+		if strings.Contains(ev.Message, forceCrumbPrefix) {
+			crumbEvents++
+		}
+		if strings.Contains(ev.Message, "duplicate destination within batch") {
+			dupEvents++
+		}
+	}
+	assert.Equal(t, 1, crumbEvents)
+	assert.Equal(t, 1, dupEvents)
+
+	// History: two successful organize rows. The winner's warnings metadata
+	// carries ONLY the crumb; the skipped loser's carries ONLY the dup
+	// demotion — the double-signal plan did not double-warn.
+	rows, err := repos.HistoryRepo.FindByBatchJobID(ctx, batchID)
+	require.NoError(t, err)
+	var organizeSuccesses int
+	for _, h := range rows {
+		if h.Operation != models.HistoryOpOrganize || h.Status != models.HistoryStatusSuccess {
+			continue
+		}
+		organizeSuccesses++
+		hasCrumb := strings.Contains(h.Metadata, forceCrumbPrefix)
+		hasDup := strings.Contains(h.Metadata, "duplicate destination within batch")
+		assert.False(t, hasCrumb && hasDup,
+			"no history row may carry both warnings (double-warn): %s", h.Metadata)
+		assert.True(t, hasCrumb || hasDup,
+			"every organize success row carries exactly one warning: %s", h.Metadata)
+	}
+	assert.Equal(t, 2, organizeSuccesses, "winner + skipped loser rows")
+}

--- a/internal/commandutil/sort_force_overwrite_audit_test.go
+++ b/internal/commandutil/sort_force_overwrite_audit_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/javinizer/javinizer-go/internal/database"
 	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
 	"github.com/javinizer/javinizer-go/internal/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -225,4 +226,79 @@ func TestRunBatchCommand_ForceDuplicateOntoOccupied_NoDoubleWarn(t *testing.T) {
 			"every organize success row carries exactly one warning: %s", h.Metadata)
 	}
 	assert.Equal(t, 2, organizeSuccesses, "winner + skipped loser rows")
+}
+
+// TestRunBatchCommand_ForceHardlinkOntoOccupiedDest_PersistsAuditCrumb pins
+// the P3 link lane through the full CLI seam: `sort -f --hardlink` onto a
+// destination already holding resident bytes must surface the same overwrite
+// crumb on every audit surface — an authorized LINK install replaces resident
+// bytes at the destination exactly like a move/copy leg.
+func TestRunBatchCommand_ForceHardlinkOntoOccupiedDest_PersistsAuditCrumb(t *testing.T) {
+	configPath, src, dest, dbPath := setupSingleFileBatch(t, "GOOD-705")
+
+	targetPath := filepath.Join(dest, "GOOD-705", "GOOD-705.mp4")
+	require.NoError(t, os.MkdirAll(filepath.Dir(targetPath), 0o700))
+	require.NoError(t, os.WriteFile(targetPath, []byte("resident bytes"), 0o600))
+
+	var buf bytes.Buffer
+	err := RunBatchCommand(context.Background(), &buf, BatchCommandOptions{
+		ConfigFile:        configPath,
+		SourcePath:        src,
+		Destination:       dest,
+		Recursive:         true,
+		MoveFiles:         false,
+		ForceUpdate:       true,
+		GenerateNFO:       true,
+		CommandLabel:      "Javinizer Sort",
+		ActionVerb:        "Processing files",
+		CompletionMessage: "Sort complete!",
+		Resolved:          &workflow.ResolvedSeamStrings{LinkMode: organizer.LinkModeHard},
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	batchID := batchIDFromOutput(t, out)
+
+	// Console: exactly one per-file warning — the link-install overwrite crumb.
+	assert.Contains(t, out, "⚠️", "the overwrite warning must print to the console\n%s", out)
+	assert.Contains(t, out, forceCrumbPrefix, "crumb text must survive to the console\n%s", out)
+	assert.Contains(t, out, targetPath, "the crumb names the replaced destination\n%s", out)
+	assert.Len(t, warningLines(out), 1, "exactly one warning line — the link lane does not double-warn\n%s", out)
+
+	// Journal evidence: the destination now aliases the source (link install
+	// replaced the resident entry); a hardlink retains its source.
+	content, readErr := os.ReadFile(targetPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "fake video", string(content), "resident bytes were replaced by the link install")
+	srcInfo, statErr := os.Stat(filepath.Join(src, "GOOD-705.mp4"))
+	require.NoError(t, statErr, "a hardlink retains its source")
+	dstInfo, statErr := os.Stat(targetPath)
+	require.NoError(t, statErr)
+	assert.True(t, os.SameFile(srcInfo, dstInfo), "destination aliases the source's inode after install")
+
+	ctx := context.Background()
+	db := openAssertionDB(t, dbPath)
+	repos := db.Repositories()
+
+	// Eventlog: one organize/warn audit entry with the crumb.
+	events, err := repos.EventRepo.FindFiltered(ctx, database.EventFilter{
+		EventType: models.EventCategoryOrganize,
+		Severity:  models.SeverityWarn,
+	}, 50, 0)
+	require.NoError(t, err)
+	require.Len(t, events, 1, "exactly one warn event — the link-install crumb")
+	assert.Contains(t, events[0].Message, forceCrumbPrefix)
+	assert.Contains(t, events[0].Message, targetPath)
+
+	// History: the organize row's warnings metadata carries the crumb.
+	rows, err := repos.HistoryRepo.FindByBatchJobID(ctx, batchID)
+	require.NoError(t, err)
+	crumbRows := 0
+	for _, h := range rows {
+		if h.Operation == models.HistoryOpOrganize && h.Status == models.HistoryStatusSuccess && h.Metadata != "" {
+			if strings.Contains(h.Metadata, forceCrumbPrefix) {
+				crumbRows++
+			}
+		}
+	}
+	assert.Equal(t, 1, crumbRows, "the organize history row carries the crumb in its warnings metadata")
 }

--- a/internal/fsutil/move.go
+++ b/internal/fsutil/move.go
@@ -51,7 +51,11 @@ func MoveFileFs(fs afero.Fs, src, dst string) error {
 // same-device leg probes one syscall ahead of the inline rename (a rename
 // publishes THE object src names — including a symlink object itself — so the
 // source identity rides the same no-follow probe, never a chased Stat); the
-// cross-device fallback inherits the staged publish's bound signal instead.
+// cross-device fallback inherits the staged publish's bound signal instead —
+// and on the fallback's ErrPublishCompleted leg (publish landed, source
+// cleanup refused) the bound signal rides ALONGSIDE the error, so callers
+// keying an audit crumb on it never lose the displacement evidence with the
+// partial publish.
 func MoveFileFsDestReplaced(fs afero.Fs, src, dst string) (destReplaced bool, err error) {
 	if err := fs.MkdirAll(filepath.Dir(dst), config.DirPerm); err != nil {
 		return false, fmt.Errorf("failed to create destination directory: %w", err)
@@ -61,6 +65,39 @@ func MoveFileFsDestReplaced(fs afero.Fs, src, dst string) (destReplaced bool, er
 		return false, nil
 	}
 
+	// Probe-adjacency adjudication (PR #249 codex P2 — the rename-atomicity
+	// thread): the occupancy probe runs ONE syscall ahead of the rename it
+	// audits, and NO construction available through this Fs abstraction closes
+	// that window:
+	//   - POSIX rename(2) replaces ATOMICALLY but SILENTLY — it reports nothing
+	//     about the displaced occupant, so no post-hoc kernel answer exists;
+	//   - Linux renameat2 offers RENAME_NOREPLACE (an atomic REFUSAL, already
+	//     the no-replace primitive in publish_noreplace_linux.go) and
+	//     RENAME_EXCHANGE — the only kernel-exact displacement detector (the
+	//     old occupant lands on src after the swap) — but it is Linux-only
+	//     (Darwin's renamex_np(RENAME_SWAP) is a separate island x/sys exposes
+	//     no wrapper for, the BSDs have no exchange primitive, Windows
+	//     MoveFileEx has none at all), unreachable through afero's Fs.Rename
+	//     for wrapper filesystems, and it leaves FOREIGN BYTES on the source
+	//     name until a second syscall removes them — a new window in which the
+	//     operator's source path addresses foreign content, which this
+	//     lineage's keep-both invariants (#224) forbid;
+	//   - a hardlink-snapshot dance (link(2) the occupant aside, rename,
+	//     compare) keeps the SAME two-syscall adjacency window as the probe,
+	//     requires hardlink support rename-only volumes (exFAT) lack, and
+	//     plants a visible extra entry in the destination directory — strictly
+	//     worse on every axis;
+	// so the publish-adjacent no-follow probe with alias exclusion IS the
+	// accuracy ceiling. Identity of the LANDED object needs no reverify on
+	// this leg: rename(2) moves the source dentry itself, so a successful
+	// rename leaves dst naming exactly the object src named at the rename
+	// instant, kernel-guaranteed (unlike the staged legs, whose publish
+	// re-resolves a substitutable staged NAME and which therefore re-verify in
+	// PublishStagedBound). The window's cost is crumb accuracy only, never
+	// publish atomicity: an occupant planted between probe and rename is
+	// displaced WITHOUT a crumb, an occupant vacated there crumbs with nothing
+	// displaced — both residual directions are pinned by test
+	// (move_destreplaced_adjacency_w249_test.go).
 	srcInfo := publishProbeIdentity(fs, src)
 	occupied := publishDisplacesForeign(fs, dst, srcInfo)
 	err = fs.Rename(src, dst)
@@ -121,8 +158,15 @@ func crossDeviceMoveFsDestReplaced(fs afero.Fs, src, dst string) (bool, error) {
 		// destination already carries THIS operation's bytes, so compensation
 		// and duplicate-claim classifiers must never read this failure as a
 		// pre-publish no-op — the same sentinel the no-replace lineage wraps
-		// on its cleanup-refusal leg (move_noreplace.go).
-		return false, fmt.Errorf("%w: failed to remove source after cross-device copy: %w", ErrPublishCompleted, err)
+		// on its cleanup-refusal leg (move_noreplace.go). PR #249 codex P2
+		// follow-up: the publish's DISPLACED-OCCUPANCY evidence survives this
+		// failure — the staged publish already landed (PublishStagedBound's
+		// union keeps a proven displacement across any retry legs), so the
+		// bound `replaced` answer returns WITH the error instead of being
+		// dropped: a partial publish that displaced resident bytes keeps its
+		// audit evidence on the FAILED result, and only genuinely replacement-
+		// free legs answer false.
+		return replaced, fmt.Errorf("%w: failed to remove source after cross-device copy: %w", ErrPublishCompleted, err)
 	}
 
 	return replaced, nil

--- a/internal/fsutil/move.go
+++ b/internal/fsutil/move.go
@@ -147,7 +147,15 @@ func crossDeviceMoveFsDestReplaced(fs afero.Fs, src, dst string) (bool, error) {
 		// The copy leg never writes to dst directly (staging only), so there is
 		// NOTHING of ours at dst to "clean up": removing it could delete a
 		// pre-existing foreign file (#224). Keep both, surface the failure.
-		return false, fmt.Errorf("failed to copy file across devices: %w", err)
+		//
+		// Union the displacement evidence with the failure (PR #249 codex
+		// follow-up, F3): a staged-publish leg that LANDED and displaced a
+		// resident before a post-publish identity break / retry exhaustion
+		// already destroyed foreign bytes — that destruction is a fact no
+		// post-publish error path may erase. Genuinely replacement-free legs
+		// (pre-publish verify/close/stream refusals) answer false exactly as
+		// before, because no successful publish leg ever displaced anything.
+		return replaced, fmt.Errorf("failed to copy file across devices: %w", err)
 	}
 
 	if err := fs.Remove(src); err != nil {
@@ -236,7 +244,17 @@ func copyFileDataFsDestReplaced(fs afero.Fs, src, dst string) (bool, error) {
 		// implementation removed its temp on failure; keep that cleanliness
 		// without ever deleting a possibly-foreign staged name.
 		discardStagedAfterFailedPublish(fs, staged, stagedIdentity, err)
-		return false, fmt.Errorf("failed to rename temp file to destination: %w", err)
+		// Union the displacement evidence with post-publish failures (PR #249
+		// codex follow-up, F3): displacedOccupant is set ONLY by a publish leg
+		// that returned success one syscall after observing a foreign occupant
+		// — so a true answer here proves a successful publish displaced resident
+		// bytes AT SOME ATTEMPT before the post-publish identity break /
+		// republish-budget exhaustion surfaced this error. That destruction is
+		// permanent (error or not), so the audit evidence must ride the FAILED
+		// result instead of being dropped — the ErrPublishCompleted partial-
+		// publish lineage's discipline (the pre-build code answered false on
+		// EVERY error leg, erasing a proven displacement).
+		return displacedOccupant, fmt.Errorf("failed to rename temp file to destination: %w", err)
 	}
 
 	return displacedOccupant, nil

--- a/internal/fsutil/move.go
+++ b/internal/fsutil/move.go
@@ -3,6 +3,7 @@ package fsutil
 import (
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 
 	"github.com/javinizer/javinizer-go/internal/config"
@@ -11,45 +12,105 @@ import (
 
 // CopyFileFs copies a file within the afero filesystem, creating destination directories as needed.
 func CopyFileFs(fs afero.Fs, src, dst string) error {
+	_, err := CopyFileFsDestReplaced(fs, src, dst)
+	return err
+}
+
+// CopyFileFsDestReplaced is CopyFileFs extended with the PUBLISH-BOUND
+// replacement signal (PR #249 codex P2): destReplaced reports whether the
+// staged replace-publish actually displaced an OCCUPIED destination whose
+// object does not alias the source's own inode — an alias entry (hardlink
+// twin of the source) names no foreign bytes, so displacing it is deliberately
+// NOT a replacement. The evidence is captured at syscall adjacency with the
+// publish rename ITSELF (the CopyFile publish identity machinery is the #234
+// bound staged publish): the copy lane stages the full source stream between
+// any caller classification and the publish, so classify-time occupancy
+// answers could be raced stale by a foreign plant/vacate anywhere in that
+// window (a false or suppressed force-overwrite audit crumb). A probe whose
+// lookup fails answers "no replacement" — no confirmation, no claim.
+func CopyFileFsDestReplaced(fs afero.Fs, src, dst string) (destReplaced bool, err error) {
 	if err := fs.MkdirAll(filepath.Dir(dst), config.DirPerm); err != nil {
-		return fmt.Errorf("failed to create destination directory: %w", err)
+		return false, fmt.Errorf("failed to create destination directory: %w", err)
 	}
 
 	if filepath.Clean(src) == filepath.Clean(dst) {
-		return nil
+		return false, nil
 	}
 
-	return copyFileDataFs(fs, src, dst)
+	return copyFileDataFsDestReplaced(fs, src, dst)
 }
 
 // MoveFileFs moves a file within the afero filesystem, falling back to copy-and-remove across devices.
 func MoveFileFs(fs afero.Fs, src, dst string) error {
+	_, err := MoveFileFsDestReplaced(fs, src, dst)
+	return err
+}
+
+// MoveFileFsDestReplaced is MoveFileFs extended with the same publish-bound
+// replacement signal as CopyFileFsDestReplaced (PR #249 codex P2). The
+// same-device leg probes one syscall ahead of the inline rename (a rename
+// publishes THE object src names — including a symlink object itself — so the
+// source identity rides the same no-follow probe, never a chased Stat); the
+// cross-device fallback inherits the staged publish's bound signal instead.
+func MoveFileFsDestReplaced(fs afero.Fs, src, dst string) (destReplaced bool, err error) {
 	if err := fs.MkdirAll(filepath.Dir(dst), config.DirPerm); err != nil {
-		return fmt.Errorf("failed to create destination directory: %w", err)
+		return false, fmt.Errorf("failed to create destination directory: %w", err)
 	}
 
 	if filepath.Clean(src) == filepath.Clean(dst) {
-		return nil
+		return false, nil
 	}
 
-	err := fs.Rename(src, dst)
+	srcInfo := publishProbeIdentity(fs, src)
+	occupied := publishDisplacesForeign(fs, dst, srcInfo)
+	err = fs.Rename(src, dst)
 	if err == nil {
-		return nil
+		return occupied, nil
 	}
 
 	if !isCrossDeviceError(err) {
-		return fmt.Errorf("failed to move file: %w", err)
+		return false, fmt.Errorf("failed to move file: %w", err)
 	}
 
-	return crossDeviceMoveFs(fs, src, dst)
+	return crossDeviceMoveFsDestReplaced(fs, src, dst)
 }
 
-func crossDeviceMoveFs(fs afero.Fs, src, dst string) error {
-	if err := copyFileDataFs(fs, src, dst); err != nil {
+// publishProbeIdentity records a path's OBJECT identity for a publish probe's
+// alias exclusion, no-follow wherever the filesystem exposes the distinction
+// (the same asideLstat discipline the bound take-aside flow uses). Any lookup
+// failure — transient or absence — answers nil, and the exclusion is simply
+// not applied (confirm-or-silent, never guess).
+func publishProbeIdentity(fs afero.Fs, name string) os.FileInfo {
+	info, _ := asideLstat(fs, name)
+	return info
+}
+
+// publishDisplacesForeign reports — probed at syscall adjacency with the
+// caller's replace-publish — whether dst names an object that publish would
+// displace that is NOT an alias of the source's own object (publishDisplaces
+// == PHYSICAL occupancy at the publish instant, minus same-inode aliases,
+// whose removal destroys no foreign bytes). A failed/absent probe answers
+// false: the crumb never fires on unconfirmed evidence.
+func publishDisplacesForeign(fs afero.Fs, dst string, srcInfo os.FileInfo) bool {
+	info := publishProbeIdentity(fs, dst)
+	if info == nil {
+		return false
+	}
+	if srcInfo != nil && os.SameFile(info, srcInfo) {
+		return false
+	}
+	return true
+}
+
+// crossDeviceMoveFsDestReplaced is the cross-device fallback's publish-bound
+// twin (the plain error-only surface is MoveFileFs's).
+func crossDeviceMoveFsDestReplaced(fs afero.Fs, src, dst string) (bool, error) {
+	replaced, err := copyFileDataFsDestReplaced(fs, src, dst)
+	if err != nil {
 		// The copy leg never writes to dst directly (staging only), so there is
 		// NOTHING of ours at dst to "clean up": removing it could delete a
 		// pre-existing foreign file (#224). Keep both, surface the failure.
-		return fmt.Errorf("failed to copy file across devices: %w", err)
+		return false, fmt.Errorf("failed to copy file across devices: %w", err)
 	}
 
 	if err := fs.Remove(src); err != nil {
@@ -61,18 +122,27 @@ func crossDeviceMoveFs(fs afero.Fs, src, dst string) error {
 		// and duplicate-claim classifiers must never read this failure as a
 		// pre-publish no-op — the same sentinel the no-replace lineage wraps
 		// on its cleanup-refusal leg (move_noreplace.go).
-		return fmt.Errorf("%w: failed to remove source after cross-device copy: %w", ErrPublishCompleted, err)
+		return false, fmt.Errorf("%w: failed to remove source after cross-device copy: %w", ErrPublishCompleted, err)
 	}
 
-	return nil
+	return replaced, nil
 }
 
-func copyFileDataFs(fs afero.Fs, src, dst string) error {
+// copyFileDataFsDestReplaced is the staging core of CopyFileFsDestReplaced:
+// the displacement evidence is captured by the publish closure ITSELF (bound
+// to the bound staged publish), never by any earlier classification.
+func copyFileDataFsDestReplaced(fs afero.Fs, src, dst string) (bool, error) {
 	srcFile, err := fs.Open(src)
 	if err != nil {
-		return fmt.Errorf("failed to open source: %w", err)
+		return false, fmt.Errorf("failed to open source: %w", err)
 	}
 	defer func() { _ = srcFile.Close() }()
+
+	// The open handle's own stat is the source identity for the publish
+	// probe's alias exclusion — bound to the very bytes being staged below,
+	// even if a foreign writer swaps the src NAME mid-stream (the staged
+	// content is whatever this descriptor reads).
+	srcInfo, _ := srcFile.Stat()
 
 	// Stage dest-adjacent with O_EXCL (a predictable O_TRUNC name could
 	// truncate a racing peer's staged bytes), stream through the open handle,
@@ -82,19 +152,35 @@ func copyFileDataFs(fs afero.Fs, src, dst string) error {
 	// NoReplace composites.
 	staged, handle, sErr := CreateExclusiveStagingFile(fs, dst, ".mvstg", noreplaceOrdinal.Add(1), stagingFileMode())
 	if sErr != nil {
-		return fmt.Errorf("failed to create destination: %w", sErr)
+		return false, fmt.Errorf("failed to create destination: %w", sErr)
 	}
 
 	if _, err := io.Copy(handle, srcFile); err != nil {
 		DiscardFailedExclusiveStaging(fs, staged, handle)
-		return fmt.Errorf("failed to copy data: %w", err)
+		return false, fmt.Errorf("failed to copy data: %w", err)
 	}
 
 	stagedIdentity := stagingIdentity(handle)
 
+	// displacedOccupant is the publish-bound audit signal (PR #249 codex P2):
+	// the occupancy probe runs ONE SYSCALL ahead of the replace-publish in the
+	// closure below, alias-excluded against the staged bytes' own source inode
+	// — a signal that stays TRUE to physical occupancy at the publish instant
+	// no matter how long the staging stream above took.
+	displacedOccupant := false
 	p := StagedPublish{
-		FS:          fs,
-		Publish:     ReplaceFile,
+		FS: fs,
+		Publish: func(pfs afero.Fs, stagedName, dest string) error {
+			occupied := publishDisplacesForeign(pfs, dest, srcInfo)
+			pubErr := ReplaceFile(pfs, stagedName, dest)
+			// Union over successful attempts: a proven-substitution retry may
+			// legitimately republish into absence, and ANY successful publish
+			// that displaced resident bytes keeps its disclosure.
+			if pubErr == nil && occupied {
+				displacedOccupant = true
+			}
+			return pubErr
+		},
 		Staged:      staged,
 		Handle:      handle,
 		Dest:        dst,
@@ -106,8 +192,8 @@ func copyFileDataFs(fs afero.Fs, src, dst string) error {
 		// implementation removed its temp on failure; keep that cleanliness
 		// without ever deleting a possibly-foreign staged name.
 		discardStagedAfterFailedPublish(fs, staged, stagedIdentity, err)
-		return fmt.Errorf("failed to rename temp file to destination: %w", err)
+		return false, fmt.Errorf("failed to rename temp file to destination: %w", err)
 	}
 
-	return nil
+	return displacedOccupant, nil
 }

--- a/internal/fsutil/move_coverage_test.go
+++ b/internal/fsutil/move_coverage_test.go
@@ -65,7 +65,7 @@ func TestCrossDeviceMoveFs_SourceRemoveFailure_KeepsBoth(t *testing.T) {
 	require.NoError(t, afero.WriteFile(memFs, "/src.txt", []byte("data"), 0644))
 
 	fs := &removeFailFs{Fs: memFs, failOn: "/src.txt"}
-	err := crossDeviceMoveFs(fs, "/src.txt", "/dst.txt")
+	_, err := crossDeviceMoveFsDestReplaced(fs, "/src.txt", "/dst.txt")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to remove source")
 
@@ -87,7 +87,7 @@ func TestCrossDeviceMoveFs_CopyFailureKeepsForeignDest(t *testing.T) {
 	require.NoError(t, afero.WriteFile(memFs, "/dst.txt", []byte("foreign"), 0644))
 
 	fs := &openFailFs{Fs: memFs, failOn: "/src.txt"}
-	err := crossDeviceMoveFs(fs, "/src.txt", "/dst.txt")
+	_, err := crossDeviceMoveFsDestReplaced(fs, "/src.txt", "/dst.txt")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to copy file across devices")
 

--- a/internal/fsutil/move_destreplaced_adjacency_w249_test.go
+++ b/internal/fsutil/move_destreplaced_adjacency_w249_test.go
@@ -1,0 +1,202 @@
+package fsutil
+
+// Probe-adjacency ceiling pins (PR #249 codex P2 — the rename-atomicity
+// adjudication, F2): the same-device DestReplaced legs probe destination
+// occupancy ONE syscall ahead of the publish rename, and no construction the
+// afero Fs abstraction can express closes that window — POSIX rename(2) is
+// atomically replace-SILENT, Linux renameat2(RENAME_EXCHANGE) / Darwin
+// renamex_np(RENAME_SWAP) (the only kernel-exact displacement detectors)
+// are non-portable islands unreachable through Fs.Rename, and the
+// hardlink-snapshot dance keeps the same two-syscall adjacency with strictly
+// more side effects (see the bound comment on MoveFileFsDestReplaced). These
+// pins drive a foreign mutation INTO the exact probe → rename window — the
+// wrapped probe answers with the filesystem's REAL state, then the
+// plant/vacate lands before the rename runs — and pin the adjudicated
+// residual RESULT shape in both directions:
+//
+//   - the publish always completes and the destination always carries OUR
+//     bytes: rename(2) atomicity is never in question, so an ERROR is not
+//     defensible (erroring a genuinely completed publish would misclassify a
+//     landed destination as a failure upstream);
+//   - what the window costs is crumb ACCURACY only — an occupant planted
+//     inside it is displaced WITHOUT a crumb (the returned DestReplaced
+//     answer is probe-instant truth), an occupant vacated inside it crumbs
+//     with nothing displaced. The crumb is publish-adjacent best-effort
+//     evidence by construction; these pins keep that contract honest.
+//
+// Dest-identity after the publish stays kernel-guaranteed on these legs (the
+// rename moves the source dentry itself — dst names exactly what src named
+// at the rename instant), so no post-publish reverify exists here; the
+// staged legs' explicit post-publish reverify (PublishStagedBound) exists
+// precisely because THEIR publish re-resolves a substitutable name.
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// probeWindowFs wedges a foreign mutation between a DestReplaced verb's dst
+// occupancy probe and its publish rename: LstatIfPossible(dst) answers from
+// the filesystem's real state and, one "scheduler tick" before the rename,
+// the wedge mutates the destination. Deterministic and goroutine-free — the
+// verbs probe dst exactly once per publish attempt.
+type probeWindowFs struct {
+	afero.Fs
+	dst     string
+	once    sync.Once
+	fired   bool
+	wedgeFn func(fs afero.Fs)
+}
+
+func (w *probeWindowFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	info, did, err := w.Fs.(afero.Lstater).LstatIfPossible(name)
+	if filepath.Clean(name) == filepath.Clean(w.dst) {
+		w.once.Do(func() {
+			w.fired = true
+			// The probe holds its truthful answer; the foreign mutation lands
+			// strictly before this call's caller issues the rename — inside
+			// the adjudicated probe → publish window.
+			w.wedgeFn(w.Fs)
+		})
+	}
+	return info, did, err
+}
+
+// adversarialRenameWedgeFs models the same window for the CROSS-DEVICE leg:
+// the union-merged occupancy probe runs inside the publish closure one
+// syscall ahead of ReplaceFile's rename of the staged name, so wedging the
+// FIRST staged-name → dst rename plants between that probe and the
+// publication. Same residual class as the same-device legs.
+type adversarialRenameWedgeFs struct {
+	afero.Fs
+	src, dst string
+	exdev    bool
+	once     sync.Once
+	fired    bool
+	wedgeFn  func(fs afero.Fs)
+}
+
+func (w *adversarialRenameWedgeFs) Rename(oldname, newname string) error {
+	if filepath.Clean(oldname) == filepath.Clean(w.src) && filepath.Clean(newname) == filepath.Clean(w.dst) {
+		// The same-device pair answers EXDEV once, forcing the cross-device leg.
+		if !w.exdev {
+			w.exdev = true
+			return &os.LinkError{Op: "rename", Old: oldname, New: newname, Err: syscall.EXDEV}
+		}
+	}
+	if filepath.Clean(newname) == filepath.Clean(w.dst) {
+		// The staged publish rename: the closure's occupancy probe already
+		// answered (one Lstat earlier) — the foreign plant lands here.
+		w.once.Do(func() {
+			w.fired = true
+			w.wedgeFn(w.Fs)
+		})
+	}
+	return w.Fs.Rename(oldname, newname)
+}
+
+func TestDestReplaced_ProbeAdjacencyWindow(t *testing.T) {
+	t.Run("move leg: occupant planted after the probe is displaced with no crumb", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(base, "/in/src.txt", []byte("winner-bytes"), 0o644))
+		fs := &probeWindowFs{Fs: base, dst: "/out/dst.txt", wedgeFn: func(under afero.Fs) {
+			require.NoError(t, under.MkdirAll("/out", 0o755))
+			require.NoError(t, afero.WriteFile(under, "/out/dst.txt", []byte("planted-foreign-bytes"), 0o644))
+		}}
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/in/src.txt", "/out/dst.txt")
+		require.NoError(t, err, "the publish genuinely completed — no error is defensible for a landed rename")
+		require.True(t, fs.fired, "the plant landed inside the probe → rename window")
+		assert.False(t, replaced,
+			"the probe answered BEFORE the plant — the adjudicated residual: displacement without a crumb")
+		content, rerr := afero.ReadFile(base, "/out/dst.txt")
+		require.NoError(t, rerr)
+		assert.Equal(t, []byte("winner-bytes"), content,
+			"the plant's foreign bytes were really displaced by the rename — the audit gap is documented, not hidden")
+		srcGone, serr := afero.Exists(base, "/in/src.txt")
+		require.NoError(t, serr)
+		assert.False(t, srcGone, "the move consumed its source")
+	})
+
+	t.Run("move leg: occupant vacated after the probe crumbs with nothing displaced", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(base, "/in/src.txt", []byte("winner-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(base, "/out/dst.txt", []byte("resident-bytes"), 0o644))
+		fs := &probeWindowFs{Fs: base, dst: "/out/dst.txt", wedgeFn: func(under afero.Fs) {
+			require.NoError(t, under.Remove("/out/dst.txt"))
+		}}
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/in/src.txt", "/out/dst.txt")
+		require.NoError(t, err)
+		require.True(t, fs.fired)
+		assert.True(t, replaced,
+			"the probe answered BEFORE the vacate — the opposite adjudicated residual: a crumb with nothing displaced")
+		content, rerr := afero.ReadFile(base, "/out/dst.txt")
+		require.NoError(t, rerr)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+
+	t.Run("rename verb: same window, same residual shapes", func(t *testing.T) {
+		t.Run("plant", func(t *testing.T) {
+			base := afero.NewMemMapFs()
+			require.NoError(t, afero.WriteFile(base, "/src.txt", []byte("winner-bytes"), 0o644))
+			fs := &probeWindowFs{Fs: base, dst: "/dst.txt", wedgeFn: func(under afero.Fs) {
+				require.NoError(t, afero.WriteFile(under, "/dst.txt", []byte("planted-foreign-bytes"), 0o644))
+			}}
+
+			replaced, err := RenameDestReplaced(fs, "/src.txt", "/dst.txt")
+			require.NoError(t, err)
+			require.True(t, fs.fired)
+			assert.False(t, replaced, "displacement inside the probe → rename window carries no crumb")
+			content, rerr := afero.ReadFile(base, "/dst.txt")
+			require.NoError(t, rerr)
+			assert.Equal(t, []byte("winner-bytes"), content)
+		})
+
+		t.Run("vacate", func(t *testing.T) {
+			base := afero.NewMemMapFs()
+			require.NoError(t, afero.WriteFile(base, "/src.txt", []byte("winner-bytes"), 0o644))
+			require.NoError(t, afero.WriteFile(base, "/dst.txt", []byte("resident-bytes"), 0o644))
+			fs := &probeWindowFs{Fs: base, dst: "/dst.txt", wedgeFn: func(under afero.Fs) {
+				require.NoError(t, under.Remove("/dst.txt"))
+			}}
+
+			replaced, err := RenameDestReplaced(fs, "/src.txt", "/dst.txt")
+			require.NoError(t, err)
+			require.True(t, fs.fired)
+			assert.True(t, replaced, "a vacate inside the window keeps the probe's crumb — nothing was displaced")
+			content, rerr := afero.ReadFile(base, "/dst.txt")
+			require.NoError(t, rerr)
+			assert.Equal(t, []byte("winner-bytes"), content)
+		})
+	})
+
+	t.Run("cross-device leg: plant between the closure probe and the publish lands silently too", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(base, "/in/src.txt", []byte("winner-bytes"), 0o644))
+		fs := &adversarialRenameWedgeFs{Fs: base, src: "/in/src.txt", dst: "/out/dst.txt", wedgeFn: func(under afero.Fs) {
+			require.NoError(t, afero.WriteFile(under, "/out/dst.txt", []byte("planted-foreign-bytes"), 0o644))
+		}}
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/in/src.txt", "/out/dst.txt")
+		require.NoError(t, err)
+		require.True(t, fs.exdev, "the move really took the cross-device leg")
+		require.True(t, fs.fired, "the plant landed between the publish closure's probe and its rename")
+		assert.False(t, replaced,
+			"the staged publish's bound probe shares the same adjacency ceiling — displacement in its window carries no crumb")
+		content, rerr := afero.ReadFile(base, "/out/dst.txt")
+		require.NoError(t, rerr)
+		assert.Equal(t, []byte("winner-bytes"), content,
+			"the publish displaced the plant and landed our bytes — kernel atomicity intact, crumb silent")
+		srcGone, serr := afero.Exists(base, "/in/src.txt")
+		require.NoError(t, serr)
+		assert.False(t, srcGone, "a completed cross-device move consumes its source")
+	})
+}

--- a/internal/fsutil/move_destreplaced_partial_publish_w249_test.go
+++ b/internal/fsutil/move_destreplaced_partial_publish_w249_test.go
@@ -1,0 +1,89 @@
+package fsutil
+
+// PR #249 codex P2 follow-up (F1) — the EXDEV partial publish must carry its
+// displaced-occupancy evidence THROUGH the ErrPublishCompleted error: the
+// bound staged publish landed (and, on an occupied destination, really
+// displaced resident bytes) before the source cleanup refused, so dropping
+// the DestReplaced answer on that leg erased exactly the audit evidence the
+// force-overwrite crumb exists to keep. The pre-build code returned
+// replaced=false pre-error and the organizer bailed before warning.
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// exdevCleanupWedgeFs drives the F1 replay deterministically: the same-volume
+// rename of the exact (src, dst) pair answers EXDEV (forcing the cross-device
+// leg — stage, bound publish, source cleanup), and exactly the post-publish
+// removal of the SOURCE is refused. Unlike the content-sniffing w241 wedge
+// this binds by name, so an occupied destination never participates in the
+// failure injection.
+type exdevCleanupWedgeFs struct {
+	afero.Fs
+	src, dst     string
+	removeFailed bool
+}
+
+func (w *exdevCleanupWedgeFs) Rename(oldname, newname string) error {
+	if filepath.Clean(oldname) == filepath.Clean(w.src) && filepath.Clean(newname) == filepath.Clean(w.dst) {
+		return &os.LinkError{Op: "rename", Old: oldname, New: newname, Err: syscall.EXDEV}
+	}
+	return w.Fs.Rename(oldname, newname)
+}
+
+func (w *exdevCleanupWedgeFs) Remove(name string) error {
+	if filepath.Clean(name) == filepath.Clean(w.src) && !w.removeFailed {
+		w.removeFailed = true
+		return &os.PathError{Op: "remove", Path: name, Err: syscall.EPERM}
+	}
+	return w.Fs.Remove(name)
+}
+
+func TestMoveFileFsDestReplaced_EXDEVCleanupFailure_KeepsDisplacementEvidence(t *testing.T) {
+	t.Run("occupied destination: displaced evidence rides the publish-completed error", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(base, "/in/src.txt", []byte("winner-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(base, "/out/dst.txt", []byte("resident-bytes"), 0o644))
+		fs := &exdevCleanupWedgeFs{Fs: base, src: "/in/src.txt", dst: "/out/dst.txt"}
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/in/src.txt", "/out/dst.txt")
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrPublishCompleted,
+			"the publish landed before the source cleanup refused — the typed ambiguity rides along")
+		require.True(t, fs.removeFailed, "the wedge really fired at the post-publish source removal")
+		assert.True(t, replaced,
+			"the bound staged publish displaced the resident occupant — its evidence must survive the cleanup failure")
+
+		dst, derr := afero.ReadFile(base, "/out/dst.txt")
+		require.NoError(t, derr, "the published destination stands")
+		assert.Equal(t, []byte("winner-bytes"), dst, "the resident bytes were really displaced")
+		src, serr := afero.ReadFile(base, "/in/src.txt")
+		require.NoError(t, serr, "the source is preserved byte-intact (both kept on the ambiguous leg, #224)")
+		assert.Equal(t, []byte("winner-bytes"), src)
+	})
+
+	t.Run("vacant destination: same error, no displacement evidence", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(base, "/in/src.txt", []byte("winner-bytes"), 0o644))
+		fs := &exdevCleanupWedgeFs{Fs: base, src: "/in/src.txt", dst: "/out/dst.txt"}
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/in/src.txt", "/out/dst.txt")
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrPublishCompleted)
+		assert.False(t, replaced,
+			"the publish displaced nothing — the crumb never fires on unconfirmed evidence, error or not")
+		dst, derr := afero.ReadFile(base, "/out/dst.txt")
+		require.NoError(t, derr)
+		assert.Equal(t, []byte("winner-bytes"), dst)
+		src, serr := afero.ReadFile(base, "/in/src.txt")
+		require.NoError(t, serr)
+		assert.Equal(t, []byte("winner-bytes"), src)
+	})
+}

--- a/internal/fsutil/move_destreplaced_test.go
+++ b/internal/fsutil/move_destreplaced_test.go
@@ -1,0 +1,301 @@
+package fsutil
+
+// Publish-bound replacement signal (PR #249 codex P2) — the DestReplaced
+// verbs report whether the publish itself displaced an occupied destination
+// not aliasing the source's own object. These pins cover the signal shape
+// (vacant → false, foreign occupant → true, same-inode alias → false even
+// though the entry is consumed) and the cross-device fallback's propagation
+// of the staged publish's bound signal. The organizer keys its
+// force-overwrite audit crumb on these answers because classify-time
+// occupancy can be raced stale across the staging stream.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyFileFsDestReplaced(t *testing.T) {
+	t.Run("vacant destination reports no replacement", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/in/src.txt", []byte("winner-bytes"), 0o644))
+
+		replaced, err := CopyFileFsDestReplaced(fs, "/in/src.txt", "/out/dst.txt")
+		require.NoError(t, err)
+		assert.False(t, replaced, "the publish landed on a provably vacant name")
+		content, err := afero.ReadFile(fs, "/out/dst.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+
+	t.Run("occupied destination reports the displacement", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/in/src.txt", []byte("winner-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(fs, "/out/dst.txt", []byte("resident-bytes"), 0o644))
+
+		replaced, err := CopyFileFsDestReplaced(fs, "/in/src.txt", "/out/dst.txt")
+		require.NoError(t, err)
+		assert.True(t, replaced, "the publish displaced the resident occupant")
+		content, err := afero.ReadFile(fs, "/out/dst.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("winner-bytes"), content, "resident bytes were replaced")
+		srcContent, err := afero.ReadFile(fs, "/in/src.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("winner-bytes"), srcContent, "a copy retains its source")
+	})
+
+	t.Run("lexical self stays a no-op with no replacement", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/src.txt", []byte("self"), 0o644))
+
+		replaced, err := CopyFileFsDestReplaced(fs, "/src.txt", "/./src.txt")
+		require.NoError(t, err)
+		assert.False(t, replaced)
+	})
+
+	t.Run("directory creation failures surface with no signal", func(t *testing.T) {
+		roFs := afero.NewReadOnlyFs(afero.NewMemMapFs())
+		replaced, err := CopyFileFsDestReplaced(roFs, "/src.txt", "/nested/dir/dst.txt")
+		require.Error(t, err, "MkdirAll must fail on a readonly fs")
+		assert.False(t, replaced)
+	})
+
+	t.Run("same-inode alias occupant is not a foreign replacement", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("os-level hardlink fixture")
+		}
+		dir := t.TempDir()
+		fs := afero.NewOsFs()
+		src := filepath.Join(dir, "src.txt")
+		dst := filepath.Join(dir, "dst.txt")
+		require.NoError(t, os.WriteFile(src, []byte("shared-bytes"), 0o644))
+		require.NoError(t, os.Link(src, dst), "destination aliases the source inode")
+
+		replaced, err := CopyFileFsDestReplaced(fs, src, dst)
+		require.NoError(t, err)
+		assert.False(t, replaced,
+			"displacing an alias ENTRY destroys no foreign bytes — the inode lives on at the source")
+		content, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("shared-bytes"), content)
+		srcInfo, err := os.Stat(src)
+		require.NoError(t, err)
+		dstInfo, err := os.Stat(dst)
+		require.NoError(t, err)
+		assert.False(t, os.SameFile(srcInfo, dstInfo),
+			"the publish installed the staged copy: dst no longer aliases the source inode")
+	})
+}
+
+func TestMoveFileFsDestReplaced(t *testing.T) {
+	t.Run("vacant destination reports no replacement", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/src.txt", []byte("winner-bytes"), 0o644))
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/src.txt", "/out/dst.txt")
+		require.NoError(t, err)
+		assert.False(t, replaced)
+		content, err := afero.ReadFile(fs, "/out/dst.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+
+	t.Run("occupied destination reports the displacement", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/src.txt", []byte("winner-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(fs, "/out/dst.txt", []byte("resident-bytes"), 0o644))
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/src.txt", "/out/dst.txt")
+		require.NoError(t, err)
+		assert.True(t, replaced, "the rename displaced the resident occupant")
+		content, err := afero.ReadFile(fs, "/out/dst.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("winner-bytes"), content)
+		srcExists, err := afero.Exists(fs, "/src.txt")
+		require.NoError(t, err)
+		assert.False(t, srcExists, "the move consumed the source name")
+	})
+
+	t.Run("lexical self stays a no-op with no replacement", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/src.txt", []byte("self"), 0o644))
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/src.txt", "/./src.txt")
+		require.NoError(t, err)
+		assert.False(t, replaced)
+	})
+
+	t.Run("directory creation failures surface with no signal", func(t *testing.T) {
+		roFs := afero.NewReadOnlyFs(afero.NewMemMapFs())
+		replaced, err := MoveFileFsDestReplaced(roFs, "/src.txt", "/nested/dir/dst.txt")
+		require.Error(t, err)
+		assert.False(t, replaced)
+	})
+
+	t.Run("rename failures stay plain errors with no signal", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		replaced, err := MoveFileFsDestReplaced(fs, "/nonexistent.txt", "/dst.txt")
+		require.Error(t, err, "a vanished source rename fails as before")
+		assert.False(t, replaced)
+		assert.Contains(t, err.Error(), "failed to move file")
+	})
+
+	t.Run("same-inode alias occupant is not a foreign replacement", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("os-level hardlink fixture")
+		}
+		dir := t.TempDir()
+		fs := afero.NewOsFs()
+		src := filepath.Join(dir, "src.txt")
+		dst := filepath.Join(dir, "dst.txt")
+		require.NoError(t, os.WriteFile(src, []byte("shared-bytes"), 0o644))
+		require.NoError(t, os.Link(src, dst))
+
+		replaced, err := MoveFileFsDestReplaced(fs, src, dst)
+		require.NoError(t, err)
+		assert.False(t, replaced,
+			"dst aliased the same inode the rename published — no foreign bytes displaced")
+		// POSIX specifies rename(2) between two hard links of ONE file as a
+		// no-op: NOTHING was displaced, and both names keep the shared bytes —
+		// exactly the silence the crumb answer asserts.
+		content, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("shared-bytes"), content)
+		srcContent, err := os.ReadFile(src)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("shared-bytes"), srcContent)
+	})
+}
+
+// exdevOnceRenameFs forces the FIRST rename of the named source to fail EXDEV
+// so MoveFileFsDestReplaced takes the cross-device fallback; every other
+// rename (the staged publish inside the fallback) delegates normally.
+type exdevOnceRenameFs struct {
+	afero.Fs
+	injectSrc string
+	injected  bool
+}
+
+func (e *exdevOnceRenameFs) Rename(src, dst string) error {
+	if !e.injected && src == e.injectSrc {
+		e.injected = true
+		return &os.LinkError{Op: "rename", Old: src, New: dst, Err: syscall.EXDEV}
+	}
+	return e.Fs.Rename(src, dst)
+}
+
+func TestMoveFileFsDestReplaced_CrossDeviceLeg(t *testing.T) {
+	t.Run("cross-device onto occupied destination propagates the publish signal", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		fs := &exdevOnceRenameFs{Fs: base, injectSrc: "/src.txt"}
+		require.NoError(t, afero.WriteFile(base, "/src.txt", []byte("winner-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(base, "/out/dst.txt", []byte("resident-bytes"), 0o644))
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/src.txt", "/out/dst.txt")
+		require.NoError(t, err)
+		assert.True(t, replaced,
+			"the fallback's staged publish displaced the resident occupant — the bound signal must survive the EXDEV hop")
+		content, err := afero.ReadFile(base, "/out/dst.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("winner-bytes"), content)
+		srcExists, err := afero.Exists(base, "/src.txt")
+		require.NoError(t, err)
+		assert.False(t, srcExists, "the cross-device move removed the source")
+	})
+
+	t.Run("cross-device onto vacant destination stays silent", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		fs := &exdevOnceRenameFs{Fs: base, injectSrc: "/src.txt"}
+		require.NoError(t, afero.WriteFile(base, "/src.txt", []byte("winner-bytes"), 0o644))
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/src.txt", "/out/dst.txt")
+		require.NoError(t, err)
+		assert.False(t, replaced)
+		content, err := afero.ReadFile(base, "/out/dst.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+}
+
+func TestRenameDestReplaced(t *testing.T) {
+	t.Run("vacant destination reports no replacement", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/src.txt", []byte("winner-bytes"), 0o644))
+
+		replaced, err := RenameDestReplaced(fs, "/src.txt", "/dst.txt")
+		require.NoError(t, err)
+		assert.False(t, replaced)
+		content, err := afero.ReadFile(fs, "/dst.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+
+	t.Run("occupied destination reports the displacement with the same bare rename", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/src.txt", []byte("winner-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(fs, "/dst.txt", []byte("resident-bytes"), 0o644))
+
+		replaced, err := RenameDestReplaced(fs, "/src.txt", "/dst.txt")
+		require.NoError(t, err)
+		assert.True(t, replaced)
+		content, err := afero.ReadFile(fs, "/dst.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+
+	t.Run("rename error surfaces with the probe's answer irrelevant", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		replaced, err := RenameDestReplaced(fs, "/nonexistent.txt", "/dst.txt")
+		require.Error(t, err)
+		assert.False(t, replaced, "a vanished source probes nothing to exclude and displaces nothing")
+	})
+}
+
+// statOnlyFs hides any Lstater capability of the wrapped filesystem so the
+// publish probes take the link-following Stat leg (the no-Lstat wrapper shape
+// the codebase's destMaybeLstat/asideLstat discipline exists for).
+type statOnlyFs struct{ afero.Fs }
+
+func TestPublishProbeIdentity_StatLegs(t *testing.T) {
+	t.Run("non-Lstater wrapper probes through Stat", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		fs := statOnlyFs{base}
+		require.NoError(t, afero.WriteFile(base, "/src.txt", []byte("winner-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(base, "/dst.txt", []byte("resident-bytes"), 0o644))
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/src.txt", "/dst.txt")
+		require.NoError(t, err)
+		assert.True(t, replaced, "Stat-leg probes still see the resident occupant")
+	})
+
+	t.Run("indeterminate probes answer no displacement — confirm-or-silent", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(base, "/src.txt", []byte("winner-bytes"), 0o644))
+		fs := probeDenyFs{Fs: statOnlyFs{base}, deny: map[string]bool{"/src.txt": true, "/dst.txt": true}}
+
+		replaced, err := MoveFileFsDestReplaced(fs, "/src.txt", "/dst.txt")
+		require.NoError(t, err)
+		assert.False(t, replaced,
+			"failed identity probes apply no alias exclusion and a failed occupancy probe claims nothing")
+	})
+}
+
+// probeDenyFs fails Stat on the denied names only, making the publish probes
+// indeterminate while every other operation (read/rename) delegates normally.
+type probeDenyFs struct {
+	afero.Fs
+	deny map[string]bool
+}
+
+func (d probeDenyFs) Stat(name string) (os.FileInfo, error) {
+	if d.deny[name] {
+		return nil, errors.New("probe denied")
+	}
+	return d.Fs.Stat(name)
+}

--- a/internal/fsutil/move_destreplaced_union_w249b_test.go
+++ b/internal/fsutil/move_destreplaced_union_w249b_test.go
@@ -1,0 +1,128 @@
+//go:build !windows
+
+package fsutil
+
+// PR #249 codex P2 follow-up (F3) — displacement evidence accumulated by the
+// publish closure across PublishStagedBound attempts must UNION with the
+// post-publish error paths: a publish leg that LANDED (displacing a resident
+// at the destination) followed by a post-publish identity break or a
+// republish-budget refusal must NOT return destReplaced=false — the resident
+// bytes are destroyed either way, and the audit crumb keys on that
+// destruction. The pre-fix staging core answered false on EVERY error leg,
+// erasing a proven displacement.
+//
+// Both tests drive the real OsFs staged publish (the only leg with the
+// publish-with-reverify loop) and wedge the post-publish destination
+// identity lookup (publishStagedBoundDestLstat, the wave-24/26 seam) to
+// fail once — after the publish landed over an OCCUPIED destination. The
+// copy FileInfo must then carry displacedOccupant=true THROUGH the
+// ErrPublishStagedIdentityBreak error, for CopyFileFsDestReplaced directly
+// AND for MoveFileFsDestReplaced's EXDEV cross-device fallback (its copy-leg
+// error branch used to hard-drop the unioned answer with `return false`).
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wedgeFirstDestReverify arms the publishStagedBoundDestLstat seam so the
+// FIRST lookup naming dst fails with a transient error (the post-publish
+// identity break leg) and every subsequent lookup delegates. The arming
+// count proves the wedge really fired at the intended call.
+func wedgeFirstDestReverify(t *testing.T, dst string) *atomic.Int64 {
+	t.Helper()
+	prev := publishStagedBoundDestLstat
+	var armed atomic.Int64
+	var lookups atomic.Int64
+	publishStagedBoundDestLstat = func(name string) (os.FileInfo, error) {
+		if filepath.Clean(name) == filepath.Clean(dst) && armed.CompareAndSwap(1, 0) {
+			lookups.Add(1)
+			return nil, &os.PathError{Op: "lstat", Path: name, Err: syscall.EIO}
+		}
+		return prev(name)
+	}
+	armed.Store(1)
+	t.Cleanup(func() { publishStagedBoundDestLstat = prev })
+	return &lookups
+}
+
+func TestCopyFileFsDestReplaced_PostPublishIdentityBreak_KeepsDisplacementEvidence(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "in", "src.txt")
+	dst := filepath.Join(dir, "out", "dst.txt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(src), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
+	require.NoError(t, os.WriteFile(src, []byte("winner-bytes"), 0o644))
+	require.NoError(t, os.WriteFile(dst, []byte("resident-bytes"), 0o644))
+	lookups := wedgeFirstDestReverify(t, dst)
+
+	replaced, err := CopyFileFsDestReplaced(afero.NewOsFs(), src, dst)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrPublishStagedIdentityBreak),
+		"the post-publish identity lookup was wedged — the publish itself already landed")
+	require.Equal(t, int64(1), lookups.Load(), "the wedge fired exactly at the first post-publish reverify")
+	assert.True(t, replaced,
+		"a publish leg that displaced resident bytes before the post-publish failure must NOT return false")
+
+	content, readErr := os.ReadFile(dst)
+	require.NoError(t, readErr, "the publish landed — the destination carries this operation's bytes")
+	assert.Equal(t, []byte("winner-bytes"), content, "the resident bytes were really displaced")
+	retained, readErr := os.ReadFile(src)
+	require.NoError(t, readErr, "a copy retains its source")
+	assert.Equal(t, []byte("winner-bytes"), retained)
+}
+
+// exdevStagedCreateWedgeFs drives the move fallback's PRE-publish copy-leg
+// failure by name: the exact (src, dst) rename refuses EXDEV (forcing the
+// cross-device fallback) and the staged O_EXCL creation refuses. The union
+// line in crossDeviceMoveFsDestReplaced then executes with legitimately
+// ZERO displacement evidence — nothing ever published, so the resident
+// occupant stays byte-intact and the answer stays false.
+type exdevStagedCreateWedgeFs struct {
+	afero.Fs
+	src, dst string
+}
+
+func (w *exdevStagedCreateWedgeFs) Rename(oldname, newname string) error {
+	if filepath.Clean(oldname) == filepath.Clean(w.src) && filepath.Clean(newname) == filepath.Clean(w.dst) {
+		return &os.LinkError{Op: "rename", Old: oldname, New: newname, Err: syscall.EXDEV}
+	}
+	return w.Fs.Rename(oldname, newname)
+}
+
+func (w *exdevStagedCreateWedgeFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	if strings.Contains(filepath.Base(name), ".mvstg") && flag&os.O_CREATE != 0 {
+		return nil, &os.PathError{Op: "open", Path: name, Err: syscall.EACCES}
+	}
+	return w.Fs.OpenFile(name, flag, perm)
+}
+
+func TestMoveFileFsDestReplaced_EXDEVCopyLegPrepublishFailure_AnswersNoDisplacement(t *testing.T) {
+	base := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(base, "/in/src.txt", []byte("winner-bytes"), 0o644))
+	require.NoError(t, afero.WriteFile(base, "/out/dst.txt", []byte("resident-bytes"), 0o644))
+	wedge := &exdevStagedCreateWedgeFs{Fs: base, src: "/in/src.txt", dst: "/out/dst.txt"}
+
+	replaced, err := MoveFileFsDestReplaced(wedge, "/in/src.txt", "/out/dst.txt")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrPublishCompleted),
+		"nothing ever published — no publish-completed typing")
+	assert.False(t, replaced,
+		"the union only ever carries PROVEN displacement: a pre-publish copy-leg failure answers false, unchanged")
+
+	content, readErr := afero.ReadFile(base, "/out/dst.txt")
+	require.NoError(t, readErr)
+	assert.Equal(t, []byte("resident-bytes"), content, "the resident occupant is untouched (#224 keep-both)")
+	retained, readErr := afero.ReadFile(base, "/in/src.txt")
+	require.NoError(t, readErr)
+	assert.Equal(t, []byte("winner-bytes"), retained)
+}

--- a/internal/fsutil/move_fs_test.go
+++ b/internal/fsutil/move_fs_test.go
@@ -87,7 +87,7 @@ func TestCrossDeviceMoveFs(t *testing.T) {
 	err := afero.WriteFile(fs, "/source.txt", []byte("cross device fs"), 0644)
 	assert.NoError(t, err)
 
-	err = crossDeviceMoveFs(fs, "/source.txt", "/dest.txt")
+	_, err = crossDeviceMoveFsDestReplaced(fs, "/source.txt", "/dest.txt")
 	assert.NoError(t, err)
 
 	content, err := afero.ReadFile(fs, "/dest.txt")
@@ -105,7 +105,7 @@ func TestCrossDeviceMoveFs_SourceRemoveFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	readonlyFs := afero.NewReadOnlyFs(fs)
-	err = crossDeviceMoveFs(readonlyFs, "/source.txt", "/dest.txt")
+	_, err = crossDeviceMoveFsDestReplaced(readonlyFs, "/source.txt", "/dest.txt")
 	assert.Error(t, err)
 }
 
@@ -115,7 +115,7 @@ func TestCopyFileDataFs_BasicMemMap(t *testing.T) {
 	err := afero.WriteFile(fs, "/source.txt", []byte("memmap copy"), 0644)
 	assert.NoError(t, err)
 
-	err = copyFileDataFs(fs, "/source.txt", "/dest.txt")
+	_, err = copyFileDataFsDestReplaced(fs, "/source.txt", "/dest.txt")
 	assert.NoError(t, err)
 
 	content, err := afero.ReadFile(fs, "/dest.txt")
@@ -126,7 +126,7 @@ func TestCopyFileDataFs_BasicMemMap(t *testing.T) {
 func TestCopyFileDataFs_SourceNotFound(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
-	err := copyFileDataFs(fs, "/nonexistent.txt", "/dest.txt")
+	_, err := copyFileDataFsDestReplaced(fs, "/nonexistent.txt", "/dest.txt")
 	assert.Error(t, err)
 }
 
@@ -187,7 +187,7 @@ func TestCopyFileDataFs_MidCopyFailureLeavesNoPartialDst(t *testing.T) {
 
 	// Source read fails after 64 bytes, mid-copy.
 	fs := &failingReadFs{Fs: memFs, failPath: src, limit: 64}
-	err := copyFileDataFs(fs, src, dst)
+	_, err := copyFileDataFsDestReplaced(fs, src, dst)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to copy data")
 
@@ -236,7 +236,8 @@ func TestCopyFileDataFs_HappyPathContentEquality(t *testing.T) {
 	content := bytes.Repeat([]byte("copy-me-"), 64) // 512 bytes
 	require.NoError(t, afero.WriteFile(fs, "/src.txt", content, 0644))
 
-	require.NoError(t, copyFileDataFs(fs, "/src.txt", "/dst.txt"))
+	_, errCopy := copyFileDataFsDestReplaced(fs, "/src.txt", "/dst.txt")
+	require.NoError(t, errCopy)
 
 	got, err := afero.ReadFile(fs, "/dst.txt")
 	require.NoError(t, err)

--- a/internal/fsutil/move_noreplace_coverage_test.go
+++ b/internal/fsutil/move_noreplace_coverage_test.go
@@ -218,7 +218,7 @@ func TestCoverMoveFsCopyFileData_PublishFailureDiscards(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	seedSrc(t, fs)
 	wrapped := &renameFailFs{Fs: fs, failRenameDst: "/out/a.mp4"}
-	err := copyFileDataFs(wrapped, "/in/a.mp4", "/out/a.mp4")
+	_, err := copyFileDataFsDestReplaced(wrapped, "/in/a.mp4", "/out/a.mp4")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to rename temp file to destination")
 	entries, derr := afero.ReadDir(fs, "/out")

--- a/internal/fsutil/move_test.go
+++ b/internal/fsutil/move_test.go
@@ -96,7 +96,7 @@ func TestCopyFileDataFs_Basic(t *testing.T) {
 	}
 
 	dstPath := filepath.Join(tmpDir, "destination.txt")
-	if err := copyFileDataFs(fs, srcPath, dstPath); err != nil {
+	if _, err := copyFileDataFsDestReplaced(fs, srcPath, dstPath); err != nil {
 		t.Fatalf("copyFileDataFs failed: %v", err)
 	}
 
@@ -117,7 +117,7 @@ func TestCrossDeviceMoveFs_Success(t *testing.T) {
 	}
 
 	dstPath := filepath.Join(tmpDir, "destination.txt")
-	if err := crossDeviceMoveFs(fs, srcPath, dstPath); err != nil {
+	if _, err := crossDeviceMoveFsDestReplaced(fs, srcPath, dstPath); err != nil {
 		t.Fatalf("crossDeviceMoveFs failed: %v", err)
 	}
 
@@ -134,13 +134,13 @@ func TestCrossDeviceMoveFs_Success(t *testing.T) {
 func TestCrossDeviceMoveFs_SourceRemovalFails(t *testing.T) {
 	fs := afero.NewReadOnlyFs(afero.NewMemMapFs())
 
-	err := crossDeviceMoveFs(fs, "/tmp/source.txt", "/tmp/destination.txt")
+	_, err := crossDeviceMoveFsDestReplaced(fs, "/tmp/source.txt", "/tmp/destination.txt")
 	assert.Error(t, err)
 }
 
 func TestCrossDeviceMoveFs_CopyFails(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	err := crossDeviceMoveFs(fs, "/nonexistent/source.txt", "/tmp/destination.txt")
+	_, err := crossDeviceMoveFsDestReplaced(fs, "/nonexistent/source.txt", "/tmp/destination.txt")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to copy file across devices")
 }

--- a/internal/fsutil/replacefile.go
+++ b/internal/fsutil/replacefile.go
@@ -20,6 +20,11 @@ var ErrReplaceUnsupported = errors.New("replace existing destination unsupported
 // an occupied destination that does not alias the source's own object (PR
 // #249 codex P2). The rename itself carries the source object's identity, so
 // the alias exclusion probes the source path no-follow here at call time.
+// The probe → rename window is the adjudicated accuracy ceiling — no portable
+// kernel primitive reports displacement AT the rename instant; see the
+// adjudication bound on MoveFileFsDestReplaced (move.go), whose residual
+// semantics this verb shares and whose pins cover both legs
+// (move_destreplaced_adjacency_w249_test.go).
 func RenameDestReplaced(fs afero.Fs, src, dst string) (destReplaced bool, err error) {
 	srcInfo := publishProbeIdentity(fs, src)
 	occupied := publishDisplacesForeign(fs, dst, srcInfo)

--- a/internal/fsutil/replacefile.go
+++ b/internal/fsutil/replacefile.go
@@ -13,6 +13,19 @@ import (
 // alongside the filesystem's own error so both stay unwrap-reachable.
 var ErrReplaceUnsupported = errors.New("replace existing destination unsupported")
 
+// RenameDestReplaced performs one bare fs.Rename exactly as the caller's
+// existing inline replace-publish does (syscall-for-syscall identical — no
+// MoveFileEx substitution on Windows, no semantics drift) and reports,
+// publish-bound ONE SYSCALL ahead of the rename, whether the publish displaced
+// an occupied destination that does not alias the source's own object (PR
+// #249 codex P2). The rename itself carries the source object's identity, so
+// the alias exclusion probes the source path no-follow here at call time.
+func RenameDestReplaced(fs afero.Fs, src, dst string) (destReplaced bool, err error) {
+	srcInfo := publishProbeIdentity(fs, src)
+	occupied := publishDisplacesForeign(fs, dst, srcInfo)
+	return occupied, fs.Rename(src, dst)
+}
+
 // replaceFileVirtualFallback is ReplaceFile's non-OsFs leg: OsFs routes to the
 // native atomic-replace primitive (replacefile_windows.go MoveFileEx), while a
 // virtual filesystem goes through its own rename here. The wrap uses %w for

--- a/internal/organizer/conflict.go
+++ b/internal/organizer/conflict.go
@@ -84,23 +84,34 @@ func logDestRefusal(c PlanConflict) {
 	logging.Warnf("[organizer] destination conflict (%s) cannot be authorized-over: %s", c.kindName(), c.Path)
 }
 
-// refuseIfUnsuppressibleAuthorizedDestination is the authorized-execute
-// leg gate (task 2.3): symlink and directory destinations refuse with a new
-// sentence (authorized overlays deliberately report a different class); regular-file
-// destinations are suppressed per authorization. self/same-inode → no-op per D2.
-func refuseIfUnsuppressibleAuthorizedDestination(fs afero.Fs, src, dst string) (identical, sameInode bool, err error) {
+// classifyAuthorizedDestination is the authorized-execute leg gate (task
+// 2.3's refuseIfUnsuppressibleAuthorizedDestination, unified) used by every
+// authorized lane: symlink and directory destinations refuse with a sentence
+// (authorized overlays deliberately report a different class; regular-file
+// destinations are suppressed per authorization; self/same-inode → no-op per
+// D2) — one classifyExistingDestination call, identical refusal rules — plus
+// the force-overwrite audit crumb's EXECUTE-TIME occupancy evidence:
+// occupiedFile reports whether the classification just saw a bytes-bearing
+// regular file the authorization suppressed (a FILE conflict). Keying the
+// crumb to the execute-side state answers both TOCTOU failure classes of
+// plan-time evidence: an occupant vacated post-plan must NOT crumb (nothing
+// is replaced), and an occupant planted post-plan MUST crumb (its resident
+// bytes are about to be replaced).
+func classifyAuthorizedDestination(fs afero.Fs, src, dst string) (identical, sameInode, occupiedFile bool, err error) {
 	c := classifyExistingDestination(fs, src, dst)
 	if c.Err != nil {
-		return false, false, c.Err
+		return false, false, false, c.Err
 	}
 	if c.Conflict == nil {
-		return c.Identical, c.SameInode, nil
+		return c.Identical, c.SameInode, false, nil
 	}
 	if c.Conflict.Kind == ConflictFile {
-		return c.Identical, c.SameInode, nil // suppressed by authorization
+		// Suppressed by authorization: resident bytes sit at the destination
+		// RIGHT NOW — the authorized execute leg replaces them.
+		return c.Identical, c.SameInode, true, nil
 	}
 	logDestRefusal(*c.Conflict)
-	return false, false, fmt.Errorf("cannot authorize-over a %s destination (refusing to replace): %s", c.Conflict.kindName(), c.Conflict.Path)
+	return false, false, false, fmt.Errorf("cannot authorize-over a %s destination (refusing to replace): %s", c.Conflict.kindName(), c.Conflict.Path)
 }
 
 // distinctConflictRenders returns each conflict's rendered form exactly once,

--- a/internal/organizer/conflict.go
+++ b/internal/organizer/conflict.go
@@ -89,29 +89,25 @@ func logDestRefusal(c PlanConflict) {
 // authorized lane: symlink and directory destinations refuse with a sentence
 // (authorized overlays deliberately report a different class; regular-file
 // destinations are suppressed per authorization; self/same-inode → no-op per
-// D2) — one classifyExistingDestination call, identical refusal rules — plus
-// the force-overwrite audit crumb's EXECUTE-TIME occupancy evidence:
-// occupiedFile reports whether the classification just saw a bytes-bearing
-// regular file the authorization suppressed (a FILE conflict). Keying the
-// crumb to the execute-side state answers both TOCTOU failure classes of
-// plan-time evidence: an occupant vacated post-plan must NOT crumb (nothing
-// is replaced), and an occupant planted post-plan MUST crumb (its resident
-// bytes are about to be replaced).
-func classifyAuthorizedDestination(fs afero.Fs, src, dst string) (identical, sameInode, occupiedFile bool, err error) {
+// D2) — one classifyExistingDestination call, identical refusal rules.
+// The force-overwrite audit crumb no longer takes ANY evidence from this
+// classification (PR #249 codex P2): a regular-file occupation seen here can
+// be raced stale before the publish (the copy lane stages the whole stream
+// between classify and publish), so every authorized lane keys the crumb to
+// the PUBLISH-BOUND replacement signal returned by the fsutil publish verbs
+// (MoveFileFsDestReplaced / CopyFileFsDestReplaced / RenameDestReplaced).
+func classifyAuthorizedDestination(fs afero.Fs, src, dst string) (identical, sameInode bool, err error) {
 	c := classifyExistingDestination(fs, src, dst)
 	if c.Err != nil {
-		return false, false, false, c.Err
+		return false, false, c.Err
 	}
-	if c.Conflict == nil {
-		return c.Identical, c.SameInode, false, nil
-	}
-	if c.Conflict.Kind == ConflictFile {
-		// Suppressed by authorization: resident bytes sit at the destination
-		// RIGHT NOW — the authorized execute leg replaces them.
-		return c.Identical, c.SameInode, true, nil
+	if c.Conflict == nil || c.Conflict.Kind == ConflictFile {
+		// A regular-file occupation is suppressed by authorization — the
+		// publish reports whether resident bytes were ACTUALLY displaced.
+		return c.Identical, c.SameInode, nil
 	}
 	logDestRefusal(*c.Conflict)
-	return false, false, false, fmt.Errorf("cannot authorize-over a %s destination (refusing to replace): %s", c.Conflict.kindName(), c.Conflict.Path)
+	return false, false, fmt.Errorf("cannot authorize-over a %s destination (refusing to replace): %s", c.Conflict.kindName(), c.Conflict.Path)
 }
 
 // distinctConflictRenders returns each conflict's rendered form exactly once,

--- a/internal/organizer/coverage_pins_test.go
+++ b/internal/organizer/coverage_pins_test.go
@@ -30,7 +30,7 @@ func TestCoverPin_RefusalErrPropagation(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = fs.MkdirAll("/dest", 0o755)
 	wrapped := statFails{fs}
-	_, _, err := refuseIfUnsuppressibleAuthorizedDestination(wrapped, "/src/a.mp4", "/dest/fail-me.mp4")
+	_, _, _, err := classifyAuthorizedDestination(wrapped, "/src/a.mp4", "/dest/fail-me.mp4")
 	assert.Error(t, err)
 }
 

--- a/internal/organizer/coverage_pins_test.go
+++ b/internal/organizer/coverage_pins_test.go
@@ -30,7 +30,7 @@ func TestCoverPin_RefusalErrPropagation(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = fs.MkdirAll("/dest", 0o755)
 	wrapped := statFails{fs}
-	_, _, _, err := classifyAuthorizedDestination(wrapped, "/src/a.mp4", "/dest/fail-me.mp4")
+	_, _, err := classifyAuthorizedDestination(wrapped, "/src/a.mp4", "/dest/fail-me.mp4")
 	assert.Error(t, err)
 }
 

--- a/internal/organizer/force_overwrite_audit_test.go
+++ b/internal/organizer/force_overwrite_audit_test.go
@@ -1,0 +1,256 @@
+package organizer
+
+// Force-overwrite audit crumb: an overwrite-AUTHORIZED organize move/copy leg
+// that replaces a bytes-bearing destination must carry the
+// "overwrite authorized: replaced existing destination <path>" warning on its
+// OrganizeResult so the audit surfaces downstream (worker history metadata,
+// API eventlog resolver, CLI console print) keep the replacement visible.
+// Absent destinations, self/same-inode no-ops, non-authorized runs, and the
+// authorized intra-batch duplicate skip keep their pre-existing behavior:
+// no crumb, and the dup skip never double-warns.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+)
+
+// forceAuditOrganizer builds the organize-mode organizer over a fresh
+// MemMapFs — the duplex fixture convention of dupBatchFixture: sources under
+// /in, destinations compute as /dest/<ID>/<ID>.mkv.
+func forceAuditOrganizer(t *testing.T) (*Organizer, afero.Fs) {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	cfg := &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+	require.NoError(t, fs.MkdirAll("/in", 0o755))
+	return org, fs
+}
+
+// forceAuditCmd builds the single-file organize command onto the /dest
+// library; force maps to the CLI's -f overwrite authorization.
+func forceAuditCmd(path string, force, move bool) OrganizeCmd {
+	return OrganizeCmd{
+		Match:       models.FileMatchInfo{MovieID: "ABC-123", Path: path, Name: filepath.Base(path), Extension: filepath.Ext(path)},
+		Movie:       &models.Movie{ID: "ABC-123"},
+		DestDir:     "/dest",
+		MoveFiles:   move,
+		LinkMode:    LinkModeNone,
+		ForceUpdate: force,
+	}
+}
+
+// plantOccupiedDest pre-seeds the computed destination with resident bytes —
+// the foreign occupant a -f run must visibly replace.
+func plantOccupiedDest(t *testing.T, fs afero.Fs) string {
+	t.Helper()
+	const dst = "/dest/ABC-123/ABC-123.mkv"
+	require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
+	require.NoError(t, afero.WriteFile(fs, dst, []byte("resident-bytes"), 0o644))
+	return dst
+}
+
+func TestForceOverwriteAudit_MoveLeg(t *testing.T) {
+	t.Run("force move onto occupied dest warns and replaces", func(t *testing.T) {
+		org, fs := forceAuditOrganizer(t)
+		require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		dst := plantOccupiedDest(t, fs)
+
+		result, err := org.Organize(context.Background(), forceAuditCmd("/in/A.mkv", true, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved, "the authorized move executed")
+		require.Len(t, result.Warnings, 1, "exactly one audit crumb — the resident bytes' replacement")
+		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		assert.Contains(t, filepath.ToSlash(result.Warnings[0]),
+			"overwrite authorized: replaced existing destination /dest/ABC-123/ABC-123.mkv")
+
+		// Journal evidence: the destination now carries the winner's bytes and
+		// the source path is gone (the move actually replaced the occupant).
+		content, readErr := afero.ReadFile(fs, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content, "resident bytes were replaced")
+		srcExists, statErr := afero.Exists(fs, "/in/A.mkv")
+		require.NoError(t, statErr)
+		assert.False(t, srcExists, "the winner's source moved")
+	})
+
+	t.Run("force move onto vacant dest stays silent", func(t *testing.T) {
+		org, fs := forceAuditOrganizer(t)
+		require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+
+		result, err := org.Organize(context.Background(), forceAuditCmd("/in/A.mkv", true, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings, "no occupant existed at plan time — no crumb")
+		content, readErr := afero.ReadFile(fs, "/dest/ABC-123/ABC-123.mkv")
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+
+	t.Run("non-force onto occupied dest conflicts exactly as before", func(t *testing.T) {
+		org, fs := forceAuditOrganizer(t)
+		require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		dst := plantOccupiedDest(t, fs)
+
+		_, err := org.Organize(context.Background(), forceAuditCmd("/in/A.mkv", false, true))
+		require.Error(t, err, "an occupied destination still blocks an unauthorized run")
+		assert.Contains(t, err.Error(), "organization validation failed")
+		assert.Contains(t, filepath.ToSlash(err.Error()), dst)
+
+		// Neither side changed: the refusal replaced nothing.
+		content, readErr := afero.ReadFile(fs, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("resident-bytes"), content, "the occupant's bytes are intact")
+		srcContent, readErr := afero.ReadFile(fs, "/in/A.mkv")
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), srcContent, "the source stayed put")
+	})
+}
+
+func TestForceOverwriteAudit_CopyLeg(t *testing.T) {
+	t.Run("force copy onto occupied dest warns and replaces", func(t *testing.T) {
+		org, fs := forceAuditOrganizer(t)
+		require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		dst := plantOccupiedDest(t, fs)
+
+		result, err := org.Organize(context.Background(), forceAuditCmd("/in/A.mkv", true, false))
+		require.NoError(t, err)
+		require.True(t, result.Moved, "the authorized copy executed")
+		require.Len(t, result.Warnings, 1, "exactly one audit crumb")
+		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+
+		content, readErr := afero.ReadFile(fs, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content, "resident bytes were replaced")
+		srcExists, statErr := afero.Exists(fs, "/in/A.mkv")
+		require.NoError(t, statErr)
+		assert.True(t, srcExists, "a copy retains its source")
+	})
+
+	t.Run("force copy onto vacant dest stays silent", func(t *testing.T) {
+		org, fs := forceAuditOrganizer(t)
+		require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+
+		result, err := org.Organize(context.Background(), forceAuditCmd("/in/A.mkv", true, false))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings, "no occupant existed at plan time — no crumb")
+	})
+
+	t.Run("non-force copy onto occupied dest conflicts exactly as before", func(t *testing.T) {
+		org, fs := forceAuditOrganizer(t)
+		require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		dst := plantOccupiedDest(t, fs)
+
+		_, err := org.Organize(context.Background(), forceAuditCmd("/in/A.mkv", false, false))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "organization validation failed")
+		content, readErr := afero.ReadFile(fs, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("resident-bytes"), content, "the occupant's bytes are intact")
+	})
+}
+
+// Same-inode alias no-op (requirement: NO crumb when nothing is replaced):
+// source and destination are hardlink aliases of one inode — even under -f
+// the plan-time classifier reports no occupation and execution no-ops.
+func TestForceOverwriteAudit_SameInodeNoOp_Silent(t *testing.T) {
+	dir := t.TempDir()
+	fs := afero.NewOsFs()
+	src := filepath.Join(dir, "in", "ABC-123.mkv")
+	dst := filepath.Join(dir, "dest", "ABC-123", "ABC-123.mkv")
+	require.NoError(t, os.MkdirAll(filepath.Dir(src), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
+	require.NoError(t, os.WriteFile(src, []byte("shared-bytes"), 0o644))
+	require.NoError(t, os.Link(src, dst))
+
+	cfg := &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}
+	org := NewOrganizer(fs, cfg, nil, nil)
+
+	result, err := org.Organize(context.Background(), OrganizeCmd{
+		Match:       models.FileMatchInfo{MovieID: "ABC-123", Path: src, Name: "ABC-123.mkv", Extension: ".mkv"},
+		Movie:       &models.Movie{ID: "ABC-123"},
+		DestDir:     filepath.Join(dir, "dest"),
+		MoveFiles:   true,
+		ForceUpdate: true,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result.Warnings, "a same-inode no-op replaced nothing — no crumb")
+	content, readErr := os.ReadFile(dst)
+	require.NoError(t, readErr)
+	assert.Equal(t, []byte("shared-bytes"), content)
+	srcExists, statErr := afero.Exists(fs, src)
+	require.NoError(t, statErr)
+	assert.True(t, srcExists, "the no-op never removed the source")
+}
+
+// The authorized intra-batch duplicate skip carries ONLY its demotion
+// warning — even when its plan ALSO saw a bytes-bearing occupant on the
+// claimed destination, the skipped loser must never double-warn with the
+// overwrite crumb (it executed nothing and replaced nothing).
+func TestForceOverwriteAudit_DuplicateSkip_NoDoubleWarn(t *testing.T) {
+	forceCasePosture(t, true)
+	org, fs := forceAuditOrganizer(t)
+	require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("a-bytes"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/in/B.mkv", []byte("b-bytes"), 0o644))
+	dst := plantOccupiedDest(t, fs)
+	tracker := NewDuplicateTracker(false)
+
+	// Winner A force-organizes FIRST onto the occupied destination: the crumb
+	// fires there (it really replaced the resident bytes).
+	winner, err := org.Organize(context.Background(), OrganizeCmd{
+		Match:            models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/A.mkv", Name: "A.mkv", Extension: ".mkv"},
+		Movie:            &models.Movie{ID: "ABC-123"},
+		DestDir:          "/dest",
+		MoveFiles:        true,
+		ForceUpdate:      true,
+		DuplicateTracker: tracker,
+	})
+	require.NoError(t, err)
+	require.Len(t, winner.Warnings, 1)
+	assert.Equal(t, authorizedOverwriteWarning(dst), winner.Warnings[0],
+		"the winner replaced the pre-seeded occupant")
+	assert.True(t, winner.Moved)
+	assert.False(t, winner.DuplicateSkipped)
+
+	// Loser B: batch duplicate AND (at plan time) an occupied destination —
+	// both warning signals exist, but the skip demotes to the dup warning
+	// alone; the overwrite crumb belongs to whoever moved bytes (winner A).
+	loser, err := org.Organize(context.Background(), OrganizeCmd{
+		Match:            models.FileMatchInfo{MovieID: "ABC-123", Path: "/in/B.mkv", Name: "B.mkv", Extension: ".mkv"},
+		Movie:            &models.Movie{ID: "ABC-123"},
+		DestDir:          "/dest",
+		MoveFiles:        true,
+		ForceUpdate:      true,
+		DuplicateTracker: tracker,
+	})
+	require.NoError(t, err)
+	assert.True(t, loser.DuplicateSkipped)
+	require.Len(t, loser.Warnings, 1, "exactly one warning — the dup demotion, never doubled")
+	assert.Contains(t, loser.Warnings[0], "duplicate destination within batch")
+	assert.NotContains(t, loser.Warnings[0], "overwrite authorized: replaced existing destination",
+		"the skipped loser replaced nothing — no overwrite crumb")
+
+	// The destination carries exactly the winner's bytes.
+	content, readErr := afero.ReadFile(fs, dst)
+	require.NoError(t, readErr)
+	assert.Equal(t, []byte("a-bytes"), content)
+}

--- a/internal/organizer/force_overwrite_audit_test.go
+++ b/internal/organizer/force_overwrite_audit_test.go
@@ -1,13 +1,22 @@
 package organizer
 
-// Force-overwrite audit crumb: an overwrite-AUTHORIZED organize move/copy leg
-// that replaces a bytes-bearing destination must carry the
+// Force-overwrite audit crumb: an overwrite-AUTHORIZED terminal leg that
+// replaces a bytes-bearing destination must carry the
 // "overwrite authorized: replaced existing destination <path>" warning on its
 // OrganizeResult so the audit surfaces downstream (worker history metadata,
 // API eventlog resolver, CLI console print) keep the replacement visible.
-// Absent destinations, self/same-inode no-ops, non-authorized runs, and the
-// authorized intra-batch duplicate skip keep their pre-existing behavior:
-// no crumb, and the dup skip never double-warns.
+// The crumb keys on EXECUTE-TIME occupancy (the leg's own classification,
+// taken under the held destination locks) — never plan-time evidence: a
+// post-plan occupant swap can neither forge a replacement (occupied@plan →
+// vacant@execute: silent) nor hide one (vacant@plan → occupied@execute:
+// crumb). Wired lanes: organize move, organize copy, organize link install
+// (hard/soft), in-place inner file rename, in-place non-rename file move,
+// in-place-norenamefolder rename. Absent destinations, self/same-inode no-ops
+// (including authorized link installs recycling a hardlink alias name),
+// non-authorized runs, the pure in-place directory rename (replaces no
+// foreign bytes by construction), and the authorized intra-batch duplicate
+// skip keep their pre-existing behavior: no crumb, and the dup skip never
+// double-warns.
 
 import (
 	"context"
@@ -253,4 +262,590 @@ func TestForceOverwriteAudit_DuplicateSkip_NoDoubleWarn(t *testing.T) {
 	content, readErr := afero.ReadFile(fs, dst)
 	require.NoError(t, readErr)
 	assert.Equal(t, []byte("a-bytes"), content)
+}
+
+// ---------------------------------------------------------------------------
+// P2 (review round 1): TOCTOU pins — the crumb must key on EXECUTE-TIME
+// occupancy, never plan-time evidence. Two failure classes are pinned shut:
+//   false positive — occupied@plan → vacant@execute: nothing is replaced, so
+//     the crumb must NOT fire (plan-time evidence claimed a replacement that
+//     never happened);
+//   false negative — vacant@plan → occupied@execute: the execute leg replaces
+//     resident bytes the plan never saw, so the crumb MUST fire.
+// ---------------------------------------------------------------------------
+
+// toctouWedgeFs wedges a filesystem mutation INTO the plan→execute window of
+// one fused Organize call: the target's FIRST LstatIfPossible probe (the
+// plan-time classification) answers truthfully; the wedge fires exactly once,
+// just before the SECOND probe — the execute-time classification — answers.
+// With plan-time crumb evidence (pre-fix) the wedge was invisible to the
+// execute legs; the execute-keyed crumb must observe it.
+type toctouWedgeFs struct {
+	afero.Fs
+	target string
+	probes int
+	wedge  func(fs afero.Fs)
+}
+
+func (w *toctouWedgeFs) LstatIfPossible(path string) (os.FileInfo, bool, error) {
+	if filepath.Clean(path) == filepath.Clean(w.target) {
+		w.probes++
+		if w.probes == 2 && w.wedge != nil {
+			w.wedge(w.Fs)
+			w.wedge = nil
+		}
+	}
+	if lst, ok := w.Fs.(afero.Lstater); ok {
+		return lst.LstatIfPossible(path)
+	}
+	info, err := w.Fs.Stat(path)
+	return info, false, err
+}
+
+// forceAuditPlan runs the EXACT plan the fused seam computes, then returns it
+// for a manual execute through the plan's captured strategy — the
+// "pre-create dest post-plan" TOCTOU wedge without racing goroutines.
+func forceAuditPlan(t *testing.T, org *Organizer, cmd OrganizeCmd) *OrganizePlan {
+	t.Helper()
+	plan, err := org.PlanOrganize(context.Background(), cmd)
+	require.NoError(t, err)
+	require.Empty(t, plan.Conflicts, "force suppresses the file-occupation conflict at plan; other kinds must not appear in these fixtures")
+	require.NotNil(t, plan.executeStrategy)
+	return plan
+}
+
+// forceAuditPlanCopy repoints a planned move onto the copy leg exactly like
+// the fused seam does (Organize sets moveFiles/LinkMode after planning).
+func forceAuditPlanCopy(t *testing.T, org *Organizer, cmd OrganizeCmd) *OrganizePlan {
+	t.Helper()
+	plan := forceAuditPlan(t, org, cmd)
+	plan.moveFiles = false
+	plan.LinkMode = LinkModeNone
+	return plan
+}
+
+func TestForceOverwriteAudit_TOCTOU_OccupiedOnlyAtExecute(t *testing.T) {
+	t.Run("move leg: occupant planted post-plan crumbs", func(t *testing.T) {
+		org, fs := forceAuditOrganizer(t)
+		require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		plan := forceAuditPlan(t, org, forceAuditCmd("/in/A.mkv", true, true))
+
+		// TOCTOU: pre-create the destination POST-plan (vacant at plan time).
+		dst := plantOccupiedDest(t, fs)
+
+		result, err := plan.executeStrategy.Execute(plan)
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.Len(t, result.Warnings, 1,
+			"the execute leg replaced resident bytes the plan never saw — the crumb must fire")
+		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+
+		content, readErr := afero.ReadFile(fs, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content, "the late resident's bytes were really replaced")
+	})
+
+	t.Run("copy leg: occupant planted post-plan crumbs", func(t *testing.T) {
+		org, fs := forceAuditOrganizer(t)
+		require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		plan := forceAuditPlanCopy(t, org, forceAuditCmd("/in/A.mkv", true, false))
+
+		dst := plantOccupiedDest(t, fs) // occupied only at execute time
+
+		result, err := plan.executeStrategy.Execute(plan)
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.Len(t, result.Warnings, 1)
+		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+
+		content, readErr := afero.ReadFile(fs, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content)
+		srcExists, statErr := afero.Exists(fs, "/in/A.mkv")
+		require.NoError(t, statErr)
+		assert.True(t, srcExists, "a copy retains its source")
+	})
+}
+
+func TestForceOverwriteAudit_TOCTOU_VacatedAtExecute(t *testing.T) {
+	t.Run("move leg: occupant removed post-plan stays silent", func(t *testing.T) {
+		org, fs := forceAuditOrganizer(t)
+		require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		dst := plantOccupiedDest(t, fs)
+		plan := forceAuditPlan(t, org, forceAuditCmd("/in/A.mkv", true, true))
+
+		// TOCTOU: vacate the destination POST-plan (occupied at plan time).
+		require.NoError(t, fs.Remove(dst))
+
+		result, err := plan.executeStrategy.Execute(plan)
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings,
+			"the execute leg replaced NOTHING (vacant at execute) — plan-time evidence would have claimed a replacement that never happened")
+
+		content, readErr := afero.ReadFile(fs, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content, "the move still landed — onto a vacant name")
+	})
+
+	t.Run("copy leg: occupant removed post-plan stays silent", func(t *testing.T) {
+		org, fs := forceAuditOrganizer(t)
+		require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		dst := plantOccupiedDest(t, fs)
+		plan := forceAuditPlanCopy(t, org, forceAuditCmd("/in/A.mkv", true, false))
+
+		require.NoError(t, fs.Remove(dst))
+
+		result, err := plan.executeStrategy.Execute(plan)
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings)
+		content, readErr := afero.ReadFile(fs, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+}
+
+// Fused-seam TOCTOU pins: same two wedges, but driven through the single
+// Organize call (plan and execute fused) with the injectable fs wrapper —
+// proving the production call shape observes the post-plan mutation.
+func TestForceOverwriteAudit_TOCTOU_FusedWedge(t *testing.T) {
+	fusedCfg := func() *Config {
+		return &Config{
+			FolderFormat:  "<ID>",
+			FileFormat:    "<ID>",
+			RenameFile:    true,
+			OperationMode: operationmode.OperationModeOrganize,
+		}
+	}
+	const dst = "/dest/ABC-123/ABC-123.mkv"
+
+	t.Run("move: occupant planted inside the plan-execute window crumbs", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		wedge := &toctouWedgeFs{Fs: base, target: dst, wedge: func(fs afero.Fs) {
+			require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
+			require.NoError(t, afero.WriteFile(fs, dst, []byte("late-resident"), 0o644))
+		}}
+		org := NewOrganizer(wedge, fusedCfg(), nil, nil)
+
+		result, err := org.Organize(context.Background(), forceAuditCmd("/in/A.mkv", true, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.Len(t, result.Warnings, 1, "the execute-time classification saw the wedged-in occupant")
+		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		assert.GreaterOrEqual(t, wedge.probes, 2, "the wedge really fired between plan and execute")
+		content, readErr := afero.ReadFile(base, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+
+	t.Run("copy: occupant planted inside the plan-execute window crumbs", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		wedge := &toctouWedgeFs{Fs: base, target: dst, wedge: func(fs afero.Fs) {
+			require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
+			require.NoError(t, afero.WriteFile(fs, dst, []byte("late-resident"), 0o644))
+		}}
+		org := NewOrganizer(wedge, fusedCfg(), nil, nil)
+
+		result, err := org.Organize(context.Background(), forceAuditCmd("/in/A.mkv", true, false))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.Len(t, result.Warnings, 1)
+		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+	})
+
+	t.Run("move: occupant vacated inside the plan-execute window stays silent", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		require.NoError(t, base.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, afero.WriteFile(base, dst, []byte("plan-time-resident"), 0o644))
+		wedge := &toctouWedgeFs{Fs: base, target: dst, wedge: func(fs afero.Fs) {
+			require.NoError(t, fs.Remove(dst))
+		}}
+		org := NewOrganizer(wedge, fusedCfg(), nil, nil)
+
+		result, err := org.Organize(context.Background(), forceAuditCmd("/in/A.mkv", true, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings,
+			"vacant at execute: nothing was replaced — plan-time evidence would have falsely crumbed")
+		content, readErr := afero.ReadFile(base, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+}
+
+// Batch-dup + occupied interplay under the execute-time keying: the crumb
+// belongs to whichever execute leg ACTUALLY replaced bytes; the skipped loser
+// never carries it regardless of what any plan observed.
+func TestForceOverwriteAudit_BatchDup_TOCTOUInterplay(t *testing.T) {
+	const dst = "/dest/ABC-123/ABC-123.mkv"
+	batchOrg := func(base afero.Fs) *Organizer {
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/in/A.mkv", []byte("a-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(base, "/in/B.mkv", []byte("b-bytes"), 0o644))
+		return NewOrganizer(base, &Config{
+			FolderFormat:  "<ID>",
+			FileFormat:    "<ID>",
+			RenameFile:    true,
+			OperationMode: operationmode.OperationModeOrganize,
+		}, nil, nil)
+	}
+	batchCmd := func(src string, tracker *DuplicateTracker) OrganizeCmd {
+		return OrganizeCmd{
+			Match:            models.FileMatchInfo{MovieID: "ABC-123", Path: src, Name: filepath.Base(src), Extension: ".mkv"},
+			Movie:            &models.Movie{ID: "ABC-123"},
+			DestDir:          "/dest",
+			MoveFiles:        true,
+			ForceUpdate:      true,
+			DuplicateTracker: tracker,
+		}
+	}
+
+	t.Run("winner occupied only at execute: crumb lands on the winner, dup warning on the loser", func(t *testing.T) {
+		forceCasePosture(t, true)
+		base := afero.NewMemMapFs()
+		wedge := &toctouWedgeFs{Fs: base, target: dst, wedge: func(fs afero.Fs) {
+			// Both plans see a VACANT destination; the winner's execute-classify
+			// probe plants the occupant mid-flight (false-negative wedge).
+			require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
+			require.NoError(t, afero.WriteFile(fs, dst, []byte("late-resident"), 0o644))
+		}}
+		org := batchOrg(wedge)
+		tracker := NewDuplicateTracker(false)
+
+		winner, err := org.Organize(context.Background(), batchCmd("/in/A.mkv", tracker))
+		require.NoError(t, err)
+		require.True(t, winner.Moved)
+		require.Len(t, winner.Warnings, 1,
+			"plan-time evidence (pre-fix) missed this replacement entirely — execute-time keying catches it")
+		assert.Equal(t, authorizedOverwriteWarning(dst), winner.Warnings[0])
+
+		loser, err := org.Organize(context.Background(), batchCmd("/in/B.mkv", tracker))
+		require.NoError(t, err)
+		require.True(t, loser.DuplicateSkipped)
+		require.Len(t, loser.Warnings, 1)
+		assert.Contains(t, loser.Warnings[0], "duplicate destination within batch")
+		assert.NotContains(t, loser.Warnings[0], "overwrite authorized: replaced existing destination")
+
+		content, readErr := afero.ReadFile(base, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("a-bytes"), content, "the winner's bytes won both the plant and the batch")
+	})
+
+	t.Run("winner occupied only at plan: no crumb anywhere — only the loser dup demotion", func(t *testing.T) {
+		forceCasePosture(t, true)
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, afero.WriteFile(base, dst, []byte("plan-time-resident"), 0o644))
+		wedge := &toctouWedgeFs{Fs: base, target: dst, wedge: func(fs afero.Fs) {
+			require.NoError(t, fs.Remove(dst))
+		}}
+		org := batchOrg(wedge)
+		tracker := NewDuplicateTracker(false)
+
+		winner, err := org.Organize(context.Background(), batchCmd("/in/A.mkv", tracker))
+		require.NoError(t, err)
+		require.True(t, winner.Moved)
+		assert.Empty(t, winner.Warnings,
+			"occupied at plan, vacant at execute: the winner replaced NOTHING (false-positive wedge)")
+
+		loser, err := org.Organize(context.Background(), batchCmd("/in/B.mkv", tracker))
+		require.NoError(t, err)
+		require.True(t, loser.DuplicateSkipped)
+		require.Len(t, loser.Warnings, 1, "exactly the dup demotion — no crumb leaked from any plan")
+		assert.Contains(t, loser.Warnings[0], "duplicate destination within batch")
+
+		content, readErr := afero.ReadFile(base, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("a-bytes"), content)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// P3 (review round 1): link-install + in-place authorized lanes. Every lane
+// whose execute leg replaces resident bytes under -f carries the same crumb,
+// keyed to execute-time occupancy; lanes that only reshape names without
+// destroying foreign bytes stay silent deliberately.
+// ---------------------------------------------------------------------------
+
+// forceAuditStrategyFixture builds a MemMapFs with a source under /in and an
+// organize-strategy wired to the given linker (MemLinker records installs;
+// nil uses OSLinker for OsFs fixtures).
+func forceAuditStrategy(t *testing.T, l linker) (*organizeStrategy, afero.Fs, string) {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/in", 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+	strategy := newOrganizeStrategy(fs, &Config{
+		FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true,
+	}, nil, l)
+	return strategy, fs, "/in/A.mkv"
+}
+
+func forceAuditLinkPlan(src, dst string, mode LinkMode, force bool) *OrganizePlan {
+	return &OrganizePlan{
+		Match:      models.FileMatchInfo{MovieID: "ABC-123", Path: src, Name: "A.mkv", Extension: ".mkv"},
+		SourcePath: src, TargetDir: filepath.Dir(dst), TargetPath: dst, TargetFile: filepath.Base(dst),
+		WillMove: true, moveFiles: false, LinkMode: mode, overwriteAuthorized: force,
+	}
+}
+
+func TestForceOverwriteAudit_LinkInstallLanes(t *testing.T) {
+	const dst = "/dest/ABC-123/ABC-123.mkv"
+
+	t.Run("force hardlink install replacing a resident file crumbs", func(t *testing.T) {
+		strategy, fs, src := forceAuditStrategy(t, &MemLinker{})
+		ml := strategy.linker.(*MemLinker)
+		require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, afero.WriteFile(fs, dst, []byte("resident-bytes"), 0o644))
+
+		result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeHard, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.Len(t, result.Warnings, 1,
+			"an authorized link install REPLACES resident bytes at the destination — the crumb must fire")
+		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		require.Len(t, ml.Links, 1)
+		assert.Equal(t, "hard", ml.Links[0].Kind)
+		assert.Equal(t, dst, ml.Links[0].NewName)
+		dstExists, statErr := afero.Exists(fs, dst)
+		require.NoError(t, statErr)
+		assert.False(t, dstExists,
+			"the resident entry was removed so the link install could take the name (MemLinker records the install itself)")
+	})
+
+	t.Run("force softlink install replacing a resident file crumbs", func(t *testing.T) {
+		strategy, fs, src := forceAuditStrategy(t, &MemLinker{})
+		ml := strategy.linker.(*MemLinker)
+		require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, afero.WriteFile(fs, dst, []byte("resident-bytes"), 0o644))
+
+		result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeSoft, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.Len(t, result.Warnings, 1)
+		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		require.Len(t, ml.Links, 1)
+		assert.Equal(t, "soft", ml.Links[0].Kind)
+	})
+
+	t.Run("force hardlink install onto a vacant dest stays silent", func(t *testing.T) {
+		strategy, _, src := forceAuditStrategy(t, &MemLinker{})
+		ml := strategy.linker.(*MemLinker)
+
+		result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeHard, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings, "no resident bytes existed — nothing was replaced")
+		require.Len(t, ml.Links, 1, "the install still ran")
+	})
+}
+
+// Same-inode alias lanes: an authorized install recycling a name that ALIASES
+// the source's own inode replaces NO foreign bytes — the crumb must stay
+// silent even though the destination entry itself is consumed and recreated.
+func TestForceOverwriteAudit_SameInodeAliasLanes_Silent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("os-level hardlink fixture")
+	}
+
+	t.Run("hardlink install onto a hardlink alias of the source stays silent", func(t *testing.T) {
+		dir := t.TempDir()
+		fs := afero.NewOsFs()
+		src := filepath.Join(dir, "in", "ABC-123.mkv")
+		dst := filepath.Join(dir, "dest", "ABC-123", "ABC-123.mkv")
+		require.NoError(t, os.MkdirAll(filepath.Dir(src), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, os.WriteFile(src, []byte("shared-bytes"), 0o644))
+		require.NoError(t, os.Link(src, dst), "destination is a hardlink ALIAS of the source — same inode, zero foreign bytes")
+
+		strategy := newOrganizeStrategy(fs, &Config{
+			FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true,
+		}, nil, nil) // OSLinker: real link installs against OsFs
+		result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeHard, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings,
+			"removing an alias NAME destroyed no bytes — the inode lives on through the source name")
+		content, readErr := os.ReadFile(dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("shared-bytes"), content)
+		srcInfo, statErr := os.Stat(src)
+		require.NoError(t, statErr)
+		dstInfo, statErr := os.Stat(dst)
+		require.NoError(t, statErr)
+		assert.True(t, os.SameFile(srcInfo, dstInfo), "the recycled name still aliases the source inode")
+	})
+
+	t.Run("copy onto a hardlink alias of the source stays silent", func(t *testing.T) {
+		dir := t.TempDir()
+		fs := afero.NewOsFs()
+		src := filepath.Join(dir, "in", "ABC-123.mkv")
+		dst := filepath.Join(dir, "dest", "ABC-123", "ABC-123.mkv")
+		require.NoError(t, os.MkdirAll(filepath.Dir(src), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, os.WriteFile(src, []byte("shared-bytes"), 0o644))
+		require.NoError(t, os.Link(src, dst))
+
+		strategy := newOrganizeStrategy(fs, &Config{
+			FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true,
+		}, nil, nil)
+		result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeNone, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings,
+			"the authorized copy republished identical bytes over an alias — no FOREIGN resident bytes were replaced")
+		content, readErr := os.ReadFile(dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("shared-bytes"), content)
+		sourceContent, readErr := os.ReadFile(src)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("shared-bytes"), sourceContent, "a copy retains its source")
+	})
+}
+
+// In-place authorized lanes: the inner FILE rename and the non-rename file
+// MOVE both genuinely replace resident bytes under -f (crumb); the pure
+// directory rename replaces nothing foreign by construction (silent).
+func TestForceOverwriteAudit_InPlaceLanes(t *testing.T) {
+	inPlaceCmd := func(src, name string, force bool) OrganizeCmd {
+		return OrganizeCmd{
+			Match:       models.FileMatchInfo{MovieID: "ABC-100", Path: src, Name: name, Extension: ".mkv"},
+			Movie:       &models.Movie{ID: "ABC-100"},
+			DestDir:     "/dest",
+			MoveFiles:   true,
+			ForceUpdate: force,
+		}
+	}
+
+	t.Run("inner rename replacing a foreign occupant crumbs", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		cfg := &Config{
+			FolderFormat: "shared", FileFormat: "<ID> vidfile",
+			RenameFile: true, OperationMode: operationmode.OperationModeInPlace,
+		}
+		require.NoError(t, fs.MkdirAll("/pool/oldA", 0o755))
+		require.NoError(t, afero.WriteFile(fs, "/pool/oldA/ABC-100 ownA.mkv", []byte("a-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(fs, "/pool/oldA/ABC-100 vidfile.mkv", []byte("plant-bytes"), 0o644),
+			"a foreign file already carries the new name inside the folder about to be renamed")
+		org := NewOrganizer(fs, cfg, nil, ipfMatcher(t))
+
+		result, err := org.Organize(context.Background(), inPlaceCmd("/pool/oldA/ABC-100 ownA.mkv", "ABC-100 ownA.mkv", true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.True(t, result.InPlaceRenamed)
+		require.Len(t, result.Warnings, 1,
+			"the authorized inner rename replaced the foreign occupant's resident bytes")
+		assert.Equal(t, authorizedOverwriteWarning(filepath.FromSlash("/pool/shared/ABC-100 vidfile.mkv")),
+			filepath.FromSlash(result.Warnings[0]))
+		content, readErr := afero.ReadFile(fs, "/pool/shared/ABC-100 vidfile.mkv")
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("a-bytes"), content, "the plant's bytes were replaced")
+	})
+
+	t.Run("inner rename onto a vacant name stays silent — the dir rename replaces no foreign bytes", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		cfg := &Config{
+			FolderFormat: "shared", FileFormat: "<ID> vidfile",
+			RenameFile: true, OperationMode: operationmode.OperationModeInPlace,
+		}
+		require.NoError(t, fs.MkdirAll("/pool/oldA", 0o755))
+		require.NoError(t, afero.WriteFile(fs, "/pool/oldA/ABC-100 ownA.mkv", []byte("a-bytes"), 0o644))
+		org := NewOrganizer(fs, cfg, nil, ipfMatcher(t))
+
+		result, err := org.Organize(context.Background(), inPlaceCmd("/pool/oldA/ABC-100 ownA.mkv", "ABC-100 ownA.mkv", true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.True(t, result.InPlaceRenamed)
+		assert.Empty(t, result.Warnings,
+			"rename-only legs (directory + file onto vacant names) replace nothing — no crumb")
+		content, readErr := afero.ReadFile(fs, "/pool/shared/ABC-100 vidfile.mkv")
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("a-bytes"), content)
+	})
+
+	t.Run("in-place non-dedicated move replacing a foreign occupant crumbs", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		cfg := &Config{
+			FolderFormat: "<ID>", FileFormat: "<ID> vidfile",
+			RenameFile: true, OperationMode: operationmode.OperationModeInPlace,
+		}
+		require.NoError(t, fs.MkdirAll("/pool/mixed", 0o755))
+		require.NoError(t, afero.WriteFile(fs, "/pool/mixed/ABC-100 ownA.mkv", []byte("a-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(fs, "/pool/mixed/DEF-999 other.mkv", []byte("other-tenant"), 0o644),
+			"a second-ID tenant keeps the folder mixed (non-dedicated → non-rename move lane)")
+		require.NoError(t, afero.WriteFile(fs, "/pool/mixed/ABC-100 vidfile.mkv", []byte("plant-bytes"), 0o644))
+		org := NewOrganizer(fs, cfg, nil, ipfMatcher(t))
+
+		result, err := org.Organize(context.Background(), inPlaceCmd("/pool/mixed/ABC-100 ownA.mkv", "ABC-100 ownA.mkv", true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.Len(t, result.Warnings, 1)
+		assert.Equal(t, authorizedOverwriteWarning(filepath.FromSlash("/pool/mixed/ABC-100 vidfile.mkv")),
+			filepath.FromSlash(result.Warnings[0]))
+		content, readErr := afero.ReadFile(fs, "/pool/mixed/ABC-100 vidfile.mkv")
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("a-bytes"), content)
+		srcExists, statErr := afero.Exists(fs, "/pool/mixed/ABC-100 ownA.mkv")
+		require.NoError(t, statErr)
+		assert.False(t, srcExists, "the move landed")
+	})
+}
+
+// In-place-norenamefolder: a same-directory file rename whose authorized leg
+// replaces a foreign file carrying the target name (crumb); vacant target
+// names stay silent.
+func TestForceOverwriteAudit_InPlaceNoRenameFolderLane(t *testing.T) {
+	fixture := func(t *testing.T, plant bool) (*Organizer, afero.Fs) {
+		t.Helper()
+		fs := afero.NewMemMapFs()
+		cfg := &Config{
+			FolderFormat: "<ID>", FileFormat: "<ID> vidfile",
+			RenameFile: true, OperationMode: operationmode.OperationModeInPlaceNoRenameFolder,
+		}
+		require.NoError(t, fs.MkdirAll("/pool", 0o755))
+		require.NoError(t, afero.WriteFile(fs, "/pool/ABC-100 ownA.mkv", []byte("a-bytes"), 0o644))
+		if plant {
+			require.NoError(t, afero.WriteFile(fs, "/pool/ABC-100 vidfile.mkv", []byte("plant-bytes"), 0o644))
+		}
+		return NewOrganizer(fs, cfg, nil, nil), fs
+	}
+	cmd := func(force bool) OrganizeCmd {
+		return OrganizeCmd{
+			Match:       models.FileMatchInfo{MovieID: "ABC-100", Path: "/pool/ABC-100 ownA.mkv", Name: "ABC-100 ownA.mkv", Extension: ".mkv"},
+			Movie:       &models.Movie{ID: "ABC-100"},
+			DestDir:     "/dest",
+			MoveFiles:   true,
+			ForceUpdate: force,
+		}
+	}
+
+	t.Run("authorized rename replacing a foreign occupant crumbs", func(t *testing.T) {
+		org, fs := fixture(t, true)
+		result, err := org.Organize(context.Background(), cmd(true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.Len(t, result.Warnings, 1)
+		assert.Equal(t, authorizedOverwriteWarning("/pool/ABC-100 vidfile.mkv"), result.Warnings[0])
+		content, readErr := afero.ReadFile(fs, "/pool/ABC-100 vidfile.mkv")
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("a-bytes"), content, "the plant's bytes were replaced")
+	})
+
+	t.Run("authorized rename onto a vacant name stays silent", func(t *testing.T) {
+		org, fs := fixture(t, false)
+		result, err := org.Organize(context.Background(), cmd(true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings)
+		content, readErr := afero.ReadFile(fs, "/pool/ABC-100 vidfile.mkv")
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("a-bytes"), content)
+	})
 }

--- a/internal/organizer/force_overwrite_audit_test.go
+++ b/internal/organizer/force_overwrite_audit_test.go
@@ -82,7 +82,7 @@ func TestForceOverwriteAudit_MoveLeg(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, result.Moved, "the authorized move executed")
 		require.Len(t, result.Warnings, 1, "exactly one audit crumb — the resident bytes' replacement")
-		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
 		assert.Contains(t, filepath.ToSlash(result.Warnings[0]),
 			"overwrite authorized: replaced existing destination /dest/ABC-123/ABC-123.mkv")
 
@@ -139,7 +139,7 @@ func TestForceOverwriteAudit_CopyLeg(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, result.Moved, "the authorized copy executed")
 		require.Len(t, result.Warnings, 1, "exactly one audit crumb")
-		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
 
 		content, readErr := afero.ReadFile(fs, dst)
 		require.NoError(t, readErr)
@@ -235,7 +235,7 @@ func TestForceOverwriteAudit_DuplicateSkip_NoDoubleWarn(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, winner.Warnings, 1)
-	assert.Equal(t, authorizedOverwriteWarning(dst), winner.Warnings[0],
+	assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(winner.Warnings[0]),
 		"the winner replaced the pre-seeded occupant")
 	assert.True(t, winner.Moved)
 	assert.False(t, winner.DuplicateSkipped)
@@ -338,7 +338,7 @@ func TestForceOverwriteAudit_TOCTOU_OccupiedOnlyAtExecute(t *testing.T) {
 		require.True(t, result.Moved)
 		require.Len(t, result.Warnings, 1,
 			"the execute leg replaced resident bytes the plan never saw — the crumb must fire")
-		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
 
 		content, readErr := afero.ReadFile(fs, dst)
 		require.NoError(t, readErr)
@@ -356,7 +356,7 @@ func TestForceOverwriteAudit_TOCTOU_OccupiedOnlyAtExecute(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, result.Moved)
 		require.Len(t, result.Warnings, 1)
-		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
 
 		content, readErr := afero.ReadFile(fs, dst)
 		require.NoError(t, readErr)
@@ -434,7 +434,7 @@ func TestForceOverwriteAudit_TOCTOU_FusedWedge(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, result.Moved)
 		require.Len(t, result.Warnings, 1, "the execute-time classification saw the wedged-in occupant")
-		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
 		assert.GreaterOrEqual(t, wedge.probes, 2, "the wedge really fired between plan and execute")
 		content, readErr := afero.ReadFile(base, dst)
 		require.NoError(t, readErr)
@@ -455,7 +455,7 @@ func TestForceOverwriteAudit_TOCTOU_FusedWedge(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, result.Moved)
 		require.Len(t, result.Warnings, 1)
-		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
 	})
 
 	t.Run("move: occupant vacated inside the plan-execute window stays silent", func(t *testing.T) {
@@ -524,7 +524,7 @@ func TestForceOverwriteAudit_BatchDup_TOCTOUInterplay(t *testing.T) {
 		require.True(t, winner.Moved)
 		require.Len(t, winner.Warnings, 1,
 			"plan-time evidence (pre-fix) missed this replacement entirely — execute-time keying catches it")
-		assert.Equal(t, authorizedOverwriteWarning(dst), winner.Warnings[0])
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(winner.Warnings[0]))
 
 		loser, err := org.Organize(context.Background(), batchCmd("/in/B.mkv", tracker))
 		require.NoError(t, err)
@@ -610,7 +610,7 @@ func TestForceOverwriteAudit_LinkInstallLanes(t *testing.T) {
 		require.True(t, result.Moved)
 		require.Len(t, result.Warnings, 1,
 			"an authorized link install REPLACES resident bytes at the destination — the crumb must fire")
-		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
 		require.Len(t, ml.Links, 1)
 		assert.Equal(t, "hard", ml.Links[0].Kind)
 		assert.Equal(t, dst, ml.Links[0].NewName)
@@ -630,7 +630,7 @@ func TestForceOverwriteAudit_LinkInstallLanes(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, result.Moved)
 		require.Len(t, result.Warnings, 1)
-		assert.Equal(t, authorizedOverwriteWarning(dst), result.Warnings[0])
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
 		require.Len(t, ml.Links, 1)
 		assert.Equal(t, "soft", ml.Links[0].Kind)
 	})
@@ -742,8 +742,8 @@ func TestForceOverwriteAudit_InPlaceLanes(t *testing.T) {
 		require.True(t, result.InPlaceRenamed)
 		require.Len(t, result.Warnings, 1,
 			"the authorized inner rename replaced the foreign occupant's resident bytes")
-		assert.Equal(t, authorizedOverwriteWarning(filepath.FromSlash("/pool/shared/ABC-100 vidfile.mkv")),
-			filepath.FromSlash(result.Warnings[0]))
+		assert.Equal(t, authorizedOverwriteWarning("/pool/shared/ABC-100 vidfile.mkv"),
+			filepath.ToSlash(result.Warnings[0]))
 		content, readErr := afero.ReadFile(fs, "/pool/shared/ABC-100 vidfile.mkv")
 		require.NoError(t, readErr)
 		assert.Equal(t, []byte("a-bytes"), content, "the plant's bytes were replaced")
@@ -787,8 +787,8 @@ func TestForceOverwriteAudit_InPlaceLanes(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, result.Moved)
 		require.Len(t, result.Warnings, 1)
-		assert.Equal(t, authorizedOverwriteWarning(filepath.FromSlash("/pool/mixed/ABC-100 vidfile.mkv")),
-			filepath.FromSlash(result.Warnings[0]))
+		assert.Equal(t, authorizedOverwriteWarning("/pool/mixed/ABC-100 vidfile.mkv"),
+			filepath.ToSlash(result.Warnings[0]))
 		content, readErr := afero.ReadFile(fs, "/pool/mixed/ABC-100 vidfile.mkv")
 		require.NoError(t, readErr)
 		assert.Equal(t, []byte("a-bytes"), content)
@@ -832,7 +832,7 @@ func TestForceOverwriteAudit_InPlaceNoRenameFolderLane(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, result.Moved)
 		require.Len(t, result.Warnings, 1)
-		assert.Equal(t, authorizedOverwriteWarning("/pool/ABC-100 vidfile.mkv"), result.Warnings[0])
+		assert.Equal(t, authorizedOverwriteWarning("/pool/ABC-100 vidfile.mkv"), filepath.ToSlash(result.Warnings[0]))
 		content, readErr := afero.ReadFile(fs, "/pool/ABC-100 vidfile.mkv")
 		require.NoError(t, readErr)
 		assert.Equal(t, []byte("a-bytes"), content, "the plant's bytes were replaced")

--- a/internal/organizer/force_overwrite_link_wedges_w249b_test.go
+++ b/internal/organizer/force_overwrite_link_wedges_w249b_test.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -79,10 +78,11 @@ func TestForceOverwriteAudit_CopyLaneFailure_KeepsUnionedDisplacementCrumb(t *te
 }
 
 // TestLinkInstallOccupantIsAlias_GuardBranches pins the confirm-or-silent
-// edges of the pre-Remove alias exclusion: a nil occupant (the probe saw the
-// name vacant), a source lookup failure, and a symlink SOURCE OBJECT (never
-// an alias of a regular-inode occupant) all answer false, while matching and
-// differing inodes answer the os.SameFile truth.
+// Edges of the pre-Remove alias exemption: nil occupant (probe observed the
+// name vacant), nil src snapshot (source lookup deferred/failed), a symlink
+// SOURCE OBJECT (never an alias of a regular-inode occupant per
+// classifyExistingDestination's symlink-over-name rule), and differing
+// inodes all exclude; same-inode positively proves alias.
 func TestLinkInstallOccupantIsAlias_GuardBranches(t *testing.T) {
 	base := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(base, "/in/src.txt", []byte("winner"), 0o644))
@@ -93,26 +93,42 @@ func TestLinkInstallOccupantIsAlias_GuardBranches(t *testing.T) {
 	otherInfo, err := base.Stat("/in/other.txt")
 	require.NoError(t, err)
 
-	assert.False(t, linkInstallOccupantIsAlias(base, "/in/src.txt", nil),
-		"nil occupant (vacant pre-Remove probe) never claims alias exclusion")
-	assert.False(t, linkInstallOccupantIsAlias(base, "/in/missing.txt", srcInfo),
-		"a failed source lookup answers false — confirm-or-silent")
-	// MemLinker's mem filesystems: SameFile on MemMapFs compares the recorded
-	// objects; a distinct entry is no alias.
-	assert.False(t, linkInstallOccupantIsAlias(base, "/in/src.txt", otherInfo))
+	assert.False(t, linkInstallOccupantIsSnapshotAlias(srcInfo, nil),
+		"nil occupant (vacant probe) never excludes")
+	assert.False(t, linkInstallOccupantIsSnapshotAlias(nil, srcInfo),
+		"nil source snapshot (lookup failed/deferred) never excludes foreign bytes")
+	assert.False(t, linkInstallOccupantIsSnapshotAlias(srcInfo, otherInfo))
 
-	// Symlink SOURCE OBJECT: even where the chase would reach the occupant's
-	// inode, the symlink's own lookup is never the destination's name-bearing
-	// link. MemMapFs has no symlink primitive, so this leg uses a skinny
-	// Lstater wrapper whose LstatIfPossible reports a symlink MODE for the
-	// link name (the exact shape a symlink-object probe sees).
 	symlinkFs := &srcSymlinkLstatFs{Fs: base, linkPath: "/in/src-link.txt", target: srcInfo}
-	linkInfo, err := symlinkFs.Stat("/in/src.txt")
+	symlinkSnapshot, _, err := symlinkFs.LstatIfPossible("/in/src-link.txt")
 	require.NoError(t, err)
-	assert.False(t, linkInstallOccupantIsAlias(symlinkFs, "/in/src-link.txt", linkInfo),
-		"a source symlink object is never an alias of the occupant's inode")
+	require.NotNil(t, symlinkSnapshot)
+	assert.False(t, linkInstallOccupantIsSnapshotAlias(symlinkSnapshot, srcInfo),
+		"symlink source object never aliases the occupant inode")
+
 }
 
+func TestLinkInstallOccupant_SnapshotAliasPositiveOnHardlink(t *testing.T) {
+	if testing.Short() {
+		t.Skip("OsFs hardlink fixture")
+	}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.bin")
+	dst := filepath.Join(dir, "dst.bin")
+	require.NoError(t, os.WriteFile(src, []byte("shared bytes"), 0o644))
+	require.NoError(t, os.Link(src, dst))
+
+	srcInfo, err := os.Lstat(src)
+	require.NoError(t, err)
+	occInfo, err := os.Lstat(dst)
+	require.NoError(t, err)
+
+	assert.True(t, linkInstallOccupantIsSnapshotAlias(srcInfo, occInfo),
+		"positively-proven same-inode pairing (pre-frozen) excludes foreign crumb")
+}
+
+// nonLstaterFs masks afero.Lstater so the link lane drops to the Stat fallback,
+// which covers the other side of the pre-Remove snapshot source lookup.
 // srcSymlinkLstatFs wraps an afero fs with an Lstater whose LstatIfPossible
 // reports a SYMLINK MODE for the given name — the shape a no-follow probe of
 // a symlink source object returns.
@@ -137,147 +153,22 @@ type symlinkModeInfo struct{ os.FileInfo }
 
 func (s symlinkModeInfo) Mode() os.FileMode { return s.FileInfo.Mode() | os.ModeSymlink }
 
-func TestForceOverwriteAudit_LinkInstallFailure_KeepsDisplacementCrumb(t *testing.T) {
-	const dst = "/dest/ABC-123/ABC-123.mkv"
+var errInjectedAbs = errors.New("injected absolute-resolution failure")
 
-	t.Run("force hardlink install fails EXDEV after the resident Remove — failure crumb", func(t *testing.T) {
-		l := &failingInstallLinker{err: &os.LinkError{Op: "link", Old: "/in/A.mkv", New: dst, Err: syscall.EXDEV}}
-		strategy, fs, src := forceAuditStrategy(t, l)
-		require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
-		require.NoError(t, afero.WriteFile(fs, dst, []byte("resident-bytes"), 0o644))
+func TestForceOverwriteAudit_LinkSoft_AbsolutizationFailureIsClean(t *testing.T) {
+	strategy, fs, _ := forceAuditStrategy(t, &MemLinker{})
+	plan := forceAuditLinkPlan("uploads/incoming-01.mkv", "/dest/ABC-123/ABC-123.mkv", LinkModeSoft, true)
 
-		result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeHard, true))
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, syscall.EXDEV), "the hard-link refusal is the surfaced failure")
-		require.NotNil(t, result)
-		assert.False(t, result.Moved, "a failed install is never a completed move")
-		require.Len(t, result.Warnings, 1,
-			"the authorized Remove already destroyed the resident bytes — the crumb rides the FAILED result")
-		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+	orig := filepathAbsFn
+	filepathAbsFn = func(string) (string, error) { return "", errInjectedAbs }
+	t.Cleanup(func() { filepathAbsFn = orig })
 
-		exists, statErr := afero.Exists(fs, dst)
-		require.NoError(t, statErr)
-		assert.False(t, exists, "the resident entry is gone — the destruction the crumb discloses is real")
-		retained, readErr := afero.ReadFile(fs, src)
-		require.NoError(t, readErr, "the source is retained on the failed lane (#224 keep-both)")
-		assert.Equal(t, []byte("winner-bytes"), retained)
-	})
-
-	t.Run("failure crumb never fires when the Remove displaced nothing", func(t *testing.T) {
-		l := &failingInstallLinker{err: errors.New("install refused")}
-		strategy, fs, src := forceAuditStrategy(t, l)
-
-		result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeHard, true))
-		require.Error(t, err)
-		require.NotNil(t, result)
-		assert.Empty(t, result.Warnings,
-			"vacant destination — nothing was destroyed, so no crumb rides the failure")
-		content, readErr := afero.ReadFile(fs, src)
-		require.NoError(t, readErr)
-		assert.Equal(t, []byte("winner-bytes"), content)
-	})
-
-	t.Run("force softlink install fails after the resident Remove — failure crumb", func(t *testing.T) {
-		l := &failingInstallLinker{err: errors.New("softlink refused")}
-		strategy, fs, src := forceAuditStrategy(t, l)
-		require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
-		require.NoError(t, afero.WriteFile(fs, dst, []byte("resident-bytes"), 0o644))
-
-		result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeSoft, true))
-		require.Error(t, err)
-		require.NotNil(t, result)
-		require.Len(t, result.Warnings, 1,
-			"the soft-link lane carries the same destruction-bound crumb")
-		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
-	})
-}
-
-// linkInstallSwapWedgeFs performs a one-shot destination swap at the exact
-// classification → pre-Remove-probe boundary: the lane-head classification
-// has already observed the fixture occupant when the strategy's interim
-// MkdirAll(targetDir) fires the swap, so only a pre-Remove-bound probe can
-// see the swapped object.
-type linkInstallSwapWedgeFs struct {
-	afero.Fs
-	targetDir string
-	swap      func() error
-	fired     bool
-	swapErr   error
-}
-
-func (w *linkInstallSwapWedgeFs) MkdirAll(path string, perm os.FileMode) error {
-	if !w.fired && filepath.Clean(path) == filepath.Clean(w.targetDir) {
-		w.fired = true
-		w.swapErr = w.swap()
-	}
-	return w.Fs.MkdirAll(path, perm)
-}
-
-func TestForceOverwriteAudit_LinkInstallAliasExclusion_BoundToPreRemoveProbe(t *testing.T) {
-	if testing.Short() {
-		t.Skip("os-level hardlink fixture")
-	}
-
-	setup := func(t *testing.T) (fs *linkInstallSwapWedgeFs, src, dst string) {
-		t.Helper()
-		dir := t.TempDir()
-		src = filepath.Join(dir, "in", "ABC-123.mkv")
-		dst = filepath.Join(dir, "dest", "ABC-123", "ABC-123.mkv")
-		require.NoError(t, os.MkdirAll(filepath.Dir(src), 0o755))
-		require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
-		require.NoError(t, os.WriteFile(src, []byte("shared-bytes"), 0o644))
-		base := afero.NewOsFs()
-		wedge := &linkInstallSwapWedgeFs{Fs: base, targetDir: filepath.Dir(dst)}
-		return wedge, src, dst
-	}
-	strategyFor := func(fs afero.Fs) *organizeStrategy {
-		return newOrganizeStrategy(fs, &Config{
-			FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true,
-		}, nil, &MemLinker{})
-	}
-
-	t.Run("lane-head alias swapped for a FOREIGN plant before the Remove: crumb fires", func(t *testing.T) {
-		wedge, src, dst := setup(t)
-		require.NoError(t, os.Link(src, dst),
-			"lane-head classification observes a hardlink ALIAS — the stale answer would suppress the crumb")
-		// Swap at the classification → probe boundary: the alias is replaced
-		// by FOREIGN resident bytes moments before the pre-Remove probe.
-		wedge.swap = func() error {
-			if err := os.Remove(dst); err != nil {
-				return err
-			}
-			return os.WriteFile(dst, []byte("foreign-plant"), 0o644)
-		}
-
-		result, err := strategyFor(wedge).Execute(forceAuditLinkPlan(src, dst, LinkModeHard, true))
-		require.NoError(t, err)
-		require.True(t, result.Moved)
-		require.True(t, wedge.fired && wedge.swapErr == nil, "the swap really landed inside the accepted probe window")
-		assert.Empty(t, result.Warnings[1:],
-			"exactly one warning — the displacement crumb")
-		require.Len(t, result.Warnings, 1,
-			"the Remove destroyed FOREIGN bytes the lane-head alias answer would have hidden")
-		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
-	})
-
-	t.Run("lane-head foreign occupant swapped for a source alias before the Remove: crumb stays silent", func(t *testing.T) {
-		wedge, src, dst := setup(t)
-		require.NoError(t, os.WriteFile(dst, []byte("foreign-resident"), 0o644),
-			"lane-head classification observes a FOREIGN occupant — the stale answer would fire the crumb")
-		// Swap: the foreign occupant vacates and the destination now aliases
-		// the source's own inode — its unlink destroys no foreign bytes.
-		wedge.swap = func() error {
-			if err := os.Remove(dst); err != nil {
-				return err
-			}
-			return os.Link(src, dst)
-		}
-
-		result, err := strategyFor(wedge).Execute(forceAuditLinkPlan(src, dst, LinkModeHard, true))
-		require.NoError(t, err)
-		require.True(t, result.Moved)
-		require.True(t, wedge.fired && wedge.swapErr == nil, "the swap really landed inside the accepted probe window")
-		assert.Empty(t, result.Warnings,
-			"removing a same-inode alias at Remove time destroyed no foreign bytes — the crumb stays silent")
-	})
+	result, err := strategy.Execute(plan)
+	require.Error(t, err, "an injected absolutization failure must surface")
+	require.ErrorContains(t, err, "failed to resolve source path for symlink")
+	require.ErrorIs(t, err, errInjectedAbs)
+	require.NotNil(t, result)
+	assert.False(t, result.Moved, "a doomed source path may not settle")
+	_, statErr := fs.Stat(plan.TargetPath)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "nothing written at the destination")
 }

--- a/internal/organizer/force_overwrite_link_wedges_w249b_test.go
+++ b/internal/organizer/force_overwrite_link_wedges_w249b_test.go
@@ -1,0 +1,283 @@
+package organizer
+
+// PR #249 codex follow-up (F1 + F2) — link-install crumb discipline.
+//
+// F1: the alias-vs-foreign exclusion must key on the LstatIfPossible taken
+// IMMEDIATELY pre-Remove, never the lane-head classification. The lane-head
+// answer can be raced stale across the interim MkdirAll and the regular-file
+// refusal gate:
+//   - a lane-head ALIAS swapped for a FOREIGN plant before the Remove is
+//     destroyed-by-Remove — the crumb must fire (pre-fix: suppressed by the
+//     stale lane-head alias answer, silently destroying foreign bytes);
+//   - a lane-head FOREIGN occupant swapped for a same-inode alias of the
+//     source destroys NO foreign bytes — the crumb must stay silent (pre-fix:
+//     fired on the stale lane-head foreign answer).
+// Both swaps ride a wedge fs whose MkdirAll(targetDir) performs the swap
+// exactly at the classification → probe boundary.
+//
+// F2: an authorized Remove that succeeded but whose link install then FAILED
+// (hardlink EXDEV / softlink refusal) leaves the resident bytes destroyed
+// forever — the FAILED result must still carry the displacement crumb, the
+// partial-publish lineage of fsutil.MoveFileFsDestReplaced's
+// ErrPublishCompleted discipline (pre-fix: the crumb was bound at install
+// success and died with the error).
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failingInstallLinker is a MemLinker whose installs all fail — the
+// authorized Remove around it still runs, modeling the hardlink-EXDEV /
+// softlink-refusal lanes whose resident displacement survives the failure.
+type failingInstallLinker struct {
+	MemLinker
+	err error
+}
+
+func (f *failingInstallLinker) hardlink(_, _ string) error { return f.err }
+func (f *failingInstallLinker) symlink(_, _ string) error  { return f.err }
+
+// failingCopyLinker fails the authorized copy lane while reporting the
+// fsutil F3 unioned displacement evidence (a staged publish landed and
+// displaced the resident, then failed post-publish).
+type failingCopyLinker struct {
+	MemLinker
+	destReplaced bool
+	err          error
+}
+
+func (f *failingCopyLinker) copyFile(_ afero.Fs, _, _ string) (bool, error) {
+	return f.destReplaced, f.err
+}
+
+// TestForceOverwriteAudit_CopyLaneFailure_KeepsUnionedDisplacementCrumb pins
+// the copy lane's consumption of fsutil's F3 union: a copy whose publish
+// displaced the resident but then failed post-publish carries the crumb on
+// the FAILED result, same destruction-bound discipline as the link lane.
+func TestForceOverwriteAudit_CopyLaneFailure_KeepsUnionedDisplacementCrumb(t *testing.T) {
+	const dst = "/dest/ABC-123/ABC-123.mkv"
+	l := &failingCopyLinker{destReplaced: true, err: errors.New("post-publish identity break")}
+	strategy, fs, src := forceAuditStrategy(t, l)
+	require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
+	require.NoError(t, afero.WriteFile(fs, dst, []byte("resident-bytes"), 0o644))
+
+	result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeNone, true))
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.Moved)
+	require.Len(t, result.Warnings, 1,
+		"the publish displaced the resident before failing — the unioned evidence rides the FAILED result")
+	assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+}
+
+// TestLinkInstallOccupantIsAlias_GuardBranches pins the confirm-or-silent
+// edges of the pre-Remove alias exclusion: a nil occupant (the probe saw the
+// name vacant), a source lookup failure, and a symlink SOURCE OBJECT (never
+// an alias of a regular-inode occupant) all answer false, while matching and
+// differing inodes answer the os.SameFile truth.
+func TestLinkInstallOccupantIsAlias_GuardBranches(t *testing.T) {
+	base := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(base, "/in/src.txt", []byte("winner"), 0o644))
+	require.NoError(t, afero.WriteFile(base, "/in/other.txt", []byte("other"), 0o644))
+
+	srcInfo, err := base.Stat("/in/src.txt")
+	require.NoError(t, err)
+	otherInfo, err := base.Stat("/in/other.txt")
+	require.NoError(t, err)
+
+	assert.False(t, linkInstallOccupantIsAlias(base, "/in/src.txt", nil),
+		"nil occupant (vacant pre-Remove probe) never claims alias exclusion")
+	assert.False(t, linkInstallOccupantIsAlias(base, "/in/missing.txt", srcInfo),
+		"a failed source lookup answers false — confirm-or-silent")
+	// MemLinker's mem filesystems: SameFile on MemMapFs compares the recorded
+	// objects; a distinct entry is no alias.
+	assert.False(t, linkInstallOccupantIsAlias(base, "/in/src.txt", otherInfo))
+
+	// Symlink SOURCE OBJECT: even where the chase would reach the occupant's
+	// inode, the symlink's own lookup is never the destination's name-bearing
+	// link. MemMapFs has no symlink primitive, so this leg uses a skinny
+	// Lstater wrapper whose LstatIfPossible reports a symlink MODE for the
+	// link name (the exact shape a symlink-object probe sees).
+	symlinkFs := &srcSymlinkLstatFs{Fs: base, linkPath: "/in/src-link.txt", target: srcInfo}
+	linkInfo, err := symlinkFs.Stat("/in/src.txt")
+	require.NoError(t, err)
+	assert.False(t, linkInstallOccupantIsAlias(symlinkFs, "/in/src-link.txt", linkInfo),
+		"a source symlink object is never an alias of the occupant's inode")
+}
+
+// srcSymlinkLstatFs wraps an afero fs with an Lstater whose LstatIfPossible
+// reports a SYMLINK MODE for the given name — the shape a no-follow probe of
+// a symlink source object returns.
+type srcSymlinkLstatFs struct {
+	afero.Fs
+	linkPath string
+	target   os.FileInfo
+}
+
+func (w *srcSymlinkLstatFs) LstatIfPossible(path string) (os.FileInfo, bool, error) {
+	if path == w.linkPath {
+		return symlinkModeInfo{w.target}, true, nil
+	}
+	if lst, ok := w.Fs.(afero.Lstater); ok {
+		return lst.LstatIfPossible(path)
+	}
+	info, err := w.Fs.Stat(path)
+	return info, false, err
+}
+
+type symlinkModeInfo struct{ os.FileInfo }
+
+func (s symlinkModeInfo) Mode() os.FileMode { return s.FileInfo.Mode() | os.ModeSymlink }
+
+func TestForceOverwriteAudit_LinkInstallFailure_KeepsDisplacementCrumb(t *testing.T) {
+	const dst = "/dest/ABC-123/ABC-123.mkv"
+
+	t.Run("force hardlink install fails EXDEV after the resident Remove — failure crumb", func(t *testing.T) {
+		l := &failingInstallLinker{err: &os.LinkError{Op: "link", Old: "/in/A.mkv", New: dst, Err: syscall.EXDEV}}
+		strategy, fs, src := forceAuditStrategy(t, l)
+		require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, afero.WriteFile(fs, dst, []byte("resident-bytes"), 0o644))
+
+		result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeHard, true))
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, syscall.EXDEV), "the hard-link refusal is the surfaced failure")
+		require.NotNil(t, result)
+		assert.False(t, result.Moved, "a failed install is never a completed move")
+		require.Len(t, result.Warnings, 1,
+			"the authorized Remove already destroyed the resident bytes — the crumb rides the FAILED result")
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+
+		exists, statErr := afero.Exists(fs, dst)
+		require.NoError(t, statErr)
+		assert.False(t, exists, "the resident entry is gone — the destruction the crumb discloses is real")
+		retained, readErr := afero.ReadFile(fs, src)
+		require.NoError(t, readErr, "the source is retained on the failed lane (#224 keep-both)")
+		assert.Equal(t, []byte("winner-bytes"), retained)
+	})
+
+	t.Run("failure crumb never fires when the Remove displaced nothing", func(t *testing.T) {
+		l := &failingInstallLinker{err: errors.New("install refused")}
+		strategy, fs, src := forceAuditStrategy(t, l)
+
+		result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeHard, true))
+		require.Error(t, err)
+		require.NotNil(t, result)
+		assert.Empty(t, result.Warnings,
+			"vacant destination — nothing was destroyed, so no crumb rides the failure")
+		content, readErr := afero.ReadFile(fs, src)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+
+	t.Run("force softlink install fails after the resident Remove — failure crumb", func(t *testing.T) {
+		l := &failingInstallLinker{err: errors.New("softlink refused")}
+		strategy, fs, src := forceAuditStrategy(t, l)
+		require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, afero.WriteFile(fs, dst, []byte("resident-bytes"), 0o644))
+
+		result, err := strategy.Execute(forceAuditLinkPlan(src, dst, LinkModeSoft, true))
+		require.Error(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result.Warnings, 1,
+			"the soft-link lane carries the same destruction-bound crumb")
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+	})
+}
+
+// linkInstallSwapWedgeFs performs a one-shot destination swap at the exact
+// classification → pre-Remove-probe boundary: the lane-head classification
+// has already observed the fixture occupant when the strategy's interim
+// MkdirAll(targetDir) fires the swap, so only a pre-Remove-bound probe can
+// see the swapped object.
+type linkInstallSwapWedgeFs struct {
+	afero.Fs
+	targetDir string
+	swap      func() error
+	fired     bool
+	swapErr   error
+}
+
+func (w *linkInstallSwapWedgeFs) MkdirAll(path string, perm os.FileMode) error {
+	if !w.fired && filepath.Clean(path) == filepath.Clean(w.targetDir) {
+		w.fired = true
+		w.swapErr = w.swap()
+	}
+	return w.Fs.MkdirAll(path, perm)
+}
+
+func TestForceOverwriteAudit_LinkInstallAliasExclusion_BoundToPreRemoveProbe(t *testing.T) {
+	if testing.Short() {
+		t.Skip("os-level hardlink fixture")
+	}
+
+	setup := func(t *testing.T) (fs *linkInstallSwapWedgeFs, src, dst string) {
+		t.Helper()
+		dir := t.TempDir()
+		src = filepath.Join(dir, "in", "ABC-123.mkv")
+		dst = filepath.Join(dir, "dest", "ABC-123", "ABC-123.mkv")
+		require.NoError(t, os.MkdirAll(filepath.Dir(src), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, os.WriteFile(src, []byte("shared-bytes"), 0o644))
+		base := afero.NewOsFs()
+		wedge := &linkInstallSwapWedgeFs{Fs: base, targetDir: filepath.Dir(dst)}
+		return wedge, src, dst
+	}
+	strategyFor := func(fs afero.Fs) *organizeStrategy {
+		return newOrganizeStrategy(fs, &Config{
+			FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true,
+		}, nil, &MemLinker{})
+	}
+
+	t.Run("lane-head alias swapped for a FOREIGN plant before the Remove: crumb fires", func(t *testing.T) {
+		wedge, src, dst := setup(t)
+		require.NoError(t, os.Link(src, dst),
+			"lane-head classification observes a hardlink ALIAS — the stale answer would suppress the crumb")
+		// Swap at the classification → probe boundary: the alias is replaced
+		// by FOREIGN resident bytes moments before the pre-Remove probe.
+		wedge.swap = func() error {
+			if err := os.Remove(dst); err != nil {
+				return err
+			}
+			return os.WriteFile(dst, []byte("foreign-plant"), 0o644)
+		}
+
+		result, err := strategyFor(wedge).Execute(forceAuditLinkPlan(src, dst, LinkModeHard, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.True(t, wedge.fired && wedge.swapErr == nil, "the swap really landed inside the accepted probe window")
+		assert.Empty(t, result.Warnings[1:],
+			"exactly one warning — the displacement crumb")
+		require.Len(t, result.Warnings, 1,
+			"the Remove destroyed FOREIGN bytes the lane-head alias answer would have hidden")
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+	})
+
+	t.Run("lane-head foreign occupant swapped for a source alias before the Remove: crumb stays silent", func(t *testing.T) {
+		wedge, src, dst := setup(t)
+		require.NoError(t, os.WriteFile(dst, []byte("foreign-resident"), 0o644),
+			"lane-head classification observes a FOREIGN occupant — the stale answer would fire the crumb")
+		// Swap: the foreign occupant vacates and the destination now aliases
+		// the source's own inode — its unlink destroys no foreign bytes.
+		wedge.swap = func() error {
+			if err := os.Remove(dst); err != nil {
+				return err
+			}
+			return os.Link(src, dst)
+		}
+
+		result, err := strategyFor(wedge).Execute(forceAuditLinkPlan(src, dst, LinkModeHard, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.True(t, wedge.fired && wedge.swapErr == nil, "the swap really landed inside the accepted probe window")
+		assert.Empty(t, result.Warnings,
+			"removing a same-inode alias at Remove time destroyed no foreign bytes — the crumb stays silent")
+	})
+}

--- a/internal/organizer/force_overwrite_partial_publish_w249_test.go
+++ b/internal/organizer/force_overwrite_partial_publish_w249_test.go
@@ -1,0 +1,219 @@
+package organizer
+
+// PR #249 codex P2 follow-up (F1) — the partial-publish audit crumb: a
+// force-overwrite move driven onto its cross-device leg (injected EXDEV)
+// whose bound staged publish LANDED on an occupied destination but whose
+// source cleanup then refused (the typed fsutil.ErrPublishCompleted
+// ambiguity) must NOT drop the displaced-occupancy evidence with the error.
+// The pre-fix chain returned replaced=false pre-error from fsutil's fallback
+// and every move lane bailed before warning — exactly the replacement the
+// audit exists to disclose vanished from every console/result warning
+// consumer. These pins wedge the source cleanup of each MoveFileFsDestReplaced
+// lane (organize move, in-place non-rename move, in-place-norenamefolder
+// rename) and assert the RESULT shape:
+//
+//   - the FAILED result carries the crumb in Warnings (the console,
+//     eventlog, and worker history surfaces all read that slice);
+//   - the error unwraps to fsutil.ErrPublishCompleted (the publish-completed
+//     typing rides up so Apply journals the ambiguity as an event
+//     nonetheless — the w241 revert-log lineage keeps that failed row
+//     revertable, pointing at the published destination);
+//   - Moved stays false and the journal-shaping markers stay untouched, so
+//     the destination is NEVER double-journaled as if a clean move/replace
+//     happened next to the partial-publish row;
+//   - both objects stay byte-intact on disk (#224 keep-both).
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/fsutil"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+)
+
+// partialPublishWedgeFs is the organizer-side F1 armature, bound by name
+// (unlike the content-sniffing w241 wedges): the same-device rename of the
+// exact (src, dst) pair answers EXDEV — forcing the authorized move onto its
+// cross-device leg (stage, bound publish, source cleanup) — and exactly the
+// post-publish source removal refuses. The staged publish's own rename
+// (staged → dst) delegates normally, as does every unrelated Remove.
+type partialPublishWedgeFs struct {
+	afero.Fs
+	src, dst     string
+	removeFailed bool
+}
+
+func (w *partialPublishWedgeFs) Rename(oldname, newname string) error {
+	if filepath.Clean(oldname) == filepath.Clean(w.src) && filepath.Clean(newname) == filepath.Clean(w.dst) {
+		return &os.LinkError{Op: "rename", Old: oldname, New: newname, Err: syscall.EXDEV}
+	}
+	return w.Fs.Rename(oldname, newname)
+}
+
+func (w *partialPublishWedgeFs) Remove(name string) error {
+	if filepath.Clean(name) == filepath.Clean(w.src) && !w.removeFailed {
+		w.removeFailed = true
+		return &os.PathError{Op: "remove", Path: name, Err: syscall.EPERM}
+	}
+	return w.Fs.Remove(name)
+}
+
+func TestForceOverwriteAudit_PartialPublishCrumb_OrganizeMoveLane(t *testing.T) {
+	const (
+		src = "/in/A.mkv"
+		dst = "/dest/ABC-123/ABC-123.mkv"
+	)
+
+	t.Run("occupied destination: FAILED result carries the crumb and the publish-completed typing", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, src, []byte("winner-bytes"), 0o644))
+		require.NoError(t, base.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, afero.WriteFile(base, dst, []byte("resident-bytes"), 0o644))
+		wedge := &partialPublishWedgeFs{Fs: base, src: src, dst: dst}
+		org := NewOrganizer(wedge, &Config{
+			FolderFormat:  "<ID>",
+			FileFormat:    "<ID>",
+			RenameFile:    true,
+			OperationMode: operationmode.OperationModeOrganize,
+		}, nil, nil)
+
+		result, err := org.Organize(context.Background(), forceAuditCmd(src, true, true))
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, fsutil.ErrPublishCompleted),
+			"the publish-completed typing propagates — Apply journals this as an event nonetheless")
+		require.True(t, wedge.removeFailed, "the wedge really fired at the post-publish source removal")
+		require.NotNil(t, result)
+		assert.False(t, result.Moved,
+			"the source is retained — this is NOT a clean move and must never journal as one")
+		assert.False(t, result.DuplicateSkipped)
+		assert.False(t, result.PrePublication,
+			"a publish-completed failure is NOT the pre-publication no-op class — the event keeps its destination")
+		assert.Equal(t, filepath.ToSlash(dst), filepath.ToSlash(result.NewPath),
+			"the failed event still names the published destination (single partial-publish journal row)")
+		require.Len(t, result.Warnings, 1,
+			"the displaced resident bytes keep their audit crumb on the FAILED result — the pre-fix drop")
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+
+		content, rerr := afero.ReadFile(base, dst)
+		require.NoError(t, rerr)
+		assert.Equal(t, []byte("winner-bytes"), content,
+			"the publish really displaced the resident bytes the crumb discloses")
+		retained, serr := afero.ReadFile(base, src)
+		require.NoError(t, serr, "the source is preserved byte-intact (#224 keep-both)")
+		assert.Equal(t, []byte("winner-bytes"), retained)
+	})
+
+	t.Run("vacant destination: same publish-completed failure, no crumb", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, src, []byte("winner-bytes"), 0o644))
+		wedge := &partialPublishWedgeFs{Fs: base, src: src, dst: dst}
+		org := NewOrganizer(wedge, &Config{
+			FolderFormat:  "<ID>",
+			FileFormat:    "<ID>",
+			RenameFile:    true,
+			OperationMode: operationmode.OperationModeOrganize,
+		}, nil, nil)
+
+		result, err := org.Organize(context.Background(), forceAuditCmd(src, true, true))
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, fsutil.ErrPublishCompleted))
+		require.NotNil(t, result)
+		assert.False(t, result.Moved)
+		assert.Empty(t, result.Warnings,
+			"nothing was displaced — the crumb never fires on unconfirmed evidence, failure or not")
+		content, rerr := afero.ReadFile(base, dst)
+		require.NoError(t, rerr)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+}
+
+func TestForceOverwriteAudit_PartialPublishCrumb_InPlaceLanes(t *testing.T) {
+	t.Run("in-place non-rename move lane keeps the crumb on the partial publish", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		cfg := &Config{
+			FolderFormat: "<ID>", FileFormat: "<ID> vidfile",
+			RenameFile: true, OperationMode: operationmode.OperationModeInPlace,
+		}
+		const (
+			src = "/pool/mixed/ABC-100 ownA.mkv"
+			dst = "/pool/mixed/ABC-100 vidfile.mkv"
+		)
+		require.NoError(t, base.MkdirAll("/pool/mixed", 0o755))
+		require.NoError(t, afero.WriteFile(base, src, []byte("a-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(base, "/pool/mixed/DEF-999 other.mkv", []byte("other-tenant"), 0o644))
+		require.NoError(t, afero.WriteFile(base, dst, []byte("resident-bytes"), 0o644))
+		wedge := &partialPublishWedgeFs{Fs: base, src: src, dst: dst}
+		org := NewOrganizer(wedge, cfg, nil, ipfMatcher(t))
+
+		result, err := org.Organize(context.Background(), OrganizeCmd{
+			Match:       models.FileMatchInfo{MovieID: "ABC-100", Path: src, Name: "ABC-100 ownA.mkv", Extension: ".mkv"},
+			Movie:       &models.Movie{ID: "ABC-100"},
+			DestDir:     "/dest",
+			MoveFiles:   true,
+			ForceUpdate: true,
+		})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, fsutil.ErrPublishCompleted),
+			"the wrapped lane error keeps the publish-completed typing unwrap-reachable")
+		require.NotNil(t, result)
+		assert.False(t, result.Moved)
+		require.Len(t, result.Warnings, 1,
+			"the in-place non-rename move lane carries the partial-publish crumb too")
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+		content, rerr := afero.ReadFile(base, dst)
+		require.NoError(t, rerr)
+		assert.Equal(t, []byte("a-bytes"), content, "the resident bytes were really displaced")
+		retained, serr := afero.ReadFile(base, src)
+		require.NoError(t, serr)
+		assert.Equal(t, []byte("a-bytes"), retained, "the source is retained byte-intact")
+	})
+
+	t.Run("in-place-norenamefolder lane keeps the crumb on the partial publish", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		cfg := &Config{
+			FolderFormat: "<ID>", FileFormat: "<ID> vidfile",
+			RenameFile: true, OperationMode: operationmode.OperationModeInPlaceNoRenameFolder,
+		}
+		const (
+			src = "/pool/ABC-100 ownA.mkv"
+			dst = "/pool/ABC-100 vidfile.mkv"
+		)
+		require.NoError(t, base.MkdirAll("/pool", 0o755))
+		require.NoError(t, afero.WriteFile(base, src, []byte("a-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(base, dst, []byte("resident-bytes"), 0o644))
+		wedge := &partialPublishWedgeFs{Fs: base, src: src, dst: dst}
+		org := NewOrganizer(wedge, cfg, nil, nil)
+
+		result, err := org.Organize(context.Background(), OrganizeCmd{
+			Match:       models.FileMatchInfo{MovieID: "ABC-100", Path: src, Name: "ABC-100 ownA.mkv", Extension: ".mkv"},
+			Movie:       &models.Movie{ID: "ABC-100"},
+			DestDir:     "/dest",
+			MoveFiles:   true,
+			ForceUpdate: true,
+		})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, fsutil.ErrPublishCompleted))
+		require.NotNil(t, result)
+		assert.False(t, result.Moved)
+		require.Len(t, result.Warnings, 1,
+			"the norenamefolder lane carries the partial-publish crumb too")
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+		content, rerr := afero.ReadFile(base, dst)
+		require.NoError(t, rerr)
+		assert.Equal(t, []byte("a-bytes"), content)
+		retained, serr := afero.ReadFile(base, src)
+		require.NoError(t, serr)
+		assert.Equal(t, []byte("a-bytes"), retained)
+	})
+}

--- a/internal/organizer/force_overwrite_postpublish_identity_w249c_test.go
+++ b/internal/organizer/force_overwrite_postpublish_identity_w249c_test.go
@@ -1,0 +1,325 @@
+package organizer
+
+// PR #249 codex P2 follow-up — the retained force-overwrite crumb keys on the
+// publish's displacement answer ALONE (movePublishDestReplaced), never on a
+// single error class. The EXDEV staged publish of an authorized move can
+// LAND (displacing the resident) and then fail POST-publish with an identity
+// class that deliberately does NOT wrap fsutil.ErrPublishCompleted —
+// fsutil.ErrPublishStagedIdentityBreak (a post-publish reverify the
+// destination lookup could not satisfy / the destination no longer provably
+// names the staged inode) and fsutil.ErrPublishStagedExhausted (a staged-name
+// substitution outlasted the bounded republish budget; always joined with
+// the identity-break class). The pre-fix caller-side predicate
+// (fsutil.PublishCompleted(mErr) && replaced) returned the displacement
+// WITHOUT the warning for exactly this shape and re-opened the
+// hidden-overwrite class PR #249 closed.
+//
+// These tuples cannot be produced through an fs-level wedge by construction:
+// the bound staged publish's post-publish identity machinery runs only
+// against the REAL *afero.OsFs (fsutil's osStagingHandle gate), while the
+// EXDEV routing a move into that staged publish can only be wedged through a
+// VIRTUAL wrapper fs — which flips the identity gate off. fsutil pins the
+// real production of every (replaced=true, identity-class) tuple itself
+// against the OsFs (move_destreplaced_union_w249b_test.go, wedging its own
+// publishStagedBoundDestLstat seam); this file replays that documented tuple
+// contract through the moveFileDestReplaced test seam at the exact call edge
+// — for the normal organize move lane and BOTH in-place legs — with the
+// landed publish's byte state replayed honestly (resident displaced, source
+// NEVER consumed: the identity classes keep the caller's backup, #224
+// keep-both). The predicate under test (foldMovePublishCrumb) stays OUTSIDE
+// the seam, so the replay exercises the production crumb keying itself —
+// running these pins against the pre-fix (PublishCompleted-gated) predicate
+// fails them.
+//
+// Every pin asserts the RESULT shape (the w249 partial-publish lineage's
+// discipline):
+//
+//   - the FAILED result carries the crumb in Warnings (the console,
+//     eventlog, and worker history surfaces all read that slice);
+//   - the error carries the identity class and NOT
+//     fsutil.ErrPublishCompleted — the pre-fix gate keyed exactly on that
+//     class, so the old predicate provably drops this result's crumb;
+//   - Moved stays false and DuplicateSkipped untouched: the failure
+//     accumulates a SINGLE failed-and-retained journal row — never a
+//     completed move/replace row alongside it;
+//   - the compensation axis stays DISTINCT from the evidence axis: without
+//     publish-completed typing the destination name is not provably this
+//     operation's own object, so the claim does NOT settle (PrePublication
+//     stands) — while the audit crumb still discloses that a landed publish
+//     destroyed resident bytes.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/fsutil"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+)
+
+// identityBreakReplayError mirrors fsutil's indeterminate post-publish
+// reverify shape verbatim (publish_staged_bound_unix.go): the lookup could
+// not prove which object the destination names — wrapping the identity-break
+// sentinel and NEVER ErrPublishCompleted.
+func identityBreakReplayError(dst string) error {
+	return fmt.Errorf("post-publish publish reverify of %s: %w: %w", dst,
+		&os.PathError{Op: "lstat", Path: dst, Err: syscall.EIO},
+		fsutil.ErrPublishStagedIdentityBreak)
+}
+
+// republishExhaustedReplayError mirrors fsutil's bounded-republish refusal
+// verbatim (publish_staged_bound_unix.go): staged-name substitution outlasted
+// the budget, always joined with the identity-break class, NEVER
+// ErrPublishCompleted.
+func republishExhaustedReplayError(dst string) error {
+	return fmt.Errorf("%w after %d attempts for %s: %w",
+		fsutil.ErrPublishStagedExhausted, fsutil.PublishStagedBoundAttempts, dst,
+		fsutil.ErrPublishStagedIdentityBreak)
+}
+
+// replayMovePostPublishFailure arms the moveFileDestReplaced seam for one
+// (src, dst) pair and replays fsutil's failed-with-displacement contract at
+// that exact call edge, byte-honestly:
+//
+//   - holds == nil: the destination is left carrying THIS operation's staged
+//     bytes (the published object itself stood at the destination when the
+//     reverify went indeterminate — the identity-break shape);
+//   - holds != nil: the destination is left carrying a preserved post-publish
+//     occupant (the wave-38 lineage never unverified-deletes a mismatch
+//     occupant — the exhaustion shape; the RESIDENT was still displaced by an
+//     earlier landed attempt);
+//   - the source is NEVER consumed (the identity classes keep the caller's
+//     backup — #224 keep-both);
+//   - replaced answers fsutil's unioned displacement evidence exactly as the
+//     real verb does (true only when a landed publish leg displaced resident
+//     bytes);
+//   - classError supplies the typed identity-class error in its production
+//     wrap shape.
+//
+// Every unrelated (src, dst) pair delegates to the real verb. The returned
+// flag proves the seam fired at the intended publish.
+func replayMovePostPublishFailure(t *testing.T, src, dst string, holds []byte, replaced bool, classError func(dst string) error) *atomic.Bool {
+	t.Helper()
+	prev := moveFileDestReplaced
+	var fired atomic.Bool
+	moveFileDestReplaced = func(fs afero.Fs, gotSrc, gotDst string) (bool, error) {
+		if filepath.Clean(gotSrc) != filepath.Clean(src) || filepath.Clean(gotDst) != filepath.Clean(dst) {
+			return prev(fs, gotSrc, gotDst)
+		}
+		fired.Store(true)
+		landed := holds
+		if landed == nil {
+			staged, rerr := afero.ReadFile(fs, gotSrc)
+			require.NoError(t, rerr, "the replay stages from the source exactly like the real verb")
+			landed = staged
+		}
+		require.NoError(t, afero.WriteFile(fs, gotDst, landed, 0o644),
+			"replay the landed publish's byte state over the destination — the resident is displaced")
+		return replaced, classError(gotDst)
+	}
+	t.Cleanup(func() { moveFileDestReplaced = prev })
+	return &fired
+}
+
+// assertFailedWithDisplacementCrumb pins the failed-move result contract
+// shared by every post-publish identity pin (see the file header): crumb on
+// the FAILED result, identity-class typing with NO publish-completed
+// wrapping, single failed-and-retained journal row accumulation (never
+// double-journaled as a clean move), and the compensation axis kept distinct
+// (no claim settlement — PrePublication stands).
+func assertFailedWithDisplacementCrumb(t *testing.T, result *OrganizeResult, err error, dst string, classes ...error) {
+	t.Helper()
+	require.Error(t, err)
+	for _, class := range classes {
+		assert.True(t, errors.Is(err, class), "the typed identity class stays unwrap-reachable: %v", class)
+	}
+	assert.False(t, errors.Is(err, fsutil.ErrPublishCompleted),
+		"the identity classes never wrap publish-completed — the pre-fix crumb gate keyed exactly on that class and dropped this crumb")
+	require.NotNil(t, result)
+	assert.False(t, result.Moved,
+		"the source is retained — this failure journals ONCE as the failed-and-retained row, never as a clean move/replace alongside it")
+	assert.False(t, result.DuplicateSkipped)
+	assert.True(t, result.PrePublication,
+		"the compensation axis stays DISTINCT from the evidence axis: without publish-completed typing the destination name is not provably this operation's own object, so the claim does not settle")
+	assert.Equal(t, filepath.ToSlash(dst), filepath.ToSlash(result.NewPath),
+		"the failed event still names the destination the displacement happened against")
+	require.Len(t, result.Warnings, 1,
+		"the displaced resident bytes keep their audit crumb on the FAILED result — the regression this wave closes")
+	assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+}
+
+// postPublishMoveLaneFixture names one move lane's replay fixture.
+type postPublishMoveLaneFixture struct {
+	name  string
+	setup func(t *testing.T) (org *Organizer, fs afero.Fs, src, dst string, cmd OrganizeCmd)
+}
+
+// postPublishOrganizeMoveLane seeds the organize-mode duplex fixture (the
+// w249 lineage's convention: sources under /in, destinations compute
+// /dest/<ID>/<ID>.mkv).
+func postPublishOrganizeMoveLane(t *testing.T) (*Organizer, afero.Fs, string, string, OrganizeCmd) {
+	t.Helper()
+	base := afero.NewMemMapFs()
+	const (
+		src = "/in/A.mkv"
+		dst = "/dest/ABC-123/ABC-123.mkv"
+	)
+	require.NoError(t, base.MkdirAll("/in", 0o755))
+	require.NoError(t, afero.WriteFile(base, src, []byte("winner-bytes"), 0o644))
+	require.NoError(t, base.MkdirAll(filepath.Dir(dst), 0o755))
+	require.NoError(t, afero.WriteFile(base, dst, []byte("resident-bytes"), 0o644))
+	org := NewOrganizer(base, &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}, nil, nil)
+	return org, base, src, dst, forceAuditCmd(src, true, true)
+}
+
+// postPublishInPlaceMoveLane seeds the in-place non-rename move lane's
+// fixture (FileFormat diverges the filename inside the source's own
+// directory, so the plan takes the plain file-move leg).
+func postPublishInPlaceMoveLane(t *testing.T) (*Organizer, afero.Fs, string, string, OrganizeCmd) {
+	t.Helper()
+	base := afero.NewMemMapFs()
+	const (
+		src = "/pool/mixed/ABC-100 ownA.mkv"
+		dst = "/pool/mixed/ABC-100 vidfile.mkv"
+	)
+	require.NoError(t, base.MkdirAll("/pool/mixed", 0o755))
+	require.NoError(t, afero.WriteFile(base, src, []byte("a-bytes"), 0o644))
+	require.NoError(t, afero.WriteFile(base, "/pool/mixed/DEF-999 other.mkv", []byte("other-tenant"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dst, []byte("resident-bytes"), 0o644))
+	org := NewOrganizer(base, &Config{
+		FolderFormat: "<ID>", FileFormat: "<ID> vidfile",
+		RenameFile: true, OperationMode: operationmode.OperationModeInPlace,
+	}, nil, ipfMatcher(t))
+	cmd := OrganizeCmd{
+		Match:       models.FileMatchInfo{MovieID: "ABC-100", Path: src, Name: "ABC-100 ownA.mkv", Extension: ".mkv"},
+		Movie:       &models.Movie{ID: "ABC-100"},
+		DestDir:     "/dest",
+		MoveFiles:   true,
+		ForceUpdate: true,
+	}
+	return org, base, src, dst, cmd
+}
+
+// postPublishNoRenameFolderLane seeds the in-place-norenamefolder lane's
+// fixture (file rename only, directly in the pooled directory).
+func postPublishNoRenameFolderLane(t *testing.T) (*Organizer, afero.Fs, string, string, OrganizeCmd) {
+	t.Helper()
+	base := afero.NewMemMapFs()
+	const (
+		src = "/pool/ABC-100 ownA.mkv"
+		dst = "/pool/ABC-100 vidfile.mkv"
+	)
+	require.NoError(t, base.MkdirAll("/pool", 0o755))
+	require.NoError(t, afero.WriteFile(base, src, []byte("a-bytes"), 0o644))
+	require.NoError(t, afero.WriteFile(base, dst, []byte("resident-bytes"), 0o644))
+	org := NewOrganizer(base, &Config{
+		FolderFormat: "<ID>", FileFormat: "<ID> vidfile",
+		RenameFile: true, OperationMode: operationmode.OperationModeInPlaceNoRenameFolder,
+	}, nil, nil)
+	cmd := OrganizeCmd{
+		Match:       models.FileMatchInfo{MovieID: "ABC-100", Path: src, Name: "ABC-100 ownA.mkv", Extension: ".mkv"},
+		Movie:       &models.Movie{ID: "ABC-100"},
+		DestDir:     "/dest",
+		MoveFiles:   true,
+		ForceUpdate: true,
+	}
+	return org, base, src, dst, cmd
+}
+
+func TestForceOverwriteAudit_PostPublishFailureCrumb_MoveLanes(t *testing.T) {
+	lanes := []postPublishMoveLaneFixture{
+		{name: "organize move lane", setup: postPublishOrganizeMoveLane},
+		{name: "in-place non-rename move lane", setup: postPublishInPlaceMoveLane},
+		{name: "in-place-norenamefolder lane", setup: postPublishNoRenameFolderLane},
+	}
+	for _, lane := range lanes {
+		t.Run(lane.name+"/identity-break: FAILED result carries the crumb", func(t *testing.T) {
+			org, fs, src, dst, cmd := lane.setup(t)
+			fired := replayMovePostPublishFailure(t, src, dst, nil, true, identityBreakReplayError)
+
+			result, err := org.Organize(context.Background(), cmd)
+			require.True(t, fired.Load(), "the seam fired at the move publish %s -> %s", src, dst)
+			assertFailedWithDisplacementCrumb(t, result, err, dst, fsutil.ErrPublishStagedIdentityBreak)
+
+			content, derr := afero.ReadFile(fs, dst)
+			require.NoError(t, derr, "the publish landed — the destination carries this operation's bytes")
+			retained, serr := afero.ReadFile(fs, src)
+			require.NoError(t, serr, "the source is preserved byte-intact (#224 keep-both)")
+			assert.Equal(t, retained, content,
+				"the destination now names the SOURCE's bytes — the resident was really displaced by the publish the identity break post-dates")
+			assert.NotEqual(t, "resident-bytes", string(content))
+		})
+
+		t.Run(lane.name+"/republish exhaustion: FAILED result carries the crumb", func(t *testing.T) {
+			org, fs, src, dst, cmd := lane.setup(t)
+			const plant = "foreign-plant"
+			fired := replayMovePostPublishFailure(t, src, dst, []byte(plant), true, republishExhaustedReplayError)
+
+			result, err := org.Organize(context.Background(), cmd)
+			require.True(t, fired.Load(), "the seam fired at the move publish %s -> %s", src, dst)
+			assertFailedWithDisplacementCrumb(t, result, err, dst,
+				fsutil.ErrPublishStagedExhausted, fsutil.ErrPublishStagedIdentityBreak)
+
+			content, derr := afero.ReadFile(fs, dst)
+			require.NoError(t, derr)
+			assert.Equal(t, []byte(plant), content,
+				"the post-publish occupant is preserved byte-intact (never unverified-deleted); the crumb discloses the RESIDENT's displacement regardless")
+			_, serr := afero.ReadFile(fs, src)
+			require.NoError(t, serr, "the source is preserved (#224 keep-both — the identity classes consume nothing)")
+		})
+	}
+}
+
+func TestForceOverwriteAudit_PostPublishIdentityBreak_NoDisplacementStaysSilent(t *testing.T) {
+	t.Run("organize move lane: publish landed into a VACANCY — indeterminate reverify, nothing displaced, no crumb", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		const (
+			src = "/in/A.mkv"
+			dst = "/dest/ABC-123/ABC-123.mkv"
+		)
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, src, []byte("winner-bytes"), 0o644))
+		require.NoError(t, base.MkdirAll(filepath.Dir(dst), 0o755))
+		org := NewOrganizer(base, &Config{
+			FolderFormat:  "<ID>",
+			FileFormat:    "<ID>",
+			RenameFile:    true,
+			OperationMode: operationmode.OperationModeOrganize,
+		}, nil, nil)
+		fired := replayMovePostPublishFailure(t, src, dst, nil, false, identityBreakReplayError)
+
+		result, err := org.Organize(context.Background(), forceAuditCmd(src, true, true))
+		require.True(t, fired.Load(), "the seam fired at the move publish")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, fsutil.ErrPublishStagedIdentityBreak))
+		assert.False(t, errors.Is(err, fsutil.ErrPublishCompleted))
+		require.NotNil(t, result)
+		assert.False(t, result.Moved)
+		assert.True(t, result.PrePublication,
+			"no publish-completed typing — the compensation axis keeps its distinct non-settling posture")
+		assert.Empty(t, result.Warnings,
+			"nothing was displaced — the crumb never fires on unconfirmed evidence, whatever the error class")
+
+		content, derr := afero.ReadFile(base, dst)
+		require.NoError(t, derr, "the publish landed into the vacancy")
+		assert.Equal(t, []byte("winner-bytes"), content)
+		retained, serr := afero.ReadFile(base, src)
+		require.NoError(t, serr, "the source is preserved byte-intact (#224 keep-both)")
+		assert.Equal(t, []byte("winner-bytes"), retained)
+	})
+}

--- a/internal/organizer/force_overwrite_publish_bound_test.go
+++ b/internal/organizer/force_overwrite_publish_bound_test.go
@@ -1,0 +1,540 @@
+package organizer
+
+// Publish-bound crumb evidence (PR #249 codex P2): the force-overwrite audit
+// crumb must key on PHYSICAL occupancy at the PUBLISH instant, never on a
+// classification the publish outdates. These wedges act as the foreign
+// process the (process-local) destination locks cannot exclude:
+//
+//   - copy lane: a wrapped fs hands back a source stream whose first Read
+//     parks INSIDE the staging stream — after the execute-time classification,
+//     before the publish — and mutates the destination there. The measured
+//     window (staging start → publish rename) is asserted to contain the
+//     wedge with real elapsed time, so the test genuinely demonstrates the
+//     long classify → publish window the finding describes;
+//   - move lane (organize + in-place-norenamefolder shape): the lane's
+//     post-classify MkdirAll is the deterministic gap between the authorized
+//     classification and the inline rename publish;
+//   - in-place inner rename: the classification's own src probe (dst was
+//     probed immediately before it, inside classifyExistingDestination) is
+//     the deterministic mark between classification and the inline publish.
+//
+// Each lane is wedged in BOTH directions: an occupant PLANTED in the window
+// must crumb (its bytes are really displaced at publish), an occupant
+// VACATED in the window must stay silent (nothing is physically replaced).
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+)
+
+// copyWindowWedgeFs is the foreign-process armature for the copy lane: the
+// wrapped Open of the source hands back a file whose first Read
+//  1. records that staging has begun (the execute-time classification is
+//     already complete — it precedes the copy by construction), and
+//  2. blocks until the test mutates the destination and releases the stream,
+//
+// holding the classify → publish window open measurably long. Rename records
+// the publish instant so the test can assert the wedge really landed INSIDE
+// the window instead of racing around it.
+type copyWindowWedgeFs struct {
+	afero.Fs
+	slowSrc string
+
+	stageStart   chan struct{}
+	stageStartAt time.Time
+	release      chan struct{}
+	stageOnce    sync.Once
+	publishAt    time.Time
+}
+
+func (w *copyWindowWedgeFs) Open(name string) (afero.File, error) {
+	f, err := w.Fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	if filepath.Clean(name) != filepath.Clean(w.slowSrc) {
+		return f, nil
+	}
+	return &wedgeSourceFile{File: f, w: w}, nil
+}
+
+func (w *copyWindowWedgeFs) Rename(oldname, newname string) error {
+	// The staged publish's replace-rename is the terminal rename of this
+	// flow; stamping it gives the window's closing edge.
+	w.publishAt = time.Now()
+	return w.Fs.Rename(oldname, newname)
+}
+
+type wedgeSourceFile struct {
+	afero.File
+	w       *copyWindowWedgeFs
+	stalled bool
+}
+
+func (s *wedgeSourceFile) Read(p []byte) (int, error) {
+	if !s.stalled {
+		s.stalled = true
+		s.w.stageOnce.Do(func() {
+			s.w.stageStartAt = time.Now()
+			close(s.w.stageStart)
+		})
+		// Park mid-stream: the staged copy cannot reach the publish until the
+		// foreign mutation below lands and the test releases the window.
+		<-s.w.release
+	}
+	return s.File.Read(p)
+}
+
+// driveCopyWindowWedge runs the authorized copy lane with the destination
+// mutated mid-staging by the wrapped-fs armature and returns the result plus
+// the measured window. mutate runs while the staging stream is provably
+// parked between classification and publish.
+func driveCopyWindowWedge(t *testing.T, base afero.Fs, src, dst string, window time.Duration, mutate func(fs afero.Fs)) (*OrganizeResult, time.Duration) {
+	t.Helper()
+	require.NoError(t, base.MkdirAll(filepath.Dir(src), 0o755))
+	require.NoError(t, afero.WriteFile(base, src, []byte("winner-bytes"), 0o644))
+
+	wedge := &copyWindowWedgeFs{
+		Fs:         base,
+		slowSrc:    src,
+		stageStart: make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	org := NewOrganizer(wedge, &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}, nil, nil)
+	plan, err := org.PlanOrganize(context.Background(), OrganizeCmd{
+		Match:       models.FileMatchInfo{MovieID: "ABC-123", Path: src, Name: filepath.Base(src), Extension: filepath.Ext(src)},
+		Movie:       &models.Movie{ID: "ABC-123"},
+		DestDir:     mustDestinationRoot(t, dst),
+		MoveFiles:   false,
+		LinkMode:    LinkModeNone,
+		ForceUpdate: true,
+	})
+	require.NoError(t, err)
+	require.Empty(t, plan.Conflicts, "force suppresses the file-occupation conflict at plan")
+	require.Equal(t, filepath.ToSlash(dst), filepath.ToSlash(plan.TargetPath))
+	plan.moveFiles = false
+	plan.LinkMode = LinkModeNone
+
+	type outcome struct {
+		res *OrganizeResult
+		err error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		res, execErr := plan.executeStrategy.Execute(plan)
+		done <- outcome{res, execErr}
+	}()
+
+	<-wedge.stageStart // staging is mid-stream: classification is behind us, publish ahead
+	wedgeAt := time.Now()
+	mutate(base) // the foreign plant/vacate the finding describes
+	time.Sleep(window)
+	close(wedge.release)
+
+	out := <-done
+	require.NoError(t, out.err)
+
+	require.False(t, wedge.publishAt.IsZero(), "the staged publish must have run")
+	assert.True(t, wedge.stageStartAt.Before(wedgeAt) || wedge.stageStartAt.Equal(wedgeAt))
+	assert.True(t, wedge.publishAt.After(wedgeAt),
+		"the mutation provably landed INSIDE the classify → publish window")
+	measured := wedge.publishAt.Sub(wedge.stageStartAt)
+	assert.GreaterOrEqual(t, measured, window,
+		"the staging window was held open for real elapsed time — no microsecond-only window")
+	return out.res, measured
+}
+
+// mustDestinationRoot extracts the destination library root from the computed
+// destination path (destDir/<ID>/<ID>.mkv).
+func mustDestinationRoot(t *testing.T, dst string) string {
+	t.Helper()
+	require.Equal(t, "ABC-123", filepath.Base(filepath.Dir(dst)),
+		"fixture layout <root>/ABC-123/ABC-123.mkv")
+	return filepath.Dir(filepath.Dir(dst))
+}
+
+func TestForceOverwriteAudit_PublishBound_CopyLaneWindow(t *testing.T) {
+	run := func(t *testing.T, mkFs func(t *testing.T) (afero.Fs, string, string)) {
+		fs, src, dst := mkFs(t)
+
+		t.Run("occupant planted mid-staging crumbs at publish", func(t *testing.T) {
+			res, window := driveCopyWindowWedge(t, fs, src, dst, 60*time.Millisecond,
+				func(base afero.Fs) {
+					require.NoError(t, base.MkdirAll(filepath.Dir(dst), 0o755))
+					require.NoError(t, afero.WriteFile(base, dst, []byte("planted-foreign-bytes"), 0o644))
+				})
+			t.Logf("measured classify→publish staging window: %s", window)
+			require.True(t, res.Moved)
+			require.Len(t, res.Warnings, 1,
+				"the publish displaced bytes a mid-staging plant landed — classify-time silence was the finding's false negative")
+			assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(res.Warnings[0]))
+			content, err := afero.ReadFile(fs, dst)
+			require.NoError(t, err)
+			assert.Equal(t, []byte("winner-bytes"), content,
+				"the plant's foreign bytes were really displaced by the publish")
+		})
+
+		t.Run("occupant vacated mid-staging stays silent", func(t *testing.T) {
+			require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
+			require.NoError(t, afero.WriteFile(fs, dst, []byte("resident-bytes"), 0o644))
+
+			res, window := driveCopyWindowWedge(t, fs, src, dst, 60*time.Millisecond,
+				func(base afero.Fs) {
+					require.NoError(t, base.Remove(dst))
+				})
+			t.Logf("measured classify→publish staging window: %s", window)
+			require.True(t, res.Moved)
+			assert.Empty(t, res.Warnings,
+				"the publish landed on a name vacated mid-staging — nothing was displaced, so no crumb may fire")
+			content, err := afero.ReadFile(fs, dst)
+			require.NoError(t, err)
+			assert.Equal(t, []byte("winner-bytes"), content)
+		})
+	}
+
+	t.Run("MemMapFs", func(t *testing.T) {
+		run(t, func(t *testing.T) (afero.Fs, string, string) {
+			fs := afero.NewMemMapFs()
+			return fs, "/in/A.mkv", "/dest/ABC-123/ABC-123.mkv"
+		})
+	})
+
+	t.Run("OsFs (bound publish POSIX leg)", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("os-level staging fixture")
+		}
+		run(t, func(t *testing.T) (afero.Fs, string, string) {
+			dir := t.TempDir()
+			fs := afero.NewOsFs()
+			return fs, filepath.Join(dir, "in", "A.mkv"), filepath.Join(dir, "dest", "ABC-123", "ABC-123.mkv")
+		})
+	})
+}
+
+// moveClassifyGapWedgeFs wedges a destination mutation between the authorized
+// move lane's execute-time classification and its publish: the lane takes a
+// post-classify MkdirAll(TargetDir), so that call gates the wedge (exactly
+// once — the fsutil composite's own MkdirAll is the second call and sees the
+// mutation's result). Deterministic, goroutine-free.
+type moveClassifyGapWedgeFs struct {
+	afero.Fs
+	dir   string
+	fired bool
+	once  sync.Once
+	wedge func(fs afero.Fs)
+}
+
+func (w *moveClassifyGapWedgeFs) MkdirAll(path string, perm os.FileMode) error {
+	err := w.Fs.MkdirAll(path, perm)
+	if filepath.Clean(path) == filepath.Clean(w.dir) {
+		w.once.Do(func() {
+			w.fired = true
+			// The classification is complete; the rename publish has not yet
+			// probed — a cross-process plant/vacate lands exactly here.
+			w.wedge(w.Fs)
+		})
+	}
+	return err
+}
+
+func moveWedgeOrganizer(base afero.Fs, targetDir string, wedge func(fs afero.Fs)) *Organizer {
+	wrapped := &moveClassifyGapWedgeFs{Fs: base, dir: targetDir, wedge: wedge}
+	return NewOrganizer(wrapped, &Config{
+		FolderFormat:  "<ID>",
+		FileFormat:    "<ID>",
+		RenameFile:    true,
+		OperationMode: operationmode.OperationModeOrganize,
+	}, nil, nil)
+}
+
+func TestForceOverwriteAudit_PublishBound_MoveLaneWindow(t *testing.T) {
+	const dst = "/dest/ABC-123/ABC-123.mkv"
+
+	t.Run("occupant planted post-classification crumbs at publish", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		org := moveWedgeOrganizer(base, "/dest/ABC-123", func(fs afero.Fs) {
+			require.NoError(t, afero.WriteFile(fs, dst, []byte("planted-foreign-bytes"), 0o644))
+		})
+
+		plan := forceAuditPlan(t, org, forceAuditCmd("/in/A.mkv", true, true))
+		result, err := plan.executeStrategy.Execute(plan)
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.Len(t, result.Warnings, 1,
+			"the plant landed between classification and publish — the rename really displaced it")
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+		content, readErr := afero.ReadFile(base, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content)
+		srcGone, statErr := afero.Exists(base, "/in/A.mkv")
+		require.NoError(t, statErr)
+		assert.False(t, srcGone, "the move consumed the source")
+	})
+
+	t.Run("occupant vacated post-classification stays silent", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		require.NoError(t, base.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, afero.WriteFile(base, dst, []byte("resident-bytes"), 0o644))
+		org := moveWedgeOrganizer(base, filepath.Dir(dst), func(fs afero.Fs) {
+			require.NoError(t, fs.Remove(dst))
+		})
+
+		plan := forceAuditPlan(t, org, forceAuditCmd("/in/A.mkv", true, true))
+		result, err := plan.executeStrategy.Execute(plan)
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings,
+			"the occupant vanished between classification and publish — nothing was displaced")
+		content, readErr := afero.ReadFile(base, dst)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+}
+
+// innerRenameWedgeFs wedges a destination mutation between the in-place inner
+// rename lane's classification and its inline rename publish: the lane's
+// classifyAuthorizedDestination probes dst then src (one
+// classifyExistingDestination call — see its implementation), so the FIRST
+// probe of the renamed source path is the deterministic mark after the
+// classification's own dst evidence went stale.
+type innerRenameWedgeFs struct {
+	afero.Fs
+	srcAfterDirRename string
+	once              sync.Once
+	wedge             func(fs afero.Fs)
+}
+
+func (w *innerRenameWedgeFs) LstatIfPossible(path string) (os.FileInfo, bool, error) {
+	if filepath.Clean(path) == filepath.Clean(w.srcAfterDirRename) {
+		w.once.Do(func() {
+			w.wedge(w.Fs) // dst already probed by the classification
+		})
+	}
+	return w.Fs.(afero.Lstater).LstatIfPossible(path)
+}
+
+// failTargetRenameFs refuses the rename publish onto dst outright (a
+// non-cross-device hard failure) so the authorized move lanes surface the
+// publish failure: no crumb, no replacement, both objects preserved.
+type failTargetRenameFs struct {
+	afero.Fs
+	dst string
+}
+
+func (f failTargetRenameFs) Rename(oldname, newname string) error {
+	if filepath.Clean(newname) == filepath.Clean(f.dst) {
+		return errors.New("simulated publish denial")
+	}
+	return f.Fs.Rename(oldname, newname)
+}
+
+func TestForceOverwriteAudit_PublishBound_FailedPublishNoCrumb(t *testing.T) {
+	t.Run("in-place move lane: refused publish carries no crumb", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		cfg := &Config{
+			FolderFormat: "<ID>", FileFormat: "<ID> vidfile",
+			RenameFile: true, OperationMode: operationmode.OperationModeInPlace,
+		}
+		require.NoError(t, base.MkdirAll("/pool/mixed", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/pool/mixed/ABC-100 ownA.mkv", []byte("a-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(base, "/pool/mixed/DEF-999 other.mkv", []byte("other-tenant"), 0o644))
+		org := NewOrganizer(failTargetRenameFs{Fs: base, dst: "/pool/mixed/ABC-100 vidfile.mkv"}, cfg, nil, ipfMatcher(t))
+
+		_, err := org.Organize(context.Background(), OrganizeCmd{
+			Match:       models.FileMatchInfo{MovieID: "ABC-100", Path: "/pool/mixed/ABC-100 ownA.mkv", Name: "ABC-100 ownA.mkv", Extension: ".mkv"},
+			Movie:       &models.Movie{ID: "ABC-100"},
+			DestDir:     "/dest",
+			MoveFiles:   true,
+			ForceUpdate: true,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to move file")
+		content, readErr := afero.ReadFile(base, "/pool/mixed/ABC-100 ownA.mkv")
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("a-bytes"), content, "a refused publish deleted nothing")
+	})
+
+	t.Run("in-place-norenamefolder lane: refused publish carries no crumb", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		cfg := &Config{
+			FolderFormat: "<ID>", FileFormat: "<ID> vidfile",
+			RenameFile: true, OperationMode: operationmode.OperationModeInPlaceNoRenameFolder,
+		}
+		require.NoError(t, base.MkdirAll("/pool", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/pool/ABC-100 ownA.mkv", []byte("a-bytes"), 0o644))
+		org := NewOrganizer(failTargetRenameFs{Fs: base, dst: "/pool/ABC-100 vidfile.mkv"}, cfg, nil, nil)
+
+		_, err := org.Organize(context.Background(), OrganizeCmd{
+			Match:       models.FileMatchInfo{MovieID: "ABC-100", Path: "/pool/ABC-100 ownA.mkv", Name: "ABC-100 ownA.mkv", Extension: ".mkv"},
+			Movie:       &models.Movie{ID: "ABC-100"},
+			DestDir:     "/dest",
+			MoveFiles:   true,
+			ForceUpdate: true,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to rename file")
+		content, readErr := afero.ReadFile(base, "/pool/ABC-100 ownA.mkv")
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("a-bytes"), content, "a refused publish deleted nothing")
+	})
+}
+
+// linkInstallWedgeFs wedges a destination mutation between the authorized
+// link lane's regular-file-gate occupancy probe (the SECOND LstatIfPossible
+// of the destination — the first is the lane-head classification) and the
+// Remove that publishes the install: the wrapped probe answers truthfully,
+// THEN mutates, so the Remove runs on the mutated physical state.
+type linkInstallWedgeFs struct {
+	afero.Fs
+	dst    string
+	probes int
+	wedge  func(fs afero.Fs)
+}
+
+func (w *linkInstallWedgeFs) LstatIfPossible(path string) (os.FileInfo, bool, error) {
+	info, did, err := w.Fs.(afero.Lstater).LstatIfPossible(path)
+	if filepath.Clean(path) == filepath.Clean(w.dst) {
+		w.probes++
+		if w.probes == 2 {
+			// The gate has its real answer; the foreign mutation lands before the
+			// lane's Remove — exactly the probe → publish window.
+			w.wedge(w.Fs)
+		}
+	}
+	return info, did, err
+}
+
+func TestForceOverwriteAudit_PublishBound_LinkLaneWindow(t *testing.T) {
+	const dst = "/dest/ABC-123/ABC-123.mkv"
+
+	t.Run("occupant planted between the probe and the Remove crumbs", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		strategy := newOrganizeStrategy(&linkInstallWedgeFs{
+			Fs:  base,
+			dst: dst,
+			wedge: func(fs afero.Fs) {
+				require.NoError(t, fs.MkdirAll(filepath.Dir(dst), 0o755))
+				require.NoError(t, afero.WriteFile(fs, dst, []byte("planted-foreign-bytes"), 0o644))
+			},
+		}, &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}, nil, &MemLinker{})
+		ml := strategy.linker.(*MemLinker)
+
+		result, err := strategy.Execute(forceAuditLinkPlan("/in/A.mkv", dst, LinkModeHard, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.Len(t, result.Warnings, 1,
+			"the Remove physically unlinked the plant's entry — probe-time ('vacant') evidence was the finding's false negative")
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+		require.Len(t, ml.Links, 1, "the install landed on the cleared name")
+	})
+
+	t.Run("occupant vacated between the probe and the Remove stays silent", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/in/A.mkv", []byte("winner-bytes"), 0o644))
+		require.NoError(t, base.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, afero.WriteFile(base, dst, []byte("resident-bytes"), 0o644))
+		strategy := newOrganizeStrategy(&linkInstallWedgeFs{
+			Fs:  base,
+			dst: dst,
+			wedge: func(fs afero.Fs) {
+				require.NoError(t, fs.Remove(dst))
+			},
+		}, &Config{FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true}, nil, &MemLinker{})
+		ml := strategy.linker.(*MemLinker)
+
+		result, err := strategy.Execute(forceAuditLinkPlan("/in/A.mkv", dst, LinkModeHard, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings,
+			"the Remove saw an already-vacant name — nothing was displaced, even though the probe saw an occupant")
+		require.Len(t, ml.Links, 1)
+	})
+}
+
+func TestForceOverwriteAudit_PublishBound_InnerRenameWindow(t *testing.T) {
+	cfg := func() *Config {
+		return &Config{
+			FolderFormat: "shared", FileFormat: "<ID> vidfile",
+			RenameFile: true, OperationMode: operationmode.OperationModeInPlace,
+		}
+	}
+	cmd := OrganizeCmd{
+		Match:       models.FileMatchInfo{MovieID: "ABC-100", Path: "/pool/oldA/ABC-100 ownA.mkv", Name: "ABC-100 ownA.mkv", Extension: ".mkv"},
+		Movie:       &models.Movie{ID: "ABC-100"},
+		DestDir:     "/dest",
+		MoveFiles:   true,
+		ForceUpdate: true,
+	}
+	const target = "/pool/shared/ABC-100 vidfile.mkv"
+
+	t.Run("occupant planted post-classification crumbs at the inline publish", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/pool/oldA", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/pool/oldA/ABC-100 ownA.mkv", []byte("a-bytes"), 0o644))
+		org := NewOrganizer(&innerRenameWedgeFs{
+			Fs:                base,
+			srcAfterDirRename: "/pool/shared/ABC-100 ownA.mkv",
+			wedge: func(fs afero.Fs) {
+				require.NoError(t, afero.WriteFile(fs, target, []byte("planted-foreign-bytes"), 0o644))
+			},
+		}, cfg(), nil, ipfMatcher(t))
+
+		result, err := org.Organize(context.Background(), cmd)
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.True(t, result.InPlaceRenamed)
+		require.Len(t, result.Warnings, 1,
+			"the classification saw the name VACANT, yet the publish displaced a plant — publish-bound evidence catches it")
+		assert.Equal(t, authorizedOverwriteWarning(target), filepath.ToSlash(result.Warnings[0]))
+		content, readErr := afero.ReadFile(base, target)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("a-bytes"), content, "the plant's bytes were displaced")
+	})
+
+	t.Run("occupant vacated post-classification stays silent", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/pool/oldA", 0o755))
+		require.NoError(t, afero.WriteFile(base, "/pool/oldA/ABC-100 ownA.mkv", []byte("a-bytes"), 0o644))
+		require.NoError(t, afero.WriteFile(base, "/pool/oldA/ABC-100 vidfile.mkv", []byte("resident-bytes"), 0o644))
+		org := NewOrganizer(&innerRenameWedgeFs{
+			Fs:                base,
+			srcAfterDirRename: "/pool/shared/ABC-100 ownA.mkv",
+			wedge: func(fs afero.Fs) {
+				require.NoError(t, fs.Remove(target))
+			},
+		}, cfg(), nil, ipfMatcher(t))
+
+		result, err := org.Organize(context.Background(), cmd)
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings,
+			"the classification saw an occupant, but it vanished before the publish displaced nothing — no crumb")
+		content, readErr := afero.ReadFile(base, target)
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("a-bytes"), content)
+	})
+}

--- a/internal/organizer/force_overwrite_rename_adjacency_test.go
+++ b/internal/organizer/force_overwrite_rename_adjacency_test.go
@@ -1,0 +1,116 @@
+package organizer
+
+// PR #249 codex P2 (F2) — the RESULT-level pin of the rename-adjacency
+// adjudication: the move lane's publish-bound crumb probes destination
+// occupancy ONE syscall ahead of the publish rename (fsutil's adjudicated
+// accuracy ceiling — no portable kernel primitive reports displacement AT
+// the rename instant; see the bound comment on fsutil.MoveFileFsDestReplaced).
+// These pins land a foreign mutation INSIDE that exact window — the wrapped
+// Rename runs the plant/vacate one "scheduler tick" before delegating, after
+// the lane's probe already answered — and document the unexpected-but-
+// adjudicated RESULT shapes:
+//
+//   - plant inside the window: the rename really displaces the foreign bytes
+//     yet the result crumb is SILENT (probe-instant truth) — the window's
+//     documented audit gap. The move still completed and the destination
+//     carries our bytes, so NO error is defensible;
+//   - vacate inside the window: the crumb FIRES although the rename
+//     displaced nothing — probe-time evidence keys it.
+//
+// The classify → publish window (the finding this PR's publish-bound rework
+// closed) is pinned separately in force_overwrite_publish_bound_test.go;
+// this file pins the narrower, physically unclosable probe → rename window
+// that rework deliberately leaves as the ceiling.
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+)
+
+// renameAdjacencyWedgeFs wedges the foreign mutation strictly between the
+// move lane's publish-adjacent occupancy probe and the publish rename: the
+// probe has already answered when this Rename runs, and the wedge mutates
+// the destination before delegating — the narrowest window any same-device
+// rename publish exposes.
+type renameAdjacencyWedgeFs struct {
+	afero.Fs
+	src, dst string
+	once     sync.Once
+	fired    bool
+	wedge    func(fs afero.Fs)
+}
+
+func (w *renameAdjacencyWedgeFs) Rename(oldname, newname string) error {
+	if filepath.Clean(oldname) == filepath.Clean(w.src) && filepath.Clean(newname) == filepath.Clean(w.dst) {
+		w.once.Do(func() {
+			w.fired = true
+			w.wedge(w.Fs)
+		})
+	}
+	return w.Fs.Rename(oldname, newname)
+}
+
+func TestForceOverwriteAudit_RenameAdjacencyWindow_ResultShape(t *testing.T) {
+	const (
+		src = "/in/A.mkv"
+		dst = "/dest/ABC-123/ABC-123.mkv"
+	)
+
+	organizerOver := func(base afero.Fs, wedge func(fs afero.Fs)) *Organizer {
+		return NewOrganizer(&renameAdjacencyWedgeFs{Fs: base, src: src, dst: dst, wedge: wedge}, &Config{
+			FolderFormat:  "<ID>",
+			FileFormat:    "<ID>",
+			RenameFile:    true,
+			OperationMode: operationmode.OperationModeOrganize,
+		}, nil, nil)
+	}
+
+	t.Run("plant inside the probe-rename window: completed move, silent crumb", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, src, []byte("winner-bytes"), 0o644))
+		org := organizerOver(base, func(fs afero.Fs) {
+			require.NoError(t, fs.MkdirAll("/dest/ABC-123", 0o755))
+			require.NoError(t, afero.WriteFile(fs, dst, []byte("planted-foreign-bytes"), 0o644))
+		})
+
+		result, err := org.Organize(context.Background(), forceAuditCmd(src, true, true))
+		require.NoError(t, err, "the publish genuinely completed — no error is defensible for a landed rename")
+		require.True(t, result.Moved)
+		assert.Empty(t, result.Warnings,
+			"the probe answered BEFORE the plant — the adjudicated audit gap: displacement without a crumb")
+		content, rerr := afero.ReadFile(base, dst)
+		require.NoError(t, rerr)
+		assert.Equal(t, []byte("winner-bytes"), content,
+			"the plant's foreign bytes were really displaced — documented, not hidden")
+	})
+
+	t.Run("vacate inside the probe-rename window: crumb fires with nothing displaced", func(t *testing.T) {
+		base := afero.NewMemMapFs()
+		require.NoError(t, base.MkdirAll("/in", 0o755))
+		require.NoError(t, afero.WriteFile(base, src, []byte("winner-bytes"), 0o644))
+		require.NoError(t, base.MkdirAll("/dest/ABC-123", 0o755))
+		require.NoError(t, afero.WriteFile(base, dst, []byte("resident-bytes"), 0o644))
+		org := organizerOver(base, func(fs afero.Fs) {
+			require.NoError(t, fs.Remove(dst))
+		})
+
+		result, err := org.Organize(context.Background(), forceAuditCmd(src, true, true))
+		require.NoError(t, err)
+		require.True(t, result.Moved)
+		require.Len(t, result.Warnings, 1,
+			"the probe answered BEFORE the vacate — the crumb keys on probe-instant evidence, nothing was displaced")
+		assert.Equal(t, authorizedOverwriteWarning(dst), filepath.ToSlash(result.Warnings[0]))
+		content, rerr := afero.ReadFile(base, dst)
+		require.NoError(t, rerr)
+		assert.Equal(t, []byte("winner-bytes"), content)
+	})
+}

--- a/internal/organizer/linker.go
+++ b/internal/organizer/linker.go
@@ -16,7 +16,12 @@ type linker interface {
 	// hardlink creates a hard link from oldname to newname.
 	hardlink(oldname, newname string) error
 	// copyFile copies the file content from src to dst using the provided fs.
-	copyFile(fs afero.Fs, src, dst string) error
+	// destReplaced reports — bound to the staged replace-publish itself, not
+	// to any earlier classification (PR #249 codex P2) — whether the publish
+	// displaced an occupied destination whose object does NOT alias the
+	// source's own inode, so the authorized overwrite audit crumb keys on
+	// publish-time PHYSICAL occupancy.
+	copyFile(fs afero.Fs, src, dst string) (destReplaced bool, err error)
 }
 
 // OSLinker wraps real OS link operations for production use.
@@ -24,8 +29,8 @@ type OSLinker struct{}
 
 func (OSLinker) symlink(oldname, newname string) error  { return os.Symlink(oldname, newname) }
 func (OSLinker) hardlink(oldname, newname string) error { return os.Link(oldname, newname) }
-func (OSLinker) copyFile(fs afero.Fs, src, dst string) error {
-	return fsutil.CopyFileFs(fs, src, dst)
+func (OSLinker) copyFile(fs afero.Fs, src, dst string) (bool, error) {
+	return fsutil.CopyFileFsDestReplaced(fs, src, dst)
 }
 
 // linkRecord records a link operation for test assertions.
@@ -52,6 +57,6 @@ func (m *MemLinker) hardlink(oldname, newname string) error {
 	return nil
 }
 
-func (m *MemLinker) copyFile(fs afero.Fs, src, dst string) error {
-	return fsutil.CopyFileFs(fs, src, dst)
+func (m *MemLinker) copyFile(fs afero.Fs, src, dst string) (bool, error) {
+	return fsutil.CopyFileFsDestReplaced(fs, src, dst)
 }

--- a/internal/organizer/linker_test.go
+++ b/internal/organizer/linker_test.go
@@ -42,8 +42,9 @@ func TestMemLinker_CopyFile(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fs, "/src.txt", []byte("hello"), 0644))
 
 	m := &MemLinker{}
-	err := m.copyFile(fs, "/src.txt", "/dst.txt")
+	replaced, err := m.copyFile(fs, "/src.txt", "/dst.txt")
 	require.NoError(t, err)
+	assert.False(t, replaced, "a vacant destination publishes into absence — no replacement")
 
 	content, err := afero.ReadFile(fs, "/dst.txt")
 	require.NoError(t, err)

--- a/internal/organizer/organize_pathclass_coverage_test.go
+++ b/internal/organizer/organize_pathclass_coverage_test.go
@@ -155,9 +155,9 @@ type errLinker struct {
 	copyErr error
 }
 
-func (l errLinker) hardlink(_, _ string) error             { return l.hardErr }
-func (l errLinker) symlink(_, _ string) error              { return l.softErr }
-func (l errLinker) copyFile(_ afero.Fs, _, _ string) error { return l.copyErr }
+func (l errLinker) hardlink(_, _ string) error                     { return l.hardErr }
+func (l errLinker) symlink(_, _ string) error                      { return l.softErr }
+func (l errLinker) copyFile(_ afero.Fs, _, _ string) (bool, error) { return false, l.copyErr }
 
 // --- refuseExistingDestination: dangling-symlink probe under Stat fallback -----------
 

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -124,9 +124,22 @@ func applyTitleTruncation(engine template.EngineInterface, ctx *template.Context
 // recorded. Idempotency: lexical self and same-inode aliases are not
 // conflicts.
 func checkTargetConflict(fs afero.Fs, sourcePath, targetPath string, forceUpdate, willMove bool) []PlanConflict {
-	conflicts := make([]PlanConflict, 0)
+	conflicts, _ := classifyTargetConflicts(fs, sourcePath, targetPath, forceUpdate, willMove)
+	return conflicts
+}
+
+// classifyTargetConflicts is checkTargetConflict plus the force-overwrite
+// audit signal (force-overwrite audit crumb): suppressedOccupant reports the
+// bytes-bearing regular file an overwrite authorization FILTERED OUT of the
+// conflict list — ConflictFile is the only authorizable kind, and the
+// suppressed lane is exactly where an authorized move/copy execute leg would
+// REPLACE resident bytes. nil when the destination was absent, a
+// lexical-self/same-inode no-op, an unsuppressible kind (directory,
+// symlink), or no authorization was in play.
+func classifyTargetConflicts(fs afero.Fs, sourcePath, targetPath string, forceUpdate, willMove bool) (conflicts []PlanConflict, suppressedOccupant *PlanConflict) {
+	conflicts = make([]PlanConflict, 0)
 	if !willMove {
-		return conflicts
+		return conflicts, nil
 	}
 	var target os.FileInfo
 	var targetErr error
@@ -148,28 +161,32 @@ func checkTargetConflict(fs afero.Fs, sourcePath, targetPath string, forceUpdate
 		if symlinkObjectExists(fs, targetPath) {
 			conflicts = append(conflicts, PlanConflict{Path: targetPath, Kind: ConflictSymlink})
 		}
-		return conflicts
+		return conflicts, nil
 	}
 	// A live symlink object at the destination is never renamed-over safely —
 	// a fallback Stat returns didLstat=false only when no Lstat was performed,
 	// so confirm via readlink before declaring it a regular file.
 	if target.Mode()&os.ModeSymlink != 0 || symlinkObjectExists(fs, targetPath) {
 		conflicts = append(conflicts, PlanConflict{Path: targetPath, Kind: ConflictSymlink})
-		return conflicts
+		return conflicts, nil
 	}
 	if target.IsDir() {
 		conflicts = append(conflicts, PlanConflict{Path: targetPath, Kind: ConflictDirectory})
-		return conflicts
+		return conflicts, nil
 	}
 	// Same-inode alias of the source is not a conflict (idempotent no-op).
 	sourceStat, sourceErr := fs.Stat(sourcePath)
 	if sourceErr == nil && os.SameFile(sourceStat, target) {
-		return conflicts
+		return conflicts, nil
 	}
 	if !forceUpdate {
 		conflicts = append(conflicts, PlanConflict{Path: targetPath, Kind: ConflictFile})
+		return conflicts, nil
 	}
-	return conflicts
+	// Authorization suppressed the occupation conflict: the destination held
+	// resident bytes at plan/check time, so the authorized execute leg
+	// REPLACES an existing file — surface the audit evidence.
+	return conflicts, &PlanConflict{Path: targetPath, Kind: ConflictFile}
 }
 
 type planContext struct {
@@ -385,6 +402,17 @@ type OrganizePlan struct {
 	// destination (cmd.ForceUpdate). When false, move execution refuses to replace a file that
 	// exists at the target even if it appeared after plan-time conflict checks (TOCTOU guard).
 	overwriteAuthorized bool
+	// forceOverwriteOccupiedDest is plan-time audit evidence for the
+	// force-overwrite audit crumb: true when destination classification found
+	// the target already occupied by a bytes-bearing regular file whose
+	// ConflictFile was SUPPRESSED by the overwrite authorization — the
+	// authorized move/copy execute leg will REPLACE resident bytes, so the
+	// strategy appends the "overwrite authorized: replaced existing
+	// destination" warning to its result instead of silently dropping the
+	// replaced occupant. Absent destinations, lexical-self/same-inode
+	// no-ops, unsuppressible occupants (directory/symlink), subtitle
+	// installs, and unauthorized runs never set it.
+	forceOverwriteOccupiedDest bool
 }
 
 // Plan creates an organization plan without executing it

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -123,23 +123,15 @@ func applyTitleTruncation(engine template.EngineInterface, ctx *template.Context
 // update suppresses ONLY ConflictFile — directories and symlinks are always
 // recorded. Idempotency: lexical self and same-inode aliases are not
 // conflicts.
+//
+// n.b.: plan-time classification is NOT the force-overwrite audit crumb's
+// evidence — crumb semantics key on EXECUTE-time occupancy (the execute
+// leg's own classification), so a post-plan occupant swap can neither forge
+// nor hide a replacement.
 func checkTargetConflict(fs afero.Fs, sourcePath, targetPath string, forceUpdate, willMove bool) []PlanConflict {
-	conflicts, _ := classifyTargetConflicts(fs, sourcePath, targetPath, forceUpdate, willMove)
-	return conflicts
-}
-
-// classifyTargetConflicts is checkTargetConflict plus the force-overwrite
-// audit signal (force-overwrite audit crumb): suppressedOccupant reports the
-// bytes-bearing regular file an overwrite authorization FILTERED OUT of the
-// conflict list — ConflictFile is the only authorizable kind, and the
-// suppressed lane is exactly where an authorized move/copy execute leg would
-// REPLACE resident bytes. nil when the destination was absent, a
-// lexical-self/same-inode no-op, an unsuppressible kind (directory,
-// symlink), or no authorization was in play.
-func classifyTargetConflicts(fs afero.Fs, sourcePath, targetPath string, forceUpdate, willMove bool) (conflicts []PlanConflict, suppressedOccupant *PlanConflict) {
-	conflicts = make([]PlanConflict, 0)
+	conflicts := make([]PlanConflict, 0)
 	if !willMove {
-		return conflicts, nil
+		return conflicts
 	}
 	var target os.FileInfo
 	var targetErr error
@@ -161,32 +153,28 @@ func classifyTargetConflicts(fs afero.Fs, sourcePath, targetPath string, forceUp
 		if symlinkObjectExists(fs, targetPath) {
 			conflicts = append(conflicts, PlanConflict{Path: targetPath, Kind: ConflictSymlink})
 		}
-		return conflicts, nil
+		return conflicts
 	}
 	// A live symlink object at the destination is never renamed-over safely —
 	// a fallback Stat returns didLstat=false only when no Lstat was performed,
 	// so confirm via readlink before declaring it a regular file.
 	if target.Mode()&os.ModeSymlink != 0 || symlinkObjectExists(fs, targetPath) {
 		conflicts = append(conflicts, PlanConflict{Path: targetPath, Kind: ConflictSymlink})
-		return conflicts, nil
+		return conflicts
 	}
 	if target.IsDir() {
 		conflicts = append(conflicts, PlanConflict{Path: targetPath, Kind: ConflictDirectory})
-		return conflicts, nil
+		return conflicts
 	}
 	// Same-inode alias of the source is not a conflict (idempotent no-op).
 	sourceStat, sourceErr := fs.Stat(sourcePath)
 	if sourceErr == nil && os.SameFile(sourceStat, target) {
-		return conflicts, nil
+		return conflicts
 	}
 	if !forceUpdate {
 		conflicts = append(conflicts, PlanConflict{Path: targetPath, Kind: ConflictFile})
-		return conflicts, nil
 	}
-	// Authorization suppressed the occupation conflict: the destination held
-	// resident bytes at plan/check time, so the authorized execute leg
-	// REPLACES an existing file — surface the audit evidence.
-	return conflicts, &PlanConflict{Path: targetPath, Kind: ConflictFile}
+	return conflicts
 }
 
 type planContext struct {
@@ -402,17 +390,6 @@ type OrganizePlan struct {
 	// destination (cmd.ForceUpdate). When false, move execution refuses to replace a file that
 	// exists at the target even if it appeared after plan-time conflict checks (TOCTOU guard).
 	overwriteAuthorized bool
-	// forceOverwriteOccupiedDest is plan-time audit evidence for the
-	// force-overwrite audit crumb: true when destination classification found
-	// the target already occupied by a bytes-bearing regular file whose
-	// ConflictFile was SUPPRESSED by the overwrite authorization — the
-	// authorized move/copy execute leg will REPLACE resident bytes, so the
-	// strategy appends the "overwrite authorized: replaced existing
-	// destination" warning to its result instead of silently dropping the
-	// replaced occupant. Absent destinations, lexical-self/same-inode
-	// no-ops, unsuppressible occupants (directory/symlink), subtitle
-	// installs, and unauthorized runs never set it.
-	forceOverwriteOccupiedDest bool
 }
 
 // Plan creates an organization plan without executing it

--- a/internal/organizer/strategy_inplace.go
+++ b/internal/organizer/strategy_inplace.go
@@ -228,6 +228,16 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 	}
 
 	if plan.InPlace {
+		// innerFileReplacedOccupant is the force-overwrite audit crumb's
+		// EXECUTE-TIME evidence for the inner file rename below: the
+		// authorized classification (taken under the held locks) saw a
+		// bytes-bearing foreign occupant at the new file name, so the rename
+		// replaces its resident bytes. No-op (identical / same-inode) and
+		// refused lanes never set it; a failed inner rename discards it
+		// through the rollback/error legs. The pure DIRECTORY rename
+		// deliberately never crumbs: its target was proven absent-or-self-alias
+		// before the rename, so it replaces nothing foreign.
+		innerFileReplacedOccupant := false
 		// The WHOLE directory sequence — stat, renames, inner file step, and any rollback —
 		// runs while holding the EXCLUSIVE TargetDir lock plus the inner TargetPath file
 		// lock, acquired up front (dir before file): a sibling worker holding only the
@@ -286,6 +296,11 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 					}
 				}
 
+				// Force-overwrite audit crumb stays silent HERE by construction
+				// (non-obvious intent): the target directory was just proven absent
+				// or a self-alias, so this rename replaces NO foreign bytes — it only
+				// changes a directory NAME. Only the inner FILE rename below can
+				// replace resident bytes, and it carries the crumb.
 				if err := s.fs.Rename(plan.OldDir, plan.TargetDir); err != nil {
 					return fmt.Errorf("failed to rename directory: %w", err)
 				}
@@ -325,7 +340,7 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 						result.NewDirectoryPath = ""
 					}
 					if plan.overwriteAuthorized {
-						identical, sameIn, lerr := refuseIfUnsuppressibleAuthorizedDestination(s.fs, currentFilePath, plan.TargetPath)
+						identical, sameIn, occupiedFile, lerr := classifyAuthorizedDestination(s.fs, currentFilePath, plan.TargetPath)
 						if lerr != nil {
 							rb()
 							return lerr
@@ -333,6 +348,7 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 						if identical || sameIn {
 							return nil
 						}
+						innerFileReplacedOccupant = occupiedFile
 					} else {
 						lexicalSelf, sameIn, e2 := refuseExistingDestination(s.fs, currentFilePath, plan.TargetPath)
 						if e2 != nil {
@@ -354,6 +370,9 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 					if err := innerOp(s.fs, currentFilePath, plan.TargetPath); err != nil {
 						return s.finishInPlaceInnerRename(plan, result, err)
 					}
+					if innerFileReplacedOccupant {
+						result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
+					}
 				}
 				return nil
 			})
@@ -365,6 +384,12 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 		result.Moved = true
 		return result, nil
 	} else {
+		// overwroteOccupiedDest records that THIS execution replaced a
+		// bytes-bearing destination the authorization suppressed — keyed to
+		// EXECUTE-TIME occupancy (its own classification under the held locks):
+		// no-op and refused lanes never set it, and a failed publish discards
+		// it by returning before the warning.
+		overwroteOccupiedDest := false
 		// Shared parent-directory lock + target-file lock (dir before file): an in-place
 		// directory rename elsewhere drains shared holders before it may move the
 		// directory, so this move can never land inside a renamed (possibly
@@ -372,13 +397,14 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 		err := withDestDirSharedLock(plan.TargetDir, func() error {
 			return withDestFileLock(plan.TargetPath, func() error {
 				if plan.overwriteAuthorized {
-					identical, sameIn, err := refuseIfUnsuppressibleAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
+					identical, sameIn, occupiedFile, err := classifyAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
 					if err != nil {
 						return err
 					}
 					if identical || sameIn {
 						return nil
 					}
+					overwroteOccupiedDest = occupiedFile
 				} else {
 					lexicalSelf, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
 					if err != nil {
@@ -406,6 +432,10 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 		}
 
 		result.Moved = true
+		// Force-overwrite audit crumb: the replace actually landed.
+		if overwroteOccupiedDest {
+			result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
+		}
 	}
 
 	return result, nil

--- a/internal/organizer/strategy_inplace.go
+++ b/internal/organizer/strategy_inplace.go
@@ -434,6 +434,14 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 				// resident bytes were displaced AT the publish instant.
 				replaced, mErr := fsutil.MoveFileFsDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
 				if mErr != nil {
+					// Partial-publish ambiguity (PR #249 codex P2 follow-up — F1):
+					// the ErrPublishCompleted leg means the cross-device publish
+					// LANDED — fsutil carries its displaced-occupancy answer through
+					// the error, so the audit crumb survives onto the FAILED result
+					// below instead of being dropped with it.
+					if fsutil.PublishCompleted(mErr) && replaced {
+						overwroteOccupiedDest = true
+					}
 					return mErr
 				}
 				overwroteOccupiedDest = replaced
@@ -442,6 +450,12 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 		})
 		if err != nil {
 			result.Error = fmt.Errorf("failed to move file: %w", err)
+			// Publish-completed failures keep their crumb on the FAILED result;
+			// Moved stays false, so the partial publish journals ONCE as the
+			// failed-and-retained row, never double-journaled as a clean replace.
+			if overwroteOccupiedDest {
+				result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
+			}
 			return result, result.Error
 		}
 

--- a/internal/organizer/strategy_inplace.go
+++ b/internal/organizer/strategy_inplace.go
@@ -396,7 +396,9 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 		// bytes-bearing destination the authorization suppressed — keyed to
 		// the PUBLISH-BOUND replacement signal of the move's own publish
 		// (PR #249 codex P2): no-op and refused lanes never set it, and a
-		// failed publish discards it by returning before the warning.
+		// replacement-free failure answers false exactly like them — while a
+		// failed publish that STILL displaced resident bytes keeps the crumb
+		// ON the FAILED result (see foldMovePublishCrumb).
 		overwroteOccupiedDest := false
 		// Shared parent-directory lock + target-file lock (dir before file): an in-place
 		// directory rename elsewhere drains shared holders before it may move the
@@ -431,28 +433,24 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 					return nil
 				}
 				// Publish-bound crumb: the move's own publish reports whether
-				// resident bytes were displaced AT the publish instant.
-				replaced, mErr := fsutil.MoveFileFsDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
+				// resident bytes were displaced AT the publish instant; the
+				// retained crumb folds on the displacement answer ALONE, failure
+				// included (see foldMovePublishCrumb).
+				replaced, mErr := moveFileDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
+				foldMovePublishCrumb(&overwroteOccupiedDest, replaced)
 				if mErr != nil {
-					// Partial-publish ambiguity (PR #249 codex P2 follow-up — F1):
-					// the ErrPublishCompleted leg means the cross-device publish
-					// LANDED — fsutil carries its displaced-occupancy answer through
-					// the error, so the audit crumb survives onto the FAILED result
-					// below instead of being dropped with it.
-					if fsutil.PublishCompleted(mErr) && replaced {
-						overwroteOccupiedDest = true
-					}
 					return mErr
 				}
-				overwroteOccupiedDest = replaced
 				return nil
 			})
 		})
 		if err != nil {
 			result.Error = fmt.Errorf("failed to move file: %w", err)
-			// Publish-completed failures keep their crumb on the FAILED result;
-			// Moved stays false, so the partial publish journals ONCE as the
-			// failed-and-retained row, never double-journaled as a clean replace.
+			// A failed publish that displaced resident bytes keeps its crumb on
+			// the FAILED result (every failed-with-displacement class — see
+			// foldMovePublishCrumb); Moved stays false, so the failure
+			// journals ONCE as the failed-and-retained row, never
+			// double-journaled as a clean replace.
 			if overwroteOccupiedDest {
 				result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
 			}

--- a/internal/organizer/strategy_inplace.go
+++ b/internal/organizer/strategy_inplace.go
@@ -229,10 +229,11 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 
 	if plan.InPlace {
 		// innerFileReplacedOccupant is the force-overwrite audit crumb's
-		// EXECUTE-TIME evidence for the inner file rename below: the
-		// authorized classification (taken under the held locks) saw a
-		// bytes-bearing foreign occupant at the new file name, so the rename
-		// replaces its resident bytes. No-op (identical / same-inode) and
+		// PUBLISH-BOUND evidence for the inner file rename below (PR #249
+		// codex P2): the authorized rename publish reports AT the publish
+		// instant whether a bytes-bearing foreign occupant at the new file
+		// name was displaced, so a post-classify plant/vacate can neither
+		// forge nor hide the crumb. No-op (identical / same-inode) and
 		// refused lanes never set it; a failed inner rename discards it
 		// through the rollback/error legs. The pure DIRECTORY rename
 		// deliberately never crumbs: its target was proven absent-or-self-alias
@@ -340,7 +341,7 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 						result.NewDirectoryPath = ""
 					}
 					if plan.overwriteAuthorized {
-						identical, sameIn, occupiedFile, lerr := classifyAuthorizedDestination(s.fs, currentFilePath, plan.TargetPath)
+						identical, sameIn, lerr := classifyAuthorizedDestination(s.fs, currentFilePath, plan.TargetPath)
 						if lerr != nil {
 							rb()
 							return lerr
@@ -348,7 +349,6 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 						if identical || sameIn {
 							return nil
 						}
-						innerFileReplacedOccupant = occupiedFile
 					} else {
 						lexicalSelf, sameIn, e2 := refuseExistingDestination(s.fs, currentFilePath, plan.TargetPath)
 						if e2 != nil {
@@ -365,7 +365,15 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 					// directory rename back exactly as before.
 					innerOp := fsutil.PublishNoReplace
 					if plan.overwriteAuthorized {
-						innerOp = func(fs afero.Fs, a, b string) error { return fs.Rename(a, b) }
+						// Publish-bound crumb (PR #249 codex P2): the inline rename
+						// publish itself reports — one syscall ahead of it — whether
+						// resident bytes were displaced; classify-time occupancy
+						// could go stale inside the classify → rename window.
+						innerOp = func(fs afero.Fs, a, b string) error {
+							replaced, err := fsutil.RenameDestReplaced(fs, a, b)
+							innerFileReplacedOccupant = err == nil && replaced
+							return err
+						}
 					}
 					if err := innerOp(s.fs, currentFilePath, plan.TargetPath); err != nil {
 						return s.finishInPlaceInnerRename(plan, result, err)
@@ -386,9 +394,9 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 	} else {
 		// overwroteOccupiedDest records that THIS execution replaced a
 		// bytes-bearing destination the authorization suppressed — keyed to
-		// EXECUTE-TIME occupancy (its own classification under the held locks):
-		// no-op and refused lanes never set it, and a failed publish discards
-		// it by returning before the warning.
+		// the PUBLISH-BOUND replacement signal of the move's own publish
+		// (PR #249 codex P2): no-op and refused lanes never set it, and a
+		// failed publish discards it by returning before the warning.
 		overwroteOccupiedDest := false
 		// Shared parent-directory lock + target-file lock (dir before file): an in-place
 		// directory rename elsewhere drains shared holders before it may move the
@@ -397,14 +405,13 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 		err := withDestDirSharedLock(plan.TargetDir, func() error {
 			return withDestFileLock(plan.TargetPath, func() error {
 				if plan.overwriteAuthorized {
-					identical, sameIn, occupiedFile, err := classifyAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
+					identical, sameIn, err := classifyAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
 					if err != nil {
 						return err
 					}
 					if identical || sameIn {
 						return nil
 					}
-					overwroteOccupiedDest = occupiedFile
 				} else {
 					lexicalSelf, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
 					if err != nil {
@@ -423,7 +430,14 @@ func (s *inPlaceStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) {
 					}
 					return nil
 				}
-				return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
+				// Publish-bound crumb: the move's own publish reports whether
+				// resident bytes were displaced AT the publish instant.
+				replaced, mErr := fsutil.MoveFileFsDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
+				if mErr != nil {
+					return mErr
+				}
+				overwroteOccupiedDest = replaced
+				return nil
 			})
 		})
 		if err != nil {

--- a/internal/organizer/strategy_inplace_norenamefolder.go
+++ b/internal/organizer/strategy_inplace_norenamefolder.go
@@ -99,6 +99,12 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 		ShouldGenerateMetadata: true,
 	}
 
+	// overwroteOccupiedDest records that THIS execution replaced a
+	// bytes-bearing destination the authorization suppressed — keyed to
+	// EXECUTE-TIME occupancy (its own classification under the held locks):
+	// no-op and refused lanes never set it, and a failed publish discards it
+	// by returning before the warning.
+	overwroteOccupiedDest := false
 	// Shared parent-directory lock + target-file lock (dir before file): an in-place
 	// rename elsewhere drains shared holders before moving the directory, so this move
 	// never lands inside a renamed (possibly about-to-rollback) directory — while
@@ -106,13 +112,14 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 	err := withDestDirSharedLock(plan.TargetDir, func() error {
 		return withDestFileLock(plan.TargetPath, func() error {
 			if plan.overwriteAuthorized {
-				identical, sameIn, err := refuseIfUnsuppressibleAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
+				identical, sameIn, occupiedFile, err := classifyAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
 				if err != nil {
 					return err
 				}
 				if identical || sameIn {
 					return nil
 				}
+				overwroteOccupiedDest = occupiedFile
 			} else {
 				lexicalSelf, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
 				if err != nil {
@@ -137,6 +144,10 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 	}
 
 	result.Moved = true
+	// Force-overwrite audit crumb: the replace actually landed.
+	if overwroteOccupiedDest {
+		result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
+	}
 
 	return result, nil
 }

--- a/internal/organizer/strategy_inplace_norenamefolder.go
+++ b/internal/organizer/strategy_inplace_norenamefolder.go
@@ -102,8 +102,10 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 	// overwroteOccupiedDest records that THIS execution replaced a
 	// bytes-bearing destination the authorization suppressed — keyed to the
 	// PUBLISH-BOUND replacement signal of the move's own publish (PR #249
-	// codex P2): no-op and refused lanes never set it, and a failed publish
-	// discards it by returning before the warning.
+	// codex P2): no-op and refused lanes never set it, and a
+	// replacement-free failure answers false exactly like them — while a
+	// failed publish that STILL displaced resident bytes keeps the crumb ON
+	// the FAILED result (see foldMovePublishCrumb).
 	overwroteOccupiedDest := false
 	// Shared parent-directory lock + target-file lock (dir before file): an in-place
 	// rename elsewhere drains shared holders before moving the directory, so this move
@@ -135,28 +137,24 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 				return nil
 			}
 			// Publish-bound crumb: the move's own publish reports whether
-			// resident bytes were displaced AT the publish instant.
-			replaced, mErr := fsutil.MoveFileFsDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
+			// resident bytes were displaced AT the publish instant; the
+			// retained crumb folds on the displacement answer ALONE, failure
+			// included (see foldMovePublishCrumb).
+			replaced, mErr := moveFileDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
+			foldMovePublishCrumb(&overwroteOccupiedDest, replaced)
 			if mErr != nil {
-				// Partial-publish ambiguity (PR #249 codex P2 follow-up — F1): the
-				// ErrPublishCompleted leg means the cross-device publish LANDED —
-				// fsutil carries its displaced-occupancy answer through the error,
-				// so the audit crumb survives onto the FAILED result below instead
-				// of being dropped with it.
-				if fsutil.PublishCompleted(mErr) && replaced {
-					overwroteOccupiedDest = true
-				}
 				return mErr
 			}
-			overwroteOccupiedDest = replaced
 			return nil
 		})
 	})
 	if err != nil {
 		result.Error = fmt.Errorf("failed to rename file: %w", err)
-		// Publish-completed failures keep their crumb on the FAILED result;
-		// Moved stays false, so the partial publish journals ONCE as the
-		// failed-and-retained row, never double-journaled as a clean replace.
+		// A failed publish that displaced resident bytes keeps its crumb on
+		// the FAILED result (every failed-with-displacement class — see
+		// foldMovePublishCrumb); Moved stays false, so the failure
+		// journals ONCE as the failed-and-retained row, never
+		// double-journaled as a clean replace.
 		if overwroteOccupiedDest {
 			result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
 		}

--- a/internal/organizer/strategy_inplace_norenamefolder.go
+++ b/internal/organizer/strategy_inplace_norenamefolder.go
@@ -100,10 +100,10 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 	}
 
 	// overwroteOccupiedDest records that THIS execution replaced a
-	// bytes-bearing destination the authorization suppressed — keyed to
-	// EXECUTE-TIME occupancy (its own classification under the held locks):
-	// no-op and refused lanes never set it, and a failed publish discards it
-	// by returning before the warning.
+	// bytes-bearing destination the authorization suppressed — keyed to the
+	// PUBLISH-BOUND replacement signal of the move's own publish (PR #249
+	// codex P2): no-op and refused lanes never set it, and a failed publish
+	// discards it by returning before the warning.
 	overwroteOccupiedDest := false
 	// Shared parent-directory lock + target-file lock (dir before file): an in-place
 	// rename elsewhere drains shared holders before moving the directory, so this move
@@ -112,14 +112,13 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 	err := withDestDirSharedLock(plan.TargetDir, func() error {
 		return withDestFileLock(plan.TargetPath, func() error {
 			if plan.overwriteAuthorized {
-				identical, sameIn, occupiedFile, err := classifyAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
+				identical, sameIn, err := classifyAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
 				if err != nil {
 					return err
 				}
 				if identical || sameIn {
 					return nil
 				}
-				overwroteOccupiedDest = occupiedFile
 			} else {
 				lexicalSelf, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
 				if err != nil {
@@ -135,7 +134,14 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 				}
 				return nil
 			}
-			return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
+			// Publish-bound crumb: the move's own publish reports whether
+			// resident bytes were displaced AT the publish instant.
+			replaced, mErr := fsutil.MoveFileFsDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
+			if mErr != nil {
+				return mErr
+			}
+			overwroteOccupiedDest = replaced
+			return nil
 		})
 	})
 	if err != nil {

--- a/internal/organizer/strategy_inplace_norenamefolder.go
+++ b/internal/organizer/strategy_inplace_norenamefolder.go
@@ -138,6 +138,14 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 			// resident bytes were displaced AT the publish instant.
 			replaced, mErr := fsutil.MoveFileFsDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
 			if mErr != nil {
+				// Partial-publish ambiguity (PR #249 codex P2 follow-up — F1): the
+				// ErrPublishCompleted leg means the cross-device publish LANDED —
+				// fsutil carries its displaced-occupancy answer through the error,
+				// so the audit crumb survives onto the FAILED result below instead
+				// of being dropped with it.
+				if fsutil.PublishCompleted(mErr) && replaced {
+					overwroteOccupiedDest = true
+				}
 				return mErr
 			}
 			overwroteOccupiedDest = replaced
@@ -146,6 +154,12 @@ func (s *inPlaceNoRenameFolderStrategy) Execute(plan *OrganizePlan) (*OrganizeRe
 	})
 	if err != nil {
 		result.Error = fmt.Errorf("failed to rename file: %w", err)
+		// Publish-completed failures keep their crumb on the FAILED result;
+		// Moved stays false, so the partial publish journals ONCE as the
+		// failed-and-retained row, never double-journaled as a clean replace.
+		if overwroteOccupiedDest {
+			result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
+		}
 		return result, result.Error
 	}
 

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -15,12 +15,16 @@ import (
 )
 
 // authorizedOverwriteWarning renders the force-overwrite audit crumb: an
-// overwrite-authorized organize move/copy leg replaced a bytes-bearing
-// destination. Composition follows the authorized-duplicate warning
-// (duplicates.go) so the whole OrganizeResult.Warnings pipeline carries it
-// verbatim — the CLI prints it per-file next to the dup warnings, the
-// eventlog persists one organize warn entry, and the worker's history writer
-// folds it into the organize history metadata.
+// overwrite-authorized terminal leg replaced a bytes-bearing destination.
+// Wired lanes (all keyed to EXECUTE-TIME occupancy): organize move, organize
+// copy, organize link install (Remove+link replaces resident bytes at the
+// destination), the in-place strategy's inner file rename and non-rename
+// file move, and the in-place-norenamefolder file rename. Composition
+// follows the authorized-duplicate warning (duplicates.go) so the whole
+// OrganizeResult.Warnings pipeline carries it verbatim — the CLI prints it
+// per-file next to the dup warnings, the eventlog persists one organize warn
+// entry, and the worker's history writer folds it into the organize history
+// metadata.
 func authorizedOverwriteWarning(targetPath string) string {
 	return fmt.Sprintf("overwrite authorized: replaced existing destination %s", targetPath)
 }
@@ -315,7 +319,7 @@ func (s *organizeStrategy) Plan(match models.FileMatchInfo, movie *models.Movie,
 
 	willMove := filepath.ToSlash(match.Path) != filepath.ToSlash(targetPath)
 
-	conflicts, suppressedOccupant := classifyTargetConflicts(s.fs, match.Path, targetPath, forceUpdate, willMove)
+	conflicts := checkTargetConflict(s.fs, match.Path, targetPath, forceUpdate, willMove)
 	// Target dir exists as a regular FILE today — nothing can be created under
 	// it, and organizing must surface this as a directory conflict through
 	// plan conflicts (not a deep MkdirAll failure) (#224 task 3.3).
@@ -352,10 +356,6 @@ func (s *organizeStrategy) Plan(match models.FileMatchInfo, movie *models.Movie,
 		executeStrategy:     s,
 		moveFiles:           true,
 		overwriteAuthorized: forceUpdate,
-		// Force-overwrite audit crumb: the authorization suppressed a
-		// bytes-bearing occupant at plan time — an executing authorized leg
-		// must surface the replacement, not hide it.
-		forceOverwriteOccupiedDest: suppressedOccupant != nil,
 	}, nil
 }
 
@@ -377,23 +377,26 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 	// Move path: moveFiles=true (default) — rename source to target
 	if plan.moveFiles {
 		// overwroteOccupiedDest records that THIS execution replaced a
-		// plan-time bytes-bearing destination the authorization suppressed:
-		// the no-op (identical / same-inode) and refused lanes never set it,
-		// and a failed publish discards it by returning before the warning.
+		// bytes-bearing destination the authorization suppressed, keyed to
+		// EXECUTE-TIME occupancy (its own classification, taken under the
+		// destination locks): an occupant vacated post-plan never crumbs,
+		// an occupant planted post-plan always does. The no-op (identical /
+		// same-inode) and refused lanes never set it, and a failed publish
+		// discards it by returning before the warning.
 		overwroteOccupiedDest := false
 		move := func() error {
 			if plan.overwriteAuthorized {
 				// Authorized: still classify (#224 Phase C) — symlink/dir dests
 				// refuse regardless of authorization; file dests replace; self
 				// and same-inode stay no-ops even here.
-				identical, sameIn, err := refuseIfUnsuppressibleAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
+				identical, sameIn, occupiedFile, err := classifyAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
 				if err != nil {
 					return err
 				}
 				if identical || sameIn {
 					return nil
 				}
-				overwroteOccupiedDest = plan.forceOverwriteOccupiedDest
+				overwroteOccupiedDest = occupiedFile
 			} else {
 				identical, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
 				if err != nil {
@@ -453,10 +456,11 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 		return result, result.Error
 	}
 
-	// overwroteOccupiedDest records that THIS execution replaced a plan-time
+	// overwroteOccupiedDest records that THIS execution replaced a
 	// bytes-bearing destination the authorization suppressed (same audit
-	// contract as the move lane): no-op and refused lanes never set it, and a
-	// failed copy discards it by returning before the warning.
+	// contract as the move lane — keyed to EXECUTE-TIME occupancy taken under
+	// the destination locks): no-op and refused lanes never set it, and a
+	// failed install discards it by returning before the warning.
 	overwroteOccupiedDest := false
 	// Every destination-touching step runs under the destination lock: unauthorized
 	// paths guard inside it (a plain copy would otherwise overwrite a late-created file),
@@ -489,6 +493,7 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 			// Remove an existing target ONLY for an authorized replacement of a
 			// REGULAR FILE — symlinks, directories, and everything else at the
 			// destination are always refused (#224). Gated on IsRegular.
+			linkInstallOccupant := false
 			if plan.LinkMode != LinkModeNone && !dstLexicalSelf && plan.overwriteAuthorized {
 				var linfo os.FileInfo
 				var lerr error
@@ -507,6 +512,13 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 					// installing the link output (#224 hole 1).
 					return fmt.Errorf("destination is not a regular file (cannot authorize-over): %s", plan.TargetPath)
 				}
+				// Force-overwrite audit crumb (link lane): an authorized link
+				// install REPLACES resident bytes AT THE DESTINATION — the
+				// Remove below discards a foreign occupant's entry (plus its
+				// bytes when it held the last link). Execute-time occupancy
+				// keys the crumb: object present + NOT a lexical-self + NOT a
+				// same-inode alias (removing an alias name destroys nothing).
+				linkInstallOccupant = lerr == nil && !dstSameInode
 				if err := s.fs.Remove(plan.TargetPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 					return fmt.Errorf("failed to prepare target path for link: %w", err)
 				}
@@ -527,6 +539,9 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 					}
 					return fmt.Errorf("failed to create hard link: %w", err)
 				}
+				// Authorized link install delivered: a foreign occupant's bytes
+				// were replaced at the destination.
+				overwroteOccupiedDest = linkInstallOccupant
 			case LinkModeSoft:
 				linkTarget := plan.SourcePath
 				if !filepath.IsAbs(linkTarget) {
@@ -542,6 +557,8 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 					}
 					return fmt.Errorf("failed to create soft link: %w", err)
 				}
+				// Same audit contract as the hard-link leg above.
+				overwroteOccupiedDest = linkInstallOccupant
 			default:
 				if dstSameInode && !plan.overwriteAuthorized {
 					return nil
@@ -557,6 +574,7 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				// a symlink/directory destination must refuse regardless of
 				// authorization (#224 codex P1). dstLexicalSelf never reaches here
 				// (refused at classification).
+				copyOccupant := false
 				if plan.overwriteAuthorized && !dstLexicalSelf {
 					linfo, followed, lerr := destMaybeLstat(s.fs, plan.TargetPath)
 					if lerr != nil && !errors.Is(lerr, os.ErrNotExist) {
@@ -572,14 +590,19 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 						if !linfo.Mode().IsRegular() {
 							return fmt.Errorf("destination is not a regular file (cannot authorize-over): %s", plan.TargetPath)
 						}
+						// Force-overwrite audit crumb (copy lane): execute-time
+						// occupancy inside the regular-file gate — an object is
+						// present that is NOT lexical-self and NOT a same-inode
+						// alias, so this copy replaces FOREIGN resident bytes.
+						copyOccupant = !dstSameInode
 					}
 				}
 				if err := s.linker.copyFile(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
 					return fmt.Errorf("failed to copy file: %w", err)
 				}
-				// Authorized copy leg actually delivered: the plan-time
-				// occupant's resident bytes were replaced.
-				overwroteOccupiedDest = plan.forceOverwriteOccupiedDest
+				// Authorized copy leg actually delivered: the occupant's resident
+				// bytes were replaced.
+				overwroteOccupiedDest = copyOccupant
 			}
 			return nil
 		})

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -49,6 +49,11 @@ func authorizedOverwriteWarning(targetPath string) string {
 // production crumb keying, never a stubbed one.
 var moveFileDestReplaced = fsutil.MoveFileFsDestReplaced
 
+// filepathAbsFn is a seam for the soft-link source-absolutization error branch
+// in executeLinkPath (organizer tests swap it to inject the Getwd/failure
+// shape deterministically).
+var filepathAbsFn = filepath.Abs
+
 // foldMovePublishCrumb is the move lanes' unified retained-crumb predicate
 // (PR #249 codex P2 follow-up) — the three strategies' duplicated
 // replace-then-key-the-crumb gates collapse into this one fold: the
@@ -74,33 +79,23 @@ func foldMovePublishCrumb(crumb *bool, replaced bool) {
 	*crumb = *crumb || replaced
 }
 
-// linkInstallOccupantIsAlias is the link-install crumb's alias-vs-foreign
-// exclusion, keyed to the LstatIfPossible taken IMMEDIATELY pre-Remove (PR
-// #249 codex follow-up — F1), never to the lane-head classification: the
-// probe → Remove window is the accepted probe window (the copy/move lanes'
-// one-syscall probe-adjacency ceiling), and any swap inside it is captured
-// by binding the exclusion to the pre-Remove observation instead of the
-// classification captured before MkdirAll and the refusal gates ran.
+// linkInstallOccupantIsAlias compares identity SNAPSHOTS that must both be
+// captured BEFORE the destination Remove: the pre-Remove occupant probe
+// (linfo at the site) and the source snapshot captured by the caller at the
+// same adjacency point. With both sides frozen pre-Remove, a process that
+// swaps SourcePath AFTER the Remove cannot rewrite the answer — the
+// helper's own read happens after vs in contract order, i.e. the earlier
+// F1 fix keyed the OCCUPANT side pre-Remove but the SOURCE side was still
+// read post-Remove; this helper now takes both reads as snapshots (PR #249
+// codex follow-up).
 //
-// occupant == nil (the pre-Remove probe saw the name vacant — the Remove
-// tolerated a NotExist) or a failed source lookup answers false: only a
-// POSITIVELY-PROVEN same-inode equality excludes. A source SYMLINK object
-// never shares the destination's name-bearing link
-// (classifyExistingDestination's rule), so a symlink source is never an
-// alias of a regular inode occupant — matching device/inode there is the
-// symlink's own lookup, not the resident's.
-func linkInstallOccupantIsAlias(fs afero.Fs, src string, occupant os.FileInfo) bool {
-	if occupant == nil {
-		return false
-	}
-	var srcInfo os.FileInfo
-	var err error
-	if lst, ok := fs.(afero.Lstater); ok {
-		srcInfo, _, err = lst.LstatIfPossible(src)
-	} else {
-		srcInfo, err = fs.Stat(src)
-	}
-	if err != nil || srcInfo == nil {
+// nil on either side (the name was vacant at its probe — the Remove then
+// tolerated NotExist on that side) or a source that is itself a symlink
+// object answers false: only POSITIVELY-PROVEN same-inode equality is an
+// alias. A symlink source never shares the destination's name-bearing link,
+// so it is never an alias of a regular occupant.
+func linkInstallOccupantIsSnapshotAlias(srcInfo, occupant os.FileInfo) bool {
+	if occupant == nil || srcInfo == nil {
 		return false
 	}
 	if srcInfo.Mode()&os.ModeSymlink != 0 {
@@ -636,22 +631,23 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				// (nothing displaced — no crumb even though the probe above saw
 				// an occupant), and a plant inside the probe → Remove window
 				// that got unlinked always crumbs.
+				// Source identity snapshot taken pre-Remove (PR #249 codex
+				// follow-up): both sides of the alias exclusion must freeze
+				// before the point of destruction — otherwise a source swap
+				// landing between Remove and the helper's read would flip the
+				// verdict. Failures/nil fall through to NOT-an-alias cautiously
+				// (never suppresses a foreign-bytes crumb).
+				var srcSnapshot os.FileInfo
+				if lst, ok := s.fs.(afero.Lstater); ok {
+					srcSnapshot, _, _ = lst.LstatIfPossible(plan.SourcePath)
+				} else {
+					srcSnapshot, _ = s.fs.Stat(plan.SourcePath)
+				}
 				rmErr := s.fs.Remove(plan.TargetPath)
 				if rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
 					return fmt.Errorf("failed to prepare target path for link: %w", rmErr)
 				}
-				// Alias-vs-foreign exclusion bound to the PRE-REMOVE probe (PR
-				// #249 codex follow-up — F1): the lane-head classification
-				// (dstSameInode) can be raced stale across the MkdirAll and the
-				// refusal gate above — a lane-head alias can be swapped for a
-				// FOREIGN plant (its destruction must crumb) and a lane-head
-				// foreign occupant likewise swapped for a source alias (whose
-				// unlink destroys no foreign bytes and must stay silent). Only
-				// positively-proven same-inode equality between the pre-Remove
-				// LstatIfPossible occupant and the source excludes; the
-				// probe → Remove swap window is the accepted probe window
-				// (identical to the copy/move lanes' probe-adjacency ceiling).
-				linkInstallOccupant := rmErr == nil && !linkInstallOccupantIsAlias(s.fs, plan.SourcePath, linfo)
+				linkInstallOccupant := rmErr == nil && !linkInstallOccupantIsSnapshotAlias(srcSnapshot, linfo)
 				// The crumb binds AT THE DESTRUCTION — not at a later install
 				// success (PR #249 codex follow-up — F2): the authorized Remove
 				// above already displaced/destroyed the resident bytes, so even a
@@ -685,7 +681,7 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 			case LinkModeSoft:
 				linkTarget := plan.SourcePath
 				if !filepath.IsAbs(linkTarget) {
-					abs, err := filepath.Abs(linkTarget)
+					abs, err := filepathAbsFn(linkTarget)
 					if err != nil {
 						return fmt.Errorf("failed to resolve source path for symlink: %w", err)
 					}

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -14,6 +14,17 @@ import (
 	"github.com/spf13/afero"
 )
 
+// authorizedOverwriteWarning renders the force-overwrite audit crumb: an
+// overwrite-authorized organize move/copy leg replaced a bytes-bearing
+// destination. Composition follows the authorized-duplicate warning
+// (duplicates.go) so the whole OrganizeResult.Warnings pipeline carries it
+// verbatim — the CLI prints it per-file next to the dup warnings, the
+// eventlog persists one organize warn entry, and the worker's history writer
+// folds it into the organize history metadata.
+func authorizedOverwriteWarning(targetPath string) string {
+	return fmt.Sprintf("overwrite authorized: replaced existing destination %s", targetPath)
+}
+
 // Destination locking is unified on ONE process-wide registry,
 // fsutil.SharedDestLocks (#224 phase D): every organizer-reachable terminal
 // operation — file moves/copies/links, subtitle installs, MkdirAll directory
@@ -304,7 +315,7 @@ func (s *organizeStrategy) Plan(match models.FileMatchInfo, movie *models.Movie,
 
 	willMove := filepath.ToSlash(match.Path) != filepath.ToSlash(targetPath)
 
-	conflicts := checkTargetConflict(s.fs, match.Path, targetPath, forceUpdate, willMove)
+	conflicts, suppressedOccupant := classifyTargetConflicts(s.fs, match.Path, targetPath, forceUpdate, willMove)
 	// Target dir exists as a regular FILE today — nothing can be created under
 	// it, and organizing must surface this as a directory conflict through
 	// plan conflicts (not a deep MkdirAll failure) (#224 task 3.3).
@@ -341,6 +352,10 @@ func (s *organizeStrategy) Plan(match models.FileMatchInfo, movie *models.Movie,
 		executeStrategy:     s,
 		moveFiles:           true,
 		overwriteAuthorized: forceUpdate,
+		// Force-overwrite audit crumb: the authorization suppressed a
+		// bytes-bearing occupant at plan time — an executing authorized leg
+		// must surface the replacement, not hide it.
+		forceOverwriteOccupiedDest: suppressedOccupant != nil,
 	}, nil
 }
 
@@ -361,6 +376,11 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 
 	// Move path: moveFiles=true (default) — rename source to target
 	if plan.moveFiles {
+		// overwroteOccupiedDest records that THIS execution replaced a
+		// plan-time bytes-bearing destination the authorization suppressed:
+		// the no-op (identical / same-inode) and refused lanes never set it,
+		// and a failed publish discards it by returning before the warning.
+		overwroteOccupiedDest := false
 		move := func() error {
 			if plan.overwriteAuthorized {
 				// Authorized: still classify (#224 Phase C) — symlink/dir dests
@@ -373,6 +393,7 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				if identical || sameIn {
 					return nil
 				}
+				overwroteOccupiedDest = plan.forceOverwriteOccupiedDest
 			} else {
 				identical, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
 				if err != nil {
@@ -411,6 +432,11 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 		}
 
 		result.Moved = true
+		// Force-overwrite audit crumb: the replace actually landed — keep the
+		// resident bytes' replacement visible to every audit consumer.
+		if overwroteOccupiedDest {
+			result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
+		}
 		return result, nil
 	}
 
@@ -427,6 +453,11 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 		return result, result.Error
 	}
 
+	// overwroteOccupiedDest records that THIS execution replaced a plan-time
+	// bytes-bearing destination the authorization suppressed (same audit
+	// contract as the move lane): no-op and refused lanes never set it, and a
+	// failed copy discards it by returning before the warning.
+	overwroteOccupiedDest := false
 	// Every destination-touching step runs under the destination lock: unauthorized
 	// paths guard inside it (a plain copy would otherwise overwrite a late-created file),
 	// and authorized Remove+link work must serialize against concurrent guarded calls.
@@ -546,6 +577,9 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				if err := s.linker.copyFile(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
 					return fmt.Errorf("failed to copy file: %w", err)
 				}
+				// Authorized copy leg actually delivered: the plan-time
+				// occupant's resident bytes were replaced.
+				overwroteOccupiedDest = plan.forceOverwriteOccupiedDest
 			}
 			return nil
 		})
@@ -556,6 +590,11 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 	}
 
 	result.Moved = true
+	// Force-overwrite audit crumb: the replace actually landed — keep the
+	// resident bytes' replacement visible to every audit consumer.
+	if overwroteOccupiedDest {
+		result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
+	}
 	result.ShouldGenerateMetadata = true
 
 	return result, nil

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -33,6 +33,47 @@ func authorizedOverwriteWarning(targetPath string) string {
 	return fmt.Sprintf("overwrite authorized: replaced existing destination %s", targetPath)
 }
 
+// moveFileDestReplaced is the test seam over fsutil.MoveFileFsDestReplaced
+// for the AUTHORIZED move lanes (the same discipline as fsutil's
+// publishStagedBoundDestLstat / publishStagedBoundRestream seams): the
+// failed-with-displacement post-publish classes (ErrPublishStagedIdentityBreak
+// / ErrPublishStagedExhausted) are producible only on the bound staged
+// publish's REAL-*afero.OsFs leg (fsutil's osStagingHandle gate), while the
+// EXDEV routing a move into that leg can only be wedged through a VIRTUAL
+// wrapper fs — the two gates are mutually exclusive at the afero layer, so no
+// fs-level wedge replays the shape. Tests replay fsutil's documented
+// (replaced == displacement-unioned, err) tuple contract at this call edge
+// instead; fsutil pins the real production of every such tuple itself
+// (move_destreplaced_union_w249b_test.go lineage). The predicate under test
+// stays OUTSIDE the seam — foldMovePublishCrumb — so the replay exercises the
+// production crumb keying, never a stubbed one.
+var moveFileDestReplaced = fsutil.MoveFileFsDestReplaced
+
+// foldMovePublishCrumb is the move lanes' unified retained-crumb predicate
+// (PR #249 codex P2 follow-up) — the three strategies' duplicated
+// replace-then-key-the-crumb gates collapse into this one fold: the
+// force-overwrite crumb keys on the displacement answer ALONE, SUCCESS and
+// FAILURE alike. fsutil unions its displaced-occupancy evidence onto EVERY
+// failed-with-displacement error shape it returns: the ErrPublishCompleted
+// partial publish (source cleanup refused after the publish landed) AND the
+// post-publish identity family (ErrPublishStagedIdentityBreak /
+// ErrPublishStagedExhausted, which DELIBERATELY never wrap
+// ErrPublishCompleted — the destination name is not provably this operation's
+// own object, so the compensation/claim axis keeps its distinct non-settling
+// posture in fsutil's pending-kind lineage and in executeFile's
+// PublishCompleted classification; that axis keys on the error CLASS, this
+// crumb on the destruction FACT). Any gate riding fsutil.PublishCompleted
+// (the pre-fix predicate) dropped the identity-break/exhaustion shapes' crumb
+// off the FAILED result and silently re-opened the hidden-overwrite class
+// PR #249 closed. A confirmed replacement-free answer — every pre-publish
+// refusal and every nothing-landed failure — is always replaced == false, so
+// an unconfirmed displacement never crumbs. The fold UNIONS (||): a crumb an
+// earlier destructive step bound (the link lane's Remove-bound lineage) can
+// never be unbound by a later clean answer.
+func foldMovePublishCrumb(crumb *bool, replaced bool) {
+	*crumb = *crumb || replaced
+}
+
 // linkInstallOccupantIsAlias is the link-install crumb's alias-vs-foreign
 // exclusion, keyed to the LstatIfPossible taken IMMEDIATELY pre-Remove (PR
 // #249 codex follow-up — F1), never to the lane-head classification: the
@@ -422,8 +463,11 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 		// crumbs, an occupant planted before the publish always does — even
 		// inside the classify → publish window under held (process-local)
 		// locks. The no-op (identical / same-inode) and refused lanes never
-		// set it, and a failed publish discards it by returning before the
-		// warning.
+		// set it; a replacement-free failure answers false exactly like
+		// them, while a failed publish that STILL displaced resident bytes
+		// (publish-completed ambiguity; the post-publish identity break /
+		// republish-exhaustion family) keeps the crumb ON the FAILED result
+		// — see foldMovePublishCrumb.
 		overwroteOccupiedDest := false
 		move := func() error {
 			if plan.overwriteAuthorized {
@@ -467,24 +511,15 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 			// publish instant — the same-device leg probes at rename adjacency,
 			// the cross-device fallback inherits the staged publish's bound
 			// signal — so a foreign plant/vacate after the classification above
-			// can neither forge nor hide it.
-			replaced, mErr := fsutil.MoveFileFsDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
+			// can neither forge nor hide it. The retained crumb folds on the
+			// displacement answer ALONE, failure included (see
+			// foldMovePublishCrumb): a failed publish that still displaced
+			// resident bytes keeps its crumb on the FAILED result below.
+			replaced, mErr := moveFileDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
+			foldMovePublishCrumb(&overwroteOccupiedDest, replaced)
 			if mErr != nil {
-				// Partial-publish ambiguity (PR #249 codex P2 follow-up — F1): the
-				// typed ErrPublishCompleted leg means the cross-device publish
-				// LANDED and only the source cleanup refused; fsutil carries its
-				// displaced-occupancy answer through that result, so the audit crumb
-				// must not be dropped with the error — Apply journals the
-				// publish-completed ambiguity as an event nonetheless, and its
-				// replacement evidence rides the FAILED result below. Every other
-				// failure leg discarded nothing because nothing landed (fsutil
-				// answers replaced=false there).
-				if fsutil.PublishCompleted(mErr) && replaced {
-					overwroteOccupiedDest = true
-				}
 				return mErr
 			}
-			overwroteOccupiedDest = replaced
 			return nil
 		}
 
@@ -496,13 +531,15 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 		})
 		if err != nil {
 			result.Error = err
-			// The publish-completed failure keeps its crumb: the destination
-			// really carries this operation's bytes — displaced resident bytes
-			// included — so the audit warning rides the FAILED result's Warnings
-			// for the console/history/eventlog consumers. Moved stays false (the
-			// source is retained): this is never journaled as a clean
-			// move/replace — the revert ledger keeps its single partial-publish
-			// row (CompleteFailed), not a completed-operation row alongside it.
+			// A failed publish that displaced resident bytes keeps its crumb in
+			// EVERY failed-with-displacement class (publish-completed ambiguity;
+			// the post-publish identity break / republish-exhaustion family —
+			// see foldMovePublishCrumb): the resident's bytes were destroyed
+			// by a publish that LANDED, so the audit warning rides the FAILED
+			// result's Warnings for the console/history/eventlog consumers.
+			// Moved stays false (the source is retained): this is never
+			// journaled as a clean move/replace — the revert ledger keeps its
+			// single failed row, not a completed-operation row alongside it.
 			if overwroteOccupiedDest {
 				result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
 			}

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -16,10 +16,14 @@ import (
 
 // authorizedOverwriteWarning renders the force-overwrite audit crumb: an
 // overwrite-authorized terminal leg replaced a bytes-bearing destination.
-// Wired lanes (all keyed to EXECUTE-TIME occupancy): organize move, organize
-// copy, organize link install (Remove+link replaces resident bytes at the
-// destination), the in-place strategy's inner file rename and non-rename
-// file move, and the in-place-norenamefolder file rename. Composition
+// Wired lanes (all keyed to PUBLISH-BOUND occupancy evidence — the publish's
+// own bound replacement signal (organize/in-place moves, organize copy,
+// inner rename via the fsutil DestReplaced verbs, PR #249 codex P2) or the
+// occupancy proven at adjacency with the destructive Remove for the link
+// install lane — never to plan-time or classify-time state): organize move,
+// organize copy, organize link install (Remove+link replaces resident bytes
+// at the destination), the in-place strategy's inner file rename and
+// non-rename file move, and the in-place-norenamefolder file rename. Composition
 // follows the authorized-duplicate warning (duplicates.go) so the whole
 // OrganizeResult.Warnings pipeline carries it verbatim — the CLI prints it
 // per-file next to the dup warnings, the eventlog persists one organize warn
@@ -378,25 +382,28 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 	if plan.moveFiles {
 		// overwroteOccupiedDest records that THIS execution replaced a
 		// bytes-bearing destination the authorization suppressed, keyed to
-		// EXECUTE-TIME occupancy (its own classification, taken under the
-		// destination locks): an occupant vacated post-plan never crumbs,
-		// an occupant planted post-plan always does. The no-op (identical /
-		// same-inode) and refused lanes never set it, and a failed publish
-		// discards it by returning before the warning.
+		// the PUBLISH-BOUND replacement signal of the move's own publish
+		// (PR #249 codex P2): an occupant vacated before the publish never
+		// crumbs, an occupant planted before the publish always does — even
+		// inside the classify → publish window under held (process-local)
+		// locks. The no-op (identical / same-inode) and refused lanes never
+		// set it, and a failed publish discards it by returning before the
+		// warning.
 		overwroteOccupiedDest := false
 		move := func() error {
 			if plan.overwriteAuthorized {
 				// Authorized: still classify (#224 Phase C) — symlink/dir dests
 				// refuse regardless of authorization; file dests replace; self
-				// and same-inode stay no-ops even here.
-				identical, sameIn, occupiedFile, err := classifyAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
+				// and same-inode stay no-ops even here. The classification
+				// carries NO crumb evidence anymore: the publish's own bound
+				// replacement signal keys it below.
+				identical, sameIn, err := classifyAuthorizedDestination(s.fs, plan.SourcePath, plan.TargetPath)
 				if err != nil {
 					return err
 				}
 				if identical || sameIn {
 					return nil
 				}
-				overwroteOccupiedDest = occupiedFile
 			} else {
 				identical, sameIn, err := refuseExistingDestination(s.fs, plan.SourcePath, plan.TargetPath)
 				if err != nil {
@@ -420,7 +427,18 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				}
 				return nil
 			}
-			return fsutil.MoveFileFs(s.fs, plan.SourcePath, plan.TargetPath)
+			// Publish-bound crumb: the move's own publish reports whether an
+			// occupied destination not aliasing the source was displaced AT the
+			// publish instant — the same-device leg probes at rename adjacency,
+			// the cross-device fallback inherits the staged publish's bound
+			// signal — so a foreign plant/vacate after the classification above
+			// can neither forge nor hide it.
+			replaced, mErr := fsutil.MoveFileFsDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
+			if mErr != nil {
+				return mErr
+			}
+			overwroteOccupiedDest = replaced
+			return nil
 		}
 
 		// Shared dir lock: concurrent organizes into one directory proceed in parallel
@@ -458,8 +476,10 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 
 	// overwroteOccupiedDest records that THIS execution replaced a
 	// bytes-bearing destination the authorization suppressed (same audit
-	// contract as the move lane — keyed to EXECUTE-TIME occupancy taken under
-	// the destination locks): no-op and refused lanes never set it, and a
+	// contract as the move lane): the copy lane keys it to the publish-bound
+	// replacement signal of its own staged publish (PR #249 codex P2), the
+	// link lane to occupancy proven at adjacency with its Remove+install —
+	// never to plan-time state. No-op and refused lanes never set it, and a
 	// failed install discards it by returning before the warning.
 	overwroteOccupiedDest := false
 	// Every destination-touching step runs under the destination lock: unauthorized
@@ -515,13 +535,20 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				// Force-overwrite audit crumb (link lane): an authorized link
 				// install REPLACES resident bytes AT THE DESTINATION — the
 				// Remove below discards a foreign occupant's entry (plus its
-				// bytes when it held the last link). Execute-time occupancy
-				// keys the crumb: object present + NOT a lexical-self + NOT a
-				// same-inode alias (removing an alias name destroys nothing).
-				linkInstallOccupant = lerr == nil && !dstSameInode
-				if err := s.fs.Remove(plan.TargetPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-					return fmt.Errorf("failed to prepare target path for link: %w", err)
+				// bytes when it held the last link). The crumb keys on the
+				// REMOVE'S OWN OUTCOME — the destructive publish itself (PR #249
+				// codex P2, same publish-bound discipline as the copy/move
+				// lanes): nil means THIS lane physically unlinked a resident
+				// entry; a tolerated NotExist means the name was already vacant
+				// (nothing displaced — no crumb even though the probe above saw
+				// an occupant), and a plant inside the probe → Remove window
+				// that got unlinked always crumbs. Same-inode alias entries
+				// (removing one destroys nothing) stay excluded.
+				rmErr := s.fs.Remove(plan.TargetPath)
+				if rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+					return fmt.Errorf("failed to prepare target path for link: %w", rmErr)
 				}
+				linkInstallOccupant = rmErr == nil && !dstSameInode
 			}
 
 			if dstLexicalSelf || (dstSameInode && !plan.overwriteAuthorized && plan.LinkMode == LinkModeHard) {
@@ -573,8 +600,12 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				// Authorized copy lane: the regular-file gate is also needed here —
 				// a symlink/directory destination must refuse regardless of
 				// authorization (#224 codex P1). dstLexicalSelf never reaches here
-				// (refused at classification).
-				copyOccupant := false
+				// (refused at classification). The gate remains a REFUSAL policy
+				// only: the crumb evidence left classify-time probing for the
+				// publish-bound signal below (PR #249 codex P2) — the staged copy
+				// can stream for arbitrary length between this classification and
+				// the publish, so any occupancy answer captured here can be raced
+				// stale by a foreign plant/vacate (a false or suppressed crumb).
 				if plan.overwriteAuthorized && !dstLexicalSelf {
 					linfo, followed, lerr := destMaybeLstat(s.fs, plan.TargetPath)
 					if lerr != nil && !errors.Is(lerr, os.ErrNotExist) {
@@ -590,19 +621,17 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 						if !linfo.Mode().IsRegular() {
 							return fmt.Errorf("destination is not a regular file (cannot authorize-over): %s", plan.TargetPath)
 						}
-						// Force-overwrite audit crumb (copy lane): execute-time
-						// occupancy inside the regular-file gate — an object is
-						// present that is NOT lexical-self and NOT a same-inode
-						// alias, so this copy replaces FOREIGN resident bytes.
-						copyOccupant = !dstSameInode
 					}
 				}
-				if err := s.linker.copyFile(s.fs, plan.SourcePath, plan.TargetPath); err != nil {
-					return fmt.Errorf("failed to copy file: %w", err)
+				destReplaced, cerr := s.linker.copyFile(s.fs, plan.SourcePath, plan.TargetPath)
+				if cerr != nil {
+					return fmt.Errorf("failed to copy file: %w", cerr)
 				}
-				// Authorized copy leg actually delivered: the occupant's resident
-				// bytes were replaced.
-				overwroteOccupiedDest = copyOccupant
+				// Authorized copy leg delivered: the staged publish reports —
+				// bound to the replace-rename itself, alias-excluded against the
+				// source it streamed — whether resident bytes were displaced at
+				// the publish instant (crumb == PHYSICAL occupancy).
+				overwroteOccupiedDest = destReplaced
 			}
 			return nil
 		})

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -435,6 +435,18 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 			// can neither forge nor hide it.
 			replaced, mErr := fsutil.MoveFileFsDestReplaced(s.fs, plan.SourcePath, plan.TargetPath)
 			if mErr != nil {
+				// Partial-publish ambiguity (PR #249 codex P2 follow-up — F1): the
+				// typed ErrPublishCompleted leg means the cross-device publish
+				// LANDED and only the source cleanup refused; fsutil carries its
+				// displaced-occupancy answer through that result, so the audit crumb
+				// must not be dropped with the error — Apply journals the
+				// publish-completed ambiguity as an event nonetheless, and its
+				// replacement evidence rides the FAILED result below. Every other
+				// failure leg discarded nothing because nothing landed (fsutil
+				// answers replaced=false there).
+				if fsutil.PublishCompleted(mErr) && replaced {
+					overwroteOccupiedDest = true
+				}
 				return mErr
 			}
 			overwroteOccupiedDest = replaced
@@ -449,6 +461,16 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 		})
 		if err != nil {
 			result.Error = err
+			// The publish-completed failure keeps its crumb: the destination
+			// really carries this operation's bytes — displaced resident bytes
+			// included — so the audit warning rides the FAILED result's Warnings
+			// for the console/history/eventlog consumers. Moved stays false (the
+			// source is retained): this is never journaled as a clean
+			// move/replace — the revert ledger keeps its single partial-publish
+			// row (CompleteFailed), not a completed-operation row alongside it.
+			if overwroteOccupiedDest {
+				result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
+			}
 			return result, result.Error
 		}
 

--- a/internal/organizer/strategy_organize.go
+++ b/internal/organizer/strategy_organize.go
@@ -33,6 +33,41 @@ func authorizedOverwriteWarning(targetPath string) string {
 	return fmt.Sprintf("overwrite authorized: replaced existing destination %s", targetPath)
 }
 
+// linkInstallOccupantIsAlias is the link-install crumb's alias-vs-foreign
+// exclusion, keyed to the LstatIfPossible taken IMMEDIATELY pre-Remove (PR
+// #249 codex follow-up — F1), never to the lane-head classification: the
+// probe → Remove window is the accepted probe window (the copy/move lanes'
+// one-syscall probe-adjacency ceiling), and any swap inside it is captured
+// by binding the exclusion to the pre-Remove observation instead of the
+// classification captured before MkdirAll and the refusal gates ran.
+//
+// occupant == nil (the pre-Remove probe saw the name vacant — the Remove
+// tolerated a NotExist) or a failed source lookup answers false: only a
+// POSITIVELY-PROVEN same-inode equality excludes. A source SYMLINK object
+// never shares the destination's name-bearing link
+// (classifyExistingDestination's rule), so a symlink source is never an
+// alias of a regular inode occupant — matching device/inode there is the
+// symlink's own lookup, not the resident's.
+func linkInstallOccupantIsAlias(fs afero.Fs, src string, occupant os.FileInfo) bool {
+	if occupant == nil {
+		return false
+	}
+	var srcInfo os.FileInfo
+	var err error
+	if lst, ok := fs.(afero.Lstater); ok {
+		srcInfo, _, err = lst.LstatIfPossible(src)
+	} else {
+		srcInfo, err = fs.Stat(src)
+	}
+	if err != nil || srcInfo == nil {
+		return false
+	}
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		return false
+	}
+	return os.SameFile(srcInfo, occupant)
+}
+
 // Destination locking is unified on ONE process-wide registry,
 // fsutil.SharedDestLocks (#224 phase D): every organizer-reachable terminal
 // operation — file moves/copies/links, subtitle installs, MkdirAll directory
@@ -535,7 +570,6 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 			// Remove an existing target ONLY for an authorized replacement of a
 			// REGULAR FILE — symlinks, directories, and everything else at the
 			// destination are always refused (#224). Gated on IsRegular.
-			linkInstallOccupant := false
 			if plan.LinkMode != LinkModeNone && !dstLexicalSelf && plan.overwriteAuthorized {
 				var linfo os.FileInfo
 				var lerr error
@@ -564,13 +598,33 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				// entry; a tolerated NotExist means the name was already vacant
 				// (nothing displaced — no crumb even though the probe above saw
 				// an occupant), and a plant inside the probe → Remove window
-				// that got unlinked always crumbs. Same-inode alias entries
-				// (removing one destroys nothing) stay excluded.
+				// that got unlinked always crumbs.
 				rmErr := s.fs.Remove(plan.TargetPath)
 				if rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
 					return fmt.Errorf("failed to prepare target path for link: %w", rmErr)
 				}
-				linkInstallOccupant = rmErr == nil && !dstSameInode
+				// Alias-vs-foreign exclusion bound to the PRE-REMOVE probe (PR
+				// #249 codex follow-up — F1): the lane-head classification
+				// (dstSameInode) can be raced stale across the MkdirAll and the
+				// refusal gate above — a lane-head alias can be swapped for a
+				// FOREIGN plant (its destruction must crumb) and a lane-head
+				// foreign occupant likewise swapped for a source alias (whose
+				// unlink destroys no foreign bytes and must stay silent). Only
+				// positively-proven same-inode equality between the pre-Remove
+				// LstatIfPossible occupant and the source excludes; the
+				// probe → Remove swap window is the accepted probe window
+				// (identical to the copy/move lanes' probe-adjacency ceiling).
+				linkInstallOccupant := rmErr == nil && !linkInstallOccupantIsAlias(s.fs, plan.SourcePath, linfo)
+				// The crumb binds AT THE DESTRUCTION — not at a later install
+				// success (PR #249 codex follow-up — F2): the authorized Remove
+				// above already displaced/destroyed the resident bytes, so even a
+				// link install that then FAILS (hardlink EXDEV, softlink refusal)
+				// leaves the resident gone forever, and the audit must disclose
+				// that on the FAILED result — the same partial-publish lineage
+				// discipline as fsutil.MoveFileFsDestReplaced's ErrPublishCompleted
+				// leg, where the displacement evidence rides the failed result
+				// instead of dying with the error.
+				overwroteOccupiedDest = linkInstallOccupant
 			}
 
 			if dstLexicalSelf || (dstSameInode && !plan.overwriteAuthorized && plan.LinkMode == LinkModeHard) {
@@ -589,8 +643,8 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 					return fmt.Errorf("failed to create hard link: %w", err)
 				}
 				// Authorized link install delivered: a foreign occupant's bytes
-				// were replaced at the destination.
-				overwroteOccupiedDest = linkInstallOccupant
+				// were replaced at the destination (crumb bound at the Remove
+				// above — F2 binds it at the destruction, not at this success).
 			case LinkModeSoft:
 				linkTarget := plan.SourcePath
 				if !filepath.IsAbs(linkTarget) {
@@ -606,8 +660,8 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 					}
 					return fmt.Errorf("failed to create soft link: %w", err)
 				}
-				// Same audit contract as the hard-link leg above.
-				overwroteOccupiedDest = linkInstallOccupant
+				// Same audit contract as the hard-link leg above (crumb bound at
+				// the Remove).
 			default:
 				if dstSameInode && !plan.overwriteAuthorized {
 					return nil
@@ -647,6 +701,14 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 				}
 				destReplaced, cerr := s.linker.copyFile(s.fs, plan.SourcePath, plan.TargetPath)
 				if cerr != nil {
+					// Unioned displacement evidence (fsutil F3) survives the
+					// copy-lane failure too: a staged publish that displaced
+					// resident bytes but failed post-publish keeps its crumb on the
+					// FAILED result — the same destruction-bound discipline as the
+					// link lane's Remove-bound crumb (F2).
+					if destReplaced {
+						overwroteOccupiedDest = true
+					}
 					return fmt.Errorf("failed to copy file: %w", cerr)
 				}
 				// Authorized copy leg delivered: the staged publish reports —
@@ -660,6 +722,15 @@ func (s *organizeStrategy) Execute(plan *OrganizePlan) (*OrganizeResult, error) 
 	})
 	if err != nil {
 		result.Error = err
+		// The crumb binds at the destruction, not the install success (F2):
+		// an authorized Remove displaced the resident even when the link
+		// install then refused — the failed result still carries the
+		// displacement disclosure for the console/eventlog/history consumers
+		// (cliBatchPostApply + the API PostApplyFunc read Warnings on Err!=nil
+		// lanes too — F4).
+		if overwroteOccupiedDest {
+			result.Warnings = append(result.Warnings, authorizedOverwriteWarning(plan.TargetPath))
+		}
 		return result, result.Error
 	}
 

--- a/internal/organizer/strategy_organize_execute_test.go
+++ b/internal/organizer/strategy_organize_execute_test.go
@@ -19,6 +19,7 @@ type mockLinker struct {
 	hardlinkCalled bool
 	symlinkCalled  bool
 	copyCalled     bool
+	copyReplaced   bool
 }
 
 func (m *mockLinker) symlink(oldname, newname string) error {
@@ -31,9 +32,9 @@ func (m *mockLinker) hardlink(oldname, newname string) error {
 	return m.hardlinkErr
 }
 
-func (m *mockLinker) copyFile(fs afero.Fs, src, dst string) error {
+func (m *mockLinker) copyFile(fs afero.Fs, src, dst string) (bool, error) {
 	m.copyCalled = true
-	return m.copyErr
+	return m.copyReplaced, m.copyErr
 }
 
 func TestOrganizeStrategy_Execute_MoveFiles(t *testing.T) {

--- a/internal/worker/history_failure_warnings_w249b_test.go
+++ b/internal/worker/history_failure_warnings_w249b_test.go
@@ -1,0 +1,47 @@
+package worker
+
+// PR #249 codex follow-up (F4) — the worker history consumer must fold a
+// FAILED lane's OrganizeResult.Warnings into the failure row's metadata:
+// the organizer now binds the force-overwrite displacement crumb at the
+// destruction (F2), so the failed organize result carries warnings whose
+// evidence must survive into the FAILED history row, not just into success
+// rows.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditOrganizeFailure_FailedResultWarningsRideHistoryMetadata(t *testing.T) {
+	db := newHistoryTestDB(t)
+	repos := db.Repositories()
+	inputs := applyPhaseInputs{JobID: "w249b-job", HistoryRepo: repos.HistoryRepo, OperationMode: "organize"}
+	movie := &models.Movie{ID: "W249B-001"}
+	crumb := "overwrite authorized: replaced existing destination /dest/lib/W249B-001.mkv"
+	result := &workflow.ApplyResult{
+		OrganizeResult: &organizer.OrganizeResult{
+			NewPath:  "/dest/lib/W249B-001.mkv",
+			Warnings: []string{crumb},
+		},
+	}
+
+	auditOrganizeFailure(inputs, movie, "/in/w249b.mkv", result, assert.AnError, ApplyPhaseConfig{})
+
+	records, err := repos.HistoryRepo.FindByMovieID(context.Background(), "W249B-001")
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, models.HistoryStatusFailed, records[0].Status)
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal([]byte(records[0].Metadata), &meta))
+	warns, ok := meta["warnings"].([]any)
+	require.True(t, ok, "the FAILED history row's metadata folds the displacement crumb")
+	require.Len(t, warns, 1)
+	assert.Equal(t, crumb, warns[0].(string))
+}


### PR DESCRIPTION
## Summary

Force-authorized organizes that **replace actual bytes** at an occupied destination now leave an audit crumb — surfacing through all three consumers that already render `OrganizeResult.Warnings`, with zero new wiring:
- console ⚠️ line: `overwrite authorized: replaced existing destination <path>`
- history rows carry it in organize metadata (same mechanism as the duplicate-skip warnings)
- eventlog gains an `organize/warn` entry carrying the batch/job id

**Where the signal comes from**: every authorized lane that can genuinely overwrite (move, copy, hard/soft link install, the three in-place rename legs) now keys the crumb on **execute-time occupancy inside the held destination locks** — not plan-time evidence. Vacant/absent identity-check lanes (same-inode alias, lexical self) stay silent; batch duplicate skips (which already warn via the #248 machinery) never double-signal.

Previously a forced single-file overwrite dropped a plain `applied` row with no indication that resident bytes were replaced.

## Test plan
- [x] TOCTOU pins: occupied-only-at-plan and occupied-only-at-execute wedges drive the same assertions through both the split and fused organize flows
- [x] all 6 authorized behaviors (move/copy/link; normal/force/same-inode) pinned per lane; batch dup interplay covered both directions
- [x] e2e through real CLI (`sort -f` over a pre-seeded destination): console line + eventlog entry + history row all verified, and the dup interplay never produces both warnings
- [x] mutation-checked: all new pins are red pre-fix and green post-fix
- [x] `go test -race` organizer/fsutil/commandutil/tests; `make coverage-patch-strict` 100% patch (77/77 hit)