### PR TITLE
fix(fsutil): probe no-clobber capability before staging streams

### DIFF
--- a/docs/10-troubleshooting.md
+++ b/docs/10-troubleshooting.md
@@ -228,6 +228,31 @@ video_file.avi
 
 
 
+### Unraid user shares (shfs): no-clobber preflight refuses
+
+An Unraid user-share destination such as `/mnt/user/Movies` may support neither
+`renameat2(RENAME_NOREPLACE)` nor hard links. A typical refusal reports
+`renameat2: invalid argument (EINVAL)` and `link: operation not permitted (EPERM)`.
+EPERM can also reflect hard-link protection policy, not just filesystem limitations.
+
+Javinizer probes the destination directory before streaming direct copies or
+cross-device moves, refusing unsupported destinations before any `.nrstg` payload
+is created. Same-volume moves still use their existing atomic publish directly.
+Conclusive probe results are cached per directory for the process lifetime;
+transient failures are retried on a later file. Restart after changing mounts or
+hard-link policy. Every final file publish still enforces atomic no-clobber.
+
+**Remedy**: bind-mount a native disk path, for example
+`/mnt/disk1/Movies:/storage` (generally `/mnt/diskN/...`), rather than an Unraid
+user-share path. Alternatively, organize into native-filesystem local staging,
+then use an external sync tool with your intended destination conflict policy.
+There is no non-atomic fallback for unauthorized writes.
+
+If probe cleanup cannot prove ownership or unlink safely, a warning identifies
+the retained zero-byte `.nrprobe.*` file. Cleanup failure does not change the
+capability verdict. Inspect retained files before manually removing them; a
+foreign substitution must not be treated as disposable probe residue.
+
 ### "File already exists"
 
 **Problem**: Target file conflicts with existing file

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -2914,6 +2914,12 @@ const docTemplate = `{
                         "description": "Filter by job status (organized, reverted, completed, etc.)",
                         "name": "status",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of jobs to return (0 = unbounded)",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -2916,6 +2916,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Filter by durable phase marker (scrape, apply); empty matches all phases",
+                        "name": "phase",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "Maximum number of jobs to return (0 = unbounded)",
                         "name": "limit",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -2914,6 +2914,12 @@
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Filter by durable phase marker (scrape, apply); empty matches all phases",
+                        "name": "phase",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "Maximum number of jobs to return (0 = unbounded)",
                         "name": "limit",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -2912,6 +2912,12 @@
                         "description": "Filter by job status (organized, reverted, completed, etc.)",
                         "name": "status",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of jobs to return (0 = unbounded)",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5459,6 +5459,11 @@ paths:
         in: query
         name: status
         type: string
+      - description: Filter by durable phase marker (scrape, apply); empty matches
+          all phases
+        in: query
+        name: phase
+        type: string
       - description: Maximum number of jobs to return (0 = unbounded)
         in: query
         name: limit

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5459,6 +5459,10 @@ paths:
         in: query
         name: status
         type: string
+      - description: Maximum number of jobs to return (0 = unbounded)
+        in: query
+        name: limit
+        type: integer
       produces:
       - application/json
       responses:

--- a/internal/api/jobs/list.go
+++ b/internal/api/jobs/list.go
@@ -18,6 +18,7 @@ import (
 // @Tags jobs
 // @Produce json
 // @Param status query string false "Filter by job status (organized, reverted, completed, etc.)"
+// @Param phase query string false "Filter by durable phase marker (scrape, apply); empty matches all phases"
 // @Param limit query int false "Maximum number of jobs to return (0 = unbounded)"
 // @Success 200 {object} contracts.JobListResponse
 // @Failure 500 {object} contracts.ErrorResponse
@@ -25,6 +26,7 @@ import (
 func listJobs(deps JobDeps) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		statusFilter := c.Query("status")
+		phaseFilter := c.Query("phase")
 		limit := 0
 		if raw := c.Query("limit"); raw != "" {
 			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed > 0 {
@@ -32,11 +34,13 @@ func listJobs(deps JobDeps) gin.HandlerFunc {
 			}
 		}
 
-		// Route the status filter down to SQL — restore probes hit
-		// /api/v1/jobs?status=running on every authenticated page load, and
-		// filtering in memory made each probe read the full job history
-		// (codex P2, PR #253).
-		results, err := deps.ListJobsWithStatsByStatus(c.Request.Context(), statusFilter, limit)
+		// Route both filters down to SQL — restore probes hit
+		// /api/v1/jobs?status=running&phase=scrape&limit=1 on every
+		// authenticated page load; filtering in memory made each probe read
+		// the full job history (codex P2, PR #253), and a row cap applied
+		// before the phase predicate could hide older scrape jobs behind
+		// newer apply-phase rows (codex P2, PR #255).
+		results, err := deps.ListJobsWithStatsByStatusAndPhase(c.Request.Context(), statusFilter, phaseFilter, limit)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: "Failed to retrieve jobs"})
 			return

--- a/internal/api/jobs/list.go
+++ b/internal/api/jobs/list.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -17,18 +18,25 @@ import (
 // @Tags jobs
 // @Produce json
 // @Param status query string false "Filter by job status (organized, reverted, completed, etc.)"
+// @Param limit query int false "Maximum number of jobs to return (0 = unbounded)"
 // @Success 200 {object} contracts.JobListResponse
 // @Failure 500 {object} contracts.ErrorResponse
 // @Router /api/v1/jobs [get]
 func listJobs(deps JobDeps) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		statusFilter := c.Query("status")
+		limit := 0
+		if raw := c.Query("limit"); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed > 0 {
+				limit = parsed
+			}
+		}
 
 		// Route the status filter down to SQL — restore probes hit
 		// /api/v1/jobs?status=running on every authenticated page load, and
 		// filtering in memory made each probe read the full job history
 		// (codex P2, PR #253).
-		results, err := deps.ListJobsWithStatsByStatus(c.Request.Context(), statusFilter)
+		results, err := deps.ListJobsWithStatsByStatus(c.Request.Context(), statusFilter, limit)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, contracts.ErrorResponse{Error: "Failed to retrieve jobs"})
 			return

--- a/internal/api/jobs/list_sql_filter_test.go
+++ b/internal/api/jobs/list_sql_filter_test.go
@@ -198,3 +198,20 @@ func TestListJobs_HandlerHonorsLimit(t *testing.T) {
 	require.NoError(t, json.Unmarshal(bogusW.Body.Bytes(), &bogusResp))
 	assert.Len(t, bogusResp.Jobs, 2)
 }
+
+// TestListJobsWithStatsByStatus_FallbackLimit: legacy repos (no seam) must be
+// bounded after in-memory filtering, so envelope decode and aggregate counts
+// only run for the requested rows (codex P2, PR #255).
+func TestListJobsWithStatsByStatus_FallbackLimit(t *testing.T) {
+	deps, db := setupJobsTestDeps(t)
+	defer func() { _ = db.Close() }()
+	seedStatusMixedJobs(t, deps)
+
+	svc := newTestJobDeps(deps)
+	svc.JobRepo = legacyRepo{svc.JobRepo}
+
+	limited, err := svc.ListJobsWithStatsByStatus(context.Background(), "running", 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+	assert.Equal(t, models.JobStatusRunning, limited[0].Job.Status)
+}

--- a/internal/api/jobs/list_sql_filter_test.go
+++ b/internal/api/jobs/list_sql_filter_test.go
@@ -310,6 +310,22 @@ func TestListJobsWithStatsByStatusAndPhase_SQLFilterErr(t *testing.T) {
 	require.Contains(t, err.Error(), "phase sql boom")
 }
 
+// TestListJobsWithStatsByStatusAndPhase_FallbackListErr: with no phase seam
+// on the repo, the fallback's unbounded status listing error propagates.
+func TestListJobsWithStatsByStatusAndPhase_FallbackListErr(t *testing.T) {
+	deps, db := setupJobsTestDeps(t)
+	defer func() { _ = db.Close() }()
+
+	mockRepo := mocks.NewMockJobRepositoryInterface(t)
+	mockRepo.EXPECT().List(mockpkg.Anything).Return(nil, errors.New("legacy list fail"))
+
+	svc := newTestJobDeps(deps)
+	svc.JobRepo = mockRepo
+	_, err := svc.ListJobsWithStatsByStatusAndPhase(context.Background(), "running", "scrape", 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "legacy list fail")
+}
+
 // TestListJobs_HandlerPhaseSQLFilterErr500: handler surfaces a failing phase
 // seam as 500 when the phase param is present.
 func TestListJobs_HandlerPhaseSQLFilterErr500(t *testing.T) {

--- a/internal/api/jobs/list_sql_filter_test.go
+++ b/internal/api/jobs/list_sql_filter_test.go
@@ -295,6 +295,13 @@ func TestListJobsWithStatsByStatusAndPhase_FallbackPath(t *testing.T) {
 	limited, err := svc.ListJobsWithStatsByStatusAndPhase(context.Background(), "running", "scrape", 1)
 	require.NoError(t, err)
 	assert.Len(t, limited, 1)
+
+	// Exact-match rule for non-scrape phases: run-apply-1 alone qualifies;
+	// the two legacy/scrape fixture rows are excluded.
+	applyOnly, err := svc.ListJobsWithStatsByStatusAndPhase(context.Background(), "running", "apply", 0)
+	require.NoError(t, err)
+	require.Len(t, applyOnly, 1)
+	assert.Equal(t, "run-apply-1", applyOnly[0].Job.ID)
 }
 
 // TestListJobsWithStatsByStatusAndPhase_SQLFilterErr: a failing phase seam

--- a/internal/api/jobs/list_sql_filter_test.go
+++ b/internal/api/jobs/list_sql_filter_test.go
@@ -45,7 +45,7 @@ type legacyRepo struct {
 // SQL-filter error branch.
 type sqlErrRepo struct{ legacyRepo }
 
-func (sqlErrRepo) ListByStatus(context.Context, string) ([]models.Job, error) {
+func (sqlErrRepo) ListByStatus(context.Context, string, int) ([]models.Job, error) {
 	return nil, errors.New("sql boom")
 }
 
@@ -96,11 +96,11 @@ func TestListJobsWithStatsByStatus_FallbackPath(t *testing.T) {
 	svc := newTestJobDeps(deps)
 	svc.JobRepo = legacyRepo{svc.JobRepo}
 
-	running, err := svc.ListJobsWithStatsByStatus(context.Background(), "running")
+	running, err := svc.ListJobsWithStatsByStatus(context.Background(), "running", 0)
 	require.NoError(t, err)
 	require.Len(t, running, 2)
 
-	all, err := svc.ListJobsWithStatsByStatus(context.Background(), "")
+	all, err := svc.ListJobsWithStatsByStatus(context.Background(), "", 0)
 	require.NoError(t, err)
 	assert.Len(t, all, 3)
 }
@@ -113,7 +113,7 @@ func TestListJobsWithStatsByStatus_SQLFilterErr(t *testing.T) {
 
 	svc := newTestJobDeps(deps)
 	svc.JobRepo = sqlErrRepo{}
-	_, err := svc.ListJobsWithStatsByStatus(context.Background(), "running")
+	_, err := svc.ListJobsWithStatsByStatus(context.Background(), "running", 0)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "sql boom")
 }
@@ -165,4 +165,36 @@ func TestListJobs_FallbackListErr500(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestListJobs_HandlerHonorsLimit: the restore probe requests limit=1 — the
+// endpoint must bound the SQL fetch instead of decoding/aggregating every
+// running row (codex P2, PR #255), and invalid values fall back to the
+// unbounded default.
+func TestListJobs_HandlerHonorsLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	deps, db := setupJobsTestDeps(t)
+	defer func() { _ = db.Close() }()
+	seedStatusMixedJobs(t, deps)
+
+	router := gin.New()
+	router.GET("/api/v1/jobs", listJobs(newTestJobDeps(deps)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/jobs?status=running&limit=1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp contracts.JobListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Jobs, 1)
+	assert.Equal(t, models.JobStatusRunning, resp.Jobs[0].Status)
+
+	bogus := httptest.NewRequest(http.MethodGet, "/api/v1/jobs?status=running&limit=bogus", nil)
+	bogusW := httptest.NewRecorder()
+	router.ServeHTTP(bogusW, bogus)
+	require.Equal(t, http.StatusOK, bogusW.Code)
+	var bogusResp contracts.JobListResponse
+	require.NoError(t, json.Unmarshal(bogusW.Body.Bytes(), &bogusResp))
+	assert.Len(t, bogusResp.Jobs, 2)
 }

--- a/internal/api/jobs/list_sql_filter_test.go
+++ b/internal/api/jobs/list_sql_filter_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	mockpkg "github.com/stretchr/testify/mock"
@@ -214,4 +215,115 @@ func TestListJobsWithStatsByStatus_FallbackLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, limited, 1)
 	assert.Equal(t, models.JobStatusRunning, limited[0].Job.Status)
+}
+
+// seedPhaseApplyJob adds a running apply-phase job whose StartedAt is NEWER
+// than the scrape fixture so an unfiltered LIMIT 1 would return it — proving
+// the phase predicate lives in SQL, ahead of the row cap (codex P2, PR #255).
+func seedPhaseApplyJob(t *testing.T, deps *core.APIDeps) {
+	t.Helper()
+	apply := &models.Job{ID: "run-apply-1", Status: models.JobStatusRunning, Progress: 0.9, Files: "[]", Excluded: "{}", Results: `{"domain":{},"current_phase":"apply"}`, FileMatchInfo: "{}", StartedAt: time.Now().Add(time.Hour)}
+	require.NoError(t, deps.Repos.JobRepo.Create(context.Background(), apply))
+}
+
+// phaseErrRepo exposes the phase seam but errors, exercising the SQL-filter
+// error branch of ListJobsWithStatsByStatusAndPhase.
+type phaseErrRepo struct{ legacyRepo }
+
+func (phaseErrRepo) ListByStatusAndPhase(context.Context, string, string, int) ([]models.Job, error) {
+	return nil, errors.New("phase sql boom")
+}
+
+// TestListJobs_SQLFilteredPhasePath: status+phase+limit all reach SQL — the
+// apply-phase job is newer than the scrape job yet LIMIT 1 still returns the
+// scrape row.
+func TestListJobs_SQLFilteredPhasePath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	deps, db := setupJobsTestDeps(t)
+	defer func() { _ = db.Close() }()
+	seedStatusMixedJobs(t, deps)
+	seedPhaseApplyJob(t, deps)
+
+	router := gin.New()
+	router.GET("/api/v1/jobs", listJobs(newTestJobDeps(deps)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/jobs?status=running&phase=scrape&limit=1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp contracts.JobListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Jobs, 1)
+	// run-apply-1 is the NEWEST running job yet must lose to any scrape-
+	// eligible row; both fixtures carry zero StartedAt, so the id-DESC
+	// tie-break makes run-legacy-1 the deterministic winner.
+	assert.Equal(t, "run-legacy-1", resp.Jobs[0].ID)
+	assert.NotEqual(t, "run-apply-1", resp.Jobs[0].ID)
+
+	unbounded := httptest.NewRequest(http.MethodGet, "/api/v1/jobs?status=running&phase=scrape", nil)
+	unboundedW := httptest.NewRecorder()
+	router.ServeHTTP(unboundedW, unbounded)
+	require.Equal(t, http.StatusOK, unboundedW.Code)
+	var ub contracts.JobListResponse
+	require.NoError(t, json.Unmarshal(unboundedW.Body.Bytes(), &ub))
+	require.Len(t, ub.Jobs, 2)
+	for _, item := range ub.Jobs {
+		assert.NotEqual(t, "run-apply-1", item.ID)
+	}
+}
+
+// TestListJobsWithStatsByStatusAndPhase_FallbackPath: repos without the
+// phase seam decode the envelope in memory over the unbounded status-filtered
+// set, then cap — apply-phase rows are excluded without hiding scrape rows.
+func TestListJobsWithStatsByStatusAndPhase_FallbackPath(t *testing.T) {
+	deps, db := setupJobsTestDeps(t)
+	defer func() { _ = db.Close() }()
+	seedStatusMixedJobs(t, deps)
+	seedPhaseApplyJob(t, deps)
+
+	svc := newTestJobDeps(deps)
+	svc.JobRepo = legacyRepo{svc.JobRepo}
+
+	unbounded, err := svc.ListJobsWithStatsByStatusAndPhase(context.Background(), "running", "scrape", 0)
+	require.NoError(t, err)
+	require.Len(t, unbounded, 2)
+	for _, stat := range unbounded {
+		assert.NotEqual(t, "run-apply-1", stat.Job.ID)
+	}
+
+	limited, err := svc.ListJobsWithStatsByStatusAndPhase(context.Background(), "running", "scrape", 1)
+	require.NoError(t, err)
+	assert.Len(t, limited, 1)
+}
+
+// TestListJobsWithStatsByStatusAndPhase_SQLFilterErr: a failing phase seam
+// propagates its error instead of falling back silently.
+func TestListJobsWithStatsByStatusAndPhase_SQLFilterErr(t *testing.T) {
+	deps, db := setupJobsTestDeps(t)
+	defer func() { _ = db.Close() }()
+
+	svc := newTestJobDeps(deps)
+	svc.JobRepo = phaseErrRepo{}
+	_, err := svc.ListJobsWithStatsByStatusAndPhase(context.Background(), "running", "scrape", 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "phase sql boom")
+}
+
+// TestListJobs_HandlerPhaseSQLFilterErr500: handler surfaces a failing phase
+// seam as 500 when the phase param is present.
+func TestListJobs_HandlerPhaseSQLFilterErr500(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	deps, db := setupJobsTestDeps(t)
+	defer func() { _ = db.Close() }()
+
+	svc := newTestJobDeps(deps)
+	svc.JobRepo = phaseErrRepo{}
+	router := gin.New()
+	router.GET("/api/v1/jobs", listJobs(svc))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/jobs?status=running&phase=scrape&limit=1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
 }

--- a/internal/api/jobs/list_sql_filter_test.go
+++ b/internal/api/jobs/list_sql_filter_test.go
@@ -333,6 +333,51 @@ func TestListJobsWithStatsByStatusAndPhase_FallbackListErr(t *testing.T) {
 	require.Contains(t, err.Error(), "legacy list fail")
 }
 
+// TestListJobs_SQLBoundedLimitOnlyPath: ?limit without a status must grade
+// into ListByStatus("", limit) so the SQL query itself is bounded, keeping
+// full-history materialization off the wire even when no status/phase
+// predicate applies (codex P2, PR #255).
+func TestListJobs_SQLBoundedLimitOnlyPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	deps, db := setupJobsTestDeps(t)
+	defer func() { _ = db.Close() }()
+	seedStatusMixedJobs(t, deps)
+	seedPhaseApplyJob(t, deps)
+
+	router := gin.New()
+	router.GET("/api/v1/jobs", listJobs(newTestJobDeps(deps)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/jobs?limit=1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp contracts.JobListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Jobs, 1)
+	// newest first: the apply fixture is started in the future
+	assert.Equal(t, "run-apply-1", resp.Jobs[0].ID)
+}
+
+// TestListJobsWithStatsByStatus_LimitWithoutStatusFallback: legacy doubles
+// without the seam still honor limit-only caps via in-memory truncation.
+func TestListJobsWithStatsByStatus_LimitOnlyFallback(t *testing.T) {
+	deps, db := setupJobsTestDeps(t)
+	defer func() { _ = db.Close() }()
+	seedStatusMixedJobs(t, deps)
+
+	svc := newTestJobDeps(deps)
+	svc.JobRepo = legacyRepo{svc.JobRepo}
+
+	limited, err := svc.ListJobsWithStatsByStatus(context.Background(), "", 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+
+	unbounded, err := svc.ListJobsWithStatsByStatus(context.Background(), "", 0)
+	require.NoError(t, err)
+	assert.Len(t, unbounded, 3)
+}
+
 // TestListJobs_HandlerPhaseSQLFilterErr500: handler surfaces a failing phase
 // seam as 500 when the phase param is present.
 func TestListJobs_HandlerPhaseSQLFilterErr500(t *testing.T) {

--- a/internal/api/jobs/service.go
+++ b/internal/api/jobs/service.go
@@ -90,7 +90,7 @@ func (d JobDeps) GetJobWithStats(ctx context.Context, jobID string) (*JobWithSta
 
 // ListJobsWithStats returns all jobs with their operation and revert counts.
 func (d JobDeps) ListJobsWithStats(ctx context.Context) ([]JobWithStats, error) {
-	return d.ListJobsWithStatsByStatus(ctx, "")
+	return d.ListJobsWithStatsByStatus(ctx, "", 0)
 }
 
 // jobStatusLister is the narrow optional seam for status-filtered job
@@ -98,7 +98,7 @@ func (d JobDeps) ListJobsWithStats(ctx context.Context) ([]JobWithStats, error) 
 // in-memory fallback below; the concrete JobRepository implements this and
 // pushes the filter down to SQL.
 type jobStatusLister interface {
-	ListByStatus(ctx context.Context, status string) ([]models.Job, error)
+	ListByStatus(ctx context.Context, status string, limit int) ([]models.Job, error)
 }
 
 // ListJobsWithStatsByStatus is ListJobsWithStats filtered by job status in SQL
@@ -106,12 +106,15 @@ type jobStatusLister interface {
 // the web layout's reload-restore probe that fires on every authenticated page
 // load) can then skip hydrating the full job history (codex P2, PR #253).
 // An empty status preserves the prior unfiltered behavior.
-func (d JobDeps) ListJobsWithStatsByStatus(ctx context.Context, status string) ([]JobWithStats, error) {
+// A positive limit additionally bounds the query: the restore probe sends
+// limit=1, so a page load with many running jobs must not fetch, decode, and
+// aggregate every row (codex P2, PR #255).
+func (d JobDeps) ListJobsWithStatsByStatus(ctx context.Context, status string, limit int) ([]JobWithStats, error) {
 	var jobs []models.Job
 	var err error
 	if status != "" {
 		if repo, ok := d.JobRepo.(jobStatusLister); ok {
-			jobs, err = repo.ListByStatus(ctx, status)
+			jobs, err = repo.ListByStatus(ctx, status, limit)
 		} else {
 			all, listErr := d.JobRepo.List(ctx)
 			if listErr != nil {
@@ -129,6 +132,13 @@ func (d JobDeps) ListJobsWithStatsByStatus(ctx context.Context, status string) (
 	}
 	if err != nil {
 		return nil, err
+	}
+	// Legacy test doubles (and any repo not exposing the narrow seam) filter in
+	// memory, so bound them the same way the SQL LIMIT bounds the repository —
+	// the aggregate-count queries below must only run for the returned slice
+	// (codex P2, PR #255).
+	if limit > 0 && len(jobs) > limit {
+		jobs = jobs[:limit]
 	}
 
 	// Batch-fetch operation and revert counts in 2 queries instead of 2N.

--- a/internal/api/jobs/service.go
+++ b/internal/api/jobs/service.go
@@ -128,6 +128,16 @@ func (d JobDeps) ListJobsWithStatsByStatus(ctx context.Context, status string, l
 				}
 			}
 		}
+	} else if limit > 0 {
+		// ?limit without a status: bound the SQL query itself as well — the
+		// documented contract is a query bound, and fetching the full job
+		// history before truncating would still scale with table size
+		// (codex P2, PR #255).
+		if repo, ok := d.JobRepo.(jobStatusLister); ok {
+			jobs, err = repo.ListByStatus(ctx, "", limit)
+		} else {
+			jobs, err = d.JobRepo.List(ctx)
+		}
 	} else {
 		jobs, err = d.JobRepo.List(ctx)
 	}

--- a/internal/api/jobs/service.go
+++ b/internal/api/jobs/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/javinizer/javinizer-go/internal/history"
 	"github.com/javinizer/javinizer-go/internal/models"
 	"github.com/javinizer/javinizer-go/internal/worker"
+	"github.com/javinizer/javinizer-go/internal/worker/jobpersist"
 )
 
 // JobDeps holds the dependencies that job API handlers need.
@@ -140,7 +141,62 @@ func (d JobDeps) ListJobsWithStatsByStatus(ctx context.Context, status string, l
 	if limit > 0 && len(jobs) > limit {
 		jobs = jobs[:limit]
 	}
+	return d.attachJobCounts(ctx, jobs)
+}
 
+// jobStatusPhaseLister is the narrow optional seam for status+phase-filtered
+// job listings, used by ListJobsWithStatsByStatusAndPhase. The concrete
+// JobRepository implements this and pushes both predicates down to SQL;
+// legacy test doubles hit the in-memory envelope-decode fallback below.
+type jobStatusPhaseLister interface {
+	ListByStatusAndPhase(ctx context.Context, status, phase string, limit int) ([]models.Job, error)
+}
+
+// ListJobsWithStatsByStatusAndPhase is ListJobsWithStatsByStatus with the
+// durable phase marker included in the SQL predicate. The restore probe asks
+// for status=running, phase=scrape, limit=1: pushing the phase into the
+// repository means the row cap can no longer hide an older scrape behind
+// newer apply-phase rows, while bounded jobs/aggregate fetches resume
+// (codex P2, PR #255). Rows missing the marker stay eligible (scrape-
+// eligible legacy rule). An empty phase degrades to the status-only variant.
+func (d JobDeps) ListJobsWithStatsByStatusAndPhase(ctx context.Context, status, phase string, limit int) ([]JobWithStats, error) {
+	if phase == "" {
+		return d.ListJobsWithStatsByStatus(ctx, status, limit)
+	}
+	if repo, ok := d.JobRepo.(jobStatusPhaseLister); ok {
+		jobs, err := repo.ListByStatusAndPhase(ctx, status, phase, limit)
+		if err != nil {
+			return nil, err
+		}
+		// No defensive re-cap here: the seam contract bounds the SQL query
+		// itself, matching ListByStatus.
+		return d.attachJobCounts(ctx, jobs)
+	}
+	// Legacy doubles without the seam decode the envelope in memory; the
+	// status-filtered set is fetched unbounded first so a row cap applied
+	// before filtering cannot hide scrape rows behind apply-phase rows.
+	stats, err := d.ListJobsWithStatsByStatus(ctx, status, 0)
+	if err != nil {
+		return nil, err
+	}
+	matched := make([]JobWithStats, 0, len(stats))
+	for _, stat := range stats {
+		job := stat.Job
+		snapshot, _ := jobpersist.Decode(&job)
+		if snapshot.CurrentPhase == "" || snapshot.CurrentPhase == phase {
+			matched = append(matched, stat)
+		}
+	}
+	if limit > 0 && len(matched) > limit {
+		matched = matched[:limit]
+	}
+	return matched, nil
+}
+
+// attachJobCounts batch-fetches operation/revert/noop counts for the given
+// jobs in 3 queries total instead of 2 per job, pairing each job with its
+// counts.
+func (d JobDeps) attachJobCounts(ctx context.Context, jobs []models.Job) ([]JobWithStats, error) {
 	// Batch-fetch operation and revert counts in 2 queries instead of 2N.
 	jobIDs := make([]string, 0, len(jobs))
 	for _, job := range jobs {
@@ -149,6 +205,7 @@ func (d JobDeps) ListJobsWithStatsByStatus(ctx context.Context, status string, l
 
 	var opCounts, revertedCounts, noopCounts map[string]int64
 	if len(jobIDs) > 0 {
+		var err error
 		opCounts, err = d.BatchFileOpRepo.CountByBatchJobIDs(ctx, jobIDs)
 		if err != nil {
 			return nil, err

--- a/internal/api/jobs/service.go
+++ b/internal/api/jobs/service.go
@@ -183,7 +183,9 @@ func (d JobDeps) ListJobsWithStatsByStatusAndPhase(ctx context.Context, status, 
 	for _, stat := range stats {
 		job := stat.Job
 		snapshot, _ := jobpersist.Decode(&job)
-		if snapshot.CurrentPhase == "" || snapshot.CurrentPhase == phase {
+		// Mirror the SQL predicate: a missing marker is only scrape-eligible
+		// legacy evidence; other phases must match exactly (codex P2, PR #255).
+		if snapshot.CurrentPhase == phase || (phase == "scrape" && snapshot.CurrentPhase == "") {
 			matched = append(matched, stat)
 		}
 	}

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -261,9 +261,13 @@ func (r *JobRepository) List(ctx context.Context) ([]models.Job, error) {
 func (r *JobRepository) ListByStatus(ctx context.Context, status string, limit int) ([]models.Job, error) {
 	var jobs []models.Job
 	query := r.GetDB().WithContext(ctx).
-		Model(&models.Job{}).
-		Where("status = ?", status).
-		Order("started_at DESC, id DESC") // matches NewJobRepository's default order
+		Model(&models.Job{})
+	if status != "" {
+		// An empty status is a LIMIT-only query (?limit=1): bound the fetch
+		// without filtering rows (codex P2, PR #255).
+		query = query.Where("status = ?", status)
+	}
+	query = query.Order("started_at DESC, id DESC") // matches NewJobRepository's default order
 	if limit > 0 {
 		query = query.Limit(limit)
 	}

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -292,10 +292,16 @@ func (r *JobRepository) ListByStatusAndPhase(ctx context.Context, status, phase 
 	}
 	if phase != "" {
 		// json_extract raises "malformed JSON" on empty/corrupt results that
-		// jobpersist.Decode historically tolerated, so guard with json_valid:
-		// unreadable rows keep the missing-marker behavior and stay
-		// scrape-eligible (codex P2, PR #255).
-		query = query.Where("COALESCE(CASE WHEN json_valid(results) THEN json_extract(results, '$.current_phase') END, '') IN ('', ?)", phase)
+		// jobpersist.Decode historically tolerated, so guard with json_valid
+		// (codex P2, PR #255). Missing markers count ONLY for the legacy
+		// scrape restore path — an exact match for any other phase, otherwise
+		// phase-less rows would displace real apply jobs under limit=1
+		// (codex P2, PR #255).
+		if phase == "scrape" {
+			query = query.Where("COALESCE(CASE WHEN json_valid(results) THEN json_extract(results, '$.current_phase') END, '') IN ('', ?)", phase)
+		} else {
+			query = query.Where("COALESCE(CASE WHEN json_valid(results) THEN json_extract(results, '$.current_phase') END, '') = ?", phase)
+		}
 	}
 	query = query.Order("started_at DESC, id DESC") // matches ListByStatus's default order
 	if limit > 0 {

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -286,10 +286,16 @@ func (r *JobRepository) ListByStatus(ctx context.Context, status string, limit i
 func (r *JobRepository) ListByStatusAndPhase(ctx context.Context, status, phase string, limit int) ([]models.Job, error) {
 	var jobs []models.Job
 	query := r.GetDB().WithContext(ctx).
-		Model(&models.Job{}).
-		Where("status = ?", status)
+		Model(&models.Job{})
+	if status != "" {
+		query = query.Where("status = ?", status)
+	}
 	if phase != "" {
-		query = query.Where("COALESCE(json_extract(results, '$.current_phase'), '') IN ('', ?)", phase)
+		// json_extract raises "malformed JSON" on empty/corrupt results that
+		// jobpersist.Decode historically tolerated, so guard with json_valid:
+		// unreadable rows keep the missing-marker behavior and stay
+		// scrape-eligible (codex P2, PR #255).
+		query = query.Where("COALESCE(CASE WHEN json_valid(results) THEN json_extract(results, '$.current_phase') END, '') IN ('', ?)", phase)
 	}
 	query = query.Order("started_at DESC, id DESC") // matches ListByStatus's default order
 	if limit > 0 {

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -255,14 +255,19 @@ func (r *JobRepository) List(ctx context.Context) ([]models.Job, error) {
 
 // ListByStatus returns jobs whose status equals the filter, ordered by the
 // base repository's default order. Used by status-filtered API lookups so a
-// "running?" probe doesn't hydrate the full history table.
-func (r *JobRepository) ListByStatus(ctx context.Context, status string) ([]models.Job, error) {
+// "running?" probe doesn't hydrate the full history table. A positive limit
+// bounds the SQL query itself (the reload-restore probe sends limit=1;
+// codex P2, PR #255); limit <= 0 keeps the unbounded behavior.
+func (r *JobRepository) ListByStatus(ctx context.Context, status string, limit int) ([]models.Job, error) {
 	var jobs []models.Job
-	err := r.GetDB().WithContext(ctx).
+	query := r.GetDB().WithContext(ctx).
 		Model(&models.Job{}).
 		Where("status = ?", status).
-		Order("started_at DESC, id DESC"). // matches NewJobRepository's default order
-		Find(&jobs).Error
+		Order("started_at DESC, id DESC") // matches NewJobRepository's default order
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	err := query.Find(&jobs).Error
 	if err != nil {
 		return nil, wrapDBErr("list", "jobs by status", err)
 	}

--- a/internal/database/job_repository.go
+++ b/internal/database/job_repository.go
@@ -274,6 +274,33 @@ func (r *JobRepository) ListByStatus(ctx context.Context, status string, limit i
 	return jobs, nil
 }
 
+// ListByStatusAndPhase is ListByStatus with the durable phase marker
+// (jobs.results envelope's current_phase key) pushed down to SQL. The
+// reload-restore probe asks for status=running, phase=scrape, limit=1, so
+// neither the fetch nor the aggregate-count queries fan out over every
+// running job when many apply-phase jobs run concurrently (codex P2,
+// PR #255). Rows whose envelope lacks the marker (pre-envelope legacy
+// records) stay eligible for any phase, matching the frontend's
+// missing-phase-is-scrape-eligible rule. An empty phase degrades to the
+// plain status filter.
+func (r *JobRepository) ListByStatusAndPhase(ctx context.Context, status, phase string, limit int) ([]models.Job, error) {
+	var jobs []models.Job
+	query := r.GetDB().WithContext(ctx).
+		Model(&models.Job{}).
+		Where("status = ?", status)
+	if phase != "" {
+		query = query.Where("COALESCE(json_extract(results, '$.current_phase'), '') IN ('', ?)", phase)
+	}
+	query = query.Order("started_at DESC, id DESC") // matches ListByStatus's default order
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if err := query.Find(&jobs).Error; err != nil {
+		return nil, wrapDBErr("list", "jobs by status and phase", err)
+	}
+	return jobs, nil
+}
+
 // Delete removes the job record with the given primary key, delegating to the base repository.
 func (r *JobRepository) Delete(ctx context.Context, id string) error {
 	return r.BaseRepository.Delete(ctx, id)

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -457,19 +457,39 @@ func TestJobRepository_ListByStatus(t *testing.T) {
 	require.NoError(t, repo.Create(context.Background(), running))
 	require.NoError(t, repo.Create(context.Background(), organized))
 
-	runningJobs, err := repo.ListByStatus(context.Background(), "running")
+	runningJobs, err := repo.ListByStatus(context.Background(), "running", 0)
 	require.NoError(t, err)
 	require.Len(t, runningJobs, 1)
 	assert.Equal(t, "jobs-lbs-run", runningJobs[0].ID)
 
-	organizedJobs, err := repo.ListByStatus(context.Background(), "organized")
+	organizedJobs, err := repo.ListByStatus(context.Background(), "organized", 0)
 	require.NoError(t, err)
 	require.Len(t, organizedJobs, 1)
 	assert.Equal(t, "jobs-lbs-org", organizedJobs[0].ID)
 
-	empty, err := repo.ListByStatus(context.Background(), "cancelled")
+	empty, err := repo.ListByStatus(context.Background(), "cancelled", 0)
 	require.NoError(t, err)
 	assert.Empty(t, empty)
+}
+
+// TestJobRepository_ListByStatus_Limit bounds the SQL query itself: the
+// reload-restore probe asks for one row even when several jobs match (codex
+// P2, PR #255).
+func TestJobRepository_ListByStatus_Limit(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+
+	for _, id := range []string{"jobs-lbs-lim-1", "jobs-lbs-lim-2"} {
+		require.NoError(t, repo.Create(context.Background(), &models.Job{ID: id, Status: models.JobStatusRunning, Files: "[]", Results: "{}", Excluded: "{}", FileMatchInfo: "{}"}))
+	}
+
+	limited, err := repo.ListByStatus(context.Background(), "running", 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+
+	unbounded, err := repo.ListByStatus(context.Background(), "running", 0)
+	require.NoError(t, err)
+	assert.Len(t, unbounded, 2)
 }
 
 // TestJobRepository_ListByStatus_Error hits the SQL error branch by
@@ -481,7 +501,7 @@ func TestJobRepository_ListByStatus_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := repo.ListByStatus(ctx, "running")
+	_, err := repo.ListByStatus(ctx, "running", 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "jobs by status")
 }

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -528,6 +528,33 @@ func TestJobRepository_ListByStatusAndPhase(t *testing.T) {
 	assert.Len(t, noPhase, 3)
 }
 
+// TestJobRepository_ListByStatusAndPhase_ResilientRows: empty or malformed
+// results blobs historically decoded fine via jobpersist.Decode and must not
+// now abort the phase-filtered query with "malformed JSON" — they keep the
+// missing-marker behavior (codex P2, PR #255). The status predicate is also
+// skipped for phase-only lookups so behavior matches the in-memory fallback.
+func TestJobRepository_ListByStatusAndPhase_ResilientRows(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	ctx := context.Background()
+	now := time.Now()
+
+	empty := &models.Job{ID: "jobs-lbp-empty", Status: models.JobStatusRunning, Files: "[]", Results: "", Excluded: "{}", FileMatchInfo: "{}", StartedAt: now}
+	corrupt := &models.Job{ID: "jobs-lbp-corrupt", Status: models.JobStatusRunning, Files: "[]", Results: "not-json{", Excluded: "{}", FileMatchInfo: "{}", StartedAt: now.Add(-time.Minute)}
+	orgScrape := &models.Job{ID: "jobs-lbp-org2", Status: models.JobStatusOrganized, Files: "[]", Results: `{"domain":{},"current_phase":"scrape"}`, Excluded: "{}", FileMatchInfo: "{}", StartedAt: now.Add(time.Minute)}
+	for _, job := range []*models.Job{empty, corrupt, orgScrape} {
+		require.NoError(t, repo.Create(ctx, job))
+	}
+
+	got, err := repo.ListByStatusAndPhase(ctx, "running", "scrape", 0)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	cross, err := repo.ListByStatusAndPhase(ctx, "", "scrape", 0)
+	require.NoError(t, err)
+	require.Len(t, cross, 3)
+}
+
 // TestJobRepository_ListByStatusAndPhase_Error hits the SQL error branch by
 // canceling the context before the query runs.
 func TestJobRepository_ListByStatusAndPhase_Error(t *testing.T) {

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -470,6 +470,16 @@ func TestJobRepository_ListByStatus(t *testing.T) {
 	empty, err := repo.ListByStatus(context.Background(), "cancelled", 0)
 	require.NoError(t, err)
 	assert.Empty(t, empty)
+
+	// empty status = limit-only bounded query without a filter (codex P2,
+	// PR #255)
+	limited, err := repo.ListByStatus(context.Background(), "", 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+
+	all, err := repo.ListByStatus(context.Background(), "", 0)
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
 }
 
 // TestJobRepository_ListByStatus_Limit bounds the SQL query itself: the

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -492,6 +492,56 @@ func TestJobRepository_ListByStatus_Limit(t *testing.T) {
 	assert.Len(t, unbounded, 2)
 }
 
+// TestJobRepository_ListByStatusAndPhase pushes the phase predicate down to
+// SQL: a newer running apply-phase job must NOT hide an older scrape job when
+// limit=1 is applied (the frontend's reload-restore probe relies on this —
+// codex P2, PR #255).
+func TestJobRepository_ListByStatusAndPhase(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+	ctx := context.Background()
+	now := time.Now()
+
+	apply := &models.Job{ID: "jobs-lbp-apply", Status: models.JobStatusRunning, Files: "[]", Results: `{"domain":{},"current_phase":"apply"}`, Excluded: "{}", FileMatchInfo: "{}", StartedAt: now} // newest — must be excluded by the SQL phase filter
+	scrape := &models.Job{ID: "jobs-lbp-scrape", Status: models.JobStatusRunning, Files: "[]", Results: `{"domain":{},"current_phase":"scrape"}`, Excluded: "{}", FileMatchInfo: "{}", StartedAt: now.Add(-time.Minute)}
+	legacy := &models.Job{ID: "jobs-lbp-legacy", Status: models.JobStatusRunning, Files: "[]", Results: `{"domain":{}}`, Excluded: "{}", FileMatchInfo: "{}", StartedAt: now.Add(-2 * time.Minute)} // no marker — stays scrape-eligible
+	// organized jobs never match the status predicate even when their
+	// envelope would satisfy the phase filter
+	orgScrape := &models.Job{ID: "jobs-lbp-org", Status: models.JobStatusOrganized, Files: "[]", Results: `{"domain":{},"current_phase":"scrape"}`, Excluded: "{}", FileMatchInfo: "{}", StartedAt: now.Add(time.Minute)}
+	for _, job := range []*models.Job{apply, scrape, legacy, orgScrape} {
+		require.NoError(t, repo.Create(ctx, job))
+	}
+
+	limited, err := repo.ListByStatusAndPhase(ctx, "running", "scrape", 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+	assert.Equal(t, "jobs-lbp-scrape", limited[0].ID)
+
+	unbounded, err := repo.ListByStatusAndPhase(ctx, "running", "scrape", 0)
+	require.NoError(t, err)
+	require.Len(t, unbounded, 2)
+	assert.Equal(t, "jobs-lbp-scrape", unbounded[0].ID)
+	assert.Equal(t, "jobs-lbp-legacy", unbounded[1].ID)
+
+	noPhase, err := repo.ListByStatusAndPhase(ctx, "running", "", 0)
+	require.NoError(t, err)
+	assert.Len(t, noPhase, 3)
+}
+
+// TestJobRepository_ListByStatusAndPhase_Error hits the SQL error branch by
+// canceling the context before the query runs.
+func TestJobRepository_ListByStatusAndPhase_Error(t *testing.T) {
+	db := newDatabaseTestDB(t)
+	repo := NewJobRepository(db)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := repo.ListByStatusAndPhase(ctx, "running", "scrape", 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "jobs by status and phase")
+}
+
 // TestJobRepository_ListByStatus_Error hits the SQL error branch by
 // canceling the context before the query runs.
 func TestJobRepository_ListByStatus_Error(t *testing.T) {

--- a/internal/database/job_repository_test.go
+++ b/internal/database/job_repository_test.go
@@ -553,6 +553,12 @@ func TestJobRepository_ListByStatusAndPhase_ResilientRows(t *testing.T) {
 	cross, err := repo.ListByStatusAndPhase(ctx, "", "scrape", 0)
 	require.NoError(t, err)
 	require.Len(t, cross, 3)
+
+	// A non-scrape phase matches only exact markers — phase-less legacy rows
+	// must NOT displace real apply jobs under a row cap (codex P2, PR #255).
+	applyOnly, err := repo.ListByStatusAndPhase(ctx, "", "apply", 0)
+	require.NoError(t, err)
+	assert.Empty(t, applyOnly)
 }
 
 // TestJobRepository_ListByStatusAndPhase_Error hits the SQL error branch by

--- a/internal/fsutil/move_noreplace.go
+++ b/internal/fsutil/move_noreplace.go
@@ -41,6 +41,22 @@ var noreplaceOrdinal atomic.Uint64
 // nextNoReplaceOrdinal hands out the next ordinal for staging-name generation.
 func nextNoReplaceOrdinal() uint64 { return noreplaceOrdinal.Add(1) }
 
+// advanceNoReplaceOrdinalBeyond fast-forwards the shared nonce past an
+// ordinal a probe collision already burned: the creation skip scan resumes
+// from nextNoReplaceOrdinal, and without this the probe retry would select
+// and collide on the same blocked name every round (codex P2, PR #255).
+func advanceNoReplaceOrdinalBeyond(v uint64) {
+	for {
+		cur := noreplaceOrdinal.Load()
+		if cur >= v {
+			return
+		}
+		if noreplaceOrdinal.CompareAndSwap(cur, v) {
+			return
+		}
+	}
+}
+
 // classifyNoreplaceDestination runs the adoption/classification pre-check:
 // PublishNoReplace carries NO adoption semantics (every occupied dst refuses),
 // while organize keeps #225's no-op rules — lexical self, and same-inode

--- a/internal/fsutil/move_noreplace.go
+++ b/internal/fsutil/move_noreplace.go
@@ -142,6 +142,10 @@ func CopyFileNoReplace(fs afero.Fs, src, dst string) error {
 		return fmt.Errorf("no-replace copy: create destination directory: %w", err)
 	}
 
+	if err := ProbeNoClobberPublish(fs, filepath.Dir(dst)); err != nil {
+		return err
+	}
+
 	srcFile, err := fs.Open(src)
 	if err != nil {
 		return fmt.Errorf("no-replace copy: open source %s: %w", src, err)

--- a/internal/fsutil/move_noreplace_hooks_linux_test.go
+++ b/internal/fsutil/move_noreplace_hooks_linux_test.go
@@ -4,6 +4,8 @@ package fsutil
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 )
@@ -57,6 +59,9 @@ func swapFileAfterNPublishCalls(t *testing.T, n int, path string, content []byte
 	prevL := publishNoReplaceLink
 	wrap := func(prev func(string, string) error) func(string, string) error {
 		return func(s, d string) error {
+			if strings.HasPrefix(filepath.Base(s), ".nrprobe.") {
+				return prev(s, d)
+			}
 			calls++
 			if calls == n {
 				if err := os.WriteFile(path, content, 0o644); err != nil {

--- a/internal/fsutil/move_noreplace_hooks_posix_test.go
+++ b/internal/fsutil/move_noreplace_hooks_posix_test.go
@@ -4,6 +4,8 @@ package fsutil
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 )
@@ -38,6 +40,9 @@ func swapFileAfterNPublishCalls(t *testing.T, n int, path string, content []byte
 	calls := 0
 	prev := publishNoReplaceLink
 	publishNoReplaceLink = func(s, d string) (err error) {
+		if strings.HasPrefix(filepath.Base(s), ".nrprobe.") {
+			return prev(s, d)
+		}
 		calls++
 		if calls == n {
 			if werr := os.WriteFile(path, content, 0o644); werr != nil {

--- a/internal/fsutil/noreplace_identity_unix.go
+++ b/internal/fsutil/noreplace_identity_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package fsutil
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// noClobberDirIdentity fingerprints a directory's hosting filesystem: dev+ino
+// both change on unmount/remount at the same absolute path and a symlink
+// retarget to another volume resolves to the new device, so probe cache keys
+// carrying this fingerprint can never leak a verdict across mounts (codex P2,
+// PR #255). Empty string signals "identity unknown" and the caller degrades
+// to path-only caching.
+func noClobberDirIdentity(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return ""
+	}
+	// Dev/Ino widths differ across unix targets (int32 on darwin, uint64 on
+	// linux), so format the raw values: any explicit conversion is flagged as
+	// unnecessary by unconvert on the target where the field is already wide.
+	return fmt.Sprintf("%x:%x", stat.Dev, stat.Ino)
+}

--- a/internal/fsutil/noreplace_identity_unix.go
+++ b/internal/fsutil/noreplace_identity_unix.go
@@ -4,7 +4,6 @@ package fsutil
 
 import (
 	"fmt"
-	"os"
 	"syscall"
 )
 
@@ -15,7 +14,7 @@ import (
 // PR #255). Empty string signals "identity unknown" and the caller degrades
 // to path-only caching.
 func noClobberDirIdentity(path string) string {
-	info, err := os.Stat(path)
+	info, err := noClobberProbeStat(path)
 	if err != nil {
 		return ""
 	}

--- a/internal/fsutil/noreplace_identity_windows.go
+++ b/internal/fsutil/noreplace_identity_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package fsutil
+
+// noClobberDirIdentity has no Stat_t identity on Windows; the probe bypasses
+// Windows entirely, and the empty string keeps path-only caching as the
+// documented degradation.
+func noClobberDirIdentity(string) string { return "" }

--- a/internal/fsutil/noreplace_probe.go
+++ b/internal/fsutil/noreplace_probe.go
@@ -1,0 +1,136 @@
+package fsutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/spf13/afero"
+
+	"github.com/javinizer/javinizer-go/internal/logging"
+)
+
+// These seams replay kernel and identity failures without requiring an
+// incapable mount. Cleanup uses Lstat: a symlink to the retained inode is
+// still a foreign directory entry, never permission to unlink that entry.
+var (
+	publishNoClobberProbe  = PublishNoReplace
+	noClobberProbePlatform = runtime.GOOS
+	noClobberProbeAbs      = filepath.Abs
+	createNoClobberProbe   = CreateExclusiveStagingFile
+	noClobberProbeOps      = caseProbeOps{
+		openFile: osCaseProbeOps.openFile,
+		stat:     os.Lstat,
+		rename:   probeRenameNoReplace,
+		remove:   os.Remove,
+	}
+	noClobberCacheMu  sync.Mutex
+	noClobberCache    = make(map[string]error)
+	noClobberInflight = make(map[string]*noClobberFlight)
+)
+
+type noClobberFlight struct {
+	done chan struct{}
+	err  error
+}
+
+// ProbeNoClobberPublish refuses an incapable destination before a staging
+// stream starts. Only conclusive outcomes live in the process cache; transient
+// failures are shared with current waiters but the next caller re-probes.
+// Keys are absolute cleaned directory paths, deliberately not mount identities.
+// No caller lock is acquired and no cache mutex is held across filesystem IO.
+// A positive verdict is advisory: every file still uses the real final publish.
+func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
+	if _, ok := fs.(*afero.OsFs); !ok || noClobberProbePlatform == "windows" {
+		return nil
+	}
+	key, err := noClobberProbeAbs(dstDir)
+	if err != nil {
+		return fmt.Errorf("resolve no-clobber probe directory: %w", err)
+	}
+	noClobberCacheMu.Lock()
+	if verdict, ok := noClobberCache[key]; ok {
+		noClobberCacheMu.Unlock()
+		return verdict
+	}
+	if flight, ok := noClobberInflight[key]; ok {
+		noClobberCacheMu.Unlock()
+		<-flight.done
+		return flight.err
+	}
+	flight := &noClobberFlight{done: make(chan struct{})}
+	noClobberInflight[key] = flight
+	noClobberCacheMu.Unlock()
+
+	conclusive, verdict := runNoClobberProbe(fs, key)
+	noClobberCacheMu.Lock()
+	if conclusive {
+		noClobberCache[key] = verdict
+	}
+	delete(noClobberInflight, key)
+	flight.err = verdict
+	close(flight.done)
+	noClobberCacheMu.Unlock()
+	return verdict
+}
+
+func runNoClobberProbe(fs afero.Fs, dir string) (bool, error) {
+	src, handle, err := createNoClobberProbe(fs, filepath.Join(dir, ".nrprobe"), "", nextNoReplaceOrdinal(), 0o600)
+	if err != nil {
+		return false, fmt.Errorf("create no-clobber probe in %s: %w", dir, err)
+	}
+	defer func() { _ = handle.Close() }()
+	created, err := handle.Stat()
+	if err != nil {
+		return false, fmt.Errorf("capture no-clobber probe identity %s (retained): %w", src, err)
+	}
+	dst := src + ".published"
+	verdict := publishNoClobberProbe(fs, src, dst)
+	conclusive := verdict == nil || (errors.Is(verdict, ErrPublishNoReplaceUnsupported) && linkUnsupportedClass(verdict))
+	var cleanupErr error
+	if verdict == nil {
+		cleanupErr = boundProbeCleanup(noClobberProbeOps, dst, created)
+	} else {
+		// A failed publish gives no authority over the destination name. Never
+		// vacate the create-path with a replacing rename, even for cleanup.
+		cleanupErr = unlinkNoClobberProbe(noClobberProbeOps, src, handle, created)
+	}
+	if cleanupErr != nil {
+		// Cleanup is diagnostic only: neither its errno nor its identity refusal
+		// may mask, reclassify, or poison the capability verdict.
+		logging.Warnf("no-clobber probe cleanup retained %s / %s: %v", src, dst, cleanupErr)
+	}
+	if verdict != nil {
+		return conclusive, fmt.Errorf("no-clobber preflight in %s: %w", dir, verdict)
+	}
+	return true, nil
+}
+
+// unlinkNoClobberProbe is the primitive-less volume's NO-VACATE cleanup.
+// The retained descriptor and a syscall-adjacent no-follow lookup must both
+// equal the creation identity. Every failed proof or unlink is reported and
+// never retried. POSIX cannot eliminate the final lookup-to-unlink window;
+// zero-byte residue is preferable to gambling on an unproven pathname.
+func unlinkNoClobberProbe(ops caseProbeOps, path string, handle caseProbeFile, created os.FileInfo) error {
+	fdInfo, err := handle.Stat()
+	if err != nil {
+		return fmt.Errorf("fstat no-clobber probe %s: %w", path, err)
+	}
+	if created == nil || !probeSameFile(created, fdInfo) {
+		return fmt.Errorf("no-clobber probe %s descriptor identity unproven: %w", path, ErrTakeAsideForeign)
+	}
+	pathInfo, err := ops.stat(path)
+	if err != nil {
+		return fmt.Errorf("lookup no-clobber probe %s: %w", path, err)
+	}
+	if !probeSameFile(fdInfo, pathInfo) {
+		return fmt.Errorf("no-clobber probe %s pathname identity diverged: %w", path, ErrTakeAsideForeign)
+	}
+	if err := ops.remove(path); err != nil {
+		return fmt.Errorf("unlink verified no-clobber probe %s (retained): %w", path, err)
+	}
+	return nil
+}

--- a/internal/fsutil/noreplace_probe.go
+++ b/internal/fsutil/noreplace_probe.go
@@ -41,9 +41,14 @@ var (
 // possibly-foreign capability answer (codex P2, PR #255).
 var ErrNoClobberProbeUnstable = errors.New("no-clobber probe: destination identity unstable across samples")
 
+// noClobberFlight shares one probe round with concurrent callers. id binds
+// err to the directory identity that produced it: a waiter whose wake-time
+// sample disagrees must NOT consume the answer — the verdict belongs to a
+// filesystem that may no longer be mounted (codex P2, PR #255).
 type noClobberFlight struct {
 	done chan struct{}
 	err  error
+	id   string
 }
 
 // ProbeNoClobberPublish refuses an incapable destination before a staging
@@ -100,10 +105,11 @@ func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
 		if flight, ok := noClobberInflight[cacheKey]; ok {
 			noClobberCacheMu.Unlock()
 			<-flight.done
-			// Same return-time revalidation for verdicts completed by a peer:
-			// a mid-wait filesystem change invalidates the key this caller
-			// joined under.
-			if noClobberProbeDirID(key) == sampledID {
+			// The shared verdict must be certified against the identity that
+			// PRODUCED it, not this caller's join sample: A->B->A pinball would
+			// otherwise let an A-sampled waiter consume B's answer
+			// (codex P2, PR #255).
+			if flight.id == noClobberProbeDirID(key) {
 				return flight.err
 			}
 			continue
@@ -142,6 +148,10 @@ func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
 		}
 		delete(noClobberInflight, flightKey)
 		flight.err = verdict
+		// The stabilized sample that produced the verdict; wake-time
+		// revalidation compares the live identity against this, so a round
+		// that drifted A->B cannot serve B's answer to a caller on A again.
+		flight.id = sampledID
 		close(flight.done)
 		noClobberCacheMu.Unlock()
 		return verdict

--- a/internal/fsutil/noreplace_probe.go
+++ b/internal/fsutil/noreplace_probe.go
@@ -34,6 +34,13 @@ var (
 	noClobberInflight   = make(map[string]*noClobberFlight)
 )
 
+// ErrNoClobberProbeUnstable marks a destination whose filesystem identity
+// flipped within every sample window of a probe round: no verdict computed
+// during the round can be trusted to describe the currently-mounted
+// filesystem, so the probe reports indeterminate instead of acting on a
+// possibly-foreign capability answer (codex P2, PR #255).
+var ErrNoClobberProbeUnstable = errors.New("no-clobber probe: destination identity unstable across samples")
+
 type noClobberFlight struct {
 	done chan struct{}
 	err  error
@@ -45,8 +52,10 @@ type noClobberFlight struct {
 // Keys pair the absolute cleaned directory path with the directory's hosting
 // filesystem identity (dev:ino): an unmount/remount or symlink retarget at
 // the same absolute path produces a different key, so a stale verdict can
-// never reject copies a new filesystem supports or skip its preflight
-// (codex P2, PR #255). No caller lock is acquired and no cache mutex is held
+// never reject copies a new filesystem supports or skip its preflight. The
+// identity is sampled before AND after the capability run; a verdict whose
+// two samples disagree describes the wrong filesystem and is re-probed
+// rather than returned or cached (codex P2, PR #255). No caller lock is acquired and no cache mutex is held
 // across filesystem IO. A positive verdict is advisory: every file still
 // uses the real final publish.
 func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
@@ -78,22 +87,40 @@ func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
 		return flight.err
 	}
 	flight := &noClobberFlight{done: make(chan struct{})}
-	noClobberInflight[cacheKey] = flight
+	// The flight stays registered under the key sampled BEFORE any drift
+	// retry — re-validation may move cacheKey to another identity mid-round,
+	// and cleanup must still drop the registration waiter keys reference.
+	flightKey := cacheKey
+	noClobberInflight[flightKey] = flight
 	noClobberCacheMu.Unlock()
 
-	conclusive, verdict := runNoClobberProbe(fs, key)
-	if conclusive && noClobberProbeDirID(key) != sampledID {
-		// The hosting filesystem changed mid-probe (mount/symlink swap): this
-		// verdict describes the OTHER filesystem, so caching it under the
-		// sampled identity would poison A-after-B-after-A sequences
-		// (codex P2, PR #255). Report it, but let the next caller re-probe.
-		conclusive = false
+	// A verdict is only trusted when the identity sampled before the probe
+	// still holds afterwards: a mid-probe mount/symlink swap means the
+	// result describes the OTHER filesystem, so it is neither returned nor
+	// cached. The round re-samples and retries, and perpetual flapping
+	// exhausts the attempt budget as indeterminate (codex P2, PR #255).
+	conclusive, verdict := false, error(nil)
+	for attempt := 0; attempt < noClobberProbeMaxAttempts; attempt++ {
+		c, v := runNoClobberProbe(fs, key)
+		afterID := noClobberProbeDirID(key)
+		if afterID == sampledID {
+			conclusive, verdict = c, v
+			break
+		}
+		sampledID = afterID
+		cacheKey = key
+		if afterID != "" {
+			cacheKey += "|" + afterID
+		}
+		verdict = fmt.Errorf("no-clobber preflight in %s: %w", key, ErrNoClobberProbeUnstable)
 	}
 	noClobberCacheMu.Lock()
 	if conclusive {
+		// The stabilized post-drift identity owns the verdict key; waiters
+		// still resolve through the original registration key below.
 		noClobberCache[cacheKey] = verdict
 	}
-	delete(noClobberInflight, cacheKey)
+	delete(noClobberInflight, flightKey)
 	flight.err = verdict
 	close(flight.done)
 	noClobberCacheMu.Unlock()

--- a/internal/fsutil/noreplace_probe.go
+++ b/internal/fsutil/noreplace_probe.go
@@ -79,12 +79,26 @@ func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
 	noClobberCacheMu.Lock()
 	if verdict, ok := noClobberCache[cacheKey]; ok {
 		noClobberCacheMu.Unlock()
-		return verdict
+		// A cache hit keys the verdict to the identity sampled above, but the
+		// sampling-to-return window admits a remount/retarget: serving the
+		// result would hand the PREVIOUS filesystem's answer to the new one
+		// (codex P2, PR #255). Drift restarts the lookup against a freshly
+		// sampled identity.
+		if noClobberProbeDirID(key) == sampledID {
+			return verdict
+		}
+		return ProbeNoClobberPublish(fs, key)
 	}
 	if flight, ok := noClobberInflight[cacheKey]; ok {
 		noClobberCacheMu.Unlock()
 		<-flight.done
-		return flight.err
+		// Same return-time revalidation for verdicts completed by a peer: a
+		// mid-wait filesystem change invalidates the key this caller joined
+		// under (codex P2, PR #255).
+		if noClobberProbeDirID(key) == sampledID {
+			return flight.err
+		}
+		return ProbeNoClobberPublish(fs, key)
 	}
 	flight := &noClobberFlight{done: make(chan struct{})}
 	// The flight stays registered under the key sampled BEFORE any drift

--- a/internal/fsutil/noreplace_probe.go
+++ b/internal/fsutil/noreplace_probe.go
@@ -59,12 +59,13 @@ func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
 	}
 	// The cache key additionally pins the hosting-filesystem identity, while
 	// the probe itself still runs against the real directory path.
+	sampledID := noClobberProbeDirID(key)
 	cacheKey := key
-	if id := noClobberProbeDirID(key); id != "" {
+	if sampledID != "" {
 		// Identity failures (already-vanished directory, non-Stat_t source)
 		// degrade to pre-keying path-only caching rather than blocking the
 		// probe entirely.
-		cacheKey += "|" + id
+		cacheKey += "|" + sampledID
 	}
 	noClobberCacheMu.Lock()
 	if verdict, ok := noClobberCache[cacheKey]; ok {
@@ -81,6 +82,13 @@ func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
 	noClobberCacheMu.Unlock()
 
 	conclusive, verdict := runNoClobberProbe(fs, key)
+	if conclusive && noClobberProbeDirID(key) != sampledID {
+		// The hosting filesystem changed mid-probe (mount/symlink swap): this
+		// verdict describes the OTHER filesystem, so caching it under the
+		// sampled identity would poison A-after-B-after-A sequences
+		// (codex P2, PR #255). Report it, but let the next caller re-probe.
+		conclusive = false
+	}
 	noClobberCacheMu.Lock()
 	if conclusive {
 		noClobberCache[cacheKey] = verdict

--- a/internal/fsutil/noreplace_probe.go
+++ b/internal/fsutil/noreplace_probe.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/spf13/afero"
@@ -169,24 +171,40 @@ const noClobberProbeMaxAttempts = 3
 func runNoClobberProbe(fs afero.Fs, dir string) (bool, error) {
 	var lastErr error
 	for attempt := 0; attempt < noClobberProbeMaxAttempts; attempt++ {
-		conclusive, collision, err := runNoClobberProbeAttempt(fs, dir)
+		conclusive, collision, selected, err := runNoClobberProbeAttempt(fs, dir)
 		if !collision {
 			return conclusive, err
+		}
+		// The occupied sibling pinned the ACTUALLY selected ordinal;
+		// retrying from the merely-requested start would recreate and
+		// recollide on the same blocked name every round (codex P2, PR #255).
+		if selected != 0 {
+			advanceNoReplaceOrdinalBeyond(selected)
 		}
 		lastErr = err
 	}
 	return false, fmt.Errorf("no-clobber preflight in %s: synthetic probe names still occupied after %d attempts (indeterminate): %w", dir, noClobberProbeMaxAttempts, lastErr)
 }
 
-func runNoClobberProbeAttempt(fs afero.Fs, dir string) (bool, bool, error) {
+func runNoClobberProbeAttempt(fs afero.Fs, dir string) (bool, bool, uint64, error) {
 	src, handle, err := createNoClobberProbe(fs, filepath.Join(dir, ".nrprobe"), "", nextNoReplaceOrdinal(), 0o600)
 	if err != nil {
-		return false, false, fmt.Errorf("create no-clobber probe in %s: %w", dir, err)
+		return false, false, 0, fmt.Errorf("create no-clobber probe in %s: %w", dir, err)
+	}
+	// The skip scan may have landed above the requested start; report that
+	// ordinal so a sibling collision can fast-forward the shared nonce
+	// beyond it instead of recreating and recolliding the same name
+	// (codex P2, PR #255).
+	var selected uint64
+	if dot := strings.LastIndexByte(src, '.'); dot >= 0 {
+		if parsed, perr := strconv.ParseUint(src[dot+1:], 16, 64); perr == nil {
+			selected = parsed
+		}
 	}
 	defer func() { _ = handle.Close() }()
 	created, err := handle.Stat()
 	if err != nil {
-		return false, false, fmt.Errorf("capture no-clobber probe identity %s (retained): %w", src, err)
+		return false, false, selected, fmt.Errorf("capture no-clobber probe identity %s (retained): %w", src, err)
 	}
 	dst := src + ".published"
 	verdict := publishNoClobberProbe(fs, src, dst)
@@ -209,11 +227,11 @@ func runNoClobberProbeAttempt(fs afero.Fs, dir string) (bool, bool, error) {
 			// Only the SYNTHETIC sibling was occupied — the verdict says nothing
 			// about the volume. Report the pair-collision so the caller retries
 			// with a fresh ordinal pair; the occupied sibling stays untouched.
-			return false, true, fmt.Errorf("no-clobber preflight in %s: %w", dir, verdict)
+			return false, true, selected, fmt.Errorf("no-clobber preflight in %s: %w", dir, verdict)
 		}
-		return conclusive, false, fmt.Errorf("no-clobber preflight in %s: %w", dir, verdict)
+		return conclusive, false, selected, fmt.Errorf("no-clobber preflight in %s: %w", dir, verdict)
 	}
-	return true, false, nil
+	return true, false, selected, nil
 }
 
 // unlinkNoClobberProbe is the primitive-less volume's NO-VACATE cleanup.

--- a/internal/fsutil/noreplace_probe.go
+++ b/internal/fsutil/noreplace_probe.go
@@ -77,15 +77,34 @@ func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
 	return verdict
 }
 
+// noClobberProbeMaxAttempts bounds probe-pair retries after a collision on
+// the SYNTHETIC destination sibling: an interrupted prior probe or retained
+// cleanup residue can hold ".published" — the retry swaps in a fresh ordinal
+// pair instead of failing the first organize on an otherwise capable volume
+// (codex P2, PR #255). The occupied sibling is never displaced or unlinked.
+const noClobberProbeMaxAttempts = 3
+
 func runNoClobberProbe(fs afero.Fs, dir string) (bool, error) {
+	var lastErr error
+	for attempt := 0; attempt < noClobberProbeMaxAttempts; attempt++ {
+		conclusive, collision, err := runNoClobberProbeAttempt(fs, dir)
+		if !collision {
+			return conclusive, err
+		}
+		lastErr = err
+	}
+	return false, fmt.Errorf("no-clobber preflight in %s: synthetic probe names still occupied after %d attempts (indeterminate): %w", dir, noClobberProbeMaxAttempts, lastErr)
+}
+
+func runNoClobberProbeAttempt(fs afero.Fs, dir string) (bool, bool, error) {
 	src, handle, err := createNoClobberProbe(fs, filepath.Join(dir, ".nrprobe"), "", nextNoReplaceOrdinal(), 0o600)
 	if err != nil {
-		return false, fmt.Errorf("create no-clobber probe in %s: %w", dir, err)
+		return false, false, fmt.Errorf("create no-clobber probe in %s: %w", dir, err)
 	}
 	defer func() { _ = handle.Close() }()
 	created, err := handle.Stat()
 	if err != nil {
-		return false, fmt.Errorf("capture no-clobber probe identity %s (retained): %w", src, err)
+		return false, false, fmt.Errorf("capture no-clobber probe identity %s (retained): %w", src, err)
 	}
 	dst := src + ".published"
 	verdict := publishNoClobberProbe(fs, src, dst)
@@ -104,9 +123,15 @@ func runNoClobberProbe(fs afero.Fs, dir string) (bool, error) {
 		logging.Warnf("no-clobber probe cleanup retained %s / %s: %v", src, dst, cleanupErr)
 	}
 	if verdict != nil {
-		return conclusive, fmt.Errorf("no-clobber preflight in %s: %w", dir, verdict)
+		if errors.Is(verdict, ErrPublishCollision) {
+			// Only the SYNTHETIC sibling was occupied — the verdict says nothing
+			// about the volume. Report the pair-collision so the caller retries
+			// with a fresh ordinal pair; the occupied sibling stays untouched.
+			return false, true, fmt.Errorf("no-clobber preflight in %s: %w", dir, verdict)
+		}
+		return conclusive, false, fmt.Errorf("no-clobber preflight in %s: %w", dir, verdict)
 	}
-	return true, nil
+	return true, false, nil
 }
 
 // unlinkNoClobberProbe is the primitive-less volume's NO-VACATE cleanup.

--- a/internal/fsutil/noreplace_probe.go
+++ b/internal/fsutil/noreplace_probe.go
@@ -28,6 +28,7 @@ var (
 		remove:   os.Remove,
 	}
 	noClobberProbeDirID = noClobberDirIdentity
+	noClobberProbeStat  = os.Stat
 	noClobberCacheMu    sync.Mutex
 	noClobberCache      = make(map[string]error)
 	noClobberInflight   = make(map[string]*noClobberFlight)

--- a/internal/fsutil/noreplace_probe.go
+++ b/internal/fsutil/noreplace_probe.go
@@ -27,9 +27,10 @@ var (
 		rename:   probeRenameNoReplace,
 		remove:   os.Remove,
 	}
-	noClobberCacheMu  sync.Mutex
-	noClobberCache    = make(map[string]error)
-	noClobberInflight = make(map[string]*noClobberFlight)
+	noClobberProbeDirID = noClobberDirIdentity
+	noClobberCacheMu    sync.Mutex
+	noClobberCache      = make(map[string]error)
+	noClobberInflight   = make(map[string]*noClobberFlight)
 )
 
 type noClobberFlight struct {
@@ -40,9 +41,13 @@ type noClobberFlight struct {
 // ProbeNoClobberPublish refuses an incapable destination before a staging
 // stream starts. Only conclusive outcomes live in the process cache; transient
 // failures are shared with current waiters but the next caller re-probes.
-// Keys are absolute cleaned directory paths, deliberately not mount identities.
-// No caller lock is acquired and no cache mutex is held across filesystem IO.
-// A positive verdict is advisory: every file still uses the real final publish.
+// Keys pair the absolute cleaned directory path with the directory's hosting
+// filesystem identity (dev:ino): an unmount/remount or symlink retarget at
+// the same absolute path produces a different key, so a stale verdict can
+// never reject copies a new filesystem supports or skip its preflight
+// (codex P2, PR #255). No caller lock is acquired and no cache mutex is held
+// across filesystem IO. A positive verdict is advisory: every file still
+// uses the real final publish.
 func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
 	if _, ok := fs.(*afero.OsFs); !ok || noClobberProbePlatform == "windows" {
 		return nil
@@ -51,26 +56,35 @@ func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
 	if err != nil {
 		return fmt.Errorf("resolve no-clobber probe directory: %w", err)
 	}
+	// The cache key additionally pins the hosting-filesystem identity, while
+	// the probe itself still runs against the real directory path.
+	cacheKey := key
+	if id := noClobberProbeDirID(key); id != "" {
+		// Identity failures (already-vanished directory, non-Stat_t source)
+		// degrade to pre-keying path-only caching rather than blocking the
+		// probe entirely.
+		cacheKey += "|" + id
+	}
 	noClobberCacheMu.Lock()
-	if verdict, ok := noClobberCache[key]; ok {
+	if verdict, ok := noClobberCache[cacheKey]; ok {
 		noClobberCacheMu.Unlock()
 		return verdict
 	}
-	if flight, ok := noClobberInflight[key]; ok {
+	if flight, ok := noClobberInflight[cacheKey]; ok {
 		noClobberCacheMu.Unlock()
 		<-flight.done
 		return flight.err
 	}
 	flight := &noClobberFlight{done: make(chan struct{})}
-	noClobberInflight[key] = flight
+	noClobberInflight[cacheKey] = flight
 	noClobberCacheMu.Unlock()
 
 	conclusive, verdict := runNoClobberProbe(fs, key)
 	noClobberCacheMu.Lock()
 	if conclusive {
-		noClobberCache[key] = verdict
+		noClobberCache[cacheKey] = verdict
 	}
-	delete(noClobberInflight, key)
+	delete(noClobberInflight, cacheKey)
 	flight.err = verdict
 	close(flight.done)
 	noClobberCacheMu.Unlock()

--- a/internal/fsutil/noreplace_probe.go
+++ b/internal/fsutil/noreplace_probe.go
@@ -53,11 +53,13 @@ type noClobberFlight struct {
 // filesystem identity (dev:ino): an unmount/remount or symlink retarget at
 // the same absolute path produces a different key, so a stale verdict can
 // never reject copies a new filesystem supports or skip its preflight. The
-// identity is sampled before AND after the capability run; a verdict whose
-// two samples disagree describes the wrong filesystem and is re-probed
-// rather than returned or cached (codex P2, PR #255). No caller lock is acquired and no cache mutex is held
-// across filesystem IO. A positive verdict is advisory: every file still
-// uses the real final publish.
+// identity is sampled before AND after the capability run, and again when a
+// cached or peer-shared verdict is returned; a verdict whose two samples
+// disagree describes the wrong filesystem and is re-probed rather than
+// returned or cached. Iteration is attempt-bounded (codex P2, PR #255).
+// No caller lock is acquired and no cache mutex is held across filesystem
+// IO. A positive verdict is advisory: every file still uses the real final
+// publish.
 func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
 	if _, ok := fs.(*afero.OsFs); !ok || noClobberProbePlatform == "windows" {
 		return nil
@@ -66,79 +68,85 @@ func ProbeNoClobberPublish(fs afero.Fs, dstDir string) error {
 	if err != nil {
 		return fmt.Errorf("resolve no-clobber probe directory: %w", err)
 	}
-	// The cache key additionally pins the hosting-filesystem identity, while
-	// the probe itself still runs against the real directory path.
-	sampledID := noClobberProbeDirID(key)
-	cacheKey := key
-	if sampledID != "" {
-		// Identity failures (already-vanished directory, non-Stat_t source)
-		// degrade to pre-keying path-only caching rather than blocking the
-		// probe entirely.
-		cacheKey += "|" + sampledID
-	}
-	noClobberCacheMu.Lock()
-	if verdict, ok := noClobberCache[cacheKey]; ok {
-		noClobberCacheMu.Unlock()
-		// A cache hit keys the verdict to the identity sampled above, but the
-		// sampling-to-return window admits a remount/retarget: serving the
-		// result would hand the PREVIOUS filesystem's answer to the new one
-		// (codex P2, PR #255). Drift restarts the lookup against a freshly
-		// sampled identity.
-		if noClobberProbeDirID(key) == sampledID {
-			return verdict
+	// Every verdict — cached, shared through a peer flight, or freshly
+	// probed — is certified against the directory identity sampled when it
+	// was produced. A mount/symlink flip between sampling and consumption
+	// means the answer describes the OTHER filesystem and must restart the
+	// round under the re-sampled identity. Iteration shares the physical
+	// probe budget: sustained flapping (real remounts or alternating failed
+	// identity reads) exits indeterminate instead of recursing into the
+	// goroutine stack (codex P2, PR #255).
+	for round := 0; round < noClobberProbeMaxAttempts; round++ {
+		sampledID := noClobberProbeDirID(key)
+		cacheKey := key
+		if sampledID != "" {
+			// Identity failures (already-vanished directory, non-Stat_t
+			// source) degrade to path-only caching rather than blocking the
+			// probe entirely.
+			cacheKey += "|" + sampledID
 		}
-		return ProbeNoClobberPublish(fs, key)
-	}
-	if flight, ok := noClobberInflight[cacheKey]; ok {
-		noClobberCacheMu.Unlock()
-		<-flight.done
-		// Same return-time revalidation for verdicts completed by a peer: a
-		// mid-wait filesystem change invalidates the key this caller joined
-		// under (codex P2, PR #255).
-		if noClobberProbeDirID(key) == sampledID {
-			return flight.err
-		}
-		return ProbeNoClobberPublish(fs, key)
-	}
-	flight := &noClobberFlight{done: make(chan struct{})}
-	// The flight stays registered under the key sampled BEFORE any drift
-	// retry — re-validation may move cacheKey to another identity mid-round,
-	// and cleanup must still drop the registration waiter keys reference.
-	flightKey := cacheKey
-	noClobberInflight[flightKey] = flight
-	noClobberCacheMu.Unlock()
 
-	// A verdict is only trusted when the identity sampled before the probe
-	// still holds afterwards: a mid-probe mount/symlink swap means the
-	// result describes the OTHER filesystem, so it is neither returned nor
-	// cached. The round re-samples and retries, and perpetual flapping
-	// exhausts the attempt budget as indeterminate (codex P2, PR #255).
-	conclusive, verdict := false, error(nil)
-	for attempt := 0; attempt < noClobberProbeMaxAttempts; attempt++ {
-		c, v := runNoClobberProbe(fs, key)
-		afterID := noClobberProbeDirID(key)
-		if afterID == sampledID {
-			conclusive, verdict = c, v
-			break
+		noClobberCacheMu.Lock()
+		if verdict, ok := noClobberCache[cacheKey]; ok {
+			noClobberCacheMu.Unlock()
+			// Validate that the hit still describes the live filesystem: a
+			// remount/retarget between the sample above and this lookup would
+			// serve the previous mount's answer to the new one.
+			if noClobberProbeDirID(key) == sampledID {
+				return verdict
+			}
+			continue
 		}
-		sampledID = afterID
-		cacheKey = key
-		if afterID != "" {
-			cacheKey += "|" + afterID
+		if flight, ok := noClobberInflight[cacheKey]; ok {
+			noClobberCacheMu.Unlock()
+			<-flight.done
+			// Same return-time revalidation for verdicts completed by a peer:
+			// a mid-wait filesystem change invalidates the key this caller
+			// joined under.
+			if noClobberProbeDirID(key) == sampledID {
+				return flight.err
+			}
+			continue
 		}
-		verdict = fmt.Errorf("no-clobber preflight in %s: %w", key, ErrNoClobberProbeUnstable)
+		flight := &noClobberFlight{done: make(chan struct{})}
+		// The flight stays registered under the key sampled BEFORE any drift
+		// retry — the probe rounds below may move cacheKey to another
+		// identity, and cleanup must still drop the registration key.
+		flightKey := cacheKey
+		noClobberInflight[flightKey] = flight
+		noClobberCacheMu.Unlock()
+
+		// A freshly computed verdict is only trusted when the identity
+		// sampled before the probe still holds afterwards; each mid-probe
+		// drift re-keys and retries within the shared attempt budget.
+		conclusive, verdict := false, error(nil)
+		for attempt := 0; attempt < noClobberProbeMaxAttempts; attempt++ {
+			c, v := runNoClobberProbe(fs, key)
+			afterID := noClobberProbeDirID(key)
+			if afterID == sampledID {
+				conclusive, verdict = c, v
+				break
+			}
+			sampledID = afterID
+			cacheKey = key
+			if afterID != "" {
+				cacheKey += "|" + afterID
+			}
+			verdict = fmt.Errorf("no-clobber preflight in %s: %w", key, ErrNoClobberProbeUnstable)
+		}
+		noClobberCacheMu.Lock()
+		if conclusive {
+			// The stabilized post-drift identity owns the verdict key;
+			// waiters resolve through the original registration key.
+			noClobberCache[cacheKey] = verdict
+		}
+		delete(noClobberInflight, flightKey)
+		flight.err = verdict
+		close(flight.done)
+		noClobberCacheMu.Unlock()
+		return verdict
 	}
-	noClobberCacheMu.Lock()
-	if conclusive {
-		// The stabilized post-drift identity owns the verdict key; waiters
-		// still resolve through the original registration key below.
-		noClobberCache[cacheKey] = verdict
-	}
-	delete(noClobberInflight, flightKey)
-	flight.err = verdict
-	close(flight.done)
-	noClobberCacheMu.Unlock()
-	return verdict
+	return fmt.Errorf("no-clobber preflight in %s: %w", key, ErrNoClobberProbeUnstable)
 }
 
 // noClobberProbeMaxAttempts bounds probe-pair retries after a collision on

--- a/internal/fsutil/noreplace_probe_linux_test.go
+++ b/internal/fsutil/noreplace_probe_linux_test.go
@@ -1,0 +1,89 @@
+//go:build linux
+
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoClobberProbeLinuxFUSERefusal(t *testing.T) {
+	for _, move := range []bool{false, true} {
+		t.Run(map[bool]string{false: "copy", true: "cross-device move"}[move], func(t *testing.T) {
+			dir := t.TempDir()
+			src, dst := filepath.Join(dir, "movie.mp4"), filepath.Join(dir, "out", "movie.mp4")
+			require.NoError(t, os.WriteFile(src, []byte("original payload"), 0o600))
+			prevK, prevL := renameNoReplaceKernel, publishNoReplaceLink
+			t.Cleanup(func() { renameNoReplaceKernel = prevK; publishNoReplaceLink = prevL })
+			probes, links := 0, 0
+			renameNoReplaceKernel = func(s, d string) error {
+				if s == src {
+					require.True(t, move)
+					return syscall.EXDEV
+				}
+				require.True(t, strings.HasPrefix(filepath.Base(s), ".nrprobe."), "no payload staging or cleanup rename")
+				require.Equal(t, filepath.Dir(dst), filepath.Dir(s))
+				probes++
+				return syscall.EINVAL
+			}
+			publishNoReplaceLink = func(s, d string) error {
+				links++
+				require.True(t, strings.HasPrefix(filepath.Base(s), ".nrprobe."))
+				return syscall.EPERM
+			}
+			op := CopyFileNoReplace
+			if move {
+				op = MoveFileNoReplace
+			}
+			for i := 0; i < 2; i++ {
+				err := op(afero.NewOsFs(), src, dst)
+				require.ErrorIs(t, err, ErrPublishNoReplaceUnsupported)
+				require.NotErrorIs(t, err, syscall.EINVAL)
+				require.False(t, isCrossDeviceError(err))
+				for _, text := range []string{"renameat2(RENAME_NOREPLACE)", syscall.EINVAL.Error(), "link(2)", syscall.EPERM.Error(), "native-filesystem path", "/mnt/diskN/", "protected_hardlinks"} {
+					require.ErrorContains(t, err, text)
+				}
+			}
+			require.Equal(t, 1, probes)
+			require.Equal(t, 1, links)
+			got, err := os.ReadFile(src)
+			require.NoError(t, err)
+			require.Equal(t, "original payload", string(got))
+			entries, err := os.ReadDir(filepath.Dir(dst))
+			require.NoError(t, err)
+			require.Empty(t, entries, "no .nrstg and successful bound cleanup leaves no probe")
+		})
+	}
+}
+
+func TestNoClobberProbeLinuxSameVolumeMoveUntouched(t *testing.T) {
+	for _, incapable := range []bool{false, true} {
+		t.Run(map[bool]string{false: "capable", true: "incapable"}[incapable], func(t *testing.T) {
+			dir := t.TempDir()
+			src, dst := filepath.Join(dir, "source"), filepath.Join(dir, "dest")
+			require.NoError(t, os.WriteFile(src, []byte("payload"), 0o600))
+			stubNoClobberProbe(t, func(afero.Fs, string, string) error { t.Fatal("same-volume move must never probe"); return nil })
+			if incapable {
+				stubRenameNoReplaceKernelW16(t, syscall.EINVAL)
+				stubPublishNoReplaceLinkW17L(t, syscall.EPERM)
+			}
+			err := MoveFileNoReplace(afero.NewOsFs(), src, dst)
+			if incapable {
+				require.ErrorIs(t, err, ErrPublishNoReplaceUnsupported)
+				require.NotErrorIs(t, err, syscall.EINVAL)
+				require.FileExists(t, src)
+				require.NoFileExists(t, dst)
+			} else {
+				require.NoError(t, err)
+				require.NoFileExists(t, src)
+				require.FileExists(t, dst)
+			}
+		})
+	}
+}

--- a/internal/fsutil/noreplace_probe_unix_test.go
+++ b/internal/fsutil/noreplace_probe_unix_test.go
@@ -320,18 +320,74 @@ func TestNoClobberProbeSingleFlightAndDirectoryCount(t *testing.T) {
 
 func TestNoClobberProbeWaiterSharesIndeterminate(t *testing.T) {
 	dir := t.TempDir()
+	stubNoClobberDirID(t, func(string) string { return "w" })
+	key := dir + "|w"
 	flight := &noClobberFlight{done: make(chan struct{}), err: syscall.EIO}
 	noClobberCacheMu.Lock()
-	noClobberInflight[dir] = flight
+	noClobberInflight[key] = flight
 	noClobberCacheMu.Unlock()
 	close(flight.done)
 	require.ErrorIs(t, ProbeNoClobberPublish(afero.NewOsFs(), dir), syscall.EIO)
 	noClobberCacheMu.Lock()
-	delete(noClobberInflight, dir)
-	_, cached := noClobberCache[dir]
+	delete(noClobberInflight, key)
+	_, cached := noClobberCache[key]
 	noClobberCacheMu.Unlock()
 	require.False(t, cached)
 	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+}
+
+func stubNoClobberDirID(t *testing.T, fn func(string) string) {
+	t.Helper()
+	prev := noClobberProbeDirID
+	noClobberProbeDirID = fn
+	t.Cleanup(func() { noClobberProbeDirID = prev })
+}
+
+// TestNoClobberProbeCacheInvalidatesOnDirectoryIdentityChange: a
+// remount/retarget under the same absolute path changes the identity in the
+// cache key, so a conclusive verdict from the old filesystem is re-probed
+// against the new one instead of being served forever (codex P2, PR #255).
+func TestNoClobberProbeCacheInvalidatesOnDirectoryIdentityChange(t *testing.T) {
+	dir := t.TempDir()
+	mount := "mountA"
+	stubNoClobberDirID(t, func(string) string { return mount })
+	refusal := fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EPERM)
+	calls := 0
+	stubNoClobberProbe(t, func(fs afero.Fs, src, dst string) error {
+		calls++
+		if mount == "mountA" {
+			return refusal
+		}
+		return PublishNoReplace(fs, src, dst)
+	})
+	require.ErrorIs(t, ProbeNoClobberPublish(afero.NewOsFs(), dir), refusal)
+	require.ErrorIs(t, ProbeNoClobberPublish(afero.NewOsFs(), dir), refusal)
+	require.Equal(t, 1, calls, "conclusive verdict caches within one filesystem identity")
+
+	mount = "mountB"
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir), "identity change invalidates the cached refusal")
+	require.Equal(t, 2, calls, "new identity pays for a fresh probe")
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.Equal(t, 2, calls)
+}
+
+// TestNoClobberProbeDirectoryIdentityDegradation: identity lookup failures
+// degrade to path-only caching instead of blocking, and the real identity
+// helper handles both missing paths and live directories.
+func TestNoClobberProbeDirectoryIdentityDegradation(t *testing.T) {
+	stubNoClobberDirID(t, func(string) string { return "" })
+	dir := t.TempDir()
+	calls := 0
+	stubNoClobberProbe(t, func(fs afero.Fs, src, dst string) error {
+		calls++
+		return PublishNoReplace(fs, src, dst)
+	})
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.Equal(t, 1, calls)
+
+	require.Empty(t, noClobberDirIdentity(filepath.Join(t.TempDir(), "missing")))
+	require.NotEmpty(t, noClobberDirIdentity(t.TempDir()))
 }
 
 func TestNoClobberProbeCopyRefusesBeforeOpeningSource(t *testing.T) {

--- a/internal/fsutil/noreplace_probe_unix_test.go
+++ b/internal/fsutil/noreplace_probe_unix_test.go
@@ -1,0 +1,321 @@
+//go:build !windows
+
+package fsutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func stubNoClobberProbe(t *testing.T, fn func(afero.Fs, string, string) error) {
+	t.Helper()
+	prev := publishNoClobberProbe
+	publishNoClobberProbe = fn
+	t.Cleanup(func() { publishNoClobberProbe = prev })
+}
+
+func TestNoClobberProbeVerdicts(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		err        error
+		conclusive bool
+	}{
+		{"capable", nil, true},
+		{"eperm", fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EPERM), true},
+		{"enosys", fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.ENOSYS), true},
+		{"eopnotsupp", fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EOPNOTSUPP), true},
+		{"enotsup", fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.ENOTSUP), true},
+		{"collision", ErrPublishCollision, false},
+		{"io", syscall.EIO, false},
+		{"access", syscall.EACCES, false},
+		{"untyped capability", syscall.EPERM, false},
+		{"unsupported without errno", ErrPublishNoReplaceUnsupported, false},
+		{"unsupported transient", fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EACCES), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			calls := 0
+			stubNoClobberProbe(t, func(fs afero.Fs, src, dst string) error {
+				calls++
+				require.Equal(t, dir, filepath.Dir(src))
+				require.Equal(t, dir, filepath.Dir(dst))
+				if calls > 1 || tc.err == nil {
+					return PublishNoReplace(fs, src, dst)
+				}
+				return tc.err
+			})
+			err := ProbeNoClobberPublish(afero.NewOsFs(), dir)
+			if tc.err == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.err)
+			}
+			err = ProbeNoClobberPublish(afero.NewOsFs(), filepath.Join(dir, "unused", ".."))
+			if tc.conclusive && tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+			want := 1
+			if !tc.conclusive {
+				want = 2
+			}
+			require.Equal(t, want, calls)
+			entries, err := os.ReadDir(dir)
+			require.NoError(t, err)
+			require.Empty(t, entries)
+		})
+	}
+}
+
+func TestNoClobberProbeBypassAndPathFailure(t *testing.T) {
+	stubNoClobberProbe(t, func(afero.Fs, string, string) error { t.Fatal("unexpected publish"); return nil })
+	require.NoError(t, ProbeNoClobberPublish(afero.NewMemMapFs(), "/missing"))
+	platform := noClobberProbePlatform
+	noClobberProbePlatform = "windows"
+	t.Cleanup(func() { noClobberProbePlatform = platform })
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), "/missing"))
+	noClobberProbePlatform = platform
+	prev := noClobberProbeAbs
+	noClobberProbeAbs = func(string) (string, error) { return "", syscall.ENOENT }
+	t.Cleanup(func() { noClobberProbeAbs = prev })
+	require.ErrorContains(t, ProbeNoClobberPublish(afero.NewOsFs(), "."), "resolve no-clobber probe directory")
+}
+
+func TestNoClobberProbeCreationFailures(t *testing.T) {
+	require.ErrorContains(t, ProbeNoClobberPublish(afero.NewOsFs(), filepath.Join(t.TempDir(), "missing")), "create no-clobber probe")
+	prev := createNoClobberProbe
+	t.Cleanup(func() { createNoClobberProbe = prev })
+	var file afero.File
+	createNoClobberProbe = func(fs afero.Fs, dest, suffix string, start uint64, mode os.FileMode) (string, afero.File, error) {
+		path, fh, err := prev(fs, dest, suffix, start, mode)
+		require.NoError(t, err)
+		file = fh
+		return path, &probeStatFailureFile{File: fh}, nil
+	}
+	dir := t.TempDir()
+	require.ErrorContains(t, ProbeNoClobberPublish(afero.NewOsFs(), dir), "capture no-clobber probe identity")
+	_, err := file.Stat()
+	require.Error(t, err, "retained handle must still close")
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "unidentified probe retained")
+}
+
+type probeStatFailureFile struct{ afero.File }
+
+func (f *probeStatFailureFile) Stat() (os.FileInfo, error) { return nil, syscall.EIO }
+
+func TestNoClobberProbeExclusiveCollision(t *testing.T) {
+	dir := t.TempDir()
+	planted := filepath.Join(dir, ".nrprobe."+strconv.FormatUint(noreplaceOrdinal.Load()+1, 16))
+	require.NoError(t, os.WriteFile(planted, []byte("foreign"), 0o600))
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	got, err := os.ReadFile(planted)
+	require.NoError(t, err)
+	require.Equal(t, "foreign", string(got))
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+}
+
+func TestNoClobberProbeBoundUnlink(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "probe")
+	fh, err := os.Create(path)
+	require.NoError(t, err)
+	defer fh.Close()
+	created, err := fh.Stat()
+	require.NoError(t, err)
+	foreign := filepath.Join(dir, "foreign")
+	require.NoError(t, os.WriteFile(foreign, []byte("foreign"), 0o600))
+	other, err := os.Stat(foreign)
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		name                       string
+		fd                         caseProbeFile
+		identity, lookup           os.FileInfo
+		lookupErr, removeErr, want error
+		removes                    int
+	}{
+		{"fstat error", w40FailStatFile{syscall.EIO}, created, created, nil, nil, syscall.EIO, 0},
+		{"no identity", fh, nil, created, nil, nil, ErrTakeAsideForeign, 0},
+		{"descriptor swap", w40ScratchFile{other}, created, created, nil, nil, ErrTakeAsideForeign, 0},
+		{"lookup error", fh, created, nil, syscall.EACCES, nil, syscall.EACCES, 0},
+		{"vanished", fh, created, nil, os.ErrNotExist, nil, os.ErrNotExist, 0},
+		{"pathname swap", fh, created, other, nil, nil, ErrTakeAsideForeign, 0},
+		{"unlink error", fh, created, created, nil, syscall.EPERM, syscall.EPERM, 1},
+		{"unlink vanished", fh, created, created, nil, os.ErrNotExist, os.ErrNotExist, 1},
+		{"success", fh, created, created, nil, nil, nil, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			removed := 0
+			ops := caseProbeOps{
+				stat:   func(p string) (os.FileInfo, error) { require.Equal(t, path, p); return tc.lookup, tc.lookupErr },
+				remove: func(p string) error { require.Equal(t, path, p); removed++; return tc.removeErr },
+				rename: func(string, string) error { t.Fatal("must never vacate"); return nil },
+			}
+			err := unlinkNoClobberProbe(ops, path, tc.fd, tc.identity)
+			if tc.want == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.want)
+			}
+			require.Equal(t, tc.removes, removed)
+		})
+	}
+}
+
+func TestNoClobberProbeCleanupNeverMasksVerdict(t *testing.T) {
+	for _, capable := range []bool{false, true} {
+		for _, substitution := range []bool{false, true} {
+			t.Run(fmt.Sprintf("capable=%v/substitution=%v", capable, substitution), func(t *testing.T) {
+				dir := t.TempDir()
+				prev := noClobberProbeOps
+				t.Cleanup(func() { noClobberProbeOps = prev })
+				if !substitution {
+					noClobberProbeOps.remove = func(string) error { return syscall.EINVAL }
+				}
+				calls := 0
+				var retained string
+				refusal := fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EPERM)
+				stubNoClobberProbe(t, func(fs afero.Fs, src, dst string) error {
+					calls++
+					retained = src
+					if capable {
+						require.NoError(t, PublishNoReplace(fs, src, dst))
+						retained = dst
+					}
+					if substitution {
+						require.NoError(t, os.Rename(retained, retained+".saved"))
+						require.NoError(t, os.WriteFile(retained, []byte("foreign"), 0o600))
+					}
+					if capable {
+						return nil
+					}
+					return refusal
+				})
+				for i := 0; i < 2; i++ {
+					err := ProbeNoClobberPublish(afero.NewOsFs(), dir)
+					if capable {
+						require.NoError(t, err)
+					} else {
+						require.ErrorIs(t, err, refusal)
+						require.NotErrorIs(t, err, syscall.EINVAL)
+					}
+				}
+				require.Equal(t, 1, calls)
+				if substitution {
+					got, err := os.ReadFile(retained)
+					require.NoError(t, err)
+					require.Equal(t, "foreign", string(got))
+				}
+			})
+		}
+	}
+}
+
+func TestNoClobberProbeSymlinkSubstitution(t *testing.T) {
+	dir := t.TempDir()
+	var source string
+	stubNoClobberProbe(t, func(_ afero.Fs, src, _ string) error {
+		source = src
+		require.NoError(t, os.Rename(src, src+".saved"))
+		require.NoError(t, os.Symlink(src+".saved", src))
+		return fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EPERM)
+	})
+	require.ErrorIs(t, ProbeNoClobberPublish(afero.NewOsFs(), dir), ErrPublishNoReplaceUnsupported)
+	info, err := os.Lstat(source)
+	require.NoError(t, err)
+	require.NotZero(t, info.Mode()&os.ModeSymlink)
+}
+
+func TestNoClobberProbeSingleFlightAndDirectoryCount(t *testing.T) {
+	var calls atomic.Int32
+	entered, release := make(chan struct{}), make(chan struct{})
+	slow, other := t.TempDir(), t.TempDir()
+	stubNoClobberProbe(t, func(fs afero.Fs, src, dst string) error {
+		calls.Add(1)
+		if filepath.Dir(src) == slow {
+			close(entered)
+			<-release
+		}
+		return PublishNoReplace(fs, src, dst)
+	})
+	var wg sync.WaitGroup
+	errs := make(chan error, 32)
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); errs <- ProbeNoClobberPublish(afero.NewOsFs(), slow) }()
+	}
+	<-entered
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), other), "another key progresses during IO")
+	close(release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.EqualValues(t, 2, calls.Load())
+	for i := 0; i < 20; i++ {
+		dir := t.TempDir()
+		for j := 0; j < 3; j++ {
+			require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+		}
+	}
+	require.EqualValues(t, 22, calls.Load())
+}
+
+func TestNoClobberProbeWaiterSharesIndeterminate(t *testing.T) {
+	dir := t.TempDir()
+	flight := &noClobberFlight{done: make(chan struct{}), err: syscall.EIO}
+	noClobberCacheMu.Lock()
+	noClobberInflight[dir] = flight
+	noClobberCacheMu.Unlock()
+	close(flight.done)
+	require.ErrorIs(t, ProbeNoClobberPublish(afero.NewOsFs(), dir), syscall.EIO)
+	noClobberCacheMu.Lock()
+	delete(noClobberInflight, dir)
+	_, cached := noClobberCache[dir]
+	noClobberCacheMu.Unlock()
+	require.False(t, cached)
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+}
+
+func TestNoClobberProbeCopyRefusesBeforeOpeningSource(t *testing.T) {
+	dir := t.TempDir()
+	src, dst := filepath.Join(dir, "source"), filepath.Join(dir, "out", "movie.mp4")
+	// A directory cannot be streamed as a file: the preflight error must win
+	// before opening/streaming the source, with no payload staging at all.
+	require.NoError(t, os.Mkdir(src, 0o700))
+	refusal := fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EPERM)
+	stubNoClobberProbe(t, func(afero.Fs, string, string) error { return refusal })
+	require.ErrorIs(t, CopyFileNoReplace(afero.NewOsFs(), src, dst), refusal)
+	entries, err := os.ReadDir(filepath.Dir(dst))
+	require.NoError(t, err)
+	require.Empty(t, entries)
+	_, err = os.Stat(src)
+	require.NoError(t, err)
+}
+
+func TestNoClobberProbePositiveCacheStillPublishes(t *testing.T) {
+	dir := t.TempDir()
+	src, dst := filepath.Join(dir, "source"), filepath.Join(dir, "out")
+	require.NoError(t, os.WriteFile(src, []byte("payload"), 0o600))
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	hookNoReplacePlantSeams(t, func() { _ = os.WriteFile(dst, []byte("foreign"), 0o600) })
+	require.True(t, errors.Is(CopyFileNoReplace(afero.NewOsFs(), src, dst), ErrPublishCollision))
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	require.Equal(t, "foreign", string(got))
+}

--- a/internal/fsutil/noreplace_probe_unix_test.go
+++ b/internal/fsutil/noreplace_probe_unix_test.go
@@ -580,6 +580,36 @@ func TestNoClobberProbeSustainedCacheDriftExitsIndeterminate(t *testing.T) {
 	require.ErrorIs(t, err, ErrNoClobberProbeUnstable)
 	require.Zero(t, calls, "stale-identity hits never reach the physical probe")
 }
+
+// TestNoClobberProbeCollisionAdvancesPastSelectedOrdinal: the creation skip
+// scan may land far above the requested ordinal; a sibling collision on that
+// NAME must advance the shared nonce beyond it or every retry round selects
+// and recollides on the same blocked name (codex P2, PR #255).
+func TestNoClobberProbeCollisionAdvancesPastSelectedOrdinal(t *testing.T) {
+	dir := t.TempDir()
+	base := noreplaceOrdinal.Load()
+	// Occupy SOURCE ordinals base+1..base+3 so the skip scan selects base+4,
+	// and occupy base+4's sibling so the collision fires on THAT name.
+	for i := uint64(1); i <= 3; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".nrprobe."+strconv.FormatUint(base+i, 16)), []byte("held"), 0o600))
+	}
+	blocked := filepath.Join(dir, ".nrprobe."+strconv.FormatUint(base+4, 16)+".published")
+	require.NoError(t, os.WriteFile(blocked, []byte("held"), 0o600))
+	collision := fmt.Errorf("occupied sibling: %w", ErrPublishCollision)
+	calls := 0
+	stubNoClobberProbe(t, func(fs afero.Fs, src, dst string) error {
+		calls++
+		if dst == blocked {
+			return collision
+		}
+		return PublishNoReplace(fs, src, dst)
+	})
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.Equal(t, 2, calls, "retry must skip the burnt ordinal instead of recreating base+4")
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 4, "planted files retained; probe pairs cleaned")
+}
 func TestNoClobberProbeCopyRefusesBeforeOpeningSource(t *testing.T) {
 	dir := t.TempDir()
 	src, dst := filepath.Join(dir, "source"), filepath.Join(dir, "out", "movie.mp4")

--- a/internal/fsutil/noreplace_probe_unix_test.go
+++ b/internal/fsutil/noreplace_probe_unix_test.go
@@ -323,7 +323,7 @@ func TestNoClobberProbeWaiterSharesIndeterminate(t *testing.T) {
 	dir := t.TempDir()
 	stubNoClobberDirID(t, func(string) string { return "w" })
 	key := dir + "|w"
-	flight := &noClobberFlight{done: make(chan struct{}), err: syscall.EIO}
+	flight := &noClobberFlight{done: make(chan struct{}), err: syscall.EIO, id: "w"}
 	noClobberCacheMu.Lock()
 	noClobberInflight[key] = flight
 	noClobberCacheMu.Unlock()
@@ -527,7 +527,8 @@ func TestNoClobberProbeWaiterRevalidatesOnWake(t *testing.T) {
 		calls++
 		return PublishNoReplace(fs, src, dst)
 	})
-	flight := &noClobberFlight{done: make(chan struct{}), err: fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EPERM)}
+	// The flight's verdict was produced under identity A.
+	flight := &noClobberFlight{done: make(chan struct{}), err: fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EPERM), id: "A"}
 	noClobberCacheMu.Lock()
 	noClobberInflight[dir+"|A"] = flight
 	noClobberCacheMu.Unlock()

--- a/internal/fsutil/noreplace_probe_unix_test.go
+++ b/internal/fsutil/noreplace_probe_unix_test.go
@@ -414,6 +414,33 @@ func TestNoClobberDirIdentityDegradedInputs(t *testing.T) {
 	require.Empty(t, noClobberDirIdentity(t.TempDir()))
 }
 
+// TestNoClobberProbeIdentityDriftForbidsCaching: an identity sample taken
+// before the probe that differs after proves the verdict belongs to another
+// filesystem — it must never be cached under the sampled key, and the next
+// call re-probes (codex P2, PR #255).
+func TestNoClobberProbeIdentityDriftForbidsCaching(t *testing.T) {
+	dir := t.TempDir()
+	ids := []string{"A", "B", "B", "B"}
+	idx := 0
+	stubNoClobberDirID(t, func(string) string {
+		v := ids[idx]
+		if idx < len(ids)-1 {
+			idx++
+		}
+		return v
+	})
+	calls := 0
+	stubNoClobberProbe(t, func(fs afero.Fs, src, dst string) error {
+		calls++
+		return PublishNoReplace(fs, src, dst)
+	})
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.Equal(t, 2, calls, "drifted verdict skipped the cache; steady identity re-probed and cached")
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.Equal(t, 2, calls)
+}
+
 func TestNoClobberProbeCopyRefusesBeforeOpeningSource(t *testing.T) {
 	dir := t.TempDir()
 	src, dst := filepath.Join(dir, "source"), filepath.Join(dir, "out", "movie.mp4")

--- a/internal/fsutil/noreplace_probe_unix_test.go
+++ b/internal/fsutil/noreplace_probe_unix_test.go
@@ -441,6 +441,33 @@ func TestNoClobberProbeIdentityDriftForbidsCaching(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
+// TestNoClobberProbePerpetualIdentityFlapReturnsIndeterminate: identities
+// that disagree on every sampling window must not surface any physical
+// probe verdict to CopyFileNoReplace — each drifted result describes the
+// other filesystem, so after the retry budget the caller gets an
+// indeterminate unstable-identity error and nothing is cached
+// (codex P2, PR #255). The flap alternates between a real identity and the
+// empty degradation marker, covering both cache-key arms mid-round.
+func TestNoClobberProbePerpetualIdentityFlapReturnsIndeterminate(t *testing.T) {
+	dir := t.TempDir()
+	idx := 0
+	stubNoClobberDirID(t, func(string) string {
+		idx++
+		if idx%2 == 0 {
+			return "A"
+		}
+		return ""
+	})
+	calls := 0
+	stubNoClobberProbe(t, func(fs afero.Fs, src, dst string) error {
+		calls++
+		return PublishNoReplace(fs, src, dst)
+	})
+	require.ErrorIs(t, ProbeNoClobberPublish(afero.NewOsFs(), dir), ErrNoClobberProbeUnstable)
+	require.Equal(t, noClobberProbeMaxAttempts, calls, "every round is fully re-probed while identities flap")
+	require.ErrorIs(t, ProbeNoClobberPublish(afero.NewOsFs(), dir), ErrNoClobberProbeUnstable)
+	require.Equal(t, 2*noClobberProbeMaxAttempts, calls, "unstable rounds are never cached")
+}
 func TestNoClobberProbeCopyRefusesBeforeOpeningSource(t *testing.T) {
 	dir := t.TempDir()
 	src, dst := filepath.Join(dir, "source"), filepath.Join(dir, "out", "movie.mp4")

--- a/internal/fsutil/noreplace_probe_unix_test.go
+++ b/internal/fsutil/noreplace_probe_unix_test.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -388,6 +389,29 @@ func TestNoClobberProbeDirectoryIdentityDegradation(t *testing.T) {
 
 	require.Empty(t, noClobberDirIdentity(filepath.Join(t.TempDir(), "missing")))
 	require.NotEmpty(t, noClobberDirIdentity(t.TempDir()))
+}
+
+type probeNonStatTInfo struct{}
+
+func (probeNonStatTInfo) Name() string       { return "fake" }
+func (probeNonStatTInfo) Size() int64        { return 0 }
+func (probeNonStatTInfo) Mode() os.FileMode  { return os.ModeDir }
+func (probeNonStatTInfo) ModTime() time.Time { return time.Now() }
+func (probeNonStatTInfo) IsDir() bool        { return true }
+func (probeNonStatTInfo) Sys() any           { return struct{}{} }
+
+// TestNoClobberDirIdentityDegradedInputs: identity lookup fails closed when
+// the stat errors or the platform reports a non-Stat_t identity source,
+// degrading callers to path-only cache keys instead of blocking probes.
+func TestNoClobberDirIdentityDegradedInputs(t *testing.T) {
+	prev := noClobberProbeStat
+	t.Cleanup(func() { noClobberProbeStat = prev })
+
+	noClobberProbeStat = func(string) (os.FileInfo, error) { return nil, syscall.EIO }
+	require.Empty(t, noClobberDirIdentity(t.TempDir()))
+
+	noClobberProbeStat = func(string) (os.FileInfo, error) { return probeNonStatTInfo{}, nil }
+	require.Empty(t, noClobberDirIdentity(t.TempDir()))
 }
 
 func TestNoClobberProbeCopyRefusesBeforeOpeningSource(t *testing.T) {

--- a/internal/fsutil/noreplace_probe_unix_test.go
+++ b/internal/fsutil/noreplace_probe_unix_test.go
@@ -545,6 +545,40 @@ func TestNoClobberProbeWaiterRevalidatesOnWake(t *testing.T) {
 	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
 	require.Equal(t, 1, calls, "B's verdict is cached")
 }
+
+// TestNoClobberProbeSustainedCacheDriftExitsIndeterminate: every
+// sample/revalidation pair disagreeing across the bounded round loop must
+// terminate with ErrNoClobberProbeUnstable — iteratively, without running a
+// physical probe and without recursion (codex P2, PR #255).
+func TestNoClobberProbeSustainedCacheDriftExitsIndeterminate(t *testing.T) {
+	dir := t.TempDir()
+	sample := 0
+	stubNoClobberDirID(t, func(string) string {
+		sample++
+		// A,B / B,C / C,D: each round's sample differs from its revalidation,
+		// so cached verdicts are never usable.
+		return string(rune('A' + sample/2))
+	})
+	refusal := fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EPERM)
+	noClobberCacheMu.Lock()
+	for _, id := range []string{"A", "B", "C"} {
+		noClobberCache[dir+"|"+id] = refusal
+	}
+	noClobberCacheMu.Unlock()
+	t.Cleanup(func() {
+		noClobberCacheMu.Lock()
+		for _, id := range []string{"A", "B", "C"} {
+			delete(noClobberCache, dir+"|"+id)
+		}
+		noClobberCacheMu.Unlock()
+	})
+	calls := 0
+	stubNoClobberProbe(t, func(afero.Fs, string, string) error { calls++; return nil })
+
+	err := ProbeNoClobberPublish(afero.NewOsFs(), dir)
+	require.ErrorIs(t, err, ErrNoClobberProbeUnstable)
+	require.Zero(t, calls, "stale-identity hits never reach the physical probe")
+}
 func TestNoClobberProbeCopyRefusesBeforeOpeningSource(t *testing.T) {
 	dir := t.TempDir()
 	src, dst := filepath.Join(dir, "source"), filepath.Join(dir, "out", "movie.mp4")

--- a/internal/fsutil/noreplace_probe_unix_test.go
+++ b/internal/fsutil/noreplace_probe_unix_test.go
@@ -35,7 +35,6 @@ func TestNoClobberProbeVerdicts(t *testing.T) {
 		{"enosys", fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.ENOSYS), true},
 		{"eopnotsupp", fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EOPNOTSUPP), true},
 		{"enotsup", fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.ENOTSUP), true},
-		{"collision", ErrPublishCollision, false},
 		{"io", syscall.EIO, false},
 		{"access", syscall.EACCES, false},
 		{"untyped capability", syscall.EPERM, false},
@@ -68,6 +67,8 @@ func TestNoClobberProbeVerdicts(t *testing.T) {
 			}
 			want := 1
 			if !tc.conclusive {
+				// Indeterminate verdicts are never cached, so the re-probe
+				// statement above paid for another full attempt.
 				want = 2
 			}
 			require.Equal(t, want, calls)
@@ -238,6 +239,47 @@ func TestNoClobberProbeSymlinkSubstitution(t *testing.T) {
 	info, err := os.Lstat(source)
 	require.NoError(t, err)
 	require.NotZero(t, info.Mode()&os.ModeSymlink)
+}
+
+// TestNoClobberProbeCollisionRetry: a collision on the synthetic sibling is
+// probe-name noise, not a verdict — the loop swaps in a fresh ordinal pair
+// (codex P2, PR #255).
+func TestNoClobberProbeCollisionRetry(t *testing.T) {
+	dir := t.TempDir()
+	calls := 0
+	stubNoClobberProbe(t, func(fs afero.Fs, src, dst string) error {
+		calls++
+		if calls == 1 {
+			return fmt.Errorf("planted sibling: %w", ErrPublishCollision)
+		}
+		return PublishNoReplace(fs, src, dst)
+	})
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.Equal(t, 2, calls)
+	// verdict is conclusive and cached: a second probe pays nothing
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.Equal(t, 2, calls)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+// TestNoClobberProbeCollisionExhausted: persistent pair collisions fail as
+// indeterminate (never cached) after noClobberProbeMaxAttempts.
+func TestNoClobberProbeCollisionExhausted(t *testing.T) {
+	dir := t.TempDir()
+	calls := 0
+	stubNoClobberProbe(t, func(afero.Fs, string, string) error {
+		calls++
+		return fmt.Errorf("planted sibling: %w", ErrPublishCollision)
+	})
+	err := ProbeNoClobberPublish(afero.NewOsFs(), dir)
+	require.ErrorIs(t, err, ErrPublishCollision)
+	require.Contains(t, err.Error(), "still occupied")
+	require.Equal(t, noClobberProbeMaxAttempts, calls)
+	// uncached: re-probing pays full attempts again
+	_ = ProbeNoClobberPublish(afero.NewOsFs(), dir)
+	require.Equal(t, 2*noClobberProbeMaxAttempts, calls)
 }
 
 func TestNoClobberProbeSingleFlightAndDirectoryCount(t *testing.T) {

--- a/internal/fsutil/noreplace_probe_unix_test.go
+++ b/internal/fsutil/noreplace_probe_unix_test.go
@@ -468,6 +468,83 @@ func TestNoClobberProbePerpetualIdentityFlapReturnsIndeterminate(t *testing.T) {
 	require.ErrorIs(t, ProbeNoClobberPublish(afero.NewOsFs(), dir), ErrNoClobberProbeUnstable)
 	require.Equal(t, 2*noClobberProbeMaxAttempts, calls, "unstable rounds are never cached")
 }
+
+// TestNoClobberProbeCachedVerdictRevalidatedAtReturn: a remount between the
+// identity sample and the cache hit must not serve the previous
+// filesystem's verdict — the lookup restarts against the new identity and
+// probes for the live mount (codex P2, PR #255).
+func TestNoClobberProbeCachedVerdictRevalidatedAtReturn(t *testing.T) {
+	dir := t.TempDir()
+	ids := []string{"A", "A", "A", "B", "B", "B", "B"}
+	idx := 0
+	stubNoClobberDirID(t, func(string) string {
+		v := ids[idx]
+		if idx < len(ids)-1 {
+			idx++
+		}
+		return v
+	})
+	refusal := fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EPERM)
+	calls := 0
+	stubNoClobberProbe(t, func(fs afero.Fs, src, dst string) error {
+		calls++
+		if calls == 1 {
+			return refusal // the old filesystem's verdict: incapable
+		}
+		return PublishNoReplace(fs, src, dst)
+	})
+	// Round one: A's verdict (refusal) is cached under A.
+	require.ErrorIs(t, ProbeNoClobberPublish(afero.NewOsFs(), dir), refusal)
+	require.Equal(t, 1, calls)
+	// Round two: identity drifted to B by return time — the stale A verdict
+	// must be discarded and the live mount probed (new filesystem: capable).
+	// Without revalidation this call would incorrectly serve A's refusal.
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.Equal(t, 2, calls)
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.Equal(t, 2, calls, "B's verdict is cached")
+}
+
+// TestNoClobberProbeWaiterRevalidatesOnWake: a waiter that joined a flight
+// keyed under one identity must not reuse the completed verdict when the
+// filesystem identity changed while it waited — it re-enters the whole
+// lookup against the new identity and probes (codex P2, PR #255).
+// Deterministic via a pre-completed flight and a scripted identity stub.
+func TestNoClobberProbeWaiterRevalidatesOnWake(t *testing.T) {
+	dir := t.TempDir()
+	// Sequence: first sample is A (joining the pre-armed A-flight), every
+	// later sample is B — the wake-time revalidation sees the drift.
+	seq := 0
+	stubNoClobberDirID(t, func(string) string {
+		seq++
+		if seq == 1 {
+			return "A"
+		}
+		return "B"
+	})
+	calls := 0
+	stubNoClobberProbe(t, func(fs afero.Fs, src, dst string) error {
+		calls++
+		return PublishNoReplace(fs, src, dst)
+	})
+	flight := &noClobberFlight{done: make(chan struct{}), err: fmt.Errorf("%w: %w", ErrPublishNoReplaceUnsupported, syscall.EPERM)}
+	noClobberCacheMu.Lock()
+	noClobberInflight[dir+"|A"] = flight
+	noClobberCacheMu.Unlock()
+	t.Cleanup(func() {
+		noClobberCacheMu.Lock()
+		delete(noClobberInflight, dir+"|A")
+		noClobberCacheMu.Unlock()
+	})
+	close(flight.done) // simulate the flight completing while this caller waited
+
+	// Without wake-time revalidation the waiter would return the flight's
+	// refusal. Instead it notices the drift, re-probes under B and succeeds.
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.Equal(t, 1, calls)
+	require.NoError(t, ProbeNoClobberPublish(afero.NewOsFs(), dir))
+	require.Equal(t, 1, calls, "B's verdict is cached")
+}
 func TestNoClobberProbeCopyRefusesBeforeOpeningSource(t *testing.T) {
 	dir := t.TempDir()
 	src, dst := filepath.Join(dir, "source"), filepath.Join(dir, "out", "movie.mp4")

--- a/internal/fsutil/noreplace_probe_windows_test.go
+++ b/internal/fsutil/noreplace_probe_windows_test.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package fsutil
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoClobberProbeWindowsBypass(t *testing.T) {
+	for _, fs := range []afero.Fs{afero.NewOsFs(), afero.NewMemMapFs()} {
+		require.NoError(t, ProbeNoClobberPublish(fs, `Z:\missing\directory`))
+	}
+}

--- a/internal/fsutil/publish_noreplace.go
+++ b/internal/fsutil/publish_noreplace.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"syscall"
 
 	"github.com/spf13/afero"
 )
@@ -121,6 +122,17 @@ var ErrPublishNoReplaceRollbackUnverified = errors.New("no-replace publish rollb
 // name as OWNED (the pending retry reaps it), exactly like the wave-20
 // completed-despite-error leg.
 var ErrPublishNoReplaceStagedUnverified = errors.New("no-replace publish staged source could not be re-proven after linking")
+
+// linkUnsupportedClass is shared by publication and its preflight. Only
+// capability-class failures justify a conclusive unsupported verdict; access,
+// IO, and other transient failures remain indeterminate. EPERM can mean an
+// incapable filesystem or hard-link policy, as the refusal diagnostic states.
+func linkUnsupportedClass(err error) bool {
+	return errors.Is(err, syscall.EPERM) ||
+		errors.Is(err, syscall.ENOSYS) ||
+		errors.Is(err, syscall.EOPNOTSUPP) ||
+		errors.Is(err, syscall.ENOTSUP)
+}
 
 // publishCollision wraps the destination name in the collision class.
 func publishCollision(dst string) error {

--- a/internal/fsutil/publish_noreplace_linux.go
+++ b/internal/fsutil/publish_noreplace_linux.go
@@ -32,7 +32,13 @@ func publishNoReplaceOSFS(src, dst string) error {
 	case errors.Is(err, syscall.EEXIST):
 		return publishCollision(dst)
 	case errors.Is(err, syscall.ENOSYS), errors.Is(err, syscall.EINVAL), errors.Is(err, syscall.EOPNOTSUPP):
-		return publishNoReplaceFallback(src, dst)
+		fallbackErr := publishNoReplaceFallback(src, dst)
+		if fallbackErr != nil {
+			// The discarded rename errno is TEXT ONLY. Wrapping EINVAL would
+			// let isCrossDeviceError reroute an unsupported refusal into a copy.
+			return fmt.Errorf("renameat2(RENAME_NOREPLACE): %v; %w", err, fallbackErr)
+		}
+		return nil
 	default:
 		return fmt.Errorf("no-replace renameat2 %s -> %s: %w", src, dst, err)
 	}

--- a/internal/fsutil/publish_noreplace_unix.go
+++ b/internal/fsutil/publish_noreplace_unix.go
@@ -3,10 +3,8 @@
 package fsutil
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"syscall"
 
 	"github.com/spf13/afero"
 )
@@ -111,21 +109,6 @@ var (
 	}
 )
 
-// linkUnsupportedClass reports whether a link(2) failure means the
-// FILESYSTEM cannot express hard links at all (FAT/exFAT-class volumes
-// answer EPERM on Linux, ENOTSUP/EPERM on Darwin), as opposed to a
-// publish-specific refusal. ENOTSUP aliases EOPNOTSUPP on Linux, so both
-// are listed for the Darwin spelling. Only these classes justify the
-// wave-17 unsupported refusal: any other failure (EACCES, EIO, EMLINK,
-// a missing staged source, ...) keeps the pre-existing degrade into the
-// classified rename leg, refusing nothing the old behavior accepted.
-func linkUnsupportedClass(err error) bool {
-	return errors.Is(err, syscall.EPERM) ||
-		errors.Is(err, syscall.ENOSYS) ||
-		errors.Is(err, syscall.EOPNOTSUPP) ||
-		errors.Is(err, syscall.ENOTSUP)
-}
-
 // publishNoReplaceFallback publishes via hard link: link(2) fails EEXIST
 // atomically when dst is occupied, giving POSIX filesystems without a
 // renameat2 wrapper the same no-replace semantics — the destination link and
@@ -169,7 +152,7 @@ func publishNoReplaceFallback(src, dst string) error {
 			return publishCollision(dst)
 		}
 		if linkUnsupportedClass(err) {
-			return fmt.Errorf("no-replace publish %s -> %s: %w: %w", src, dst, ErrPublishNoReplaceUnsupported, err)
+			return fmt.Errorf("no-replace publish %s -> %s: %w; link(2): %w — volume may lack hard-link support (FUSE/shfs-class) or EPERM may reflect protected_hardlinks policy; organize to a native-filesystem path (Unraid: bind-mount /mnt/diskN/...), or local staging plus external sync", src, dst, ErrPublishNoReplaceUnsupported, err)
 		}
 		return fmt.Errorf("no-replace publish %s -> %s: %w: %w", src, dst, ErrPublishNoReplaceLinkFailed, err)
 	}

--- a/internal/organizer/subtitle_preflight_test.go
+++ b/internal/organizer/subtitle_preflight_test.go
@@ -1,0 +1,52 @@
+package organizer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/operationmode"
+)
+
+func TestOrganizeSubtitlePreflightOsFs(t *testing.T) {
+	for _, move := range []bool{false, true} {
+		t.Run(map[bool]string{false: "copy", true: "move"}[move], func(t *testing.T) {
+			dir := t.TempDir()
+			src := filepath.Join(dir, "ABC-123.mkv")
+			sub := filepath.Join(dir, "ABC-123.srt")
+			require.NoError(t, os.WriteFile(src, []byte("video"), 0o600))
+			require.NoError(t, os.WriteFile(sub, []byte("subtitle"), 0o600))
+			org := NewOrganizer(afero.NewOsFs(), &Config{
+				FolderFormat: "<ID>", FileFormat: "<ID>", RenameFile: true,
+				OperationMode: operationmode.OperationModeOrganize,
+				MoveSubtitles: true, SubtitleExtensions: []string{".srt"},
+			}, nil, nil)
+			dest := filepath.Join(dir, "out")
+			result, err := org.Organize(context.Background(), OrganizeCmd{
+				Match: models.FileMatchInfo{MovieID: "ABC-123", Path: src, Name: "ABC-123.mkv", Extension: ".mkv"},
+				Movie: &models.Movie{ID: "ABC-123"}, DestDir: dest, MoveFiles: move, LinkMode: LinkModeNone,
+			})
+			require.NoError(t, err)
+			require.Len(t, result.Subtitles, 1)
+			require.Equal(t, move, result.Subtitles[0].Moved)
+			require.Equal(t, !move, result.Subtitles[0].Copied)
+			output := filepath.Join(dest, "ABC-123")
+			got, err := os.ReadFile(filepath.Join(output, "ABC-123.srt"))
+			require.NoError(t, err)
+			require.Equal(t, "subtitle", string(got))
+			if move {
+				require.NoFileExists(t, sub)
+			} else {
+				require.FileExists(t, sub)
+			}
+			entries, err := os.ReadDir(output)
+			require.NoError(t, err)
+			require.Len(t, entries, 2, "video and subtitle only; no probe/staging residue")
+		})
+	}
+}

--- a/web/frontend/src/lib/api/clients/history.ts
+++ b/web/frontend/src/lib/api/clients/history.ts
@@ -51,11 +51,13 @@ export class HistoryClient extends BaseClient {
 export class JobsClient extends BaseClient {
 	async listOrganizedJobs(params?: {
 		status?: string;
+		phase?: string;
 		limit?: number;
 		offset?: number;
 	}): Promise<JobListResponse> {
 		const queryParams = new URLSearchParams();
 		if (params?.status) queryParams.set('status', params.status);
+		if (params?.phase) queryParams.set('phase', params.phase);
 		if (params?.limit) queryParams.set('limit', params.limit.toString());
 		if (params?.offset) queryParams.set('offset', params.offset.toString());
 		const query = queryParams.toString() ? `?${queryParams}` : '';

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -102,6 +102,7 @@
 	// is already tracked (a scrape may have started while the HTTP call was in
 	// flight) and never restore after logout (authAuthenticated flipped false).
 	async function maybeRestoreRunningJob(retry = true) {
+		let restored = false;
 		try {
 			const result = await apiClient.listOrganizedJobs({ status: 'running', limit: 1 });
 			if (!authAuthenticated) return;
@@ -115,21 +116,27 @@
 			);
 			if (running && !getBackgroundJobState().jobId) {
 				restoreJob(running.id);
-			} else if (!running && retry) {
-				// A scrape job is persisted synchronously as 'pending' and flips
-				// to 'running' only when its background goroutine starts; a
-				// reload inside that window finds nothing and would lose the
-				// indicator for the entire scrape (issue #256). Reconcile exactly
-				// once instead of tracking dead-pending rows (a job whose runner
-				// never started must NOT be restored). The retry timer is
-				// component-scoped so unmount cancels it.
-				restoreRetryTimer = window.setTimeout(() => {
-					restoreRetryTimer = undefined;
-					void maybeRestoreRunningJob(false);
-				}, 1500);
+				restored = true;
 			}
 		} catch {
-			// Restore failure is non-critical — never surface it to the user.
+			// Restore failure is non-critical — never surface it to the user —
+			// but a transient lookup failure (temporary 500/network blip) takes
+			// the same one-shot reconcile below, otherwise an SSR-authenticated
+			// reload loses the indicator for the whole session (codex P2,
+			// PR #255 round 3).
+		}
+		if (!restored && retry && authAuthenticated) {
+			// A scrape job is persisted synchronously as 'pending' and flips to
+			// 'running' only when its background goroutine starts; a reload
+			// inside that window finds nothing and would lose the indicator for
+			// the entire scrape (issue #256). Reconcile exactly once instead of
+			// tracking dead-pending rows (a job whose runner never started must
+			// NOT be restored). The retry timer is component-scoped so unmount
+			// cancels it.
+			restoreRetryTimer = window.setTimeout(() => {
+				restoreRetryTimer = undefined;
+				void maybeRestoreRunningJob(false);
+			}, 1500);
 		}
 	}
 

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -35,6 +35,7 @@
 	let authLoading = $state(!initialAuthStatus);
 	let showAuthLoading = $state(false);
 	let authLoadingTimer: number | undefined;
+	let restoreRetryTimer: number | undefined;
 	let authSubmitting = $state(false);
 	let authUnavailable = $state(false);
 	let authInitialized = $state(initialAuthStatus?.initialized ?? false);
@@ -100,7 +101,7 @@
 	// reappears without reopening the modal. Guards: skip on refresh when a job
 	// is already tracked (a scrape may have started while the HTTP call was in
 	// flight) and never restore after logout (authAuthenticated flipped false).
-	async function maybeRestoreRunningJob() {
+	async function maybeRestoreRunningJob(retry = true) {
 		try {
 			const result = await apiClient.listOrganizedJobs({ status: 'running', limit: 1 });
 			if (!authAuthenticated) return;
@@ -114,6 +115,18 @@
 			);
 			if (running && !getBackgroundJobState().jobId) {
 				restoreJob(running.id);
+			} else if (!running && retry) {
+				// A scrape job is persisted synchronously as 'pending' and flips
+				// to 'running' only when its background goroutine starts; a
+				// reload inside that window finds nothing and would lose the
+				// indicator for the entire scrape (issue #256). Reconcile exactly
+				// once instead of tracking dead-pending rows (a job whose runner
+				// never started must NOT be restored). The retry timer is
+				// component-scoped so unmount cancels it.
+				restoreRetryTimer = window.setTimeout(() => {
+					restoreRetryTimer = undefined;
+					void maybeRestoreRunningJob(false);
+				}, 1500);
 			}
 		} catch {
 			// Restore failure is non-critical — never surface it to the user.
@@ -185,6 +198,7 @@
 
 	onDestroy(() => {
 		if (authLoadingTimer !== undefined) window.clearTimeout(authLoadingTimer);
+		if (restoreRetryTimer !== undefined) window.clearTimeout(restoreRetryTimer);
 		getThemeStore().destroyTheme();
 		websocketStore.disconnect();
 	});

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -104,12 +104,14 @@
 	async function maybeRestoreRunningJob(retry = true) {
 		let restored = false;
 		try {
-			// No limit: phase selection happens client-side after the SQL
-			// status filter, so any row cap could hide an older scrape behind
-			// newer apply-phase rows (codex P2, PR #255). Running-job volume is
-			// bounded by worker concurrency in practice, so the unbounded but
-			// status-filtered probe stays cheap.
-			const result = await apiClient.listOrganizedJobs({ status: 'running' });
+			// Phase predicate and row cap both live server-side: the
+			// repository filters running jobs by the durable current_phase
+			// marker in SQL before LIMIT 1 applies, so the probe returns the
+			// newest scrape job without fetching/decoding every running row
+			// even with many concurrent apply-phase jobs (codex P2, PR #255).
+			// The client-side phase check below stays as a legacy-backend
+			// guard — older servers ignore the param and return any running job.
+			const result = await apiClient.listOrganizedJobs({ status: 'running', phase: 'scrape', limit: 1 });
 			if (!authAuthenticated) return;
 			// Restore only scrape-phase jobs: an apply (organize) job also sits in
 			// 'running' but isn't the scrape progress the indicator/modal renders

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -104,12 +104,12 @@
 	async function maybeRestoreRunningJob(retry = true) {
 		let restored = false;
 		try {
-			// Limit trades bytes for correctness: several jobs can run at once,
-			// and SQL returns newest-first while phase filtering happens here —
-			// limit: 1 would hide an older scrape behind a newer apply job
-			// (codex P2, PR #255). 10 rows is bounded yet wide enough to find
-			// the scrape-phase row in practice.
-			const result = await apiClient.listOrganizedJobs({ status: 'running', limit: 10 });
+			// No limit: phase selection happens client-side after the SQL
+			// status filter, so any row cap could hide an older scrape behind
+			// newer apply-phase rows (codex P2, PR #255). Running-job volume is
+			// bounded by worker concurrency in practice, so the unbounded but
+			// status-filtered probe stays cheap.
+			const result = await apiClient.listOrganizedJobs({ status: 'running' });
 			if (!authAuthenticated) return;
 			// Restore only scrape-phase jobs: an apply (organize) job also sits in
 			// 'running' but isn't the scrape progress the indicator/modal renders

--- a/web/frontend/src/routes/+layout.svelte
+++ b/web/frontend/src/routes/+layout.svelte
@@ -104,7 +104,12 @@
 	async function maybeRestoreRunningJob(retry = true) {
 		let restored = false;
 		try {
-			const result = await apiClient.listOrganizedJobs({ status: 'running', limit: 1 });
+			// Limit trades bytes for correctness: several jobs can run at once,
+			// and SQL returns newest-first while phase filtering happens here —
+			// limit: 1 would hide an older scrape behind a newer apply job
+			// (codex P2, PR #255). 10 rows is bounded yet wide enough to find
+			// the scrape-phase row in practice.
+			const result = await apiClient.listOrganizedJobs({ status: 'running', limit: 10 });
 			if (!authAuthenticated) return;
 			// Restore only scrape-phase jobs: an apply (organize) job also sits in
 			// 'running' but isn't the scrape progress the indicator/modal renders

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -190,7 +190,7 @@ it('renders server-authenticated navigation immediately without a blank or loadi
 		render(Layout, { data: { authStatus: authenticatedStatus() } });
 
 		await waitFor(() => expect(apiClient.listOrganizedJobs).toHaveBeenCalledTimes(1));
-		expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running', limit: 1 });
+		expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running', limit: 10 });
 		expect(bgJob.restoreJob).toHaveBeenCalledWith('job-run-1');
 	});
 
@@ -242,6 +242,23 @@ it('renders server-authenticated navigation immediately without a blank or loadi
 		render(Layout);
 
 		await waitFor(() => expect(bgJob.restoreJob).toHaveBeenCalledWith('job-legacy-1'));
+	});
+
+	it('restores the scrape row even when a newer apply job heads the running list (codex P2)', async () => {
+		const bgJob = await import('$lib/stores/background-job.svelte');
+		apiClient.getAuthStatus.mockResolvedValue(authenticatedStatus());
+		apiClient.listOrganizedJobs.mockResolvedValue({
+			jobs: [
+				{ id: 'job-apply-new', status: 'running', current_phase: 'apply' },
+				{ id: 'job-scrape-old', status: 'running', current_phase: 'scrape' },
+			],
+		} as unknown as Awaited<ReturnType<typeof apiClient.listOrganizedJobs>>);
+
+		render(Layout);
+
+		// base branch used limit: 1 and would only ever see the apply row
+		expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running', limit: 10 });
+		await waitFor(() => expect(bgJob.restoreJob).toHaveBeenCalledWith('job-scrape-old'));
 	});
 
 	it('reconciles once when the probe races the pending-to-running flip (issue #256)', async () => {

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -244,6 +244,30 @@ it('renders server-authenticated navigation immediately without a blank or loadi
 		await waitFor(() => expect(bgJob.restoreJob).toHaveBeenCalledWith('job-legacy-1'));
 	});
 
+	it('reconciles once when the probe races the pending-to-running flip (issue #256)', async () => {
+		const bgJob = await import('$lib/stores/background-job.svelte');
+		apiClient.getAuthStatus.mockResolvedValue(authenticatedStatus());
+		apiClient.listOrganizedJobs
+			.mockResolvedValueOnce(
+				{ jobs: [] } as unknown as Awaited<ReturnType<typeof apiClient.listOrganizedJobs>>,
+			)
+			.mockResolvedValueOnce({
+				jobs: [{ id: 'job-flip-1', status: 'running', current_phase: 'scrape' }],
+			} as unknown as Awaited<ReturnType<typeof apiClient.listOrganizedJobs>>);
+
+		render(Layout);
+
+		await waitFor(() => expect(apiClient.listOrganizedJobs).toHaveBeenCalledTimes(1));
+		expect(bgJob.restoreJob).not.toHaveBeenCalled();
+
+		await waitFor(() => expect(bgJob.restoreJob).toHaveBeenCalledWith('job-flip-1'), {
+			timeout: 3000,
+		});
+		// The reconcile is one-shot: nothing probes a third time.
+		await new Promise((resolve) => setTimeout(resolve, 1600));
+		expect(apiClient.listOrganizedJobs).toHaveBeenCalledTimes(2);
+	});
+
 	it('does not restore a completed job returned despite the running filter', async () => {
 		const bgJob = await import('$lib/stores/background-job.svelte');
 		apiClient.getAuthStatus.mockResolvedValue(authenticatedStatus());

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -257,7 +257,9 @@ it('renders server-authenticated navigation immediately without a blank or loadi
 		render(Layout);
 
 		// base branch used limit: 1 and would only ever see the apply row
-		expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running', limit: 10 });
+		await waitFor(() =>
+			expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running', limit: 10 }),
+		);
 		await waitFor(() => expect(bgJob.restoreJob).toHaveBeenCalledWith('job-scrape-old'));
 	});
 

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -190,7 +190,7 @@ it('renders server-authenticated navigation immediately without a blank or loadi
 		render(Layout, { data: { authStatus: authenticatedStatus() } });
 
 		await waitFor(() => expect(apiClient.listOrganizedJobs).toHaveBeenCalledTimes(1));
-		expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running', limit: 10 });
+		expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running' });
 		expect(bgJob.restoreJob).toHaveBeenCalledWith('job-run-1');
 	});
 
@@ -256,9 +256,9 @@ it('renders server-authenticated navigation immediately without a blank or loadi
 
 		render(Layout);
 
-		// base branch used limit: 1 and would only ever see the apply row
+		// no row cap: any limit would let newest-first SQL discard the scrape row
 		await waitFor(() =>
-			expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running', limit: 10 }),
+			expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running' }),
 		);
 		await waitFor(() => expect(bgJob.restoreJob).toHaveBeenCalledWith('job-scrape-old'));
 	});

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -190,7 +190,7 @@ it('renders server-authenticated navigation immediately without a blank or loadi
 		render(Layout, { data: { authStatus: authenticatedStatus() } });
 
 		await waitFor(() => expect(apiClient.listOrganizedJobs).toHaveBeenCalledTimes(1));
-		expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running' });
+		expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running', phase: 'scrape', limit: 1 });
 		expect(bgJob.restoreJob).toHaveBeenCalledWith('job-run-1');
 	});
 
@@ -258,7 +258,7 @@ it('renders server-authenticated navigation immediately without a blank or loadi
 
 		// no row cap: any limit would let newest-first SQL discard the scrape row
 		await waitFor(() =>
-			expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running' }),
+			expect(apiClient.listOrganizedJobs).toHaveBeenCalledWith({ status: 'running', phase: 'scrape', limit: 1 }),
 		);
 		await waitFor(() => expect(bgJob.restoreJob).toHaveBeenCalledWith('job-scrape-old'));
 	});

--- a/web/frontend/src/routes/layout.test.ts
+++ b/web/frontend/src/routes/layout.test.ts
@@ -268,6 +268,26 @@ it('renders server-authenticated navigation immediately without a blank or loadi
 		expect(apiClient.listOrganizedJobs).toHaveBeenCalledTimes(2);
 	});
 
+	it('re-probes once after a transient restore lookup failure (codex P2)', async () => {
+		const bgJob = await import('$lib/stores/background-job.svelte');
+		apiClient.getAuthStatus.mockResolvedValue(authenticatedStatus());
+		apiClient.listOrganizedJobs
+			.mockRejectedValueOnce(new Error('temporary 500'))
+			.mockResolvedValueOnce({
+				jobs: [{ id: 'job-flip-2', status: 'running', current_phase: 'scrape' }],
+			} as unknown as Awaited<ReturnType<typeof apiClient.listOrganizedJobs>>);
+
+		render(Layout);
+
+		await waitFor(() => expect(apiClient.listOrganizedJobs).toHaveBeenCalledTimes(1));
+		expect(bgJob.restoreJob).not.toHaveBeenCalled();
+
+		// the failed probe schedules the bounded retry, and the retry restores
+		await waitFor(() => expect(bgJob.restoreJob).toHaveBeenCalledWith('job-flip-2'), {
+			timeout: 3000,
+		});
+	});
+
 	it('does not restore a completed job returned despite the running filter', async () => {
 		const bgJob = await import('$lib/stores/background-job.svelte');
 		apiClient.getAuthStatus.mockResolvedValue(authenticatedStatus());


### PR DESCRIPTION
## Problem

Organizing onto FUSE/shfs-class destinations (Unraid user shares, mergerfs without hardlinks, exFAT) failed with `destination volume cannot express an atomic no-clobber write` only **after** the entire multi-GB payload had been streamed into `.nrstg.N` staging. The destination's incapability was discovered at publish time — post-stream.

Verified failure chain (moves): same-volume `renameat2(RENAME_NOREPLACE)` returns `EXDEV` across the container's mount boundary → cross-device leg streams the full file → bound publish on the FUSE destination retries `renameat2` (`EINVAL`, no flagged-rename support) → hardlink fallback `link(2)` (`EPERM`, FUSE cached `no_link`) → refusal. Direct copies stage unconditionally and hit the same late refusal even same-filesystem.

## Fix

**Fail-fast capability preflight** — before any staging stream begins, `CopyFileNoReplace` consults `ProbeNoClobberPublish(fs, dstDir)`:

- Exercises the real `PublishNoReplace` primitive on exclusive zero-byte probe siblings inside the destination directory
- Caches **conclusive** verdicts per destination directory, single-flight (mutex released before I/O); indeterminate results (collision/transient/`EACCES`) are never cached so later files re-probe
- Refusal names both primitive errnos as **text** (`renameat2: EINVAL; link: EPERM`) plus the remedy — the errno is deliberately never `%w`-joined (an `errors.Is(EINVAL)`-reachable refusal would be misrouted by `isCrossDeviceError` into a full-copy leg; regression test pins `errors.Is(err, syscall.EINVAL) == false`)

**Cleanup honesty on incapable volumes:** no clobbering vacate rename (prohibited); a no-vacate `bindScratchForUnlink`-class descriptor+lookup double-proof pathname unlink; any identity-proof failure retains + reports the probe without masking the verdict. Zero-byte `.nrprobe` residue is an accepted consequence.

**Unchanged:** the adversarial no-clobber guarantee (no classify-then-rename fallback, opt-in or otherwise), same-volume move publishes (already fail fast), non-OsFs and Windows paths (bypass).

## Gates

- ✅ full `go test ./...` green; race detector clean on fsutil+organizer
- ✅ `go vet` + `golangci-lint` clean (with `GOTOOLCHAIN=go1.26.6`, matching repo pin)
- ✅ 100% coverage on every touched/new function; new seam-replay tests for capable/incapable/indeterminate verdicts, substitution cleanup, single-flight, EINVAL isolation, subtitle installs, Windows/non-OsFs bypass
- Workaround documented in `docs/10-troubleshooting.md` (bind-mount `/mnt/diskN/...` instead of `/mnt/user/...`)

Closes #252
Closes #256
