### PR TITLE
fix(update): joinable background-check shutdown (Windows TempDir race)

### DIFF
--- a/internal/api/core/dependencies_test.go
+++ b/internal/api/core/dependencies_test.go
@@ -179,6 +179,13 @@ func TestShutdownDeps(t *testing.T) {
 		}, "shutdownDeps should not panic when runtime is nil")
 	})
 
+	t.Run("no-op when runtime state is nil", func(t *testing.T) {
+		rt := NewAPIRuntime(&APIDeps{})
+		assert.NotPanics(t, func() {
+			shutdownDeps(rt)
+		}, "shutdownDeps should not panic when runtime state is nil")
+	})
+
 	t.Run("calls runtime shutdown", func(t *testing.T) {
 		rs := NewRuntimeState()
 		_ = rs.ResetWebSocketHub()

--- a/internal/api/core/runtime_manager.go
+++ b/internal/api/core/runtime_manager.go
@@ -162,6 +162,15 @@ type APIRuntime struct {
 	serverCtx     context.Context
 	serverCancel  context.CancelFunc
 
+	// updateCheckerDone is the join handle for the background update-check
+	// goroutine started by startUpdateChecker: closed when that goroutine
+	// has fully exited (ticker stopped, in-flight check returned). Written
+	// once during bootstrap, before the server serves, and joined by
+	// Shutdown after cancelling serverCtx, so teardown cannot race the
+	// update checker's final state-store write. Nil when version checks
+	// are disabled (startUpdateChecker returned early).
+	updateCheckerDone <-chan struct{}
+
 	// startupSweep is configured during bootstrap and started by the API server
 	// after bootstrap has returned. Once makes the startup repair one-shot even
 	// if a caller constructs the router more than once for the same runtime.

--- a/internal/api/core/runtime_manager.go
+++ b/internal/api/core/runtime_manager.go
@@ -687,20 +687,6 @@ func (r *APIRuntime) SetConfig(cfg *config.Config) {
 	r.invalidateFactoriesLocked(cfg)
 }
 
-// shutdownDeps gracefully shuts down runtime resources in APIRuntime.
-//
-//nolint:unused // used by same-package tests
-func shutdownDeps(rt *APIRuntime) {
-	if rt == nil {
-		return
-	}
-	rs := rt.GetRuntime()
-	if rs == nil {
-		return
-	}
-	rs.Shutdown()
-}
-
 // ---------------------------------------------------------------------------
 // Legacy compatibility — these package-level functions delegate to APIRuntime.
 // They exist so that callers that only have *APIDeps can still perform

--- a/internal/api/core/runtime_manager_shutdown.go
+++ b/internal/api/core/runtime_manager_shutdown.go
@@ -1,0 +1,15 @@
+package core
+
+// shutdownDeps gracefully shuts down runtime resources in APIRuntime.
+//
+//nolint:unused // used by same-package tests
+func shutdownDeps(rt *APIRuntime) {
+	if rt == nil {
+		return
+	}
+	rs := rt.GetRuntime()
+	if rs == nil {
+		return
+	}
+	rs.Shutdown()
+}

--- a/internal/api/core/server_lifecycle.go
+++ b/internal/api/core/server_lifecycle.go
@@ -34,6 +34,17 @@ func (r *APIRuntime) Shutdown() {
 	if r.serverCancel != nil {
 		r.serverCancel()
 	}
+	// Join the background update checker (when it was started) so its goroutine
+	// is confirmed exited — and done writing to the on-disk state cache —
+	// before teardown completes. Nil-safe: startUpdateChecker leaves the field
+	// nil when version checks are disabled, and receiving from a nil channel
+	// would block forever. No timeout on the join (tasks.md 3.3): after
+	// serverCancel the in-flight BackgroundCheck aborts promptly via ctx, and
+	// the check self-bounds (30s ctx timeout; 10s GitHub HTTP client timeout),
+	// so the join cannot stall indefinitely.
+	if r.updateCheckerDone != nil {
+		<-r.updateCheckerDone
+	}
 }
 
 // TrackBackgroundTask delegates to the runtime state — implemented there to

--- a/internal/api/core/update_checker.go
+++ b/internal/api/core/update_checker.go
@@ -13,8 +13,10 @@ import (
 //
 // Both the periodic ticker (StartBackgroundCheck) and the one-shot cache-warming
 // check (BackgroundCheck) are bound to rt.ServerCtx(), which rt.Shutdown()
-// cancels — so background work stops cleanly on server shutdown rather than
-// leaking past process lifetime.
+// cancels; Shutdown then joins the ticker goroutine via the done channel stashed
+// on rt.updateCheckerDone — so background work stops cleanly on server shutdown
+// rather than leaking past process lifetime or racing teardown of the on-disk
+// state cache.
 //
 // opts allows tests to inject a stub Checker (no real network) and a temp-dir
 // StatePath (no real filesystem writes); production callers pass a zero-value
@@ -46,6 +48,9 @@ func startUpdateChecker(rt *APIRuntime, cfg *config.Config, opts update.ServiceO
 	svc.BackgroundCheck(ctx)
 
 	// Periodic ticker; stops when ctx (rt.ServerCtx) is cancelled on shutdown.
-	svc.StartBackgroundCheck(ctx, svc.Interval())
+	// The returned done channel is stashed on the runtime so APIRuntime.Shutdown
+	// can join the goroutine — it is confirmed exited, and done touching the
+	// on-disk state cache, before teardown completes.
+	rt.updateCheckerDone = svc.StartBackgroundCheck(ctx, svc.Interval())
 	logging.Infof("Background update checker started (interval: %s)", svc.Interval())
 }

--- a/internal/update/coverage_boost_test.go
+++ b/internal/update/coverage_boost_test.go
@@ -253,10 +253,12 @@ func TestService_StartBgCheck_Cancel(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	svc.StartBackgroundCheck(ctx, 50*time.Millisecond)
+	done := svc.StartBackgroundCheck(ctx, 50*time.Millisecond)
 	time.Sleep(120 * time.Millisecond)
 	cancel()
-	time.Sleep(50 * time.Millisecond)
+	// Join before returning: t.TempDir cleanup must not race the ticker
+	// goroutine's state-store writes (Windows unlinkat flake).
+	<-done
 }
 
 func TestCompareVersions_LegacyComparison(t *testing.T) {

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -315,9 +315,25 @@ func (s *Service) BackgroundCheck(ctx context.Context) {
 }
 
 // StartBackgroundCheck starts a background goroutine for periodic checks.
-func (s *Service) StartBackgroundCheck(ctx context.Context, interval time.Duration) {
+//
+// It returns a done channel that is closed once the goroutine has fully exited
+// — ticker stopped and any in-flight BackgroundCheck returned. Callers request
+// shutdown by cancelling ctx, then join with <-done; after done closes the
+// goroutine performs no further state-store writes, so resources the store
+// depends on (e.g. its on-disk directory) can be torn down without racing an
+// outstanding write. A disabled service starts no goroutine and returns an
+// already-closed channel so a join never blocks.
+//
+// REGRESSION NOTE: the join guarantee relies on BackgroundCheck being invoked
+// synchronously in the ticker case below — close(done) fires only after an
+// in-flight check returns. If BackgroundCheck is ever dispatched as its own
+// goroutine, the done channel would close while a check is still writing and
+// the join contract breaks.
+func (s *Service) StartBackgroundCheck(ctx context.Context, interval time.Duration) <-chan struct{} {
+	done := make(chan struct{})
 	if !s.enabled {
-		return
+		close(done)
+		return done
 	}
 
 	// Normalize non-positive intervals before creating the ticker, otherwise
@@ -328,6 +344,10 @@ func (s *Service) StartBackgroundCheck(ctx context.Context, interval time.Durati
 	}
 
 	go func() {
+		// Deferred FIRST so it runs LAST: done closes after the recover
+		// below (and after any in-flight BackgroundCheck) has completed, so
+		// even a panicking check can never leave a joiner blocked forever.
+		defer close(done)
 		defer func() {
 			if r := recover(); r != nil {
 				err := panicutil.FormatRecover(r)
@@ -343,10 +363,14 @@ func (s *Service) StartBackgroundCheck(ctx context.Context, interval time.Durati
 				logging.Info("Background update check stopped")
 				return
 			case <-ticker.C:
+				// Synchronous by design: the goroutine cannot select ctx.Done()
+				// and exit while a check is in flight, so close(done) only
+				// fires after the check's state-store writes have finished.
 				s.BackgroundCheck(ctx)
 			}
 		}
 	}()
+	return done
 }
 
 // IsUpdateAvailable checks if an update is available without modifying state.

--- a/internal/update/service_test.go
+++ b/internal/update/service_test.go
@@ -202,10 +202,15 @@ func TestService_StartBackgroundCheck(t *testing.T) {
 	defer cancel()
 
 	// Start background check
-	service.StartBackgroundCheck(ctx, 1*time.Second)
+	done := service.StartBackgroundCheck(ctx, 1*time.Second)
 
 	// Wait a bit to let it run
 	time.Sleep(1500 * time.Millisecond)
+
+	// Join the ticker before returning so t.TempDir cleanup cannot race a
+	// final state-store write by the still-running goroutine.
+	cancel()
+	<-done
 
 	// Verify state was updated (or at least tried)
 	state, _ := store.LoadState()
@@ -231,13 +236,18 @@ func TestService_StartBackgroundCheck_Disabled(t *testing.T) {
 	defer cancel()
 
 	// Start background check on disabled service - should not run
-	service.StartBackgroundCheck(ctx, 1*time.Second)
+	done := service.StartBackgroundCheck(ctx, 1*time.Second)
 
 	// Wait and verify state was not modified
 	time.Sleep(1500 * time.Millisecond)
 
 	state, _ := store.LoadState()
 	assert.Nil(t, state, "Disabled service should not modify state")
+
+	// A disabled service starts no goroutine; its done channel is already
+	// closed, so a join returns immediately (an unclosed channel would hang
+	// here until the test timeout).
+	<-done
 }
 
 func TestService_ShouldCheck(t *testing.T) {

--- a/internal/update/wiring_test.go
+++ b/internal/update/wiring_test.go
@@ -120,10 +120,15 @@ func TestService_StartBackgroundCheck_StubTickerFiresOnInterval(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	svc.StartBackgroundCheck(ctx, 30*time.Millisecond)
+	done := svc.StartBackgroundCheck(ctx, 30*time.Millisecond)
 
 	require.Eventually(t, func() bool { return chk.callsCount() >= 3 }, 2*time.Second, 10*time.Millisecond,
 		"background ticker must fire multiple times on interval")
+
+	// Join before return so goleak sees the goroutine deterministically exited
+	// and t.TempDir cleanup cannot race an in-flight state write.
+	cancel()
+	<-done
 }
 
 // TestService_StartBackgroundCheck_StubStopsOnCancel covers AC (c): after the
@@ -136,21 +141,17 @@ func TestService_StartBackgroundCheck_StubStopsOnCancel(t *testing.T) {
 
 	// A longer interval widens the gap between ticks so a tick is less likely
 	// to be in-flight exactly when cancel() runs.
-	svc.StartBackgroundCheck(ctx, 50*time.Millisecond)
+	done := svc.StartBackgroundCheck(ctx, 50*time.Millisecond)
 
 	require.Eventually(t, func() bool { return chk.callsCount() >= 2 }, 2*time.Second, 10*time.Millisecond,
 		"ticker must fire before cancellation")
 
 	cancel()
 
-	// A tick that was already in-flight when cancel() was called may finish
-	// before the goroutine observes ctx.Done() and exits, so it can bump the
-	// call count once after cancellation. Wait long enough for any in-flight
-	// check to complete and the goroutine to wind down, then record the count
-	// and assert no further calls arrive. The generous stabilization window
-	// keeps the test stable on slow Windows runners with unpredictable
-	// scheduling latency.
-	time.Sleep(150 * time.Millisecond)
+	// Join the goroutine: <-done returns only after any tick that was in-flight
+	// when cancel() ran has finished and bumped the call count, so the count
+	// recorded here is final — no stabilization sleep needed.
+	<-done
 	callsAfterCancel := chk.callsCount()
 
 	time.Sleep(300 * time.Millisecond)
@@ -166,9 +167,13 @@ func TestService_StartBackgroundCheck_StubDisabledNoCalls(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	svc.StartBackgroundCheck(ctx, 20*time.Millisecond)
+	done := svc.StartBackgroundCheck(ctx, 20*time.Millisecond)
 
 	time.Sleep(120 * time.Millisecond)
 	assert.Equal(t, 0, chk.callsCount(),
 		"disabled service must not start the background checker")
+
+	// A disabled service returns an already-closed done channel; the join must
+	// not block (otherwise this test hangs until the go test timeout).
+	<-done
 }


### PR DESCRIPTION
## Summary

The Windows CI flare `TestService_StartBgCheck_Cancel` and, once, `TestService_StartBackgroundCheck`'s 10-minute hang were the same bug: the update-check background goroutine kept writing `.tmp` state files *after* the test's `t.TempDir()` teardown began, because callers could only cancel the context, never wait for the goroutine to exit. This makes the background check joinable end-to-end:

- `Service.StartBackgroundCheck` returns `<-chan struct{}` (closed via defer, so even a panic's recovery closes it)
- Every consumer updated to join: tests now synchronously prove the goroutine has stopped before TempDir's `RemoveAll` runs; the API runtime (`internal/api/core/update_checker.go`) joins during `Shutdown()` after cancelling `ServerCtx()`
- Unbounded join at production shutdown is deliberate per the change's resolved open question (30 s per-check ctx + 10 s HTTP client ceiling already bound the worst case)

Drove the local `fix-update-bgcheck-cancel-flake` change spec end-to-end; design/tasks/specs ticked on disk (openspec remains local-only by repo convention).

## Test plan
- [x] `go test -race -count=20 ./internal/update/` clean; `-count=40` on the bgcheck tests specifically
- [x] `go test -race -count=20 -run StartUpdateChecker/Shutdown ./internal/api/core/` + full pkg `-race`
- [x] Full `go test -short ./...` suite green; make lint; patch coverage 100%
