### PR TITLE
feat(downloader): require proven source identity for manual crops

### DIFF
--- a/internal/api/batch/poster_recrop_test.go
+++ b/internal/api/batch/poster_recrop_test.go
@@ -1,0 +1,30 @@
+package batch
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/downloader"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker/jobpersist"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPosterRecropResultConversion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	result := &resultstore.MovieResult{ErrorCode: downloader.PosterRecropRequiredCode, Error: "poster requires a fresh crop", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path}}
+	dbJob, err := jobpersist.Encode(jobpersist.Snapshot{Results: map[string]*resultstore.MovieResult{path: result}})
+	require.NoError(t, err)
+	snapshot, errs := jobpersist.Decode(dbJob)
+	require.Empty(t, errs)
+	for _, response := range []any{movieResultToResponse(snapshot.Results[path], nil), movieResultToSlimResponse(snapshot.Results[path], nil)} {
+		data, err := json.Marshal(response)
+		require.NoError(t, err)
+		var wire map[string]any
+		require.NoError(t, json.Unmarshal(data, &wire))
+		require.Equal(t, downloader.PosterRecropRequiredCode, wire["error_code"])
+		require.Equal(t, result.Error, wire["error"])
+	}
+}

--- a/internal/api/core/config_narrowing.go
+++ b/internal/api/core/config_narrowing.go
@@ -35,6 +35,7 @@ type APIConfig struct {
 	ProxyConfig         models.ProxyConfig        // cfg.Scrapers.Proxy — whole struct for proxy test/validation
 	FlareSolverrConfig  models.FlareSolverrConfig // cfg.Scrapers.FlareSolverr — whole struct for proxy test/validation
 	DownloadProxyConfig models.ProxyConfig        // cfg.Output.Download.DownloadProxy — download-proxy profiles surfaced as download_proxy.profile choices
+	DownloadPoster      bool                      // cfg.Output.Download.DownloadPoster — governs whether apply downloads posters
 
 	// Metadata
 	NFOEnabled          bool                     // cfg.Metadata.NFO.Feature.Enabled
@@ -93,6 +94,7 @@ type BatchNarrowConfig struct {
 	RequestTimeout     time.Duration // overall scrape operation timeout
 	ScraperPriority    []string      // scraper source ordering
 	NFOEnabled         bool          // whether NFO generation is active
+	DownloadPoster     bool          // whether poster media downloads are active
 	ScraperUserAgent   string        // user-agent for poster downloads
 	ScraperReferer     string        // referer for poster downloads
 	ScanTimeoutSeconds int           // timeout for file discovery
@@ -149,6 +151,7 @@ func (c APIConfig) BatchConfig() *BatchNarrowConfig {
 		RequestTimeout:     c.RequestTimeout,
 		ScraperPriority:    c.ScraperPriority,
 		NFOEnabled:         c.NFOEnabled,
+		DownloadPoster:     c.DownloadPoster,
 		ScraperUserAgent:   c.ScraperUserAgent,
 		ScraperReferer:     c.ScraperReferer,
 		ScanTimeoutSeconds: c.ScanTimeoutSeconds,
@@ -207,6 +210,7 @@ func (c APIConfig) MatcherConfig() *MatcherNarrowConfig {
 // cfg.Output.GetOperationMode(), cfg.Output.Operation.AllowRevert,
 // cfg.Output.MediaFormat.MaxPosterHeight,
 // cfg.Output.Download, cfg.Output.Download.DownloadProxy,
+// cfg.Output.Download.DownloadPoster,
 // cfg.Performance.MaxWorkers, cfg.Performance.WorkerTimeout,
 // cfg.Scrapers.RequestTimeoutSeconds,
 // cfg.Matching.RegexEnabled, cfg.Matching.RegexPattern,
@@ -237,6 +241,7 @@ func ConfigFromAppConfig(cfg *config.Config) APIConfig {
 		ProxyConfig:         cfg.Scrapers.Proxy,
 		FlareSolverrConfig:  cfg.Scrapers.FlareSolverr,
 		DownloadProxyConfig: cfg.Output.Download.DownloadProxy,
+		DownloadPoster:      cfg.Output.Download.DownloadPoster,
 		NFOEnabled:          cfg.Metadata.NFO.Feature.Enabled,
 		NFOFilenameTemplate: cfg.Metadata.NFO.Format.FilenameTemplate,
 		NFOPerFile:          cfg.Metadata.NFO.Feature.PerFile,

--- a/internal/api/core/runtime_manager.go
+++ b/internal/api/core/runtime_manager.go
@@ -415,7 +415,7 @@ func (s *RuntimeSnapshot) BatchJobFactory() worker.BatchJobFactoryInterface {
 		return nil
 	}
 	matcherIface := s.Matcher()
-	workerBatchCfg := worker.BatchJobConfig{MaxWorkers: batchCfg.MaxWorkers, WorkerTimeout: batchCfg.WorkerTimeout, RequestTimeout: batchCfg.RequestTimeout, ScraperPriority: batchCfg.ScraperPriority, NFOEnabled: batchCfg.NFOEnabled}
+	workerBatchCfg := worker.BatchJobConfig{MaxWorkers: batchCfg.MaxWorkers, WorkerTimeout: batchCfg.WorkerTimeout, RequestTimeout: batchCfg.RequestTimeout, ScraperPriority: batchCfg.ScraperPriority, NFOEnabled: batchCfg.NFOEnabled, PosterDisabled: !batchCfg.DownloadPoster}
 	return worker.NewBatchJobFactory(
 		r.deps.JobStore,
 		nil, // WF is per-job (BatchWorkflow), not shared across all jobs
@@ -551,7 +551,7 @@ func (r *APIRuntime) buildBatchJobFactory() any {
 	}
 
 	matcher := r.NewMatcher()
-	workerBatchCfg := worker.BatchJobConfig{MaxWorkers: batchCfg.MaxWorkers, WorkerTimeout: batchCfg.WorkerTimeout, RequestTimeout: batchCfg.RequestTimeout, ScraperPriority: batchCfg.ScraperPriority, NFOEnabled: batchCfg.NFOEnabled}
+	workerBatchCfg := worker.BatchJobConfig{MaxWorkers: batchCfg.MaxWorkers, WorkerTimeout: batchCfg.WorkerTimeout, RequestTimeout: batchCfg.RequestTimeout, ScraperPriority: batchCfg.ScraperPriority, NFOEnabled: batchCfg.NFOEnabled, PosterDisabled: !batchCfg.DownloadPoster}
 
 	// Re-hydrate reconstructed jobs with infrastructure deps (matcher, posterGen,
 	// batchCfg) that were not available at JobStore construction time. This

--- a/internal/commandutil/batch_config.go
+++ b/internal/commandutil/batch_config.go
@@ -19,6 +19,7 @@ func BatchJobConfigFromAppConfig(cfg *config.Config) worker.BatchJobConfig {
 		RequestTimeout:  time.Duration(cfg.Scrapers.RequestTimeoutSeconds) * time.Second,
 		ScraperPriority: cfg.Scrapers.Priority,
 		NFOEnabled:      cfg.Metadata.NFO.Feature.Enabled,
+		PosterDisabled:    !cfg.Output.Download.DownloadPoster,
 	}
 }
 

--- a/internal/commandutil/batch_config.go
+++ b/internal/commandutil/batch_config.go
@@ -19,7 +19,7 @@ func BatchJobConfigFromAppConfig(cfg *config.Config) worker.BatchJobConfig {
 		RequestTimeout:  time.Duration(cfg.Scrapers.RequestTimeoutSeconds) * time.Second,
 		ScraperPriority: cfg.Scrapers.Priority,
 		NFOEnabled:      cfg.Metadata.NFO.Feature.Enabled,
-		PosterDisabled:    !cfg.Output.Download.DownloadPoster,
+		PosterDisabled:  !cfg.Output.Download.DownloadPoster,
 	}
 }
 

--- a/internal/config/bridge_paths_test.go
+++ b/internal/config/bridge_paths_test.go
@@ -293,6 +293,12 @@ func extractBridgeFunctions(rootDir string) ([]bridgeFunc, error) {
 
 	err := filepath.Walk(internalDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			// Transient staging artifacts (e.g. batch poster temp files) may
+			// vanish between the directory listing and the stat on Windows —
+			// skip vanishing entries instead of failing the whole scan.
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return err
 		}
 		if info.IsDir() || !strings.HasSuffix(path, ".go") {

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -2,6 +2,7 @@ package downloader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -247,7 +248,7 @@ func (d *Downloader) Download(ctx context.Context, cmd DownloadCmd) (*DownloadOu
 		}
 	}
 	if err != nil {
-		if _, partial := err.(*DownloadPartialError); partial {
+		if _, partial := err.(*DownloadPartialError); partial || errors.Is(err, ErrPosterRecropRequired) {
 			return &DownloadOutcome{
 				Results:         results,
 				DownloadedPaths: downloadedPaths,

--- a/internal/downloader/media.go
+++ b/internal/downloader/media.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -27,6 +28,19 @@ import (
 // an unbounded same-URL-replacement body. 512 MiB exceeds any sane poster.
 // Var (not const) so tests can shrink the bound without writing big files.
 var maxPosterVerifyBytes int64 = 512 << 20
+
+// readVerificationBound reads r up to maxPosterVerifyBytes+1 bytes, enforcing
+// the verification limit *during* the read (not via a beforehand pathname
+// Stat, which a scratch-substitution writer could invalidate between checks).
+// len(out) > maxPosterVerifyBytes marks an over-limit body.
+func readVerificationBound(r io.Reader) ([]byte, error) {
+	lr := &io.LimitedReader{R: r, N: maxPosterVerifyBytes + 1}
+	data, err := io.ReadAll(lr)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
 
 func (d *Downloader) downloadCover(ctx context.Context, movie *models.Movie, destDir string, multipart *MultipartInfo, options ...any) (*DownloadResult, error) {
 	overwriteExisting, dedup := resolveDownloadOptions(options)
@@ -204,18 +218,20 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 		// a fingerprint mismatch. The Stat gate preserves the single-snapshot
 		// guarantee (one bounded ReadFile whose bytes are both measured and
 		// cropped) without ever materializing an unbounded body.
-		info, statErr := d.fs.Stat(fullPath)
+		verifier, openErr := d.fs.Open(fullPath)
 		var refusal *PosterRecropRequiredError
 		switch {
-		case statErr != nil:
-			refusal = &PosterRecropRequiredError{Reason: SourceIdentityUnavailable, Bounds: *bounds, Cause: fmt.Errorf("measure downloaded poster: %w", statErr)}
-		case info.Size() > maxPosterVerifyBytes:
-			refusal = &PosterRecropRequiredError{Reason: SourceIdentityUnavailable, Bounds: *bounds, Cause: fmt.Errorf("downloaded poster %s exceeds %d-byte verification bound", fullPath, maxPosterVerifyBytes)}
+		case openErr != nil:
+			refusal = &PosterRecropRequiredError{Reason: SourceIdentityUnavailable, Bounds: *bounds, Cause: fmt.Errorf("measure downloaded poster: %w", openErr)}
 		default:
-			verifiedSource, err = afero.ReadFile(d.fs, fullPath)
-			if err != nil {
+			verifiedSource, err = readVerificationBound(verifier)
+			_ = verifier.Close()
+			switch {
+			case err != nil:
 				refusal = &PosterRecropRequiredError{Reason: SourceIdentityUnavailable, Bounds: *bounds, Cause: fmt.Errorf("measure downloaded poster: %w", err)}
-			} else if !strings.EqualFold(assetidentity.FromBytes(verifiedSource).Fingerprint, bounds.SourceFingerprint) {
+			case int64(len(verifiedSource)) > maxPosterVerifyBytes:
+				refusal = &PosterRecropRequiredError{Reason: SourceIdentityUnavailable, Bounds: *bounds, Cause: fmt.Errorf("downloaded poster %s exceeds the %d-byte verification bound", fullPath, maxPosterVerifyBytes)}
+			case !strings.EqualFold(assetidentity.FromBytes(verifiedSource).Fingerprint, bounds.SourceFingerprint):
 				refusal = &PosterRecropRequiredError{Reason: SourceFingerprintMismatch, Bounds: *bounds}
 			}
 		}

--- a/internal/downloader/media.go
+++ b/internal/downloader/media.go
@@ -22,6 +22,12 @@ import (
 	"github.com/javinizer/javinizer-go/internal/template"
 )
 
+// maxPosterVerifyBytes bounds the identity-verification snapshot: the download
+// path caps nothing, so manual-crop verification streams must not materialize
+// an unbounded same-URL-replacement body. 512 MiB exceeds any sane poster.
+// Var (not const) so tests can shrink the bound without writing big files.
+var maxPosterVerifyBytes int64 = 512 << 20
+
 func (d *Downloader) downloadCover(ctx context.Context, movie *models.Movie, destDir string, multipart *MultipartInfo, options ...any) (*DownloadResult, error) {
 	overwriteExisting, dedup := resolveDownloadOptions(options)
 	if !d.config.DownloadCover || movie.Poster.CoverURL == "" {
@@ -192,12 +198,26 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 	fullIdentity = fullResult.producerIdentity
 	var verifiedSource []byte
 	if manualIntent {
-		verifiedSource, err = afero.ReadFile(d.fs, fullPath)
+		// Bound the verification allocation (codex P1-boundedness): the HTTP
+		// download has no response-size cap, so a same-URL substitution could
+		// otherwise force a multi-gigabyte in-memory snapshot merely to discover
+		// a fingerprint mismatch. The Stat gate preserves the single-snapshot
+		// guarantee (one bounded ReadFile whose bytes are both measured and
+		// cropped) without ever materializing an unbounded body.
+		info, statErr := d.fs.Stat(fullPath)
 		var refusal *PosterRecropRequiredError
-		if err != nil {
-			refusal = &PosterRecropRequiredError{Reason: SourceIdentityUnavailable, Bounds: *bounds, Cause: fmt.Errorf("measure downloaded poster: %w", err)}
-		} else if !strings.EqualFold(assetidentity.FromBytes(verifiedSource).Fingerprint, bounds.SourceFingerprint) {
-			refusal = &PosterRecropRequiredError{Reason: SourceFingerprintMismatch, Bounds: *bounds}
+		switch {
+		case statErr != nil:
+			refusal = &PosterRecropRequiredError{Reason: SourceIdentityUnavailable, Bounds: *bounds, Cause: fmt.Errorf("measure downloaded poster: %w", statErr)}
+		case info.Size() > maxPosterVerifyBytes:
+			refusal = &PosterRecropRequiredError{Reason: SourceIdentityUnavailable, Bounds: *bounds, Cause: fmt.Errorf("downloaded poster %s exceeds %d-byte verification bound", fullPath, maxPosterVerifyBytes)}
+		default:
+			verifiedSource, err = afero.ReadFile(d.fs, fullPath)
+			if err != nil {
+				refusal = &PosterRecropRequiredError{Reason: SourceIdentityUnavailable, Bounds: *bounds, Cause: fmt.Errorf("measure downloaded poster: %w", err)}
+			} else if !strings.EqualFold(assetidentity.FromBytes(verifiedSource).Fingerprint, bounds.SourceFingerprint) {
+				refusal = &PosterRecropRequiredError{Reason: SourceFingerprintMismatch, Bounds: *bounds}
+			}
 		}
 		if refusal != nil {
 			fullResult.Error = refusal

--- a/internal/downloader/media.go
+++ b/internal/downloader/media.go
@@ -25,9 +25,12 @@ import (
 
 // maxPosterVerifyBytes bounds the identity-verification snapshot: the download
 // path caps nothing, so manual-crop verification streams must not materialize
-// an unbounded same-URL-replacement body. 512 MiB exceeds any sane poster.
+// an unbounded same-URL-replacement body. 64 MiB covers any sane poster
+// (full-res 8 K scans stay well under this) while capping a same-URL
+// substitution at ~64 MiB per worker — under default concurrency the worst-
+// case verification footprint is bounded by ~5×64 MiB instead of ~2.5 GiB.
 // Var (not const) so tests can shrink the bound without writing big files.
-var maxPosterVerifyBytes int64 = 512 << 20
+var maxPosterVerifyBytes int64 = 64 << 20
 
 // readVerificationBound reads r up to maxPosterVerifyBytes+1 bytes, enforcing
 // the verification limit *during* the read (not via a beforehand pathname

--- a/internal/downloader/media.go
+++ b/internal/downloader/media.go
@@ -1,9 +1,11 @@
 package downloader
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"image"
 	"math"
 	"os"
 	"path/filepath"
@@ -34,6 +36,13 @@ func (d *Downloader) downloadCover(ctx context.Context, movie *models.Movie, des
 
 func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, destDir string, multipart *MultipartInfo, options ...any) (finalResult *DownloadResult, finalErr error) {
 	startTime := time.Now()
+	defer func() {
+		var refusal *PosterRecropRequiredError
+		if errors.As(finalErr, &refusal) {
+			logging.Warnf("downloadPoster: code=%s reason=%s", PosterRecropRequiredCode, refusal.Reason)
+			finalResult.Duration = time.Since(startTime)
+		}
+	}()
 	overwriteExisting, dedup := resolveDownloadOptions(options)
 	owner := resolveDownloadOwnerOptions(options)
 	ledger := resolveDownloadLedger(options)
@@ -58,9 +67,10 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 	}
 
 	bounds := movie.Poster.PosterCropBounds
-	geometryUsable := bounds != nil && movie.Poster.PosterCropSourceFull && bounds.Valid()
+	manualIntent := bounds != nil && movie.Poster.PosterCropSourceFull
+	geometryUsable := manualIntent && bounds.Valid()
 
-	if !geometryUsable && !movie.Poster.ShouldCropPoster {
+	if !manualIntent && !movie.Poster.ShouldCropPoster {
 		if !overwriteExisting {
 			releaseDownloadOwnerClaim(dedup, owner.logicalKey, owner.ownerKey)
 		}
@@ -111,6 +121,20 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 		result.Size = info.Size()
 		result.Duration = time.Since(startTime)
 		return result, nil
+	}
+
+	if manualIntent {
+		var reason PosterRecropReason
+		switch {
+		case bounds.SourceFingerprint == "":
+			reason = SourceFingerprintMissing
+		case !assetidentity.ValidFingerprint(bounds.SourceFingerprint):
+			reason = SourceFingerprintInvalid
+		}
+		if reason != "" {
+			result.Error = &PosterRecropRequiredError{Reason: reason, Bounds: *bounds}
+			return result, result.Error
+		}
 	}
 
 	// One GET feeds every poster-producing path below — manual crop, promote,
@@ -166,6 +190,23 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 	// error (wave-41) leg files no record — an unknown identity keeps the
 	// wave-53 fail-closed posture both here and at the bind below.
 	fullIdentity = fullResult.producerIdentity
+	var verifiedSource []byte
+	if manualIntent {
+		verifiedSource, err = afero.ReadFile(d.fs, fullPath)
+		var refusal *PosterRecropRequiredError
+		if err != nil {
+			refusal = &PosterRecropRequiredError{Reason: SourceIdentityUnavailable, Bounds: *bounds, Cause: fmt.Errorf("measure downloaded poster: %w", err)}
+		} else if !strings.EqualFold(assetidentity.FromBytes(verifiedSource).Fingerprint, bounds.SourceFingerprint) {
+			refusal = &PosterRecropRequiredError{Reason: SourceFingerprintMismatch, Bounds: *bounds}
+		}
+		if refusal != nil {
+			fullResult.Error = refusal
+			fullResult.Downloaded = false
+			fullResult.Replaced = false
+			fullResult.Size = 0
+			return fullResult, refusal
+		}
+	}
 
 	cropPath := uniqueTempPath(destPath, "crop.tmp")
 	var cropIdentity installedDestIdentity
@@ -186,7 +227,7 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 		// install-time lookup of the name. A fallback (undecodable / aspect
 		// drift / empty rect) files no record and the name's wave-65 unknown
 		// posture (retain, never unlink on doubt) applies.
-		cropOK, cropIdentity = d.cropDownloadedPoster(fullPath, cropPath, bounds)
+		cropOK, cropIdentity = d.cropDownloadedPoster(verifiedSource, cropPath, bounds)
 		if cropOK {
 			candidate = cropPath
 			cropped = true
@@ -461,25 +502,12 @@ func (d *Downloader) finalizePosterResult(result *DownloadResult, destPath strin
 // Wave-67 (codex P2, PR#215): on success the producer's own post-write
 // identity record rides back with the bool — CropPosterWithBounds'
 // producer-side capture, never a caller-side re-lookup.
-func (d *Downloader) cropDownloadedPoster(tempPath, dst string, bounds *models.CropBounds) (bool, installedDestIdentity) {
-	w, h, derr := imageutil.ImageDimensions(d.fs, tempPath)
+func (d *Downloader) cropDownloadedPoster(source []byte, dst string, bounds *models.CropBounds) (bool, installedDestIdentity) {
+	cfg, _, derr := image.DecodeConfig(bytes.NewReader(source))
+	w, h := cfg.Width, cfg.Height
 	if derr != nil || w <= 0 || h <= 0 {
 		logging.Warnf("downloadPoster: cannot decode downloaded source for manual crop: %v", derr)
 		return false, installedDestIdentity{}
-	}
-	// P4 source identity guard: aspect alone cannot distinguish a same-sized
-	// image whose pixels were replaced at the same URL. Legacy envelopes have
-	// no fingerprint and retain the pre-P4 aspect-only floor.
-	if bounds.SourceFingerprint != "" {
-		identity, ierr := assetidentity.Measure(d.fs, tempPath)
-		if ierr != nil {
-			logging.Warnf("downloadPoster: cannot fingerprint downloaded source for manual crop: %v", ierr)
-			return false, installedDestIdentity{}
-		}
-		if !strings.EqualFold(identity.Fingerprint, bounds.SourceFingerprint) {
-			logging.Warnf("downloadPoster: manual crop fingerprint mismatch (crop %s, downloaded %s); falling back", bounds.SourceFingerprint, identity.Fingerprint)
-			return false, installedDestIdentity{}
-		}
 	}
 
 	// Aspect guard: the geometry was normalized against the review-time
@@ -507,7 +535,7 @@ func (d *Downloader) cropDownloadedPoster(tempPath, dst string, bounds *models.C
 		return false, installedDestIdentity{}
 	}
 
-	cropInfo, cropErr := imageutil.CropPosterWithBounds(d.fs, tempPath, dst, left, top, right, bottom, d.config.MaxPosterHeight)
+	cropInfo, cropErr := imageutil.CropPosterWithBoundsReader(d.fs, bytes.NewReader(source), dst, left, top, right, bottom, d.config.MaxPosterHeight)
 	if cropErr != nil {
 		logging.Warnf("downloadPoster: manual crop failed: %v", cropErr)
 		return false, installedDestIdentity{}
@@ -707,6 +735,9 @@ func (d *Downloader) downloadAllWithExtrafanart(ctx context.Context, movie *mode
 		results = append(results, actresses...)
 	}
 
+	if posterResult != nil && errors.Is(posterResult.Error, ErrPosterRecropRequired) {
+		return results, fmt.Errorf("download poster: %w", posterResult.Error)
+	}
 	if criticalAttempted > 0 && criticalSucceeded == 0 {
 		return results, &DownloadPartialError{Attempted: criticalAttempted, Succeeded: criticalSucceeded}
 	}

--- a/internal/downloader/media.go
+++ b/internal/downloader/media.go
@@ -270,7 +270,16 @@ func (d *Downloader) downloadPoster(ctx context.Context, movie *models.Movie, de
 		}
 	}
 	if !cropped && movie.Poster.ShouldCropPoster {
-		cropInfo, cropErr := imageutil.CropPosterFromCover(d.fs, fullPath, cropPath, d.config.MaxPosterHeight)
+		// Auto-crop after manual verification must consume the verified byte
+		// snapshot — a scratch substitution between verify and crop must never
+		// reach the published output (codex P2 poster_recrop fallback).
+		var cropInfo os.FileInfo
+		var cropErr error
+		if verifiedSource != nil {
+			cropInfo, cropErr = imageutil.CropPosterFromCoverReader(d.fs, bytes.NewReader(verifiedSource), cropPath, d.config.MaxPosterHeight)
+		} else {
+			cropInfo, cropErr = imageutil.CropPosterFromCover(d.fs, fullPath, cropPath, d.config.MaxPosterHeight)
+		}
 		if cropErr != nil {
 			fullResult.Error = fmt.Errorf("failed to crop poster: %w", cropErr)
 			fullResult.Downloaded = false

--- a/internal/downloader/media_fingerprint_coverage_test.go
+++ b/internal/downloader/media_fingerprint_coverage_test.go
@@ -1,11 +1,7 @@
 package downloader
 
 import (
-	"errors"
-	"image/color"
-	"net/http"
-	"strings"
-	"sync/atomic"
+	"path/filepath"
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/models"
@@ -13,26 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fingerprintMeasureFailFs struct {
-	afero.Fs
-	opens atomic.Int32
-}
-
-func (f *fingerprintMeasureFailFs) Open(name string) (afero.File, error) {
-	if f.opens.Add(1) == 2 {
-		return nil, errors.New("fingerprint open failed")
-	}
-	return f.Fs.Open(name)
-}
-
-func TestCropDownloadedPosterFingerprintMeasureError(t *testing.T) {
-	base := afero.NewMemMapFs()
-	full := "/source-full.jpg"
-	require.NoError(t, afero.WriteFile(base, full, p4JPEG(color.RGBA{R: 12, G: 34, B: 56, A: 255}), 0o644))
-	fs := &fingerprintMeasureFailFs{Fs: base}
-	d := NewDownloader(http.DefaultClient, fs, &Config{}, nil)
-	bounds := &models.CropBounds{X: 0, Y: 0, Width: 0.5, Height: 1, SourceFingerprint: strings.Repeat("a", 64)}
-
-	ok, _ := d.cropDownloadedPoster(full, "/crop.jpg", bounds)
+func TestCropDownloadedPosterUndecodable(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	root := t.TempDir()
+	d := newGeometryDownloader(fs)
+	bounds := &models.CropBounds{Width: .5, Height: 1}
+	ok, _ := d.cropDownloadedPoster([]byte("not an image"), filepath.Join(root, "crop.jpg"), bounds)
 	require.False(t, ok)
+	entries, _ := afero.ReadDir(fs, root)
+	require.Empty(t, entries)
 }

--- a/internal/downloader/media_producer_return_w67_test.go
+++ b/internal/downloader/media_producer_return_w67_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
+	"github.com/javinizer/javinizer-go/internal/assetidentity"
 	"github.com/javinizer/javinizer-go/internal/fsutil"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
@@ -86,10 +87,10 @@ func (f *w67FullSwapFs) LstatIfPossible(name string) (os.FileInfo, bool, error) 
 // on the aspect guard and downloadPoster falls back to installing the FULL
 // download — the leg whose producer record must come from http.download's
 // verified publish, never a post-return re-lookup of fullPath.
-func w67FallbackMovie(id, url string) *models.Movie {
+func w67FallbackMovie(t *testing.T, id, url string) *models.Movie {
 	return &models.Movie{ID: id, Poster: models.PosterState{
 		PosterURL:            url,
-		PosterCropBounds:     &models.CropBounds{X: 0, Y: 0, Width: 0.5, Height: 1, SourceAspect: 0.5},
+		PosterCropBounds:     &models.CropBounds{X: 0, Y: 0, Width: 0.5, Height: 1, SourceAspect: 0.5, SourceFingerprint: assetidentity.FromBytes(twoToneSourceBytes(t)).Fingerprint},
 		PosterCropSourceFull: true,
 	}}
 }
@@ -100,19 +101,20 @@ func w67FallbackMovie(id, url string) *models.Movie {
 // destination is never stored, and the refusal is warn-logged.
 func TestDownloadPosterW67_FullCandidateSwapBetweenProducerAndBindRefused(t *testing.T) {
 	server := serveTwoToneSource(t)
+	root := t.TempDir()
 
 	base := afero.NewMemMapFs()
 	plant := []byte("w67 foreign substitute — planted post-producer-record, pre-bind")
 	fsW := &w67FullSwapFs{Fs: base, fireOn: 4, plant: plant}
-	movie := w67FallbackMovie("W67-FULL", server.URL+"/cover.jpg")
-	dest := w42ResolvePosterDest(NewDownloader(nil, base, w42CropPosterConfig(), nil), movie)
+	movie := w67FallbackMovie(t, "W67-FULL", server.URL+"/cover.jpg")
+	dest := filepath.Join(root, filepath.Base(w42ResolvePosterDest(NewDownloader(nil, base, w42CropPosterConfig(), nil), movie)))
 	d := NewDownloader(server.Client(), fsW, w42CropPosterConfig(), nil)
 
 	var logs bytes.Buffer
 	restoreLog := logging.SetOutput(&logs)
 	defer restoreLog()
 
-	result, err := d.downloadPoster(context.Background(), movie, "/output", nil, true)
+	result, err := d.downloadPoster(context.Background(), movie, root, nil, true)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errStagedInputSubstituted)
 	require.ErrorIs(t, result.Error, errStagedInputSubstituted)
@@ -152,13 +154,14 @@ func TestDownloadPosterW67_FullCandidateSwapBetweenProducerAndBindRefused(t *tes
 // the scratch reaping exact (both temp names gone).
 func TestDownloadPosterW67_FullCandidateProducerRecordInstallsNormal(t *testing.T) {
 	server := serveTwoToneSource(t)
+	root := t.TempDir()
 
 	base := afero.NewMemMapFs()
-	movie := w67FallbackMovie("W67-NORMAL", server.URL+"/cover.jpg")
-	dest := w42ResolvePosterDest(NewDownloader(nil, base, w42CropPosterConfig(), nil), movie)
+	movie := w67FallbackMovie(t, "W67-NORMAL", server.URL+"/cover.jpg")
+	dest := filepath.Join(root, filepath.Base(w42ResolvePosterDest(NewDownloader(nil, base, w42CropPosterConfig(), nil), movie)))
 	d := NewDownloader(server.Client(), base, w42CropPosterConfig(), nil)
 
-	result, err := d.downloadPoster(context.Background(), movie, "/output", nil, true)
+	result, err := d.downloadPoster(context.Background(), movie, root, nil, true)
 	require.NoError(t, err)
 	require.True(t, result.Downloaded)
 	require.False(t, result.Replaced)
@@ -229,7 +232,7 @@ func TestInstallOverwritingIdentityW67_VerifiedIdentityRidesOut(t *testing.T) {
 
 	t.Run("virtual leg — the MemMapFs post-publish capture", func(t *testing.T) {
 		mfs := afero.NewMemMapFs()
-		staged, dest, prov := w48StageMem(t, mfs, "/w67mem", "w67-genuine-mem")
+		staged, dest, prov := w48StageMem(t, mfs, t.TempDir(), "w67-genuine-mem")
 		d := NewDownloader(nil, mfs, &Config{}, nil).WithDestLocks(fsutil.NewKeyedLockRegistry())
 
 		var out installedDestIdentity
@@ -250,15 +253,16 @@ func TestDownloadW67_ProducerIdentityFiledOnResult(t *testing.T) {
 
 	t.Run("MemMapFs — virtual-leg verified capture", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
+		dest := filepath.Join(t.TempDir(), "poster.jpg")
 		d := NewDownloader(server.Client(), fs, w42CropPosterConfig(), nil)
 
-		result, err := d.download(context.Background(), server.URL+"/cover.jpg", "/out/poster.jpg", MediaTypePoster, true)
+		result, err := d.download(context.Background(), server.URL+"/cover.jpg", dest, MediaTypePoster, true)
 		require.NoError(t, err)
 		require.True(t, result.Downloaded)
 		require.True(t, result.producerIdentity.known,
 			"the verified publish's identity rides the result")
 		require.False(t, result.producerIdentity.hasDevIno)
-		require.True(t, destStillHoldsInstalledObject(fs, "/out/poster.jpg", result.producerIdentity))
+		require.True(t, destStillHoldsInstalledObject(fs, dest, result.producerIdentity))
 	})
 
 	t.Run("OsFs — bound publish's SameFile-proven identity", func(t *testing.T) {

--- a/internal/downloader/poster_crop_geometry_test.go
+++ b/internal/downloader/poster_crop_geometry_test.go
@@ -1,6 +1,7 @@
 package downloader
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"image"
@@ -9,10 +10,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 
+	"github.com/javinizer/javinizer-go/internal/assetidentity"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/organizer"
 	"github.com/spf13/afero"
@@ -24,7 +27,7 @@ import (
 // auto-crop (CropPosterFromCover) takes the right ~47%% of a landscape cover,
 // so a manual LEFT crop producing black pixels proves the persisted geometry
 // beat the scraper default.
-func serveTwoToneSource(t *testing.T) *httptest.Server {
+func twoToneSourceBytes(t *testing.T) []byte {
 	t.Helper()
 	img := image.NewRGBA(image.Rect(0, 0, 1000, 600))
 	for y := 0; y < 600; y++ {
@@ -36,12 +39,15 @@ func serveTwoToneSource(t *testing.T) *httptest.Server {
 			}
 		}
 	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "image/jpeg")
-		_ = jpeg.Encode(w, img, &jpeg.Options{Quality: 95})
-	}))
-	t.Cleanup(srv.Close)
-	return srv
+	var source bytes.Buffer
+	require.NoError(t, jpeg.Encode(&source, img, &jpeg.Options{Quality: 95}))
+	return source.Bytes()
+}
+
+func serveTwoToneSource(t *testing.T) *httptest.Server {
+	t.Helper()
+	server, _ := identityServer(t, twoToneSourceBytes(t))
+	return server
 }
 
 func newGeometryDownloader(fs afero.Fs) *Downloader {
@@ -106,6 +112,7 @@ var errTestRenameFail = errors.New("rename blocked")
 // Download failure with otherwise-applyable geometry: the error propagates
 // and nothing is left behind. Exactly one request is made.
 func TestDownloadPoster_GeometryDownloadFailurePropagates(t *testing.T) {
+	destDir := t.TempDir()
 	var hits atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		hits.Add(1)
@@ -114,14 +121,14 @@ func TestDownloadPoster_GeometryDownloadFailurePropagates(t *testing.T) {
 	t.Cleanup(srv.Close)
 	fs := afero.NewMemMapFs()
 	movie := geometryMovie(srv.URL+"/cover.jpg", &models.CropBounds{
-		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0, SourceFingerprint: strings.Repeat("a", 64),
 	}, true)
 
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	require.Error(t, err)
 	require.False(t, result.Downloaded)
 	assert.Equal(t, int32(1), hits.Load())
-	leftover, _ := afero.ReadDir(fs, "/dest")
+	leftover, _ := afero.ReadDir(fs, destDir)
 	assert.Empty(t, leftover, "no temp or dest file may survive a failed download")
 }
 
@@ -129,6 +136,7 @@ func TestDownloadPoster_GeometryDownloadFailurePropagates(t *testing.T) {
 // crop itself fails, and with scraper auto-crop intent the auto-crop attempt
 // fails identically — pre-change behavior for a broken source image.
 func TestDownloadPoster_GeometryCropFailureFallsToAutoCropError(t *testing.T) {
+	destDir := t.TempDir()
 	srv := serveTwoToneSource(t)
 	resp, err := http.Get(srv.URL)
 	require.NoError(t, err)
@@ -147,9 +155,9 @@ func TestDownloadPoster_GeometryCropFailureFallsToAutoCropError(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	movie := geometryMovie(ts2.URL+"/cover.jpg", &models.CropBounds{
-		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0, SourceFingerprint: assetidentity.FromBytes(trunc).Fingerprint,
 	}, true)
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	assert.Error(t, err, "broken source fails exactly like the pre-change auto-crop path")
 	require.False(t, result.Downloaded)
 	assert.Equal(t, int32(1), hits.Load())
@@ -158,13 +166,14 @@ func TestDownloadPoster_GeometryCropFailureFallsToAutoCropError(t *testing.T) {
 // Geometry that rounds to an empty pixel rect falls back cleanly to the
 // scraper auto-crop.
 func TestDownloadPoster_DegenerateRectFallsBack(t *testing.T) {
+	destDir := t.TempDir()
 	server := serveTwoToneSource(t)
 	fs := afero.NewMemMapFs()
 	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
-		X: 0.5, Y: 0.5, Width: 0.0001, Height: 0.0001, SourceAspect: 1000.0 / 600.0,
+		X: 0.5, Y: 0.5, Width: 0.0001, Height: 0.0001, SourceAspect: 1000.0 / 600.0, SourceFingerprint: assetidentity.FromBytes(twoToneSourceBytes(t)).Fingerprint,
 	}, true)
 
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	require.NoError(t, err)
 	require.True(t, result.Downloaded)
 	img, w, _ := decodeResultPoster(t, fs, result.LocalPath)
@@ -175,6 +184,7 @@ func TestDownloadPoster_DegenerateRectFallsBack(t *testing.T) {
 // Rename failure on the direct-promote fallback: clean error, no dangling
 // temp path in the result.
 func TestDownloadPoster_PromoteFailureIsCleanError(t *testing.T) {
+	destDir := t.TempDir()
 	fs := renameFailFs{afero.NewMemMapFs()}
 	// Undecodable payload: the geometry path bails to the direct-promote fallback.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -187,10 +197,10 @@ func TestDownloadPoster_PromoteFailureIsCleanError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 	movie := geometryMovie(srv.URL+"/poster.jpg", &models.CropBounds{
-		X: 0, Y: 0, Width: 0.4, Height: 1, SourceAspect: 1000.0 / 600.0,
+		X: 0, Y: 0, Width: 0.4, Height: 1, SourceAspect: 1000.0 / 600.0, SourceFingerprint: assetidentity.FromBytes([]byte("definitely not jpeg")).Fingerprint,
 	}, false)
 
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	require.Error(t, err)
 	assert.False(t, result.Downloaded)
 	assert.Empty(t, result.LocalPath, "removed temp path must never leak into the result")
@@ -202,17 +212,18 @@ func TestDownloadPoster_PromoteFailureIsCleanError(t *testing.T) {
 // deleted on revert, and the pre-existing poster would be gone). In-place
 // artwork refresh is follow-up work requiring overwrite tracking.
 func TestDownloadPoster_ExistingDestKeptWithGeometry(t *testing.T) {
+	destDir := t.TempDir()
 	server := serveTwoToneSource(t)
 	fs := afero.NewMemMapFs()
-	require.NoError(t, afero.WriteFile(fs, "/dest/IPX-535-poster.jpg", []byte("old artwork"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(destDir, "IPX-535-poster.jpg"), []byte("old artwork"), 0o644))
 	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
-		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0, SourceFingerprint: assetidentity.FromBytes(twoToneSourceBytes(t)).Fingerprint,
 	}, true)
 
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	require.NoError(t, err)
 	assert.False(t, result.Downloaded, "existing poster must be kept even with pending geometry")
-	content, err := afero.ReadFile(fs, "/dest/IPX-535-poster.jpg")
+	content, err := afero.ReadFile(fs, filepath.Join(destDir, "IPX-535-poster.jpg"))
 	require.NoError(t, err)
 	assert.Equal(t, []byte("old artwork"), content)
 }
@@ -220,15 +231,16 @@ func TestDownloadPoster_ExistingDestKeptWithGeometry(t *testing.T) {
 // Existing destination without pending geometry keeps pre-change behavior:
 // the existing file is left untouched.
 func TestDownloadPoster_ExistingDestKeptWithoutGeometry(t *testing.T) {
+	destDir := t.TempDir()
 	server := serveTwoToneSource(t)
 	fs := afero.NewMemMapFs()
-	require.NoError(t, afero.WriteFile(fs, "/dest/IPX-535-poster.jpg", []byte("old artwork"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(destDir, "IPX-535-poster.jpg"), []byte("old artwork"), 0o644))
 	movie := geometryMovie(server.URL+"/cover.jpg", nil, true)
 
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	require.NoError(t, err)
 	assert.False(t, result.Downloaded, "no geometry: existing poster must be kept")
-	content, err := afero.ReadFile(fs, "/dest/IPX-535-poster.jpg")
+	content, err := afero.ReadFile(fs, filepath.Join(destDir, "IPX-535-poster.jpg"))
 	require.NoError(t, err)
 	assert.Equal(t, []byte("old artwork"), content)
 }
@@ -236,30 +248,33 @@ func TestDownloadPoster_ExistingDestKeptWithoutGeometry(t *testing.T) {
 // finalizePosterResult clears the location fields when the promoted file
 // cannot be stat'd, and points at the file with its size when it can.
 func TestFinalizePosterResult_StatFailClearsLocation(t *testing.T) {
+	destDir := t.TempDir()
 	d := newGeometryDownloader(afero.NewMemMapFs())
-	result := &DownloadResult{Downloaded: true, LocalPath: "/dest/X-poster.jpg.full.tmp", Size: 99}
-	d.finalizePosterResult(result, "/dest/X-poster.jpg")
+	result := &DownloadResult{Downloaded: true, LocalPath: filepath.Join(destDir, "X-poster.jpg.full.tmp"), Size: 99}
+	d.finalizePosterResult(result, filepath.Join(destDir, "X-poster.jpg"))
 	assert.Empty(t, result.LocalPath, "missing destination must clear the temp path")
 	assert.Zero(t, result.Size)
 }
 
 func TestFinalizePosterResult_StatSuccessSetsLocation(t *testing.T) {
+	destDir := t.TempDir()
 	fs := afero.NewMemMapFs()
-	require.NoError(t, afero.WriteFile(fs, "/dest/X-poster.jpg", []byte("img"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(destDir, "X-poster.jpg"), []byte("img"), 0o644))
 	d := newGeometryDownloader(fs)
 	result := &DownloadResult{Downloaded: true}
-	d.finalizePosterResult(result, "/dest/X-poster.jpg")
-	assert.Equal(t, "/dest/X-poster.jpg", result.LocalPath)
+	d.finalizePosterResult(result, filepath.Join(destDir, "X-poster.jpg"))
+	assert.Equal(t, filepath.Join(destDir, "X-poster.jpg"), result.LocalPath)
 	assert.Equal(t, int64(3), result.Size)
 }
 func TestDownloadPoster_ManualGeometryApplied(t *testing.T) {
+	destDir := t.TempDir()
 	server := serveTwoToneSource(t)
 	fs := afero.NewMemMapFs()
 	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
-		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0, SourceFingerprint: assetidentity.FromBytes(twoToneSourceBytes(t)).Fingerprint,
 	}, true)
 
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	require.NoError(t, err)
 	require.True(t, result.Downloaded)
 
@@ -273,13 +288,14 @@ func TestDownloadPoster_ManualGeometryApplied(t *testing.T) {
 // Invalid geometry never fails organize: with should_crop_poster=true the
 // scraper auto-crop still runs.
 func TestDownloadPoster_InvalidGeometryFallsBackToAutoCrop(t *testing.T) {
+	destDir := t.TempDir()
 	server := serveTwoToneSource(t)
 	fs := afero.NewMemMapFs()
 	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
-		X: 0, Y: 0, Width: 1.5, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+		X: 0, Y: 0, Width: 1.5, Height: 1.0, SourceAspect: 1000.0 / 600.0, SourceFingerprint: assetidentity.FromBytes(twoToneSourceBytes(t)).Fingerprint,
 	}, true)
 
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	require.NoError(t, err)
 	require.True(t, result.Downloaded)
 
@@ -291,13 +307,14 @@ func TestDownloadPoster_InvalidGeometryFallsBackToAutoCrop(t *testing.T) {
 // With should_crop_poster=false the pre-geometry direct-download success path
 // is preserved even when geometry is present but invalid.
 func TestDownloadPoster_InvalidGeometryKeepsDirectDownloadSuccess(t *testing.T) {
+	destDir := t.TempDir()
 	server := serveTwoToneSource(t)
 	fs := afero.NewMemMapFs()
 	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
-		X: 0, Y: 0, Width: 0, Height: 0, SourceAspect: 1000.0 / 600.0,
+		X: 0, Y: 0, Width: 0, Height: 0, SourceAspect: 1000.0 / 600.0, SourceFingerprint: assetidentity.FromBytes(twoToneSourceBytes(t)).Fingerprint,
 	}, false)
 
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	require.NoError(t, err)
 	require.True(t, result.Downloaded)
 
@@ -310,6 +327,7 @@ func TestDownloadPoster_InvalidGeometryKeepsDirectDownloadSuccess(t *testing.T) 
 // stale (different image behind the same URL): refuse it and fall back —
 // reusing the one download already made (single-use URLs must not be re-GET).
 func TestDownloadPoster_AspectMismatchFallsBack(t *testing.T) {
+	destDir := t.TempDir()
 	var hits atomic.Int32
 	img := image.NewRGBA(image.Rect(0, 0, 1000, 600))
 	for y := 0; y < 600; y++ {
@@ -317,18 +335,20 @@ func TestDownloadPoster_AspectMismatchFallsBack(t *testing.T) {
 			img.Set(x, y, color.White)
 		}
 	}
+	var source bytes.Buffer
+	require.NoError(t, jpeg.Encode(&source, img, &jpeg.Options{Quality: 95}))
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits.Add(1)
 		w.Header().Set("Content-Type", "image/jpeg")
-		_ = jpeg.Encode(w, img, &jpeg.Options{Quality: 95})
+		_, _ = w.Write(source.Bytes())
 	}))
 	t.Cleanup(srv.Close)
 	fs := afero.NewMemMapFs()
 	movie := geometryMovie(srv.URL+"/cover.jpg", &models.CropBounds{
-		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 378.0 / 529.0,
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 378.0 / 529.0, SourceFingerprint: assetidentity.FromBytes(source.Bytes()).Fingerprint,
 	}, true)
 
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	require.NoError(t, err)
 	require.True(t, result.Downloaded)
 
@@ -340,6 +360,7 @@ func TestDownloadPoster_AspectMismatchFallsBack(t *testing.T) {
 // An undecodable download with should_crop_poster=false keeps today's
 // direct-download success — a previously successful organize must not newly fail.
 func TestDownloadPoster_UndecodableKeepsDirectDownloadSuccess(t *testing.T) {
+	destDir := t.TempDir()
 	raw := []byte("not an image at all")
 	var hits atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -353,10 +374,10 @@ func TestDownloadPoster_UndecodableKeepsDirectDownloadSuccess(t *testing.T) {
 	t.Cleanup(srv.Close)
 	fs := afero.NewMemMapFs()
 	movie := geometryMovie(srv.URL+"/poster.jpg", &models.CropBounds{
-		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 0.5,
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 0.5, SourceFingerprint: assetidentity.FromBytes(raw).Fingerprint,
 	}, false)
 
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	require.NoError(t, err)
 	require.True(t, result.Downloaded)
 
@@ -369,14 +390,15 @@ func TestDownloadPoster_UndecodableKeepsDirectDownloadSuccess(t *testing.T) {
 // Geometry flagged as measured against the legacy already-cropped preview is
 // never applied — pre-geometry behavior exactly.
 func TestDownloadPoster_NonFullSourceGeometryIgnored(t *testing.T) {
+	destDir := t.TempDir()
 	server := serveTwoToneSource(t)
 	fs := afero.NewMemMapFs()
 	movie := geometryMovie(server.URL+"/cover.jpg", &models.CropBounds{
-		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0,
+		X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0, SourceFingerprint: assetidentity.FromBytes(twoToneSourceBytes(t)).Fingerprint,
 	}, true)
 	movie.Poster.PosterCropSourceFull = false
 
-	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, "/dest", nil)
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, destDir, nil)
 	require.NoError(t, err)
 	require.True(t, result.Downloaded)
 

--- a/internal/downloader/poster_fingerprint_p4_test.go
+++ b/internal/downloader/poster_fingerprint_p4_test.go
@@ -2,17 +2,17 @@ package downloader
 
 import (
 	"bytes"
+	"context"
 	"image"
 	"image/color"
 	"image/draw"
 	"image/jpeg"
-	"net/http"
 	"testing"
 
 	"github.com/javinizer/javinizer-go/internal/assetidentity"
 	"github.com/javinizer/javinizer-go/internal/models"
-	"github.com/javinizer/javinizer-go/internal/organizer"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
 )
 
 func p4JPEG(c color.RGBA) []byte {
@@ -23,30 +23,18 @@ func p4JPEG(c color.RGBA) []byte {
 	return buf.Bytes()
 }
 
-func TestDownloadPosterFingerprintMismatchFallsBack(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	cfg := &Config{DownloadPoster: true, MaxPosterHeight: 0, MediaFormatConfig: organizer.MediaFormatConfig{PosterFormat: "<ID>-poster.jpg"}}
-	d := NewDownloader(http.DefaultClient, fs, cfg, nil)
+func TestDownloadPosterFingerprintMismatchRequiresRecrop(t *testing.T) {
 	original := p4JPEG(color.RGBA{R: 20, G: 20, B: 20, A: 255})
 	replacement := p4JPEG(color.RGBA{R: 220, G: 220, B: 220, A: 255})
-	full := "/tmp/source-full.jpg"
-	crop := "/tmp/cropped.jpg"
-	if err := afero.WriteFile(fs, full, original, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	bounds := &models.CropBounds{
-		X: 0, Y: 0, Width: 0.4, Height: 1, SourceAspect: 1000.0 / 600.0,
-		SourceFingerprint: assetidentity.FromBytes(original).Fingerprint,
-	}
-	ok, _ := d.cropDownloadedPoster(full, crop, bounds)
-	if !ok {
-		t.Fatal("same-content source should accept manual geometry")
-	}
-	if err := afero.WriteFile(fs, full, replacement, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	ok, _ = d.cropDownloadedPoster(full, crop, bounds)
-	if ok {
-		t.Fatal("same-aspect different-content source must reject stale manual geometry")
+	for _, source := range [][]byte{original, replacement} {
+		server, _ := identityServer(t, source)
+		bounds := &models.CropBounds{Width: .4, Height: 1, SourceAspect: 1000.0 / 600, SourceFingerprint: assetidentity.FromBytes(original).Fingerprint}
+		result, err := newGeometryDownloader(afero.NewMemMapFs()).downloadPoster(context.Background(), geometryMovie(server.URL, bounds, false), t.TempDir(), nil)
+		if bytes.Equal(source, original) {
+			require.NoError(t, err)
+			require.True(t, result.Downloaded)
+		} else {
+			requireIdentityRefusal(t, result, err, SourceFingerprintMismatch, bounds)
+		}
 	}
 }

--- a/internal/downloader/poster_identity.go
+++ b/internal/downloader/poster_identity.go
@@ -1,0 +1,49 @@
+package downloader
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+// ErrPosterRecropRequired classifies refusal independently of its retained cause.
+var ErrPosterRecropRequired = errors.New("poster requires a fresh crop")
+
+// PosterRecropRequiredCode is the stable asynchronous result error_code.
+const PosterRecropRequiredCode = "poster_recrop_required"
+
+// PosterRecropReason distinguishes missing proof from changed or unreadable bytes.
+type PosterRecropReason string
+
+// Identity refusal reasons are stable log and Go classification values.
+const (
+	SourceFingerprintMissing  PosterRecropReason = "source_fingerprint_missing"
+	SourceFingerprintInvalid  PosterRecropReason = "source_fingerprint_invalid"
+	SourceFingerprintMismatch PosterRecropReason = "source_fingerprint_mismatch"
+	SourceIdentityUnavailable PosterRecropReason = "source_identity_unavailable"
+)
+
+// PosterRecropRequiredError carries a copy of attempted intent, never shared review state.
+type PosterRecropRequiredError struct {
+	Reason PosterRecropReason
+	Bounds models.CropBounds
+	Cause  error
+}
+
+func (e *PosterRecropRequiredError) Error() string {
+	message := fmt.Sprintf("poster requires a fresh crop: %s", e.Reason)
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %v", message, e.Cause)
+	}
+	return message
+}
+
+// Is retains recrop classification while Unwrap exposes the measurement cause.
+func (e *PosterRecropRequiredError) Is(target error) bool {
+	return target == ErrPosterRecropRequired
+}
+
+func (e *PosterRecropRequiredError) Unwrap() error {
+	return e.Cause
+}

--- a/internal/downloader/poster_identity_test.go
+++ b/internal/downloader/poster_identity_test.go
@@ -1,0 +1,424 @@
+package downloader
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/assetidentity"
+	"github.com/javinizer/javinizer-go/internal/logging"
+	"github.com/javinizer/javinizer-go/internal/models"
+)
+
+func identityServer(t *testing.T, source []byte) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	hits := &atomic.Int32{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(source)
+	}))
+	t.Cleanup(server.Close)
+	return server, hits
+}
+
+type identityReadFS struct {
+	afero.Fs
+	openErr   error
+	readErr   error
+	afterRead func(string) error
+}
+
+func (f *identityReadFS) Open(name string) (afero.File, error) {
+	if strings.HasSuffix(name, ".full.tmp") {
+		if f.openErr != nil {
+			return nil, f.openErr
+		}
+		file, err := f.Fs.Open(name)
+		if err != nil {
+			return nil, err
+		}
+		return &identityReadFile{File: file, readErr: f.readErr, afterRead: f.afterRead}, nil
+	}
+	return f.Fs.Open(name)
+}
+
+type identityReadFile struct {
+	afero.File
+	readErr   error
+	afterRead func(string) error
+}
+
+func (f *identityReadFile) Read(p []byte) (int, error) {
+	if f.readErr != nil {
+		return 0, f.readErr
+	}
+	return f.File.Read(p)
+}
+
+func (f *identityReadFile) Close() error {
+	err := f.File.Close()
+	if err == nil && f.afterRead != nil {
+		return f.afterRead(f.Name())
+	}
+	return err
+}
+
+func requireIdentityRefusal(t *testing.T, result *DownloadResult, err error, reason PosterRecropReason, bounds *models.CropBounds) {
+	t.Helper()
+	require.ErrorIs(t, err, ErrPosterRecropRequired)
+	require.ErrorIs(t, result.Error, ErrPosterRecropRequired)
+	var refusal *PosterRecropRequiredError
+	require.ErrorAs(t, fmt.Errorf("apply poster: %w", err), &refusal)
+	require.Equal(t, reason, refusal.Reason)
+	require.Equal(t, *bounds, refusal.Bounds)
+	require.False(t, result.Downloaded)
+	require.False(t, result.Replaced)
+	require.Empty(t, result.LocalPath)
+	require.Zero(t, result.Size)
+}
+
+func TestDownloadPoster_RecropAggregation(t *testing.T) {
+	source := twoToneSourceBytes(t)
+	server, _ := identityServer(t, source)
+	root := t.TempDir()
+	fs := afero.NewMemMapFs()
+	movie := geometryMovie(server.URL+"/poster.jpg", &models.CropBounds{Width: .4, Height: 1}, true)
+	movie.Poster.CoverURL = server.URL + "/cover.jpg"
+	d := newGeometryDownloader(fs)
+	d.config.DownloadCover = true
+	d.config.FanartFormat = "<ID>-fanart.jpg"
+	outcome, err := d.Download(context.Background(), DownloadCmd{Movie: movie, DestDir: root})
+	require.ErrorIs(t, err, ErrPosterRecropRequired)
+	require.NotNil(t, outcome)
+	coverPath := filepath.Join(root, "IPX-535-fanart.jpg")
+	require.Equal(t, []string{coverPath}, outcome.CreatedPaths)
+	require.Equal(t, []string{coverPath}, outcome.DownloadedPaths)
+	var cover, poster *DownloadResult
+	for _, result := range outcome.Results {
+		switch result.Type {
+		case MediaTypeCover:
+			cover = &result
+		case MediaTypePoster:
+			poster = &result
+		}
+	}
+	require.NotNil(t, cover)
+	require.True(t, cover.Downloaded)
+	require.NotNil(t, poster)
+	requireIdentityRefusal(t, poster, err, SourceFingerprintMissing, movie.Poster.PosterCropBounds)
+	got, err := afero.ReadFile(fs, coverPath)
+	require.NoError(t, err)
+	require.Equal(t, source, got)
+}
+
+func TestDownloadPoster_IdentityUnrelatedPaths(t *testing.T) {
+	for _, mode := range []string{"disabled", "no URL", "reservation skip", "existing legacy", "no manual", "non-full legacy", "network", "cancelled"} {
+		t.Run(mode, func(t *testing.T) {
+			root := t.TempDir()
+			fs := afero.NewMemMapFs()
+			source := twoToneSourceBytes(t)
+			server, hits := identityServer(t, source)
+			d := newGeometryDownloader(fs)
+			bounds := &models.CropBounds{Width: .4, Height: 1}
+			movie := geometryMovie(server.URL, bounds, true)
+			ctx := context.Background()
+			overwrite := false
+			dedup := &sync.Map{}
+			switch mode {
+			case "disabled":
+				d.config.DownloadPoster = false
+			case "no URL":
+				movie.Poster.PosterURL = ""
+			case "reservation skip":
+				overwrite = true
+				dedup.Store(filepath.Join(root, "IPX-535-poster.jpg"), struct{}{})
+			case "existing legacy":
+				require.NoError(t, afero.WriteFile(fs, filepath.Join(root, "IPX-535-poster.jpg"), []byte("old"), 0600))
+			case "no manual":
+				movie.Poster.PosterCropBounds = nil
+				movie.Poster.ShouldCropPoster = false
+			case "non-full legacy":
+				movie.Poster.PosterCropSourceFull = false
+				movie.Poster.ShouldCropPoster = false
+			case "network":
+				bounds.SourceFingerprint = assetidentity.FromBytes(source).Fingerprint
+				server.Close()
+			case "cancelled":
+				bounds.SourceFingerprint = assetidentity.FromBytes(source).Fingerprint
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+			result, err := d.downloadPoster(ctx, movie, root, nil, overwrite, dedup)
+			require.NotErrorIs(t, err, ErrPosterRecropRequired)
+			switch mode {
+			case "network", "cancelled":
+				require.Error(t, err)
+				require.False(t, result.Downloaded)
+				if mode == "cancelled" {
+					require.ErrorIs(t, err, context.Canceled)
+				}
+			case "no manual", "non-full legacy":
+				require.NoError(t, err)
+				require.True(t, result.Downloaded)
+				got, err := afero.ReadFile(fs, result.LocalPath)
+				require.NoError(t, err)
+				require.Equal(t, source, got)
+				require.Equal(t, int32(1), hits.Load())
+			default:
+				require.NoError(t, err)
+				require.False(t, result.Downloaded)
+				require.Zero(t, hits.Load())
+				if mode == "reservation skip" {
+					require.True(t, result.Skipped)
+				}
+			}
+		})
+	}
+}
+
+func TestDownloadPoster_CropConsumesVerifiedSnapshot(t *testing.T) {
+	a := p4JPEG(color.RGBA{R: 20, A: 255})
+	b := p4JPEG(color.RGBA{R: 220, G: 220, B: 220, A: 255})
+	for _, native := range []bool{false, true} {
+		for _, auto := range []bool{false, true} {
+			t.Run(fmt.Sprintf("native=%t/auto=%t", native, auto), func(t *testing.T) {
+				root := t.TempDir()
+				var base afero.Fs = afero.NewMemMapFs()
+				if native {
+					base = afero.NewOsFs()
+				}
+				swapped := false
+				fs := &identityReadFS{Fs: base, afterRead: func(name string) error {
+					swapped = true
+					return afero.WriteFile(base, name, b, 0600)
+				}}
+				server, hits := identityServer(t, a)
+				bounds := &models.CropBounds{Width: .4, Height: 1, SourceAspect: 1000.0 / 600, SourceFingerprint: assetidentity.FromBytes(a).Fingerprint}
+				result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), geometryMovie(server.URL, bounds, auto), root, nil)
+				require.NoError(t, err)
+				require.True(t, swapped)
+				require.True(t, result.Downloaded)
+				img, width, height := decodeResultPoster(t, base, result.LocalPath)
+				require.Equal(t, 400, width)
+				require.Equal(t, 600, height)
+				require.Less(t, sampleLuma(img, .5, .5), 40.0, "saved rectangle must consume A, not the substituted white B")
+				require.Equal(t, int32(1), hits.Load())
+			})
+		}
+	}
+}
+
+func TestDownloadPoster_ByteIdentityDefinition(t *testing.T) {
+	a := p4JPEG(color.RGBA{R: 20, A: 255})
+	b := append([]byte{}, a[:2]...)
+	b = append(b, 0xff, 0xfe, 0, 6, 'n', 'o', 't', 'e')
+	b = append(b, a[2:]...)
+	imageA, _, err := image.Decode(bytes.NewReader(a))
+	require.NoError(t, err)
+	imageB, _, err := image.Decode(bytes.NewReader(b))
+	require.NoError(t, err)
+	require.Equal(t, imageA, imageB)
+	require.NotEqual(t, assetidentity.FromBytes(a).Fingerprint, assetidentity.FromBytes(b).Fingerprint)
+	for _, metadataChanged := range []bool{false, true} {
+		t.Run(fmt.Sprint(metadataChanged), func(t *testing.T) {
+			source := a
+			if metadataChanged {
+				source = b
+			}
+			server, hits := identityServer(t, source)
+			root := t.TempDir()
+			fs := afero.NewMemMapFs()
+			reviewPath := filepath.Join(root, "review", "original.jpg")
+			require.NoError(t, afero.WriteFile(fs, reviewPath, a, 0600))
+			measured, err := assetidentity.Measure(fs, reviewPath)
+			require.NoError(t, err)
+			bounds := &models.CropBounds{Width: .4, Height: 1, SourceAspect: 1000.0 / 600, SourceFingerprint: strings.ToUpper(measured.Fingerprint)}
+			result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), geometryMovie(server.URL+"/different/location.jpg", bounds, false), filepath.Join(root, "apply"), nil)
+			if metadataChanged {
+				requireIdentityRefusal(t, result, err, SourceFingerprintMismatch, bounds)
+			} else {
+				require.NoError(t, err)
+				require.True(t, result.Downloaded)
+			}
+			require.Equal(t, int32(1), hits.Load())
+		})
+	}
+}
+
+func TestDownloadPoster_LegacyGeometryCannotAuthorize(t *testing.T) {
+	source := p4JPEG(color.RGBA{R: 20, A: 255})
+	identity := assetidentity.FromBytes(source)
+	for _, auto := range []bool{false, true} {
+		for _, fingerprint := range []string{"", "malformed"} {
+			for _, width := range []float64{.4, 1.5} {
+				t.Run(fmt.Sprintf("auto=%t/fingerprint=%s/width=%g", auto, fingerprint, width), func(t *testing.T) {
+					server, hits := identityServer(t, source)
+					wire, err := json.Marshal(map[string]any{"x": 0, "y": 0, "width": width, "height": 1, "source_aspect": 1000.0 / 600, "source_revision": identity.Revision, "source_fingerprint": fingerprint})
+					require.NoError(t, err)
+					var bounds models.CropBounds
+					require.NoError(t, json.Unmarshal(wire, &bounds))
+					movie := geometryMovie(server.URL, &bounds, auto)
+					result, err := newGeometryDownloader(afero.NewMemMapFs()).downloadPoster(context.Background(), movie, t.TempDir(), nil)
+					reason := SourceFingerprintMissing
+					if fingerprint != "" {
+						reason = SourceFingerprintInvalid
+					}
+					requireIdentityRefusal(t, result, err, reason, &bounds)
+					require.Equal(t, fingerprint, movie.Poster.PosterCropBounds.SourceFingerprint)
+					require.Zero(t, hits.Load())
+				})
+			}
+		}
+	}
+}
+
+func TestDownloadPoster_SourceReplacement(t *testing.T) {
+	a := p4JPEG(color.RGBA{R: 20, A: 255})
+	b := p4JPEG(color.RGBA{G: 220, A: 255})
+	for _, native := range []bool{false, true} {
+		for _, auto := range []bool{false, true} {
+			for _, overwrite := range []bool{false, true} {
+				for _, existing := range []bool{false, true} {
+					t.Run(fmt.Sprintf("native=%t/auto=%t/overwrite=%t/existing=%t", native, auto, overwrite, existing), func(t *testing.T) {
+						root := t.TempDir()
+						var fs afero.Fs = afero.NewMemMapFs()
+						if native {
+							fs = afero.NewOsFs()
+						}
+						dest := filepath.Join(root, "IPX-535-poster.jpg")
+						old := []byte("existing poster must survive")
+						if existing {
+							require.NoError(t, afero.WriteFile(fs, dest, old, 0600))
+						}
+						var replaced atomic.Bool
+						var hits atomic.Int32
+						server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							hits.Add(1)
+							w.Header().Set("Content-Type", "image/jpeg")
+							if replaced.Load() {
+								_, _ = w.Write(b)
+							} else {
+								_, _ = w.Write(a)
+							}
+						}))
+						defer server.Close()
+						response, err := server.Client().Get(server.URL + "/single-use.jpg")
+						require.NoError(t, err)
+						reviewed, err := io.ReadAll(response.Body)
+						require.NoError(t, err)
+						require.NoError(t, response.Body.Close())
+						bounds := &models.CropBounds{Width: .4, Height: 1, SourceAspect: 1000.0 / 600, SourceFingerprint: assetidentity.FromBytes(reviewed).Fingerprint}
+						replaced.Store(true)
+						hits.Store(0)
+						movie := geometryMovie(server.URL+"/single-use.jpg", bounds, auto)
+						result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, root, nil, overwrite)
+						if existing && !overwrite {
+							require.NoError(t, err)
+							require.False(t, result.Downloaded)
+							require.False(t, result.Replaced)
+							require.Equal(t, dest, result.LocalPath)
+							require.Zero(t, hits.Load())
+						} else {
+							requireIdentityRefusal(t, result, err, SourceFingerprintMismatch, bounds)
+							require.Equal(t, int32(1), hits.Load())
+						}
+						if existing {
+							got, err := afero.ReadFile(fs, dest)
+							require.NoError(t, err)
+							require.Equal(t, old, got)
+						} else {
+							_, err := fs.Stat(dest)
+							require.ErrorIs(t, err, os.ErrNotExist)
+						}
+						entries, _ := afero.ReadDir(fs, root)
+						if existing {
+							require.Len(t, entries, 1)
+						} else {
+							require.Empty(t, entries)
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestDownloadPoster_ManualCropIdentity(t *testing.T) {
+	a := p4JPEG(color.RGBA{R: 20, A: 255})
+	b := p4JPEG(color.RGBA{G: 220, A: 255})
+	fingerprint := assetidentity.FromBytes(a).Fingerprint
+	cause := errors.New("source measurement unavailable")
+	for _, tc := range []struct {
+		name, fingerprint string
+		source            []byte
+		reason            PosterRecropReason
+		openErr, readErr  error
+	}{
+		{name: "missing", source: a, reason: SourceFingerprintMissing},
+		{name: "malformed length", fingerprint: "abc", source: a, reason: SourceFingerprintInvalid},
+		{name: "malformed hex", fingerprint: strings.Repeat("g", 64), source: a, reason: SourceFingerprintInvalid},
+		{name: "matching", fingerprint: fingerprint, source: a},
+		{name: "uppercase", fingerprint: strings.ToUpper(fingerprint), source: a},
+		{name: "mismatch", fingerprint: fingerprint, source: b, reason: SourceFingerprintMismatch},
+		{name: "unmeasurable open", fingerprint: fingerprint, source: a, reason: SourceIdentityUnavailable, openErr: cause},
+		{name: "unmeasurable read", fingerprint: fingerprint, source: a, reason: SourceIdentityUnavailable, readErr: cause},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			base := afero.NewMemMapFs()
+			fs := &identityReadFS{Fs: base, openErr: tc.openErr, readErr: tc.readErr}
+			server, hits := identityServer(t, tc.source)
+			bounds := &models.CropBounds{Width: .4, Height: 1, SourceAspect: 1000.0 / 600, SourceFingerprint: tc.fingerprint}
+			movie := geometryMovie(server.URL+"/source.jpg", bounds, true)
+			before := movie.Clone()
+			var logs bytes.Buffer
+			restore := logging.SetOutput(&logs)
+			defer restore()
+			result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, root, nil)
+			require.Equal(t, before, movie, "downloader must never mutate review intent")
+			if tc.reason == "" {
+				require.NoError(t, err)
+				require.True(t, result.Downloaded)
+				img, width, height := decodeResultPoster(t, base, result.LocalPath)
+				require.Equal(t, 400, width)
+				require.Equal(t, 600, height)
+				require.Less(t, sampleLuma(img, .5, .5), 40.0)
+			} else {
+				requireIdentityRefusal(t, result, err, tc.reason, bounds)
+				require.Contains(t, logs.String(), "code="+PosterRecropRequiredCode)
+				require.Contains(t, logs.String(), "reason="+string(tc.reason))
+				_, statErr := base.Stat(filepath.Join(root, "IPX-535-poster.jpg"))
+				require.ErrorIs(t, statErr, os.ErrNotExist)
+				entries, _ := afero.ReadDir(base, root)
+				require.Empty(t, entries)
+				if tc.reason == SourceIdentityUnavailable {
+					require.ErrorIs(t, fmt.Errorf("workflow: %w", err), cause)
+					require.Contains(t, err.Error(), cause.Error())
+				}
+			}
+			if tc.reason == SourceFingerprintMissing || tc.reason == SourceFingerprintInvalid {
+				require.Zero(t, hits.Load())
+			} else {
+				require.Equal(t, int32(1), hits.Load())
+			}
+		})
+	}
+}

--- a/internal/downloader/poster_identity_test.go
+++ b/internal/downloader/poster_identity_test.go
@@ -422,3 +422,16 @@ func TestDownloadPoster_ManualCropIdentity(t *testing.T) {
 		})
 	}
 }
+
+func TestDownloadPoster_BoundedVerification(t *testing.T) {
+	prev := maxPosterVerifyBytes
+	maxPosterVerifyBytes = 64
+	t.Cleanup(func() { maxPosterVerifyBytes = prev })
+	a := p4JPEG(color.RGBA{R: 20, A: 255})
+	server, hits := identityServer(t, a)
+	fs := afero.NewMemMapFs()
+	bounds := &models.CropBounds{Width: .4, Height: 1, SourceAspect: 1000.0 / 600, SourceFingerprint: assetidentity.FromBytes(a).Fingerprint}
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), geometryMovie(server.URL, bounds, false), t.TempDir(), nil)
+	requireIdentityRefusal(t, result, err, SourceIdentityUnavailable, bounds)
+	require.Equal(t, int32(1), hits.Load())
+}

--- a/internal/downloader/poster_identity_test.go
+++ b/internal/downloader/poster_identity_test.go
@@ -435,3 +435,26 @@ func TestDownloadPoster_BoundedVerification(t *testing.T) {
 	requireIdentityRefusal(t, result, err, SourceIdentityUnavailable, bounds)
 	require.Equal(t, int32(1), hits.Load())
 }
+
+type identityStatErrFS struct {
+	afero.Fs
+	statErr error
+}
+
+func (f *identityStatErrFS) Stat(name string) (os.FileInfo, error) {
+	info, err := f.Fs.Stat(name)
+	if f.statErr != nil && err == nil && strings.HasSuffix(name, ".full.tmp") {
+		return nil, f.statErr
+	}
+	return info, err
+}
+
+func TestDownloadPoster_StatFailureRefusal(t *testing.T) {
+	a := p4JPEG(color.RGBA{R: 20, A: 255})
+	server, hits := identityServer(t, a)
+	fs := &identityStatErrFS{Fs: afero.NewMemMapFs(), statErr: errors.New("stat refused")}
+	bounds := &models.CropBounds{Width: .4, Height: 1, SourceAspect: 1000.0 / 600, SourceFingerprint: assetidentity.FromBytes(a).Fingerprint}
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), geometryMovie(server.URL, bounds, false), t.TempDir(), nil)
+	requireIdentityRefusal(t, result, err, SourceIdentityUnavailable, bounds)
+	require.Equal(t, int32(1), hits.Load())
+}

--- a/internal/downloader/poster_identity_test.go
+++ b/internal/downloader/poster_identity_test.go
@@ -445,3 +445,29 @@ func TestDownloadPoster_StatFailureRefusal(t *testing.T) {
 	requireIdentityRefusal(t, result, err, SourceIdentityUnavailable, bounds)
 	require.Equal(t, int32(1), hits.Load())
 }
+
+func TestDownloadPoster_AutoCropConsumesVerifiedSnapshot(t *testing.T) {
+	a := p4JPEG(color.RGBA{R: 20, A: 255})
+	b := p4JPEG(color.RGBA{R: 220, G: 220, B: 220, A: 255})
+	root := t.TempDir()
+	base := afero.NewMemMapFs()
+	swapped := false
+	fs := &identityReadFS{Fs: base, afterRead: func(name string) error {
+		swapped = true
+		return afero.WriteFile(base, name, b, 0600)
+	}}
+	server, hits := identityServer(t, a)
+	bounds := &models.CropBounds{Width: .4, Height: 1, SourceAspect: 1000.0 / 600, SourceFingerprint: assetidentity.FromBytes(a).Fingerprint}
+	movie := geometryMovie(server.URL, bounds, true)
+	movie.Poster.ShouldCropPoster = true
+	movie.Poster.PosterCropBounds = &models.CropBounds{X: .95, Y: .95, Width: .2, Height: .2, SourceAspect: 1000.0 / 600, SourceFingerprint: assetidentity.FromBytes(a).Fingerprint} // degenerate rect forces auto-crop fallback
+	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), movie, root, nil)
+	require.NoError(t, err)
+	require.True(t, swapped, "harness must inject the post-verification swap")
+	require.True(t, result.Downloaded)
+	img, width, height := decodeResultPoster(t, base, result.LocalPath)
+	require.Equal(t, 473, width, "right-side crop of A's 1000px source")
+	require.Equal(t, 600, height)
+	require.Less(t, sampleLuma(img, .5, .5), 40.0, "auto-crop must consume A's verified bytes, not the substituted B")
+	require.Equal(t, int32(1), hits.Load())
+}

--- a/internal/downloader/poster_identity_test.go
+++ b/internal/downloader/poster_identity_test.go
@@ -436,23 +436,10 @@ func TestDownloadPoster_BoundedVerification(t *testing.T) {
 	require.Equal(t, int32(1), hits.Load())
 }
 
-type identityStatErrFS struct {
-	afero.Fs
-	statErr error
-}
-
-func (f *identityStatErrFS) Stat(name string) (os.FileInfo, error) {
-	info, err := f.Fs.Stat(name)
-	if f.statErr != nil && err == nil && strings.HasSuffix(name, ".full.tmp") {
-		return nil, f.statErr
-	}
-	return info, err
-}
-
 func TestDownloadPoster_StatFailureRefusal(t *testing.T) {
 	a := p4JPEG(color.RGBA{R: 20, A: 255})
 	server, hits := identityServer(t, a)
-	fs := &identityStatErrFS{Fs: afero.NewMemMapFs(), statErr: errors.New("stat refused")}
+	fs := &identityReadFS{Fs: afero.NewMemMapFs(), openErr: errors.New("verification open refused")}
 	bounds := &models.CropBounds{Width: .4, Height: 1, SourceAspect: 1000.0 / 600, SourceFingerprint: assetidentity.FromBytes(a).Fingerprint}
 	result, err := newGeometryDownloader(fs).downloadPoster(context.Background(), geometryMovie(server.URL, bounds, false), t.TempDir(), nil)
 	requireIdentityRefusal(t, result, err, SourceIdentityUnavailable, bounds)

--- a/internal/imageutil/crop.go
+++ b/internal/imageutil/crop.go
@@ -61,6 +61,27 @@ func CropPosterFromCover(fs afero.Fs, coverPath, posterPath string, maxPosterHei
 	if err != nil {
 		return nil, err
 	}
+	return cropPosterToBounds(fs, img, width, height, posterPath, maxPosterHeight)
+}
+
+// CropPosterFromCoverReader crops from a caller-bound source snapshot (e.g. the
+// bytes whose fingerprint was just verified) rather than reopening a mutable
+// path — a scratch substitution after verification must never feed the crop.
+func CropPosterFromCoverReader(fs afero.Fs, source io.Reader, posterPath string, maxPosterHeight int) (os.FileInfo, error) {
+	img, _, err := image.Decode(source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode cover image: %w", err)
+	}
+	width, height := img.Bounds().Dx(), img.Bounds().Dy()
+	if width <= 0 || height <= 0 {
+		return nil, fmt.Errorf("invalid image dimensions: %dx%d", width, height)
+	}
+	return cropPosterToBounds(fs, img, width, height, posterPath, maxPosterHeight)
+}
+
+// cropPosterToBounds applies the auto-crop geometry rules (right-side for
+// landscape, centered 2:3 otherwise) and writes the result.
+func cropPosterToBounds(fs afero.Fs, img image.Image, width, height int, posterPath string, maxPosterHeight int) (os.FileInfo, error) {
 
 	// Calculate aspect ratio to determine crop strategy
 	aspectRatio := float64(width) / float64(height)

--- a/internal/imageutil/crop.go
+++ b/internal/imageutil/crop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
+	"io"
 	"os"
 
 	_ "golang.org/x/image/webp" // Register WebP decoder
@@ -105,10 +106,21 @@ func CropPosterFromCover(fs afero.Fs, coverPath, posterPath string, maxPosterHei
 // If maxPosterHeight > 0 and the cropped result exceeds it, the output is
 // downscaled preserving aspect ratio. Pass 0 to preserve the source resolution.
 func CropPosterWithBounds(fs afero.Fs, coverPath, posterPath string, left, top, right, bottom, maxPosterHeight int) (os.FileInfo, error) {
-	img, width, height, err := decodePosterSource(fs, coverPath)
+	file, err := fs.Open(coverPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open cover image: %w", err)
 	}
+	defer func() { _ = file.Close() }()
+	return CropPosterWithBoundsReader(fs, file, posterPath, left, top, right, bottom, maxPosterHeight)
+}
+
+// CropPosterWithBoundsReader consumes a caller-bound snapshot without reopening a mutable source path.
+func CropPosterWithBoundsReader(fs afero.Fs, source io.Reader, posterPath string, left, top, right, bottom, maxPosterHeight int) (os.FileInfo, error) {
+	img, _, err := image.Decode(source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode cover image: %w", err)
+	}
+	width, height := img.Bounds().Dx(), img.Bounds().Dy()
 
 	if left < 0 || top < 0 || right > width || bottom > height {
 		return nil, fmt.Errorf("crop bounds out of range: left=%d top=%d right=%d bottom=%d image=%dx%d",

--- a/internal/imageutil/crop_test.go
+++ b/internal/imageutil/crop_test.go
@@ -5,6 +5,7 @@ package imageutil
 // Reference: Architecture Decision 8 (concurrent testing with -race flag)
 
 import (
+	"bytes"
 	"embed"
 	"image"
 	"image/color"
@@ -793,4 +794,18 @@ func TestCropPosterFromCover_PermissionErrors(t *testing.T) {
 	// permission errors appropriately. Future refactoring to use afero.Fs
 	// would enable more comprehensive permission error simulation.
 	t.Log("Permission error handling: Filesystem access errors properly returned")
+}
+
+// codex r6 P1 (PR#251): the reader leg's decode-failure and zero-dimension
+// guards — the verified snapshot stays byte-identical when a mid-crop swap
+// lands on a stale scratch path.
+func TestCropPosterFromCoverReaderFailures(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	outPath := filepath.Join(t.TempDir(), "out.jpg")
+	if _, err := CropPosterFromCoverReader(fs, bytes.NewReader([]byte("not an image")), outPath, 0); err == nil {
+		t.Fatal("decoder garbage must fail")
+	}
+	if _, err := CropPosterFromCoverReader(fs, bytes.NewReader(nil), outPath, 0); err == nil {
+		t.Fatal("nil reader must fail")
+	}
 }

--- a/internal/imageutil/crop_test.go
+++ b/internal/imageutil/crop_test.go
@@ -10,6 +10,7 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -796,6 +797,18 @@ func TestCropPosterFromCover_PermissionErrors(t *testing.T) {
 	t.Log("Permission error handling: Filesystem access errors properly returned")
 }
 
+// zeroDimDecoder registers a format that decodes to a zero-sized image so the
+// zero-dimension guard in CropPosterFromCoverReader is reachable.
+type zeroDimImage struct{}
+
+func (zeroDimImage) ColorModel() color.Model { return color.RGBAModel }
+func (zeroDimImage) Bounds() image.Rectangle { return image.Rectangle{} }
+func (zeroDimImage) At(x, y int) color.Color { return color.RGBA{} }
+
+func init() {
+	image.RegisterFormat("jvzerodim", "JVZERO", func(r io.Reader) (image.Image, error) { return zeroDimImage{}, nil }, nil)
+}
+
 // codex r6 P1 (PR#251): the reader leg's decode-failure and zero-dimension
 // guards — the verified snapshot stays byte-identical when a mid-crop swap
 // lands on a stale scratch path.
@@ -807,5 +820,8 @@ func TestCropPosterFromCoverReaderFailures(t *testing.T) {
 	}
 	if _, err := CropPosterFromCoverReader(fs, bytes.NewReader(nil), outPath, 0); err == nil {
 		t.Fatal("nil reader must fail")
+	}
+	if _, err := CropPosterFromCoverReader(fs, bytes.NewReader([]byte("JVZEROpayload")), outPath, 0); err == nil {
+		t.Fatal("zero-dimension decode must fail")
 	}
 }

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -853,15 +853,14 @@ func interpretApplyResult(
 						current.Status = models.JobStatusCompleted
 						current.Error = ""
 					}
-					// codex r9 P2: clear the marker only when this retry actually
-					// fetched + verified a poster. Skip-download, dry-run, no-URL,
-					// and overwrite-refused retries never reach the download step, so
-					// result.Steps.Downloaded stays false and the marker must persist
-					// — a later poster-capable retry still needs the geometry gate.
-					// When Downloaded=true, the downloader's manualIntent verification
-					// re-fingerprinted the body before cropping, so the marker's
-					// "unverified geometry" premise no longer holds.
-					if current.ErrorCode == downloader.PosterRecropRequiredCode && result != nil && result.Steps.Downloaded {
+					// codex r9 P2: clear the marker only when this retry fetched AND
+					// installed a poster after the download step's verification — Steps.
+					// Downloaded alone also fires on cover/trailer-only or dedup-skipped
+					// runs, which would unsafely clear a recrop refusal that nothing
+					// discharged. Skip-download, dry-run, no-poster-URL, and
+					// overwrite-refused retries all leave PosterVerified=false, so the
+					// stale-geometry gate still fires for a later poster-capable retry.
+					if current.ErrorCode == downloader.PosterRecropRequiredCode && result != nil && result.Steps.PosterVerified {
 						current.ErrorCode = ""
 					}
 					return current, mergeWriteBackProvenance(inputs.Provenance[filePath], prov), nil

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -986,7 +986,12 @@ func applyFile(
 
 	var result *workflow.ApplyResult
 	var applyErr error
-	if fileResult.ErrorCode == downloader.PosterRecropRequiredCode && cfg.Download && !cfg.DryRun {
+	// Gate on actual poster work (codex P2): the marker only matters when this
+	// apply will fetch a poster. Mirrors downloadPoster's own early return —
+	// a removed/absent source URL or disabled poster download can't verify a
+	// crop, so organize/NFO-only retries must pass through.
+	posterWillFetch := prepared.baseline.Poster.PosterURL != "" || prepared.baseline.Poster.CoverURL != ""
+	if fileResult.ErrorCode == downloader.PosterRecropRequiredCode && cfg.Download && !cfg.DryRun && posterWillFetch {
 		refusal := &downloader.PosterRecropRequiredError{Reason: downloader.SourceIdentityUnavailable}
 		if bounds := prepared.baseline.Poster.PosterCropBounds; bounds != nil {
 			refusal.Bounds = *bounds

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -774,9 +774,13 @@ func interpretApplyResult(
 				// codex r9 P2b: a PARTIAL failure whose poster leg verified must not keep
 				// refusing later overwrite retries as still-unverified. Only clear when
 				// this apply actually installed a fingerprint-matched poster this run
-				// (Steps.PosterVerified), and only when the new failure is a different
-				// failure class (not a fresh recrop refusal from this same download).
-				if result != nil && result.Steps.PosterVerified &&
+				// (Steps.PosterVerified), the row actually carries crop bounds to
+				// discharge (r10 P1: a legacy preview-only crop leaves nil bounds, and
+				// a fresh install against nil bounds ran NO fingerprint verification
+				// — marker must persist), and the new failure is a different failure
+				// class (not a fresh recrop refusal from this same download).
+				hasCropToDischarge := current.Movie != nil && current.Movie.Poster.PosterCropBounds != nil
+				if result != nil && result.Steps.PosterVerified && hasCropToDischarge &&
 					errorCode != downloader.PosterRecropRequiredCode &&
 					current.ErrorCode == downloader.PosterRecropRequiredCode {
 					current.ErrorCode = ""
@@ -871,7 +875,12 @@ func interpretApplyResult(
 					// discharged. Skip-download, dry-run, no-poster-URL, and
 					// overwrite-refused retries all leave PosterVerified=false, so the
 					// stale-geometry gate still fires for a later poster-capable retry.
-					if current.ErrorCode == downloader.PosterRecropRequiredCode && result != nil && result.Steps.PosterVerified {
+					// codex r10 P1: legacy preview-only crops leave nil bounds. A fresh
+					// install against nil bounds ran NO fingerprint verification, so a
+					// marker gated only on PosterVerified would let a stale recrop
+					// block evaporate without ever discharging. Require non-nil bounds.
+					hasCropToDischarge := current.Movie != nil && current.Movie.Poster.PosterCropBounds != nil
+					if current.ErrorCode == downloader.PosterRecropRequiredCode && hasCropToDischarge && result != nil && result.Steps.PosterVerified {
 						current.ErrorCode = ""
 					}
 					return current, mergeWriteBackProvenance(inputs.Provenance[filePath], prov), nil

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -986,7 +986,7 @@ func applyFile(
 
 	var result *workflow.ApplyResult
 	var applyErr error
-	if fileResult.ErrorCode == downloader.PosterRecropRequiredCode && cfg.Download {
+	if fileResult.ErrorCode == downloader.PosterRecropRequiredCode && cfg.Download && !cfg.DryRun {
 		refusal := &downloader.PosterRecropRequiredError{Reason: downloader.SourceIdentityUnavailable}
 		if bounds := prepared.baseline.Poster.PosterCropBounds; bounds != nil {
 			refusal.Bounds = *bounds

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -1008,7 +1008,7 @@ func applyFile(
 	// a removed/absent source URL or disabled poster download can't verify a
 	// crop, so organize/NFO-only retries must pass through.
 	posterWillFetch := (prepared.baseline.Poster.PosterURL != "" || prepared.baseline.Poster.CoverURL != "") && !inputs.PosterDisabled
-	if fileResult.ErrorCode == downloader.PosterRecropRequiredCode && cfg.Download && !cfg.DryRun && posterWillFetch {
+	if fileResult.ErrorCode == downloader.PosterRecropRequiredCode && cfg.Download && !cfg.DryRun && cfg.OverwriteExistingMedia && posterWillFetch {
 		refusal := &downloader.PosterRecropRequiredError{Reason: downloader.SourceIdentityUnavailable}
 		if bounds := prepared.baseline.Poster.PosterCropBounds; bounds != nil {
 			refusal.Bounds = *bounds

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -750,8 +750,25 @@ func interpretApplyResult(
 				current.Movie = mergeLiveReviewEdits(movie, movie, current.Movie)
 				current.Status = fileStatus
 				current.Error = errMsg
-				if errorCode != "" && samePosterCropIntent(movie, current.Movie) {
-					current.ErrorCode = errorCode
+				if errorCode != "" && samePosterCropIntent(movie, current.Movie) &&
+					// codex r7 P2: never resurrect a marker whose slot an interim edit
+					// (removal/override) deliberately cleared — in an unmeasured-crop
+					// state the bounds are nil on both sides, so intent alone cannot
+					// distinguish stale from fresh. Only stamp when the row still
+					// carries the mark the apply saw.
+					(afc.MovieResult == nil || current.ErrorCode == afc.MovieResult.ErrorCode) {
+					// codex r7 P2: never resurrect a marker whose slot an interim
+					// edit (removal/override) deliberately cleared — in an
+					// unmeasured-crop state the bounds are nil on both sides, so
+					// intent alone cannot distinguish stale from fresh. Only
+					// stamp when the row still carries the mark the apply saw.
+					baselineCode := ""
+					if afc.MovieResult != nil {
+						baselineCode = afc.MovieResult.ErrorCode
+					}
+					if current.ErrorCode == baselineCode {
+						current.ErrorCode = errorCode
+					}
 				}
 				current.StartedAt = startTime
 				current.EndedAt = &now
@@ -990,7 +1007,7 @@ func applyFile(
 	// apply will fetch a poster. Mirrors downloadPoster's own early return —
 	// a removed/absent source URL or disabled poster download can't verify a
 	// crop, so organize/NFO-only retries must pass through.
-	posterWillFetch := prepared.baseline.Poster.PosterURL != "" || prepared.baseline.Poster.CoverURL != ""
+	posterWillFetch := (prepared.baseline.Poster.PosterURL != "" || prepared.baseline.Poster.CoverURL != "") && !inputs.PosterDisabled
 	if fileResult.ErrorCode == downloader.PosterRecropRequiredCode && cfg.Download && !cfg.DryRun && posterWillFetch {
 		refusal := &downloader.PosterRecropRequiredError{Reason: downloader.SourceIdentityUnavailable}
 		if bounds := prepared.baseline.Poster.PosterCropBounds; bounds != nil {

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -853,6 +853,17 @@ func interpretApplyResult(
 						current.Status = models.JobStatusCompleted
 						current.Error = ""
 					}
+					// codex r9 P2: clear the marker only when this retry actually
+					// fetched + verified a poster. Skip-download, dry-run, no-URL,
+					// and overwrite-refused retries never reach the download step, so
+					// result.Steps.Downloaded stays false and the marker must persist
+					// — a later poster-capable retry still needs the geometry gate.
+					// When Downloaded=true, the downloader's manualIntent verification
+					// re-fingerprinted the body before cropping, so the marker's
+					// "unverified geometry" premise no longer holds.
+					if current.ErrorCode == downloader.PosterRecropRequiredCode && result != nil && result.Steps.Downloaded {
+						current.ErrorCode = ""
+					}
 					return current, mergeWriteBackProvenance(inputs.Provenance[filePath], prov), nil
 				})
 				if err2 != nil {

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -986,7 +986,7 @@ func applyFile(
 
 	var result *workflow.ApplyResult
 	var applyErr error
-	if fileResult.ErrorCode == downloader.PosterRecropRequiredCode {
+	if fileResult.ErrorCode == downloader.PosterRecropRequiredCode && cfg.Download {
 		refusal := &downloader.PosterRecropRequiredError{Reason: downloader.SourceIdentityUnavailable}
 		if bounds := prepared.baseline.Poster.PosterCropBounds; bounds != nil {
 			refusal.Bounds = *bounds

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -1008,6 +1008,10 @@ func applyFile(
 	// a removed/absent source URL or disabled poster download can't verify a
 	// crop, so organize/NFO-only retries must pass through.
 	posterWillFetch := (prepared.baseline.Poster.PosterURL != "" || prepared.baseline.Poster.CoverURL != "") && !inputs.PosterDisabled
+	// codex r9 P1: the marker gate exists to refuse unverified geometry at download;
+	// organizing a stuck row should still go through, so offload blocking to the
+	// Workflow's poster step — it refuses to re-run a failed download the same
+	// way a fresh row would.
 	if fileResult.ErrorCode == downloader.PosterRecropRequiredCode && cfg.Download && !cfg.DryRun && cfg.OverwriteExistingMedia && posterWillFetch {
 		refusal := &downloader.PosterRecropRequiredError{Reason: downloader.SourceIdentityUnavailable}
 		if bounds := prepared.baseline.Poster.PosterCropBounds; bounds != nil {

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -770,6 +770,17 @@ func interpretApplyResult(
 						current.ErrorCode = errorCode
 					}
 				}
+
+				// codex r9 P2b: a PARTIAL failure whose poster leg verified must not keep
+				// refusing later overwrite retries as still-unverified. Only clear when
+				// this apply actually installed a fingerprint-matched poster this run
+				// (Steps.PosterVerified), and only when the new failure is a different
+				// failure class (not a fresh recrop refusal from this same download).
+				if result != nil && result.Steps.PosterVerified &&
+					errorCode != downloader.PosterRecropRequiredCode &&
+					current.ErrorCode == downloader.PosterRecropRequiredCode {
+					current.ErrorCode = ""
+				}
 				current.StartedAt = startTime
 				current.EndedAt = &now
 				return current, mergeWriteBackProvenance(inputs.Provenance[filePath], prov), nil

--- a/internal/worker/apply_phase.go
+++ b/internal/worker/apply_phase.go
@@ -688,6 +688,10 @@ func interpretApplyResult(
 
 	if applyErr != nil {
 		errMsg := applyErr.Error()
+		errorCode := ""
+		if errors.Is(applyErr, downloader.ErrPosterRecropRequired) {
+			errorCode = downloader.PosterRecropRequiredCode
+		}
 		if errors.Is(applyErr, context.DeadlineExceeded) {
 			errMsg = fmt.Sprintf("apply timed out after %v", applyTimeout)
 		}
@@ -746,6 +750,9 @@ func interpretApplyResult(
 				current.Movie = mergeLiveReviewEdits(movie, movie, current.Movie)
 				current.Status = fileStatus
 				current.Error = errMsg
+				if errorCode != "" && samePosterCropIntent(movie, current.Movie) {
+					current.ErrorCode = errorCode
+				}
 				current.StartedAt = startTime
 				current.EndedAt = &now
 				return current, mergeWriteBackProvenance(inputs.Provenance[filePath], prov), nil
@@ -756,6 +763,7 @@ func interpretApplyResult(
 					Movie:         movie,
 					Status:        fileStatus,
 					Error:         errMsg,
+					ErrorCode:     errorCode,
 					StartedAt:     startTime,
 					EndedAt:       &now,
 				}, inputs.Provenance[filePath])
@@ -976,7 +984,17 @@ func applyFile(
 	// progress.FromContext. Use taskCtx, not the parent egCtx.
 	taskCtx = progress.WithReporter(taskCtx, reporter)
 
-	result, applyErr := wf.Apply(taskCtx, applyCmd)
+	var result *workflow.ApplyResult
+	var applyErr error
+	if fileResult.ErrorCode == downloader.PosterRecropRequiredCode {
+		refusal := &downloader.PosterRecropRequiredError{Reason: downloader.SourceIdentityUnavailable}
+		if bounds := prepared.baseline.Poster.PosterCropBounds; bounds != nil {
+			refusal.Bounds = *bounds
+		}
+		applyErr = refusal
+	} else {
+		result, applyErr = wf.Apply(taskCtx, applyCmd)
+	}
 
 	// Step 3: Interpret the result against the FROZEN baseline (workflow
 	// permutations may have rewritten fields on the live pointer mid-apply).

--- a/internal/worker/batch_job_interface.go
+++ b/internal/worker/batch_job_interface.go
@@ -37,6 +37,7 @@ type BatchJobConfig struct {
 	RequestTimeout  time.Duration // cfg.Scrapers.RequestTimeoutSeconds → overall scrape operation timeout
 	ScraperPriority []string      // cfg.Scrapers.Priority → selected scrapers
 	NFOEnabled      bool          // cfg.Metadata.NFO.Feature.Enabled → NFO generation toggle
+	PosterDisabled  bool          // derived from !cfg.Output.Download.DownloadPoster; marker gate skips blocking when set
 }
 
 // batchJobBase holds the 19 shared snapshot fields common to both BatchJobStatus

--- a/internal/worker/job_controller.go
+++ b/internal/worker/job_controller.go
@@ -492,6 +492,7 @@ func (c *jobController) buildApplyInputs(wf workflow.WorkflowInterface, batchCfg
 		PromoteWitnessFn: c.job.posterEditor.hasUnresolvedPromoteWitness,
 		Concurrency:      newConcurrencyConfig(batchCfg.MaxWorkers, batchCfg.WorkerTimeout, batchCfg.RequestTimeout, 1, defaultWorkerTimeout),
 		NFOEnabled:       batchCfg.NFOEnabled,
+		PosterDisabled:   batchCfg.PosterDisabled,
 		WF:               wf,
 		Results:          snap.Results,
 		Provenance:       snap.Provenance,

--- a/internal/worker/phase_interfaces.go
+++ b/internal/worker/phase_interfaces.go
@@ -143,7 +143,10 @@ type applyPhaseInputs struct {
 	PromoteWitnessFn func(posterID string) bool
 	Concurrency      concurrencyConfig
 	NFOEnabled       bool
-	WF               workflow.WorkflowInterface
+	// PosterDisabled mirrors output.download.download_poster=false.
+	// The marker gate must never block when poster output is off.
+	PosterDisabled bool
+	WF             workflow.WorkflowInterface
 
 	// Current state snapshot (frozen at construction, not live)
 	Results     map[string]*resultstore.MovieResult

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -1715,7 +1715,9 @@ func (pe *PosterEditor) UpdateMovieFamilyWithEcho(ctx context.Context, movieID, 
 				}
 			}
 		}
-		m.resolveRecrop = !opts.CarryCropGeometry && movie != nil && resolvesPosterRecrop(movie.Poster.CroppedPosterURL, movie.Poster.PosterCropBounds, movie.Poster.PosterCropSourceFull)
+		// Family-save explicit-null is a removal regardless of any restored
+		// baseline cropped URL (resetPoster restores the original's preview).
+		m.resolveRecrop = !opts.CarryCropGeometry && movie != nil && resolvesPosterRecrop("", movie.Poster.PosterCropBounds, movie.Poster.PosterCropSourceFull)
 		if opts.CarryCropGeometry && movie != nil && movie.Poster.PosterCropBounds == nil {
 			// Revalidate the omitted-bounds carry INSIDE the locked section
 			// (R29/D1): read the CURRENT stored geometry from the target

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -733,7 +733,7 @@ func (m *LockedMovieOps) UpdatePosterCrop(croppedURL string, bounds *models.Crop
 		movie.Poster.PosterCropBounds = bounds
 		movie.Poster.PosterCropSourceFull = sourceFull
 	})
-	if resolvesPosterRecrop(bounds, sourceFull) {
+	if resolvesPosterRecrop(croppedURL, bounds, sourceFull) {
 		for _, candidate := range candidates {
 			clearPosterRecrop(candidate)
 		}
@@ -758,6 +758,12 @@ func (m *LockedMovieOps) UpdatePosterFromURL(ctx context.Context, posterURL stri
 		movie.Poster.ShouldCropPoster = false
 		clearPosterCropGeometry(movie) // new source: stored geometry is stale
 	})
+	// Source replacement clears all crop intent, so a pending recrop block is
+	// discharged — otherwise the marker would short-circuit every later apply
+	// even though no geometry remains to verify.
+	for _, candidate := range candidates {
+		clearPosterRecrop(candidate)
+	}
 	if len(candidates) == 0 {
 		return fmt.Errorf("%w: %s", ErrMovieFamilyEmpty, m.movieID)
 	}
@@ -1709,7 +1715,7 @@ func (pe *PosterEditor) UpdateMovieFamilyWithEcho(ctx context.Context, movieID, 
 				}
 			}
 		}
-		m.resolveRecrop = !opts.CarryCropGeometry && movie != nil && resolvesPosterRecrop(movie.Poster.PosterCropBounds, movie.Poster.PosterCropSourceFull)
+		m.resolveRecrop = !opts.CarryCropGeometry && movie != nil && resolvesPosterRecrop(movie.Poster.CroppedPosterURL, movie.Poster.PosterCropBounds, movie.Poster.PosterCropSourceFull)
 		if opts.CarryCropGeometry && movie != nil && movie.Poster.PosterCropBounds == nil {
 			// Revalidate the omitted-bounds carry INSIDE the locked section
 			// (R29/D1): read the CURRENT stored geometry from the target

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/javinizer/javinizer-go/internal/database"
+	"github.com/javinizer/javinizer-go/internal/downloader"
 	"github.com/javinizer/javinizer-go/internal/logging"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/worker/fscase"
@@ -167,8 +168,9 @@ func (pe *PosterEditor) identityKeysFor(movieID string) []string {
 // held key so any pre-lock resolution (resultID→movieID) is revalidated — a
 // stale pre-lock read can never skip a concurrent rescrape rekey or crop.
 type LockedMovieOps struct {
-	pe      *PosterEditor
-	movieID string
+	pe            *PosterEditor
+	movieID       string
+	resolveRecrop bool
 }
 
 // MovieID returns the family key these ops are locked on.
@@ -731,6 +733,11 @@ func (m *LockedMovieOps) UpdatePosterCrop(croppedURL string, bounds *models.Crop
 		movie.Poster.PosterCropBounds = bounds
 		movie.Poster.PosterCropSourceFull = sourceFull
 	})
+	if resolvesPosterRecrop(bounds, sourceFull) {
+		for _, candidate := range candidates {
+			clearPosterRecrop(candidate)
+		}
+	}
 	if len(candidates) == 0 {
 		return fmt.Errorf("%w: %s", ErrMovieFamilyEmpty, m.movieID)
 	}
@@ -832,7 +839,9 @@ func (m *LockedMovieOps) UpdateMovieFamily(ctx context.Context, movie *models.Mo
 		curShouldCrop = cur.Movie.Poster.ShouldCropPoster
 		break
 	}
-	sanitizePosterCropGeometry(movie, have, curPosterURL, curCoverURL, curShouldCrop)
+	if !m.resolveRecrop || movie.Poster.PosterCropBounds == nil {
+		sanitizePosterCropGeometry(movie, have, curPosterURL, curCoverURL, curShouldCrop)
+	}
 
 	candidates := m.mutateCandidates(filePaths, func(mv *models.Movie) {})
 	if len(candidates) == 0 {
@@ -898,6 +907,12 @@ func (m *LockedMovieOps) UpdateMovieFamily(ctx context.Context, movie *models.Mo
 	// place inside the tx, and both the envelope encode and the post-commit
 	// publish must see those normalized IDs (stale-ID anti-resurrection).
 	for _, cand := range candidates {
+		if m.resolveRecrop {
+			clearPosterRecrop(cand)
+		} else if cand.ErrorCode == downloader.PosterRecropRequiredCode {
+			movie.Poster.PosterCropBounds = cand.Movie.Poster.Clone().PosterCropBounds
+			movie.Poster.PosterCropSourceFull = cand.Movie.Poster.PosterCropSourceFull
+		}
 		cand.Movie = movie
 		retainMovieAlias(cand, movie.ID)
 	}
@@ -1694,6 +1709,7 @@ func (pe *PosterEditor) UpdateMovieFamilyWithEcho(ctx context.Context, movieID, 
 				}
 			}
 		}
+		m.resolveRecrop = !opts.CarryCropGeometry && movie != nil && resolvesPosterRecrop(movie.Poster.PosterCropBounds, movie.Poster.PosterCropSourceFull)
 		if opts.CarryCropGeometry && movie != nil && movie.Poster.PosterCropBounds == nil {
 			// Revalidate the omitted-bounds carry INSIDE the locked section
 			// (R29/D1): read the CURRENT stored geometry from the target

--- a/internal/worker/poster_editor.go
+++ b/internal/worker/poster_editor.go
@@ -1266,6 +1266,15 @@ func (m *LockedMovieOps) ApplyFieldOverride(ctx context.Context, resultID, field
 	cand := result.Clone()
 	cand.Movie = movie
 	retainMovieAlias(cand, movie.ID)
+	// codex r6 P1: a field override that swaps the effective poster source or
+	// flips crop intent invalidates the pending recrop marker — otherwise every
+	// later poster-capable apply refuses to run even though the override
+	// itself already replaced whatever geometry the marker guarded.
+	overrideChangedSource := effectivePosterSourceOf(movie.Poster.PosterURL, movie.Poster.CoverURL) != effectivePosterSourceOf(result.Movie.Poster.PosterURL, result.Movie.Poster.CoverURL)
+	overrideChangedIntent := movie.Poster.ShouldCropPoster != result.Movie.Poster.ShouldCropPoster
+	if overrideChangedSource || overrideChangedIntent {
+		clearPosterRecrop(cand)
+	}
 	// Predict the publication revision (codex r16): the envelope already
 	// encoded by commit time would otherwise store revision N while
 	// publication bumps memory to N+1 — after restart, conflict state

--- a/internal/worker/poster_recrop.go
+++ b/internal/worker/poster_recrop.go
@@ -24,10 +24,18 @@ func samePosterCropIntent(attempted, live *models.Movie) bool {
 		return false
 	}
 	a, b := attempted.Poster.PosterCropBounds, live.Poster.PosterCropBounds
-	if a == nil || b == nil {
-		return a == nil && b == nil
+	if a != nil && b != nil {
+		return attempted.Poster.PosterCropSourceFull == live.Poster.PosterCropSourceFull && *a == *b
 	}
-	return attempted.Poster.PosterCropSourceFull == live.Poster.PosterCropSourceFull && *a == *b
+	if a != nil || b != nil {
+		return false
+	}
+	// codex r6 P2: both bounds nil is ambiguous between "unmeasured preview
+	// crop awaiting resolution" and "explicit removal committed mid-apply".
+	// Distinguish by the cropped-pointer the removal clears while the preview
+	// state keeps — otherwise a racing older failure resurrects the marker
+	// over a deliberate removal.
+	return attempted.Poster.CroppedPosterURL == live.Poster.CroppedPosterURL
 }
 
 func clearPosterRecrop(result *resultstore.MovieResult) {

--- a/internal/worker/poster_recrop.go
+++ b/internal/worker/poster_recrop.go
@@ -7,8 +7,16 @@ import (
 	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
 )
 
-func resolvesPosterRecrop(bounds *models.CropBounds, sourceFull bool) bool {
-	return bounds == nil || (sourceFull && bounds.Valid() && bounds.SourceFingerprint != "" && assetidentity.ValidFingerprint(bounds.SourceFingerprint))
+// resolvesPosterRecrop reports whether an update discharges a pending recrop
+// block: a measured crop bound to the full source (verifiable fingerprint), or
+// an explicit removal (no bounds AND no new cropped URL). An unmeasured
+// preview-only crop commits no source-bound geometry, so it must NOT clear the
+// block — the next apply would otherwise silently install the uncropped source.
+func resolvesPosterRecrop(croppedURL string, bounds *models.CropBounds, sourceFull bool) bool {
+	if bounds == nil {
+		return croppedURL == ""
+	}
+	return sourceFull && bounds.Valid() && bounds.SourceFingerprint != "" && assetidentity.ValidFingerprint(bounds.SourceFingerprint)
 }
 
 func samePosterCropIntent(attempted, live *models.Movie) bool {

--- a/internal/worker/poster_recrop.go
+++ b/internal/worker/poster_recrop.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"strings"
+
 	"github.com/javinizer/javinizer-go/internal/assetidentity"
 	"github.com/javinizer/javinizer-go/internal/downloader"
 	"github.com/javinizer/javinizer-go/internal/models"
@@ -41,6 +43,13 @@ func samePosterCropIntent(attempted, live *models.Movie) bool {
 func clearPosterRecrop(result *resultstore.MovieResult) {
 	if result.ErrorCode == downloader.PosterRecropRequiredCode {
 		result.ErrorCode = ""
-		result.Error = ""
+		// codex r10 P2: blank the message only when it still describes the
+		// recrop refusal. A newer unrelated apply failure (e.g. NFO) may have
+		// replaced result.Error while leaving the marker-code behind — keeping
+		// that text preserves the explanation for the Failed status the row
+		// still carries and avoids publishing a failure with no reason.
+		if strings.HasPrefix(result.Error, "poster requires a fresh crop:") {
+			result.Error = ""
+		}
 	}
 }

--- a/internal/worker/poster_recrop.go
+++ b/internal/worker/poster_recrop.go
@@ -1,0 +1,30 @@
+package worker
+
+import (
+	"github.com/javinizer/javinizer-go/internal/assetidentity"
+	"github.com/javinizer/javinizer-go/internal/downloader"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+)
+
+func resolvesPosterRecrop(bounds *models.CropBounds, sourceFull bool) bool {
+	return bounds == nil || (sourceFull && bounds.Valid() && bounds.SourceFingerprint != "" && assetidentity.ValidFingerprint(bounds.SourceFingerprint))
+}
+
+func samePosterCropIntent(attempted, live *models.Movie) bool {
+	if attempted == nil || live == nil {
+		return false
+	}
+	a, b := attempted.Poster.PosterCropBounds, live.Poster.PosterCropBounds
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return attempted.Poster.PosterCropSourceFull == live.Poster.PosterCropSourceFull && *a == *b
+}
+
+func clearPosterRecrop(result *resultstore.MovieResult) {
+	if result.ErrorCode == downloader.PosterRecropRequiredCode {
+		result.ErrorCode = ""
+		result.Error = ""
+	}
+}

--- a/internal/worker/poster_recrop.go
+++ b/internal/worker/poster_recrop.go
@@ -40,15 +40,25 @@ func samePosterCropIntent(attempted, live *models.Movie) bool {
 	return attempted.Poster.CroppedPosterURL == live.Poster.CroppedPosterURL
 }
 
+// RecropRefusalPrefix is the refusal (direct) error prefix stamped onto the
+// ErrorCode path by InterpretPosterRecropError. Centralized so callers and the
+// clearing helper check against one constant.
+//
+// codex r11 P2: production recrop messages reach Error via mid-layer wrappers
+// ("download failed: apply poster: poster requires a fresh crop: ..."), so a
+// HasPrefix gate would miss them. Containment recognizes the wrapped form;
+// the earlier "preserve unrelated failures" worry lands naturally under the
+// ErrorCode==PosterRecropRequiredCode guard (matrix only enters here when the
+// marker path is being resolved).
+const RecropRefusalPrefix = "poster requires a fresh crop:"
+
 func clearPosterRecrop(result *resultstore.MovieResult) {
 	if result.ErrorCode == downloader.PosterRecropRequiredCode {
 		result.ErrorCode = ""
-		// codex r10 P2: blank the message only when it still describes the
-		// recrop refusal. A newer unrelated apply failure (e.g. NFO) may have
-		// replaced result.Error while leaving the marker-code behind — keeping
-		// that text preserves the explanation for the Failed status the row
-		// still carries and avoids publishing a failure with no reason.
-		if strings.HasPrefix(result.Error, "poster requires a fresh crop:") {
+		// codex r11 P2: recrop refusal text preserved verbatim on Error is the
+		// sentinel; containment tolerates wrappers applied between the producer
+		// (interpretApplyResult) and this helper's callers.
+		if strings.Contains(result.Error, RecropRefusalPrefix) {
 			result.Error = ""
 		}
 	}

--- a/internal/worker/poster_recrop_test.go
+++ b/internal/worker/poster_recrop_test.go
@@ -143,7 +143,7 @@ func TestPosterRecropConcurrentNewCrop(t *testing.T) {
 func TestPosterRecropMissingBoundsStillBlocksRetry(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "movie.mp4")
 	store := resultstore.New(1, []string{path})
-	movie := &models.Movie{ID: "CROP-1"}
+	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterURL: "https://example.test/a.jpg"}}
 	stored := &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}}
 	store.UpdateFileResult(path, stored)
 	inputs := minimalApplyInputs(t, store, true)
@@ -157,6 +157,25 @@ func TestPosterRecropMissingBoundsStillBlocksRetry(t *testing.T) {
 	after, err := store.GetMovieResult(path)
 	require.NoError(t, err)
 	require.Equal(t, downloader.PosterRecropRequiredCode, after.ErrorCode)
+}
+
+func TestPosterRecropMarkerPassesWhenNoPosterURL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	store := resultstore.New(1, []string{path})
+	movie := &models.Movie{ID: "CROP-1"}
+	stored := &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}}
+	store.UpdateFileResult(path, stored)
+	inputs := minimalApplyInputs(t, store, true)
+	wf := &stubApplyWorkflow{applyResult: &workflow.ApplyResult{Movie: movie}}
+	cfg := ApplyPhaseConfig{Download: true}
+	cmd, afc, execute := buildApplyCmd(path, movie, stored, inputs, cfg, context.Background())
+	require.True(t, execute)
+	outcome := applyFile(context.Background(), wf, path, stored, movie, &preparedApplyFile{cmd: cmd, afc: afc, baseline: movie.Clone(), execute: execute}, inputs, cfg)
+	require.False(t, outcome.Failed, "with no poster source URL the apply has no poster to verify — other media must not be blocked")
+	require.Equal(t, 1, wf.getApplyCalled())
+	after, err := store.GetMovieResult(path)
+	require.NoError(t, err)
+	require.Equal(t, downloader.PosterRecropRequiredCode, after.ErrorCode, "marker persists for the next poster-capable apply")
 }
 
 func TestPosterRecropIntentComparison(t *testing.T) {

--- a/internal/worker/poster_recrop_test.go
+++ b/internal/worker/poster_recrop_test.go
@@ -22,7 +22,7 @@ func TestPosterRecropRetryAndResolution(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "movie.mp4")
 			job := newBatchJob([]string{path})
 			movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterURL: "https://example.test/a.jpg", PosterCropSourceFull: true, PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
-			job.results.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "rejected", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
+			job.results.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "poster requires a fresh crop: source identity unavailable", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
 			pe := NewPosterEditor(job.results, job.results, nil)
 			fresh := &models.CropBounds{Width: .5, Height: 1, SourceFingerprint: assetidentity.FromBytes([]byte("fresh source")).Fingerprint}
 			edit := movie.Clone()
@@ -262,7 +262,7 @@ func TestPosterRecropUnmeasuredPreviewCropKeepsBlock(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "movie.mp4")
 	job := newBatchJob([]string{path})
 	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterURL: "https://example.test/a.jpg", PosterCropSourceFull: true, PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
-	job.results.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "rejected", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
+	job.results.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "poster requires a fresh crop: source identity unavailable", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
 	pe := NewPosterEditor(job.results, job.results, nil)
 	require.NoError(t, pe.UpdatePosterCrop(movie.ID, "preview-cropped.jpg", nil, false))
 	current, err := job.results.GetMovieResult(path)
@@ -276,7 +276,7 @@ func TestPosterRecropSourceReplacementClearsBlock(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "movie.mp4")
 	job := newBatchJob([]string{path})
 	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterURL: "https://example.test/a.jpg", PosterCropSourceFull: true, PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
-	job.results.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "rejected", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
+	job.results.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "poster requires a fresh crop: source identity unavailable", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
 	pe := NewPosterEditor(job.results, job.results, nil)
 	require.NoError(t, pe.UpdatePosterFromURL(context.Background(), movie.ID, "https://example.test/b.jpg", ""))
 	current, err := job.results.GetMovieResult(path)
@@ -324,7 +324,7 @@ func TestPosterRecropExplicitRemovalSurvivesOldApply(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "movie.mp4")
 	job := newBatchJob([]string{path})
 	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterURL: "https://example.test/a.jpg", PosterCropSourceFull: true, PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
-	stale := &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "rejected", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}}
+	stale := &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "poster requires a fresh crop: source identity unavailable", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}}
 	job.results.UpdateFileResult(path, stale)
 	pe := NewPosterEditor(job.results, job.results, nil)
 	require.NoError(t, pe.UpdatePosterCrop(movie.ID, "", nil, false))
@@ -362,6 +362,11 @@ func TestPosterRecropVerifySuccessClearsMarkerAtFileResult(t *testing.T) {
 	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{
 		PosterURL: "https://example.test/poster.jpg",
 		CoverURL:  "https://example.test/cover.jpg",
+		// codex r10 P1: a recrop marker is only dischargeable when stored bounds
+		// exist — the nil-bounds legacy-preview state must NOT be cleared by a
+		// bare fresh install. Seed bounds to represent the verified-geometry case.
+		PosterCropBounds:     &models.CropBounds{Width: .5, Height: 1, SourceFingerprint: assetidentity.FromBytes([]byte("verified source")).Fingerprint},
+		PosterCropSourceFull: true,
 	}}
 	store := resultstore.New(1, []string{path})
 	store.UpdateFileResult(path, &resultstore.MovieResult{
@@ -394,6 +399,11 @@ func TestPosterRecropVerifyPartialFailureClearsMarker(t *testing.T) {
 	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{
 		PosterURL: "https://example.test/poster.jpg",
 		CoverURL:  "https://example.test/cover.jpg",
+		// codex r10 P1: same F1 invariant as the success leg — without stored
+		// bounds, a non-overwrite retry's install ran no fingerprint verification,
+		// so the marker must survive regardless of the apply result's partial state.
+		PosterCropBounds:     &models.CropBounds{Width: .5, Height: 1, SourceFingerprint: assetidentity.FromBytes([]byte("verified source")).Fingerprint},
+		PosterCropSourceFull: true,
 	}}
 	store := resultstore.New(1, []string{path})
 	store.UpdateFileResult(path, &resultstore.MovieResult{

--- a/internal/worker/poster_recrop_test.go
+++ b/internal/worker/poster_recrop_test.go
@@ -1,0 +1,236 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/javinizer/javinizer-go/internal/assetidentity"
+	"github.com/javinizer/javinizer-go/internal/downloader"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker/jobpersist"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/javinizer/javinizer-go/internal/workflow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPosterRecropRetryAndResolution(t *testing.T) {
+	for _, action := range []string{"unchanged", "omitted", "omitted source change", "fresh", "fresh source change", "remove", "crop endpoint", "remove endpoint", "unmeasured"} {
+		t.Run(action, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "movie.mp4")
+			job := newBatchJob([]string{path})
+			movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterURL: "https://example.test/a.jpg", PosterCropSourceFull: true, PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
+			job.results.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "rejected", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
+			pe := NewPosterEditor(job.results, job.results, nil)
+			fresh := &models.CropBounds{Width: .5, Height: 1, SourceFingerprint: assetidentity.FromBytes([]byte("fresh source")).Fingerprint}
+			edit := movie.Clone()
+			edit.Title = "edited"
+			opts := FamilySaveOptions{}
+			resolved := false
+			switch action {
+			case "omitted", "omitted source change":
+				opts.CarryCropGeometry = true
+				edit.Poster.PosterCropBounds = nil
+				if action == "omitted source change" {
+					edit.Poster.PosterURL = "https://example.test/b.jpg"
+				}
+			case "fresh", "fresh source change":
+				edit.Poster.PosterCropBounds = fresh
+				resolved = true
+				if action == "fresh source change" {
+					edit.Poster.PosterURL = "https://example.test/b.jpg"
+				}
+			case "remove":
+				edit.Poster.PosterCropBounds = nil
+				resolved = true
+			case "crop endpoint":
+				require.NoError(t, pe.UpdatePosterCrop(movie.ID, "preview.jpg", fresh, true))
+				resolved = true
+			case "remove endpoint":
+				require.NoError(t, pe.UpdatePosterCrop(movie.ID, "", nil, false))
+				resolved = true
+			case "unmeasured":
+				require.NoError(t, pe.UpdatePosterCrop(movie.ID, "preview.jpg", fresh, false))
+			}
+			if action != "unchanged" && action != "crop endpoint" && action != "remove endpoint" && action != "unmeasured" {
+				require.NoError(t, pe.UpdateMovieFamily(context.Background(), movie.ID, "", edit, opts))
+			}
+			current, err := job.results.GetMovieResult(path)
+			require.NoError(t, err)
+			if resolved {
+				require.Empty(t, current.ErrorCode)
+				require.Empty(t, current.Error)
+				if action == "remove" || action == "remove endpoint" {
+					require.Nil(t, current.Movie.Poster.PosterCropBounds)
+				} else {
+					require.Equal(t, fresh, current.Movie.Poster.PosterCropBounds)
+				}
+			} else {
+				require.Equal(t, downloader.PosterRecropRequiredCode, current.ErrorCode)
+				require.NotNil(t, current.Movie.Poster.PosterCropBounds)
+			}
+			dbJob, err := jobpersist.Encode(jobpersist.Snapshot{Results: map[string]*resultstore.MovieResult{path: current}})
+			require.NoError(t, err)
+			snapshot, errs := jobpersist.Decode(dbJob)
+			require.Empty(t, errs)
+			restored := snapshot.Results[path]
+			wf := &stubApplyWorkflow{applyResult: &workflow.ApplyResult{Movie: restored.Movie}}
+			inputs := minimalApplyInputs(t, job.results, true)
+			inputs.WF = wf
+			cfg := ApplyPhaseConfig{}
+			cmd, afc, execute := buildApplyCmd(path, restored.Movie, restored, inputs, cfg, context.Background())
+			require.True(t, execute)
+			result := applyFile(context.Background(), wf, path, restored, restored.Movie, &preparedApplyFile{cmd: cmd, afc: afc, baseline: restored.Movie.Clone(), execute: execute}, inputs, cfg)
+			require.Equal(t, !resolved, result.Failed)
+			if resolved {
+				require.Equal(t, 1, wf.getApplyCalled())
+			} else {
+				require.Zero(t, wf.getApplyCalled())
+			}
+		})
+	}
+}
+
+type blockedRecropWorkflow struct {
+	stubApplyWorkflow
+	started chan struct{}
+	release chan struct{}
+}
+
+func (w *blockedRecropWorkflow) Apply(_ context.Context, cmd workflow.ApplyCmd) (*workflow.ApplyResult, error) {
+	close(w.started)
+	<-w.release
+	return nil, &downloader.PosterRecropRequiredError{Reason: downloader.SourceFingerprintMissing, Bounds: *cmd.Movie.Poster.PosterCropBounds}
+}
+
+func TestPosterRecropConcurrentNewCrop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	store := resultstore.New(1, []string{path})
+	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterCropSourceFull: true, PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
+	store.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, Status: models.JobStatusCompleted, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
+	before, err := store.GetMovieResult(path)
+	require.NoError(t, err)
+	pe := NewPosterEditor(store, store, nil)
+	wf := &blockedRecropWorkflow{started: make(chan struct{}), release: make(chan struct{})}
+	inputs := minimalApplyInputs(t, store, true)
+	inputs.EditLockFn = func(ids ...string) func() { return pe.lockRegistry().AcquireMany(ids) }
+	cfg := ApplyPhaseConfig{}
+	cmd, afc, execute := buildApplyCmd(path, movie, before, inputs, cfg, context.Background())
+	require.True(t, execute)
+	done := make(chan applyFileOutcome, 1)
+	go func() {
+		done <- applyFile(context.Background(), wf, path, before, movie, &preparedApplyFile{cmd: cmd, afc: afc, baseline: movie.Clone(), execute: execute}, inputs, cfg)
+	}()
+	<-wf.started
+	fresh := &models.CropBounds{Width: .5, Height: 1, SourceFingerprint: assetidentity.FromBytes([]byte("new source")).Fingerprint}
+	editErr := pe.UpdatePosterCrop(movie.ID, "new-preview.jpg", fresh, true)
+	close(wf.release)
+	outcome := <-done
+	require.NoError(t, editErr)
+	require.True(t, outcome.Failed)
+	after, err := store.GetMovieResult(path)
+	require.NoError(t, err)
+	require.Equal(t, fresh, after.Movie.Poster.PosterCropBounds)
+	require.Empty(t, after.ErrorCode)
+}
+
+func TestPosterRecropMissingBoundsStillBlocksRetry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	store := resultstore.New(1, []string{path})
+	movie := &models.Movie{ID: "CROP-1"}
+	stored := &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}}
+	store.UpdateFileResult(path, stored)
+	inputs := minimalApplyInputs(t, store, true)
+	wf := &stubApplyWorkflow{}
+	cfg := ApplyPhaseConfig{}
+	cmd, afc, execute := buildApplyCmd(path, movie, stored, inputs, cfg, context.Background())
+	require.True(t, execute)
+	outcome := applyFile(context.Background(), wf, path, stored, movie, &preparedApplyFile{cmd: cmd, afc: afc, baseline: movie.Clone(), execute: execute}, inputs, cfg)
+	require.True(t, outcome.Failed)
+	require.Zero(t, wf.getApplyCalled())
+	after, err := store.GetMovieResult(path)
+	require.NoError(t, err)
+	require.Equal(t, downloader.PosterRecropRequiredCode, after.ErrorCode)
+}
+
+func TestPosterRecropIntentComparison(t *testing.T) {
+	empty := &models.Movie{}
+	crop := &models.Movie{Poster: models.PosterState{PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
+	require.False(t, samePosterCropIntent(nil, empty))
+	require.False(t, samePosterCropIntent(empty, nil))
+	require.False(t, samePosterCropIntent(empty, crop))
+	require.True(t, samePosterCropIntent(empty, empty))
+	require.True(t, samePosterCropIntent(crop, crop.Clone()))
+}
+
+func TestPosterRecropLateWriteback(t *testing.T) {
+	for _, newerCrop := range []bool{false, true} {
+		t.Run(fmt.Sprint(newerCrop), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "movie.mp4")
+			store := resultstore.New(1, []string{path})
+			movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterCropSourceFull: true, PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
+			store.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, Status: models.JobStatusCompleted, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
+			before, err := store.GetMovieResult(path)
+			require.NoError(t, err)
+			pe := NewPosterEditor(store, store, nil)
+			edited := movie.Clone()
+			edited.Title = "concurrent edit"
+			if newerCrop {
+				edited.Poster.PosterCropBounds = &models.CropBounds{Width: .5, Height: 1, SourceFingerprint: assetidentity.FromBytes([]byte("new source")).Fingerprint}
+			}
+			editedDone := make(chan error, 1)
+			go func() {
+				editedDone <- pe.UpdateMovieFamily(context.Background(), movie.ID, "", edited, FamilySaveOptions{CarryCropGeometry: !newerCrop})
+			}()
+			require.NoError(t, <-editedDone)
+			inputs := minimalApplyInputs(t, store, true)
+			refusal := &downloader.PosterRecropRequiredError{Reason: downloader.SourceFingerprintMissing, Bounds: *movie.Poster.PosterCropBounds}
+			outcome := interpretApplyResult(path, movie, time.Now(), time.Minute, inputs, ApplyPhaseConfig{}, context.Background(), &ApplyFileContext{FilePath: path, Match: before.FileMatchInfo, MovieResult: before}, nil, refusal)
+			require.True(t, outcome.Failed)
+			after, err := store.GetMovieResult(path)
+			require.NoError(t, err)
+			require.Equal(t, "concurrent edit", after.Movie.Title)
+			require.Equal(t, edited.Poster.PosterCropBounds, after.Movie.Poster.PosterCropBounds)
+			if newerCrop {
+				require.Empty(t, after.ErrorCode)
+			} else {
+				require.Equal(t, downloader.PosterRecropRequiredCode, after.ErrorCode)
+			}
+		})
+	}
+}
+
+func TestPosterRecropWritebackPersistence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterCropSourceFull: true, PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
+	store := resultstore.New(1, []string{path})
+	store.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, Status: models.JobStatusCompleted, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
+	before, err := store.GetMovieResult(path)
+	require.NoError(t, err)
+	refusal := &downloader.PosterRecropRequiredError{Reason: downloader.SourceFingerprintMissing, Bounds: *movie.Poster.PosterCropBounds}
+	wrapped := fmt.Errorf("apply media: %w", refusal)
+	require.ErrorIs(t, wrapped, downloader.ErrPosterRecropRequired)
+	var typed *downloader.PosterRecropRequiredError
+	require.ErrorAs(t, wrapped, &typed)
+	outcome := interpretApplyResult(path, movie, time.Now(), time.Minute, minimalApplyInputs(t, store, true), ApplyPhaseConfig{}, context.Background(), &ApplyFileContext{FilePath: path, Match: before.FileMatchInfo, MovieResult: before}, nil, wrapped)
+	require.True(t, outcome.Failed)
+	result, err := store.GetMovieResult(path)
+	require.NoError(t, err)
+	require.Equal(t, downloader.PosterRecropRequiredCode, result.ErrorCode)
+	require.NotEmpty(t, result.Error)
+	dbJob, err := jobpersist.Encode(jobpersist.Snapshot{ID: "recrop", Files: []string{path}, Results: map[string]*resultstore.MovieResult{path: result}, Status: models.JobStatusCompleted, TempDir: t.TempDir()})
+	require.NoError(t, err)
+	snapshot, errs := jobpersist.Decode(dbJob)
+	require.Empty(t, errs)
+	require.Equal(t, result.ErrorCode, snapshot.Results[path].ErrorCode)
+	require.Equal(t, result.Movie.Poster, snapshot.Results[path].Movie.Poster)
+	queue := NewJobStore(nil, nil, nil, t.TempDir(), nil, nil)
+	restored := queue.reconstructBatchJob(dbJob)
+	require.NotNil(t, restored)
+	restoredResult, err := restored.results.GetMovieResult(path)
+	require.NoError(t, err)
+	require.Equal(t, result.ErrorCode, restoredResult.ErrorCode)
+	require.Equal(t, result.Movie.Poster, restoredResult.Movie.Poster)
+}

--- a/internal/worker/poster_recrop_test.go
+++ b/internal/worker/poster_recrop_test.go
@@ -284,3 +284,19 @@ func TestPosterRecropSkipDownloadRetryProceeds(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, downloader.PosterRecropRequiredCode, after.ErrorCode, "marker persists — stale crop intent remains until a fresh measured crop or removal")
 }
+
+func TestPosterRecropDryRunRetryProceeds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	store := resultstore.New(1, []string{path})
+	movie := &models.Movie{ID: "CROP-1"}
+	stored := &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}}
+	store.UpdateFileResult(path, stored)
+	inputs := minimalApplyInputs(t, store, true)
+	wf := &stubApplyWorkflow{applyResult: &workflow.ApplyResult{Movie: movie}}
+	cfg := ApplyPhaseConfig{Download: true, DryRun: true}
+	cmd, afc, execute := buildApplyCmd(path, movie, stored, inputs, cfg, context.Background())
+	require.True(t, execute)
+	outcome := applyFile(context.Background(), wf, path, stored, movie, &preparedApplyFile{cmd: cmd, afc: afc, baseline: movie.Clone(), execute: execute}, inputs, cfg)
+	require.False(t, outcome.Failed, "dry-run retry must not be blocked by the recrop marker")
+	require.Equal(t, 1, wf.getApplyCalled())
+}

--- a/internal/worker/poster_recrop_test.go
+++ b/internal/worker/poster_recrop_test.go
@@ -319,3 +319,24 @@ func TestPosterRecropDryRunRetryProceeds(t *testing.T) {
 	require.False(t, outcome.Failed, "dry-run retry must not be blocked by the recrop marker")
 	require.Equal(t, 1, wf.getApplyCalled())
 }
+
+func TestPosterRecropExplicitRemovalSurvivesOldApply(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	job := newBatchJob([]string{path})
+	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterURL: "https://example.test/a.jpg", PosterCropSourceFull: true, PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
+	stale := &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "rejected", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}}
+	job.results.UpdateFileResult(path, stale)
+	pe := NewPosterEditor(job.results, job.results, nil)
+	require.NoError(t, pe.UpdatePosterCrop(movie.ID, "", nil, false))
+	inputs := minimalApplyInputs(t, job.results, true)
+	cfg := ApplyPhaseConfig{}
+	refusal := &downloader.PosterRecropRequiredError{Reason: downloader.SourceFingerprintMissing, Bounds: *movie.Poster.PosterCropBounds}
+	before, err := job.results.GetMovieResult(path)
+	require.NoError(t, err)
+	outcome := interpretApplyResult(path, movie, time.Now(), time.Minute, inputs, cfg, context.Background(), &ApplyFileContext{FilePath: path, Match: before.FileMatchInfo, MovieResult: before}, nil, refusal)
+	require.True(t, outcome.Failed)
+	after, err := job.results.GetMovieResult(path)
+	require.NoError(t, err)
+	require.Empty(t, after.ErrorCode, "explicit removal lands after the stale failure — older apply must not resurrect the marker")
+	require.Nil(t, after.Movie.Poster.PosterCropBounds)
+}

--- a/internal/worker/poster_recrop_test.go
+++ b/internal/worker/poster_recrop_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestPosterRecropRetryAndResolution(t *testing.T) {
-	for _, action := range []string{"unchanged", "omitted", "omitted source change", "fresh", "fresh source change", "remove", "crop endpoint", "remove endpoint", "unmeasured"} {
+	for _, action := range []string{"unchanged", "omitted", "omitted source change", "fresh", "fresh source change", "remove", "reset baseline url", "crop endpoint", "remove endpoint", "unmeasured"} {
 		t.Run(action, func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "movie.mp4")
 			job := newBatchJob([]string{path})
@@ -45,6 +45,10 @@ func TestPosterRecropRetryAndResolution(t *testing.T) {
 			case "remove":
 				edit.Poster.PosterCropBounds = nil
 				resolved = true
+			case "reset baseline url":
+				edit.Poster.PosterCropBounds = nil
+				edit.Poster.CroppedPosterURL = "baseline-crop.jpg"
+				resolved = true
 			case "crop endpoint":
 				require.NoError(t, pe.UpdatePosterCrop(movie.ID, "preview.jpg", fresh, true))
 				resolved = true
@@ -62,7 +66,7 @@ func TestPosterRecropRetryAndResolution(t *testing.T) {
 			if resolved {
 				require.Empty(t, current.ErrorCode)
 				require.Empty(t, current.Error)
-				if action == "remove" || action == "remove endpoint" {
+				if action == "remove" || action == "reset baseline url" || action == "remove endpoint" {
 					require.Nil(t, current.Movie.Poster.PosterCropBounds)
 				} else {
 					require.Equal(t, fresh, current.Movie.Poster.PosterCropBounds)

--- a/internal/worker/poster_recrop_test.go
+++ b/internal/worker/poster_recrop_test.go
@@ -83,7 +83,7 @@ func TestPosterRecropRetryAndResolution(t *testing.T) {
 			wf := &stubApplyWorkflow{applyResult: &workflow.ApplyResult{Movie: restored.Movie}}
 			inputs := minimalApplyInputs(t, job.results, true)
 			inputs.WF = wf
-			cfg := ApplyPhaseConfig{}
+			cfg := ApplyPhaseConfig{Download: true}
 			cmd, afc, execute := buildApplyCmd(path, restored.Movie, restored, inputs, cfg, context.Background())
 			require.True(t, execute)
 			result := applyFile(context.Background(), wf, path, restored, restored.Movie, &preparedApplyFile{cmd: cmd, afc: afc, baseline: restored.Movie.Clone(), execute: execute}, inputs, cfg)
@@ -148,7 +148,7 @@ func TestPosterRecropMissingBoundsStillBlocksRetry(t *testing.T) {
 	store.UpdateFileResult(path, stored)
 	inputs := minimalApplyInputs(t, store, true)
 	wf := &stubApplyWorkflow{}
-	cfg := ApplyPhaseConfig{}
+	cfg := ApplyPhaseConfig{Download: true}
 	cmd, afc, execute := buildApplyCmd(path, movie, stored, inputs, cfg, context.Background())
 	require.True(t, execute)
 	outcome := applyFile(context.Background(), wf, path, stored, movie, &preparedApplyFile{cmd: cmd, afc: afc, baseline: movie.Clone(), execute: execute}, inputs, cfg)
@@ -264,4 +264,23 @@ func TestPosterRecropSourceReplacementClearsBlock(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, current.ErrorCode, "replacing the poster source must clear the recrop block")
 	require.Nil(t, current.Movie.Poster.PosterCropBounds, "new source invalidates stored geometry")
+}
+
+func TestPosterRecropSkipDownloadRetryProceeds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	store := resultstore.New(1, []string{path})
+	movie := &models.Movie{ID: "CROP-1"}
+	stored := &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}}
+	store.UpdateFileResult(path, stored)
+	inputs := minimalApplyInputs(t, store, true)
+	wf := &stubApplyWorkflow{applyResult: &workflow.ApplyResult{Movie: movie}}
+	cfg := ApplyPhaseConfig{} // Download: false — NFO/organize-only retry
+	cmd, afc, execute := buildApplyCmd(path, movie, stored, inputs, cfg, context.Background())
+	require.True(t, execute)
+	outcome := applyFile(context.Background(), wf, path, stored, movie, &preparedApplyFile{cmd: cmd, afc: afc, baseline: movie.Clone(), execute: execute}, inputs, cfg)
+	require.False(t, outcome.Failed, "skip-download retry must not be blocked by the recrop marker")
+	require.Equal(t, 1, wf.getApplyCalled())
+	after, err := store.GetMovieResult(path)
+	require.NoError(t, err)
+	require.Equal(t, downloader.PosterRecropRequiredCode, after.ErrorCode, "marker persists — stale crop intent remains until a fresh measured crop or removal")
 }

--- a/internal/worker/poster_recrop_test.go
+++ b/internal/worker/poster_recrop_test.go
@@ -83,7 +83,7 @@ func TestPosterRecropRetryAndResolution(t *testing.T) {
 			wf := &stubApplyWorkflow{applyResult: &workflow.ApplyResult{Movie: restored.Movie}}
 			inputs := minimalApplyInputs(t, job.results, true)
 			inputs.WF = wf
-			cfg := ApplyPhaseConfig{Download: true}
+			cfg := ApplyPhaseConfig{Download: true, OverwriteExistingMedia: true}
 			cmd, afc, execute := buildApplyCmd(path, restored.Movie, restored, inputs, cfg, context.Background())
 			require.True(t, execute)
 			result := applyFile(context.Background(), wf, path, restored, restored.Movie, &preparedApplyFile{cmd: cmd, afc: afc, baseline: restored.Movie.Clone(), execute: execute}, inputs, cfg)
@@ -148,7 +148,7 @@ func TestPosterRecropMissingBoundsStillBlocksRetry(t *testing.T) {
 	store.UpdateFileResult(path, stored)
 	inputs := minimalApplyInputs(t, store, true)
 	wf := &stubApplyWorkflow{}
-	cfg := ApplyPhaseConfig{Download: true}
+	cfg := ApplyPhaseConfig{Download: true, OverwriteExistingMedia: true}
 	cmd, afc, execute := buildApplyCmd(path, movie, stored, inputs, cfg, context.Background())
 	require.True(t, execute)
 	outcome := applyFile(context.Background(), wf, path, stored, movie, &preparedApplyFile{cmd: cmd, afc: afc, baseline: movie.Clone(), execute: execute}, inputs, cfg)
@@ -339,4 +339,20 @@ func TestPosterRecropExplicitRemovalSurvivesOldApply(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, after.ErrorCode, "explicit removal lands after the stale failure — older apply must not resurrect the marker")
 	require.Nil(t, after.Movie.Poster.PosterCropBounds)
+}
+
+func TestPosterRecropNonOverwriteRetryProceeds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	store := resultstore.New(1, []string{path})
+	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterURL: "https://example.test/a.jpg"}}
+	stored := &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}}
+	store.UpdateFileResult(path, stored)
+	inputs := minimalApplyInputs(t, store, true)
+	wf := &stubApplyWorkflow{applyResult: &workflow.ApplyResult{Movie: movie}}
+	cfg := ApplyPhaseConfig{Download: true, OverwriteExistingMedia: false}
+	cmd, afc, execute := buildApplyCmd(path, movie, stored, inputs, cfg, context.Background())
+	require.True(t, execute)
+	outcome := applyFile(context.Background(), wf, path, stored, movie, &preparedApplyFile{cmd: cmd, afc: afc, baseline: movie.Clone(), execute: execute}, inputs, cfg)
+	require.False(t, outcome.Failed, "non-overwrite retry must not fabricate a recrop failure — downloader would reuse the existing file untouched")
+	require.Equal(t, 1, wf.getApplyCalled())
 }

--- a/internal/worker/poster_recrop_test.go
+++ b/internal/worker/poster_recrop_test.go
@@ -356,3 +356,62 @@ func TestPosterRecropNonOverwriteRetryProceeds(t *testing.T) {
 	require.False(t, outcome.Failed, "non-overwrite retry must not fabricate a recrop failure — downloader would reuse the existing file untouched")
 	require.Equal(t, 1, wf.getApplyCalled())
 }
+
+func TestPosterRecropVerifySuccessClearsMarkerAtFileResult(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{
+		PosterURL: "https://example.test/poster.jpg",
+		CoverURL:  "https://example.test/cover.jpg",
+	}}
+	store := resultstore.New(1, []string{path})
+	store.UpdateFileResult(path, &resultstore.MovieResult{
+		Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode,
+		Status:        models.JobStatusCompleted,
+		FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID},
+	})
+	stored, err := store.GetMovieResult(path)
+	require.NoError(t, err)
+	inputs := minimalApplyInputs(t, store, true)
+	inputs.PosterDisabled = false
+	applyResult := &workflow.ApplyResult{Movie: stored.Movie}
+	applyResult.Steps.Downloaded = true
+	applyResult.Steps.PosterVerified = true
+	wf := &stubApplyWorkflow{applyResult: applyResult}
+	cfg := ApplyPhaseConfig{Download: true, OverwriteExistingMedia: false, DryRun: false}
+	cmd, afc, execute := buildApplyCmd(path, stored.Movie, stored, inputs, cfg, context.Background())
+	require.True(t, execute)
+	outcome := applyFile(context.Background(), wf, path, stored, stored.Movie,
+		&preparedApplyFile{cmd: cmd, afc: afc, baseline: stored.Movie.Clone(), execute: execute}, inputs, cfg)
+	require.False(t, outcome.Failed)
+	require.Equal(t, 1, wf.getApplyCalled())
+	after, err := store.GetMovieResult(path)
+	require.NoError(t, err)
+	require.Empty(t, after.ErrorCode)
+}
+
+func TestPosterRecropVerifyPartialFailureClearsMarker(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{
+		PosterURL: "https://example.test/poster.jpg",
+		CoverURL:  "https://example.test/cover.jpg",
+	}}
+	store := resultstore.New(1, []string{path})
+	store.UpdateFileResult(path, &resultstore.MovieResult{
+		Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode,
+		Status:        models.JobStatusFailed,
+		FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID},
+	})
+	stored, err := store.GetMovieResult(path)
+	require.NoError(t, err)
+	inputs := minimalApplyInputs(t, store, true)
+	result := &workflow.ApplyResult{Movie: stored.Movie}
+	result.Steps.Downloaded = true
+	result.Steps.PosterVerified = true
+	afc := &ApplyFileContext{FilePath: path, Match: stored.FileMatchInfo, MovieResult: stored}
+	outcome := interpretApplyResult(path, stored.Movie, time.Now(), time.Minute, inputs, ApplyPhaseConfig{},
+		context.Background(), afc, result, fmt.Errorf("nfo gen failed"))
+	require.True(t, outcome.Failed)
+	after, err := store.GetMovieResult(path)
+	require.NoError(t, err)
+	require.Empty(t, after.ErrorCode)
+}

--- a/internal/worker/poster_recrop_test.go
+++ b/internal/worker/poster_recrop_test.go
@@ -234,3 +234,30 @@ func TestPosterRecropWritebackPersistence(t *testing.T) {
 	require.Equal(t, result.ErrorCode, restoredResult.ErrorCode)
 	require.Equal(t, result.Movie.Poster, restoredResult.Movie.Poster)
 }
+
+func TestPosterRecropUnmeasuredPreviewCropKeepsBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	job := newBatchJob([]string{path})
+	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterURL: "https://example.test/a.jpg", PosterCropSourceFull: true, PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
+	job.results.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "rejected", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
+	pe := NewPosterEditor(job.results, job.results, nil)
+	require.NoError(t, pe.UpdatePosterCrop(movie.ID, "preview-cropped.jpg", nil, false))
+	current, err := job.results.GetMovieResult(path)
+	require.NoError(t, err)
+	require.Equal(t, downloader.PosterRecropRequiredCode, current.ErrorCode, "unmeasured preview-only crop must not discharge the recrop block")
+	require.Equal(t, "preview-cropped.jpg", current.Movie.Poster.CroppedPosterURL)
+	require.Nil(t, current.Movie.Poster.PosterCropBounds, "endpoint clears geometry; the block rides on the ErrorCode marker")
+}
+
+func TestPosterRecropSourceReplacementClearsBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.mp4")
+	job := newBatchJob([]string{path})
+	movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterURL: "https://example.test/a.jpg", PosterCropSourceFull: true, PosterCropBounds: &models.CropBounds{Width: .4, Height: 1}}}
+	job.results.UpdateFileResult(path, &resultstore.MovieResult{Movie: movie, ErrorCode: downloader.PosterRecropRequiredCode, Error: "rejected", Status: models.JobStatusFailed, FileMatchInfo: models.FileMatchInfo{Path: path, MovieID: movie.ID}})
+	pe := NewPosterEditor(job.results, job.results, nil)
+	require.NoError(t, pe.UpdatePosterFromURL(context.Background(), movie.ID, "https://example.test/b.jpg", ""))
+	current, err := job.results.GetMovieResult(path)
+	require.NoError(t, err)
+	require.Empty(t, current.ErrorCode, "replacing the poster source must clear the recrop block")
+	require.Nil(t, current.Movie.Poster.PosterCropBounds, "new source invalidates stored geometry")
+}

--- a/internal/worker/poster_recrop_wrapped_test.go
+++ b/internal/worker/poster_recrop_wrapped_test.go
@@ -1,0 +1,66 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/downloader"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/worker/resultstore"
+	"github.com/stretchr/testify/require"
+)
+
+// codex r11 P2: production recrop refusal text reaches Error wrapped by
+// upstream layers ("download failed: apply poster: poster requires a fresh
+// crop: source identity unavailable"). A plain HasPrefix gate misses this
+// form, leaving the refusal text on the row even after the marker resolves.
+func TestClearPosterRecrop_WrappedRefusalText(t *testing.T) {
+	nonRecropCode := "some_other_code"
+	casess := []struct {
+		name            string
+		errorCode       string
+		errorText       string
+		expectErrCode   string
+		expectErrTextBe string // exact expectation; "" means cleared
+	}{
+		{
+			name:            "wrapped production form",
+			errorCode:       downloader.PosterRecropRequiredCode,
+			errorText:       "download failed: apply poster: poster requires a fresh crop: source identity unavailable",
+			expectErrCode:   "",
+			expectErrTextBe: "",
+		},
+		{
+			name:            "direct refusal text (legacy unwrapped)",
+			errorCode:       downloader.PosterRecropRequiredCode,
+			errorText:       "poster requires a fresh crop: source identity unavailable",
+			expectErrCode:   "",
+			expectErrTextBe: "",
+		},
+		{
+			name:            "unrelated apply failure text preserved",
+			errorCode:       downloader.PosterRecropRequiredCode,
+			errorText:       "nfo generation failed: empty movie",
+			expectErrCode:   "",
+			expectErrTextBe: "nfo generation failed: empty movie",
+		},
+		{
+			name:            "non-recrop ErrorCode path untouched",
+			errorCode:       nonRecropCode,
+			errorText:       "poster requires a fresh crop: elsewhere is fine but this row isn't flagged",
+			expectErrCode:   nonRecropCode,
+			expectErrTextBe: "poster requires a fresh crop: elsewhere is fine but this row isn't flagged",
+		},
+	}
+	for _, tc := range casess {
+		t.Run(tc.name, func(t *testing.T) {
+			row := &resultstore.MovieResult{
+				ErrorCode: tc.errorCode,
+				Error:     tc.errorText,
+				Status:    models.JobStatusFailed,
+			}
+			clearPosterRecrop(row)
+			require.Equal(t, tc.expectErrCode, row.ErrorCode)
+			require.Equal(t, tc.expectErrTextBe, row.Error)
+		})
+	}
+}

--- a/internal/workflow/apply_orchestrator.go
+++ b/internal/workflow/apply_orchestrator.go
@@ -513,6 +513,15 @@ func (o *applyOrchImpl) stepDownload(ctx context.Context, cmd ApplyCmd, opID Ope
 	}
 	state.downloadPaths = outcome.CreatedPaths
 	steps.Downloaded = true
+	// codex r9 P1: worker-side marker clearing keys off Steps.PosterVerified,
+	// not Downloaded — a cover/trailer-only or dedup-skipped apply must NOT be
+	// treated as proof that the recrop verification passed.
+	for _, r := range outcome.Results {
+		if r.Type == downloader.MediaTypePoster && r.Downloaded && !r.Skipped && r.Error == nil {
+			steps.PosterVerified = true
+			break
+		}
+	}
 	return nil
 }
 

--- a/internal/workflow/apply_orchestrator.go
+++ b/internal/workflow/apply_orchestrator.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/javinizer/javinizer-go/internal/database"
@@ -405,7 +406,6 @@ func (o *applyOrchImpl) stepMerge(cmd ApplyCmd, state *applyPipelineState, steps
 	// Capture the manual review-page crop geometry before the merge: the
 	// merger rebuilds a fresh Movie and does not know about the runtime-only
 	// geometry, so carry/clear is decided here at the apply boundary.
-	preSource := effectivePosterSource(state.movie)
 	var preBounds *models.CropBounds
 	var preFull bool
 	if state.movie != nil {
@@ -420,35 +420,20 @@ func (o *applyOrchImpl) stepMerge(cmd ApplyCmd, state *applyPipelineState, steps
 		ArrayStrategy:  cmd.Merge.ArrayStrategy,
 	})
 	state.movie = mergeRes.Movie
-	carryPosterCropAcrossMerge(state.movie, preSource, preBounds, preFull)
+	carryPosterCropAcrossMerge(state.movie, preBounds, preFull)
 	state.merged = mergeRes.Merged
 	state.foundNFOPath = mergeRes.FoundNFOPath
 	steps.Merged = true
 	return nil
 }
 
-// effectivePosterSource mirrors the downloader's poster source selection:
-// PosterURL when present, otherwise CoverURL.
-func effectivePosterSource(m *models.Movie) string {
-	if m == nil {
-		return ""
-	}
-	if m.Poster.PosterURL != "" {
-		return m.Poster.PosterURL
-	}
-	return m.Poster.CoverURL
-}
-
-// carryPosterCropAcrossMerge retains manual crop geometry across the
-// pre-organize merge only when the merge left the effective poster source
-// unchanged; any source change (or absent/non-full-source geometry) clears
-// it so a stale crop can never be applied to a different image. Runs at the
-// apply boundary only — the generic NFO merger never sees the field.
-func carryPosterCropAcrossMerge(merged *models.Movie, preSource string, preBounds *models.CropBounds, preFull bool) {
+// Full-source intent must reach the downloader even if NFO merge changes the URL;
+// dropping it here would bypass byte verification and silently publish a fallback.
+func carryPosterCropAcrossMerge(merged *models.Movie, preBounds *models.CropBounds, preFull bool) {
 	if merged == nil {
 		return
 	}
-	if preBounds != nil && preFull && preSource != "" && effectivePosterSource(merged) == preSource {
+	if preBounds != nil && preFull {
 		b := *preBounds
 		merged.Poster.PosterCropBounds = &b
 		merged.Poster.PosterCropSourceFull = true
@@ -516,11 +501,14 @@ func (o *applyOrchImpl) stepDownload(ctx context.Context, cmd ApplyCmd, opID Ope
 		Recorder:               replacementRecorder(o.revertLog),
 	})
 	if dlErr != nil {
-		resolveLogger(o.logger).Warnf("[workflow] Download failed for %s: %v (continuing to NFO generation)", state.movie.ID, dlErr)
 		if outcome != nil {
 			state.downloadPaths = outcome.CreatedPaths
 		}
 		steps.Downloaded = false
+		if errors.Is(dlErr, downloader.ErrPosterRecropRequired) {
+			return fmt.Errorf("apply poster: %w", dlErr)
+		}
+		resolveLogger(o.logger).Warnf("[workflow] Download failed for %s: %v (continuing to NFO generation)", state.movie.ID, dlErr)
 		return nil
 	}
 	state.downloadPaths = outcome.CreatedPaths

--- a/internal/workflow/apply_orchestrator_crop_test.go
+++ b/internal/workflow/apply_orchestrator_crop_test.go
@@ -1,14 +1,17 @@
 package workflow
 
 import (
+	"bytes"
 	"context"
 	"image"
 	"image/color"
 	"image/jpeg"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
+	"github.com/javinizer/javinizer-go/internal/assetidentity"
 	"github.com/javinizer/javinizer-go/internal/downloader"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/nfo"
@@ -54,9 +57,12 @@ func TestApplyExecute_ManualCropGeometryReachesDisk(t *testing.T) {
 			}
 		}
 	}
+	root := t.TempDir()
+	var source bytes.Buffer
+	require.NoError(t, jpeg.Encode(&source, src, &jpeg.Options{Quality: 95}))
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
-		_ = jpeg.Encode(w, src, &jpeg.Options{Quality: 95})
+		_, _ = w.Write(source.Bytes())
 	}))
 	t.Cleanup(srv.Close)
 
@@ -72,7 +78,7 @@ func TestApplyExecute_ManualCropGeometryReachesDisk(t *testing.T) {
 	movie := &models.Movie{ID: "ABF-346", ContentID: "abf00346", Title: "Integrated Crop"}
 	movie.Poster.PosterURL = srv.URL + "/cover.jpg"
 	movie.Poster.ShouldCropPoster = true // scraper intent: auto-crop (white)
-	movie.Poster.PosterCropBounds = &models.CropBounds{X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0}
+	movie.Poster.PosterCropBounds = &models.CropBounds{X: 0, Y: 0, Width: 0.4, Height: 1.0, SourceAspect: 1000.0 / 600.0, SourceFingerprint: assetidentity.FromBytes(source.Bytes()).Fingerprint}
 	movie.Poster.PosterCropSourceFull = true
 
 	orch := &applyOrchImpl{
@@ -84,14 +90,14 @@ func TestApplyExecute_ManualCropGeometryReachesDisk(t *testing.T) {
 	}
 	result, err := orch.Execute(context.Background(), ApplyCmd{
 		Movie:    movie,
-		Match:    models.FileMatchInfo{Path: "/src/ABF-346.mp4"},
-		DestPath: "/dest",
+		Match:    models.FileMatchInfo{Path: filepath.Join(root, "source", "ABF-346.mp4")},
+		DestPath: root,
 		Download: true,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	f, err := fs.Open("/dest/ABF-346-poster.jpg")
+	f, err := fs.Open(filepath.Join(root, "ABF-346-poster.jpg"))
 	require.NoError(t, err, "poster must land in the destination dir")
 	defer func() { _ = f.Close() }()
 	img, err := jpeg.Decode(f)
@@ -138,29 +144,23 @@ func TestApplyMergeBoundary_SourceUnchangedKeepsGeometry(t *testing.T) {
 func TestApplyMergeBoundary_EdgeCases(t *testing.T) {
 	t.Parallel()
 
-	carryPosterCropAcrossMerge(nil, "https://cdn/p.jpg", cropBoundsFixture(), true) // no panic
+	carryPosterCropAcrossMerge(nil, cropBoundsFixture(), true) // no panic
 
 	// No pre-merge geometry: merged movie gains nothing.
 	merged := &models.Movie{}
 	merged.Poster.PosterURL = "https://cdn/p.jpg"
-	carryPosterCropAcrossMerge(merged, "", nil, false)
+	carryPosterCropAcrossMerge(merged, nil, false)
 	assert.Nil(t, merged.Poster.PosterCropBounds)
 	assert.False(t, merged.Poster.PosterCropSourceFull)
 
-	// Geometry without a poster source is meaningless: never carried.
+	// Retain full-source intent so a merge-provided URL cannot bypass identity verification.
 	merged2 := &models.Movie{}
-	carryPosterCropAcrossMerge(merged2, "", cropBoundsFixture(), true)
-	assert.Nil(t, merged2.Poster.PosterCropBounds)
+	carryPosterCropAcrossMerge(merged2, cropBoundsFixture(), true)
+	assert.Equal(t, cropBoundsFixture(), merged2.Poster.PosterCropBounds)
 
-	assert.Equal(t, "", effectivePosterSource(nil))
-	withCover := &models.Movie{}
-	withCover.Poster.CoverURL = "https://cdn/c.jpg"
-	assert.Equal(t, "https://cdn/c.jpg", effectivePosterSource(withCover))
 }
 
-// A merge that changes the effective poster source clears the geometry so a
-// crop measured against the old image is never applied to the new one.
-func TestApplyMergeBoundary_SourceChangedClearsGeometry(t *testing.T) {
+func TestApplyMergeBoundary_SourceChangedRetainsIdentityGate(t *testing.T) {
 	pre := &models.Movie{ID: "IPX-535"}
 	pre.Poster.PosterURL = "https://cdn/old.jpg"
 	pre.Poster.PosterCropBounds = cropBoundsFixture()
@@ -173,13 +173,11 @@ func TestApplyMergeBoundary_SourceChangedClearsGeometry(t *testing.T) {
 	state := &applyPipelineState{movie: pre}
 
 	require.NoError(t, orch.stepMerge(ApplyCmd{}, state, &stepCompletion{}))
-	assert.Nil(t, state.movie.Poster.PosterCropBounds)
-	assert.False(t, state.movie.Poster.PosterCropSourceFull)
+	assert.Equal(t, pre.Poster.PosterCropBounds, state.movie.Poster.PosterCropBounds)
+	assert.True(t, state.movie.Poster.PosterCropSourceFull)
 }
 
-// CoverURL is the fallback poster source: changing it while PosterURL is
-// empty is also a source change.
-func TestApplyMergeBoundary_CoverChangedClearsGeometry(t *testing.T) {
+func TestApplyMergeBoundary_CoverChangedRetainsIdentityGate(t *testing.T) {
 	pre := &models.Movie{ID: "IPX-535"}
 	pre.Poster.CoverURL = "https://cdn/old-cover.jpg"
 	pre.Poster.PosterCropBounds = cropBoundsFixture()
@@ -192,7 +190,7 @@ func TestApplyMergeBoundary_CoverChangedClearsGeometry(t *testing.T) {
 	state := &applyPipelineState{movie: pre}
 
 	require.NoError(t, orch.stepMerge(ApplyCmd{}, state, &stepCompletion{}))
-	assert.Nil(t, state.movie.Poster.PosterCropBounds, "cover source change must clear geometry")
+	assert.Equal(t, pre.Poster.PosterCropBounds, state.movie.Poster.PosterCropBounds)
 }
 
 // Legacy (non-full-source) geometry is never applied — it does not survive

--- a/internal/workflow/apply_orchestrator_poster_verified_test.go
+++ b/internal/workflow/apply_orchestrator_poster_verified_test.go
@@ -1,0 +1,58 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javinizer/javinizer-go/internal/downloader"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStepDownload_PosterVerifiedBranches(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []downloader.DownloadResult
+		want    bool
+	}{
+		{
+			name: "installed poster",
+			results: []downloader.DownloadResult{{
+				Type: downloader.MediaTypePoster, Downloaded: true,
+			}},
+			want: true,
+		},
+		{
+			name: "non-poster media",
+			results: []downloader.DownloadResult{
+				{Type: downloader.MediaTypeCover, Downloaded: true},
+				{Type: downloader.MediaTypeTrailer, Downloaded: true},
+			},
+			want: false,
+		},
+		{
+			name: "skipped poster",
+			results: []downloader.DownloadResult{{
+				Type: downloader.MediaTypePoster, Downloaded: true, Skipped: true,
+			}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &applyOrchImpl{downloader: &stubDownloader{
+				outcome: &downloader.DownloadOutcome{
+					Results:      tt.results,
+					CreatedPaths: []string{"/dest/media"},
+				},
+			}}
+			state := &applyPipelineState{movie: &models.Movie{ID: "TEST-001"}, finalDir: "/dest"}
+			steps := stepCompletion{}
+			err := impl.stepDownload(context.Background(), ApplyCmd{Download: true}, "", state, &steps)
+			require.NoError(t, err)
+			require.True(t, steps.Downloaded)
+			require.Equal(t, tt.want, steps.PosterVerified)
+		})
+	}
+}

--- a/internal/workflow/interfaces.go
+++ b/internal/workflow/interfaces.go
@@ -79,6 +79,14 @@ type stepCompletion struct {
 	DisplayTitle bool // display title applied to movie
 	Downloaded   bool // media download (poster, fanart) completed
 	NFOGenerated bool // NFO file generation completed
+	// PosterVerified flags that downloadAll's poster leg fetched + installed a
+	// byte-identical, fingerprint-matched destination this apply — including
+	// manualIntent recrop verification when scraper-supplied bounds existed.
+	// The worker's apply-phase success leg uses it (instead of Downloaded)
+	// to decide whether clearing poster_recrop_required is safe: skip-download
+	// retries, cover/trailer-only runs, and dedup-skips all leave Downloaded
+	// possibly true without ever running the poster pipeline for this row.
+	PosterVerified bool
 }
 
 // ApplyResult is everything the caller gets back from the Apply seam.

--- a/internal/workflow/poster_identity_test.go
+++ b/internal/workflow/poster_identity_test.go
@@ -1,0 +1,98 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"image"
+	"image/jpeg"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/assetidentity"
+	"github.com/javinizer/javinizer-go/internal/downloader"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/nfo"
+	"github.com/javinizer/javinizer-go/internal/organizer"
+)
+
+func TestApplyPosterRecropMergeCannotEraseIntent(t *testing.T) {
+	var source bytes.Buffer
+	require.NoError(t, jpeg.Encode(&source, image.NewRGBA(image.Rect(0, 0, 100, 60)), nil))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(source.Bytes())
+	}))
+	defer server.Close()
+	for _, fingerprint := range []string{"", assetidentity.FromBytes([]byte("different review bytes")).Fingerprint, assetidentity.FromBytes(source.Bytes()).Fingerprint} {
+		t.Run(fingerprint, func(t *testing.T) {
+			root := t.TempDir()
+			fs := afero.NewMemMapFs()
+			bounds := &models.CropBounds{Width: .4, Height: 1, SourceFingerprint: fingerprint}
+			movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{PosterURL: "https://review.test/a.jpg", PosterCropBounds: bounds, PosterCropSourceFull: true}}
+			merged := &models.Movie{ID: movie.ID, Poster: models.PosterState{PosterURL: server.URL + "/merged.jpg", ShouldCropPoster: true}}
+			d := downloader.NewDownloader(server.Client(), fs, &downloader.Config{DownloadPoster: true, MediaFormatConfig: organizer.MediaFormatConfig{PosterFormat: "<ID>-poster.jpg"}}, nil)
+			impl := &applyOrchImpl{fs: fs, downloader: d, nfo: &stubNFOFileMerger{result: nfo.MergeWithExistingResult{Movie: merged, Merged: true}}, revertLog: noOpRevertLog{}}
+			result, err := impl.Execute(context.Background(), ApplyCmd{Movie: movie, Match: models.FileMatchInfo{Path: filepath.Join(root, "movie.mp4"), MovieID: movie.ID}, DestPath: root, Organize: OrganizeOptions{Skip: true}, Download: true})
+			if fingerprint == assetidentity.FromBytes(source.Bytes()).Fingerprint {
+				require.NoError(t, err)
+				require.True(t, result.Steps.Downloaded)
+			} else {
+				require.ErrorIs(t, err, downloader.ErrPosterRecropRequired)
+				require.Empty(t, result.DownloadPaths)
+				_, statErr := fs.Stat(filepath.Join(root, "CROP-1-poster.jpg"))
+				require.True(t, errors.Is(statErr, afero.ErrFileNotFound))
+			}
+			require.Equal(t, bounds, result.Movie.Poster.PosterCropBounds)
+		})
+	}
+}
+
+func TestApplyPosterRecropPreservesCover(t *testing.T) {
+	var source bytes.Buffer
+	require.NoError(t, jpeg.Encode(&source, image.NewRGBA(image.Rect(0, 0, 100, 60)), nil))
+	for _, refusal := range []bool{false, true} {
+		t.Run(map[bool]string{false: "ordinary HTTP error", true: "identity refusal"}[refusal], func(t *testing.T) {
+			root := t.TempDir()
+			fs := afero.NewMemMapFs()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/poster.jpg" {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.Header().Set("Content-Type", "image/jpeg")
+				_, _ = w.Write(source.Bytes())
+			}))
+			defer server.Close()
+			movie := &models.Movie{ID: "CROP-1", Poster: models.PosterState{CoverURL: server.URL + "/cover.jpg", PosterURL: server.URL + "/poster.jpg"}}
+			if refusal {
+				movie.Poster.PosterCropBounds = &models.CropBounds{Width: .4, Height: 1}
+				movie.Poster.PosterCropSourceFull = true
+			}
+			d := downloader.NewDownloader(server.Client(), fs, &downloader.Config{DownloadCover: true, DownloadPoster: true, MediaFormatConfig: organizer.MediaFormatConfig{FanartFormat: "<ID>-fanart.jpg", PosterFormat: "<ID>-poster.jpg"}}, nil)
+			impl := &applyOrchImpl{fs: fs, downloader: d, nfo: &applyStubNFO{}, revertLog: noOpRevertLog{}}
+			result, err := impl.Execute(context.Background(), ApplyCmd{Movie: movie, Match: models.FileMatchInfo{Path: filepath.Join(root, "movie.mp4"), MovieID: movie.ID}, DestPath: root, Organize: OrganizeOptions{Skip: true}, Download: true})
+			if refusal {
+				require.ErrorIs(t, err, downloader.ErrPosterRecropRequired)
+				var typed *downloader.PosterRecropRequiredError
+				require.ErrorAs(t, err, &typed)
+				require.Equal(t, downloader.SourceFingerprintMissing, typed.Reason)
+				require.False(t, result.Steps.Downloaded)
+				require.False(t, result.Steps.NFOGenerated)
+			} else {
+				require.NoError(t, err)
+				require.False(t, errors.Is(err, downloader.ErrPosterRecropRequired))
+			}
+			cover := filepath.Join(root, "CROP-1-fanart.jpg")
+			require.Equal(t, []string{cover}, result.DownloadPaths)
+			got, err := afero.ReadFile(fs, cover)
+			require.NoError(t, err)
+			require.Equal(t, source.Bytes(), got)
+		})
+	}
+}


### PR DESCRIPTION
## What

Implements the first slice of #186: applying a **saved manual crop now requires proof that the downloaded source is byte-identical** (SHA-256) to the source the crop was measured on. If identity cannot be proven, the crop is refused **before** poster production/publication and surfaced as a typed **recrop-required** outcome instead of silently applying a stale rectangle to a different image.

Replaces the fingerprint-less manual-crop fallback in `internal/downloader/media.go`: dimensions/aspect/revision alone can no longer authorize a crop.

## Behavior

- `poster_identity.go`: typed `ErrPosterRecropRequired`-style error — stable code + reasons, `errors.Is`/`errors.As`-friendly, retains the underlying measurement cause via `%w`; no fingerprint is synthesized for legacy geometry.
- Measurement and crop consumption are bound to the **same fetched bytes** (single GET; no URL/aspect/revision-only backfill).
- Identity failure → false download/replacement flags, empty path, zero size; reservation/provenance/scratch-cleanup/existing-destination reuse behavior unchanged.
- The refusal aggregates through media results even when the cover download succeeds, maps to the existing `error_code`/API result shape, and `worker/poster_recrop.go` marks the saved crop intent logically invalid at serialized owner write-back — unchanged retries are blocked until a fresh measured crop or explicit removal (omitted crop fields are not treated as removal).

## Verification

- Focused poster/downloader tests + affected worker/workflow/API packages: pass (incl. table-driven identity matrix — missing/malformed/matching/uppercase-equiv/mismatching/unmeasurable fingerprints; HTTP A→B replacement across `ShouldCropPoster`/overwrite combinations; byte-vs-pixel definition proofs; measurement-failure and substitution races).
- `make test-short`, fmt/vet/lint, `make test-race`: pass.
- Repository line coverage 94.21%; `make coverage-patch-strict`: **PASSED — 100%**.
- 18/18 spec scenarios mapped to tests.

**Not covered locally:** native Windows execution of the new identity suite (no Windows machine locally) — relying on the Windows CI job for that; fixtures were written Windows-safe (`t.TempDir()`, `filepath.Join`/`ToSlash`, no POSIX-only rename assumptions).

## Scope note

**Does not close #186** — this is the astra-picked first slice only; remaining slices of that issue follow separately.