### PR TITLE
fix(proxy): test unsaved profiles during initial setup

### DIFF
--- a/internal/api/system/proxy.go
+++ b/internal/api/system/proxy.go
@@ -109,8 +109,8 @@ func testProxy(rt *core.APIRuntime) gin.HandlerFunc {
 					normalized := req.Proxy
 					if normalized.DefaultProfile == "" && normalized.Profile != "" {
 						normalized.DefaultProfile = normalized.Profile
-						normalized.Profile = ""
 					}
+					normalized.Profile = ""
 					configHash, hashErr = core.HashProxyConfig(normalized)
 				} else {
 					configHash, hashErr = core.HashProxyConfig(req.FlareSolverr)
@@ -154,10 +154,10 @@ func testProxy(rt *core.APIRuntime) gin.HandlerFunc {
 
 func resolveProxyTestProfile(persisted, requested models.ProxyConfig) *models.ProxyProfile {
 	if requested.Profiles != nil {
-		if requested.Profile != "" {
+		if requested.DefaultProfile == "" {
 			requested.DefaultProfile = requested.Profile
 		}
-		return models.ResolveGlobalProxy(requested)
+		return models.ResolveScraperProxy(requested, &requested)
 	}
 	persisted.Enabled = requested.Enabled
 	if requested.DefaultProfile != "" {

--- a/internal/api/system/proxy.go
+++ b/internal/api/system/proxy.go
@@ -66,10 +66,12 @@ func testProxy(rt *core.APIRuntime) gin.HandlerFunc {
 			return
 		}
 
+		apiCfg := rt.GetAPIConfig()
+		preserveRedactedProxyProfiles(apiCfg.ProxyConfig.Profiles, req.Proxy.Profiles)
+
 		var result ProxyTestResult
 		switch req.Mode {
 		case "direct":
-			apiCfg := rt.GetAPIConfig()
 			proxyProfile := resolveProxyTestProfile(apiCfg.ProxyConfig, req.Proxy)
 
 			if !req.Proxy.Enabled || strings.TrimSpace(proxyProfile.URL) == "" {
@@ -83,7 +85,6 @@ func testProxy(rt *core.APIRuntime) gin.HandlerFunc {
 				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: "flaresolverr.enabled=true and flaresolverr.url are required for flaresolverr test"})
 				return
 			}
-			apiCfg := rt.GetAPIConfig()
 			proxyProfile := resolveProxyTestProfile(apiCfg.ProxyConfig, req.Proxy)
 
 			result = TestFlareSolverr(targetURL, req.FlareSolverr, proxyProfile)

--- a/internal/api/system/proxy.go
+++ b/internal/api/system/proxy.go
@@ -70,9 +70,7 @@ func testProxy(rt *core.APIRuntime) gin.HandlerFunc {
 		switch req.Mode {
 		case "direct":
 			apiCfg := rt.GetAPIConfig()
-			globalProxy := &apiCfg.ProxyConfig
-			scraperProxy := &req.Proxy
-			proxyProfile := models.ResolveScraperProxy(*globalProxy, scraperProxy)
+			proxyProfile := resolveProxyTestProfile(apiCfg.ProxyConfig, req.Proxy)
 
 			if !req.Proxy.Enabled || strings.TrimSpace(proxyProfile.URL) == "" {
 				c.JSON(http.StatusBadRequest, contracts.ErrorResponse{Error: "proxy.enabled=true and proxy profile with url are required for direct proxy test"})
@@ -86,9 +84,7 @@ func testProxy(rt *core.APIRuntime) gin.HandlerFunc {
 				return
 			}
 			apiCfg := rt.GetAPIConfig()
-			globalProxy := &apiCfg.ProxyConfig
-			scraperProxy := &req.Proxy
-			proxyProfile := models.ResolveScraperProxy(*globalProxy, scraperProxy)
+			proxyProfile := resolveProxyTestProfile(apiCfg.ProxyConfig, req.Proxy)
 
 			result = TestFlareSolverr(targetURL, req.FlareSolverr, proxyProfile)
 
@@ -153,6 +149,20 @@ func testProxy(rt *core.APIRuntime) gin.HandlerFunc {
 			TokenExpiresAt:    result.TokenExpiresAt,
 		})
 	}
+}
+
+func resolveProxyTestProfile(persisted, requested models.ProxyConfig) *models.ProxyProfile {
+	if requested.Profiles != nil {
+		if requested.Profile != "" {
+			requested.DefaultProfile = requested.Profile
+		}
+		return models.ResolveGlobalProxy(requested)
+	}
+	persisted.Enabled = requested.Enabled
+	if requested.DefaultProfile != "" {
+		persisted.DefaultProfile = requested.DefaultProfile
+	}
+	return models.ResolveScraperProxy(persisted, &requested)
 }
 
 // TestDirectProxy tests direct proxy connectivity to a target URL.

--- a/internal/api/system/proxy_request_test.go
+++ b/internal/api/system/proxy_request_test.go
@@ -1,0 +1,97 @@
+package system
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/javinizer/javinizer-go/internal/api/contracts"
+	"github.com/javinizer/javinizer-go/internal/api/core"
+	"github.com/javinizer/javinizer-go/internal/api/testkit"
+	"github.com/javinizer/javinizer-go/internal/config"
+	"github.com/javinizer/javinizer-go/internal/models"
+	"github.com/javinizer/javinizer-go/internal/ssrf"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveProxyTestProfile(t *testing.T) {
+	saved := models.ProxyProfile{URL: "http://saved:8080", Username: "saved-user", Password: "saved-password"}
+	draft := models.ProxyProfile{URL: "http://draft:8080"}
+	persisted := models.ProxyConfig{Enabled: true, DefaultProfile: "main", Profiles: map[string]models.ProxyProfile{"main": saved}}
+	for _, tc := range []struct {
+		name    string
+		request models.ProxyConfig
+		want    models.ProxyProfile
+	}{
+		{"saved fallback", models.ProxyConfig{Enabled: true}, saved},
+		{"named saved fallback", models.ProxyConfig{Enabled: true, Profile: "main"}, saved},
+		{"default saved fallback", models.ProxyConfig{Enabled: true, DefaultProfile: "main"}, saved},
+		{"disabled", models.ProxyConfig{}, models.ProxyProfile{}},
+		{"empty profiles do not use saved", models.ProxyConfig{Enabled: true, Profiles: map[string]models.ProxyProfile{}}, models.ProxyProfile{}},
+		{"missing requested profile", models.ProxyConfig{Enabled: true, Profile: "missing", Profiles: map[string]models.ProxyProfile{"main": draft}}, models.ProxyProfile{}},
+		{"non-default draft without stale credentials", models.ProxyConfig{Enabled: true, Profile: "backup", Profiles: map[string]models.ProxyProfile{"backup": draft}}, draft},
+		{"disabled draft", models.ProxyConfig{Profile: "main", Profiles: map[string]models.ProxyProfile{"main": draft}}, models.ProxyProfile{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) { require.Equal(t, tc.want, *resolveProxyTestProfile(persisted, tc.request)) })
+	}
+}
+
+func TestProxy_RequestProfiles(t *testing.T) {
+	t.Cleanup(ssrf.SetLookupIPForTest(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("8.8.8.8")}, nil
+	}))
+	for _, tc := range []struct {
+		name       string
+		persisted  models.ProxyConfig
+		useDefault bool
+	}{
+		{name: "first setup"},
+		{name: "default profile field", useDefault: true},
+		{name: "replace saved profile", persisted: models.ProxyConfig{Enabled: true, DefaultProfile: "main", Profiles: map[string]models.ProxyProfile{"main": {URL: "http://127.0.0.1:1"}}}},
+		{name: "enable disabled saved proxy", persisted: models.ProxyConfig{DefaultProfile: "main", Profiles: map[string]models.ProxyProfile{"main": {URL: "http://127.0.0.1:1"}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "http://example.com/proxy-probe", r.URL.String())
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer proxy.Close()
+			cfg := config.DefaultConfig(nil, nil)
+			cfg.Scrapers.Proxy = tc.persisted
+			before, err := json.Marshal(cfg.Scrapers.Proxy)
+			require.NoError(t, err)
+			tokens := core.NewTokenStore()
+			deps := newTestDeps(cfg, func(d *core.APIDeps) { d.TokenStore = tokens })
+			rt := testkit.GetTestRuntime(deps)
+			router := gin.New()
+			router.POST("/proxy/test", testProxy(rt))
+			requestProxy := models.ProxyConfig{Enabled: true, Profile: "main", Profiles: map[string]models.ProxyProfile{"main": {URL: proxy.URL}}}
+			if tc.useDefault {
+				requestProxy.Profile = ""
+				requestProxy.DefaultProfile = "main"
+			}
+			body, err := json.Marshal(contracts.ProxyTestRequest{Mode: "direct", TargetURL: "http://example.com/proxy-probe", Proxy: requestProxy})
+			require.NoError(t, err)
+			req := httptest.NewRequest(http.MethodPost, "/proxy/test", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			var response contracts.ProxyTestResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			require.True(t, response.Success, response.Message)
+			requestProxy.Profile = ""
+			requestProxy.DefaultProfile = "main"
+			hash, err := core.HashProxyConfig(requestProxy)
+			require.NoError(t, err)
+			require.True(t, tokens.Validate(response.VerificationToken, "global", hash))
+			after, err := json.Marshal(rt.GetAPIConfig().ProxyConfig)
+			require.NoError(t, err)
+			require.JSONEq(t, string(before), string(after))
+		})
+	}
+}

--- a/internal/api/system/proxy_request_test.go
+++ b/internal/api/system/proxy_request_test.go
@@ -54,6 +54,7 @@ func TestProxy_RedactedRequestCredentials(t *testing.T) {
 		{"new username", models.ProxyProfile{Username: "new-user", Password: models.RedactedValue}, models.ProxyProfile{Username: "new-user", Password: "saved-password"}},
 		{"new password", models.ProxyProfile{Username: models.RedactedValue, Password: "new-password"}, models.ProxyProfile{Username: "saved-user", Password: "new-password"}},
 		{"cleared credentials", models.ProxyProfile{}, models.ProxyProfile{}},
+		{"inherited credentials", models.ProxyProfile{Username: models.RedactedValue, Password: models.RedactedValue}, models.ProxyProfile{Username: "saved-user", Password: "saved-password"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -86,6 +87,11 @@ func TestProxy_RedactedRequestCredentials(t *testing.T) {
 				"main":   requested,
 				"backup": {URL: "http://backup:8080", Username: models.RedactedValue, Password: models.RedactedValue},
 			}}
+			if tc.name == "inherited credentials" {
+				requestProxy.Profile = "backup"
+				requestProxy.DefaultProfile = "main"
+				requestProxy.Profiles["backup"] = models.ProxyProfile{URL: proxy.URL}
+			}
 			body, err := json.Marshal(contracts.ProxyTestRequest{Mode: "direct", TargetURL: "http://example.com/proxy-probe", Proxy: requestProxy})
 			require.NoError(t, err)
 			req := httptest.NewRequest(http.MethodPost, "/proxy/test", bytes.NewReader(body))
@@ -102,9 +108,15 @@ func TestProxy_RedactedRequestCredentials(t *testing.T) {
 			requestProxy.DefaultProfile = "main"
 			requestProxy.Profiles["main"] = expected
 			requestProxy.Profiles["backup"] = cfg.Scrapers.Proxy.Profiles["backup"]
+			if tc.name == "inherited credentials" {
+				requestProxy.Profiles["backup"] = models.ProxyProfile{URL: proxy.URL}
+			}
 			hash, err := core.HashProxyConfig(requestProxy)
 			require.NoError(t, err)
 			require.True(t, tokens.Validate(response.VerificationToken, "global", hash))
+			saveCfg := cfg.Clone()
+			saveCfg.Scrapers.Proxy = requestProxy
+			require.NoError(t, validateProxySaveConfig(deps, saveCfg, map[string]string{"global": response.VerificationToken}))
 			after, err := json.Marshal(rt.GetAPIConfig().ProxyConfig)
 			require.NoError(t, err)
 			require.JSONEq(t, string(before), string(after))
@@ -161,6 +173,9 @@ func TestProxy_RequestProfiles(t *testing.T) {
 			hash, err := core.HashProxyConfig(requestProxy)
 			require.NoError(t, err)
 			require.True(t, tokens.Validate(response.VerificationToken, "global", hash))
+			saveCfg := cfg.Clone()
+			saveCfg.Scrapers.Proxy = requestProxy
+			require.NoError(t, validateProxySaveConfig(deps, saveCfg, map[string]string{"global": response.VerificationToken}))
 			after, err := json.Marshal(rt.GetAPIConfig().ProxyConfig)
 			require.NoError(t, err)
 			require.JSONEq(t, string(before), string(after))

--- a/internal/api/system/proxy_request_test.go
+++ b/internal/api/system/proxy_request_test.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"net"
 	"net/http"
@@ -37,6 +38,77 @@ func TestResolveProxyTestProfile(t *testing.T) {
 		{"disabled draft", models.ProxyConfig{Profile: "main", Profiles: map[string]models.ProxyProfile{"main": draft}}, models.ProxyProfile{}},
 	} {
 		t.Run(tc.name, func(t *testing.T) { require.Equal(t, tc.want, *resolveProxyTestProfile(persisted, tc.request)) })
+	}
+}
+
+func TestProxy_RedactedRequestCredentials(t *testing.T) {
+	t.Cleanup(ssrf.SetLookupIPForTest(func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("8.8.8.8")}, nil
+	}))
+	for _, tc := range []struct {
+		name      string
+		requested models.ProxyProfile
+		expected  models.ProxyProfile
+	}{
+		{"both redacted", models.ProxyProfile{Username: models.RedactedValue, Password: models.RedactedValue}, models.ProxyProfile{Username: "saved-user", Password: "saved-password"}},
+		{"new username", models.ProxyProfile{Username: "new-user", Password: models.RedactedValue}, models.ProxyProfile{Username: "new-user", Password: "saved-password"}},
+		{"new password", models.ProxyProfile{Username: models.RedactedValue, Password: "new-password"}, models.ProxyProfile{Username: "saved-user", Password: "new-password"}},
+		{"cleared credentials", models.ProxyProfile{}, models.ProxyProfile{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				wantAuth := ""
+				if tc.expected.Username != "" || tc.expected.Password != "" {
+					wantAuth = "Basic " + base64.StdEncoding.EncodeToString([]byte(tc.expected.Username+":"+tc.expected.Password))
+				}
+				if r.Header.Get("Proxy-Authorization") != wantAuth {
+					w.WriteHeader(http.StatusProxyAuthRequired)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer proxy.Close()
+			cfg := config.DefaultConfig(nil, nil)
+			cfg.Scrapers.Proxy = models.ProxyConfig{Enabled: true, DefaultProfile: "main", Profiles: map[string]models.ProxyProfile{
+				"main":   {URL: "http://old-proxy:8080", Username: "saved-user", Password: "saved-password"},
+				"backup": {URL: "http://backup:8080", Username: "backup-user", Password: "backup-password"},
+			}}
+			before, err := json.Marshal(cfg.Scrapers.Proxy)
+			require.NoError(t, err)
+			tokens := core.NewTokenStore()
+			deps := newTestDeps(cfg, func(d *core.APIDeps) { d.TokenStore = tokens })
+			rt := testkit.GetTestRuntime(deps)
+			router := gin.New()
+			router.POST("/proxy/test", testProxy(rt))
+			requested := tc.requested
+			requested.URL = proxy.URL
+			requestProxy := models.ProxyConfig{Enabled: true, Profile: "main", Profiles: map[string]models.ProxyProfile{
+				"main":   requested,
+				"backup": {URL: "http://backup:8080", Username: models.RedactedValue, Password: models.RedactedValue},
+			}}
+			body, err := json.Marshal(contracts.ProxyTestRequest{Mode: "direct", TargetURL: "http://example.com/proxy-probe", Proxy: requestProxy})
+			require.NoError(t, err)
+			req := httptest.NewRequest(http.MethodPost, "/proxy/test", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			var response contracts.ProxyTestResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			require.True(t, response.Success, response.Message)
+			expected := tc.expected
+			expected.URL = proxy.URL
+			requestProxy.Profile = ""
+			requestProxy.DefaultProfile = "main"
+			requestProxy.Profiles["main"] = expected
+			requestProxy.Profiles["backup"] = cfg.Scrapers.Proxy.Profiles["backup"]
+			hash, err := core.HashProxyConfig(requestProxy)
+			require.NoError(t, err)
+			require.True(t, tokens.Validate(response.VerificationToken, "global", hash))
+			after, err := json.Marshal(rt.GetAPIConfig().ProxyConfig)
+			require.NoError(t, err)
+			require.JSONEq(t, string(before), string(after))
+		})
 	}
 }
 

--- a/web/frontend/src/routes/settings/stores/proxy-store.svelte.ts
+++ b/web/frontend/src/routes/settings/stores/proxy-store.svelte.ts
@@ -343,12 +343,6 @@ export function createProxyStore(deps: ProxyStoreDeps): ProxyStore {
 					delete next['global'];
 					verificationTokens = next;
 				}
-			} else if (
-				result.success &&
-				result.verification_token &&
-				(config?.scrapers?.proxy?.enabled ?? false)
-			) {
-				verificationTokens['global'] = result.verification_token;
 			}
 
 			if (result.success) {

--- a/web/frontend/src/routes/settings/stores/proxy-store.svelte.ts
+++ b/web/frontend/src/routes/settings/stores/proxy-store.svelte.ts
@@ -309,7 +309,7 @@ export function createProxyStore(deps: ProxyStoreDeps): ProxyStore {
 						}
 					: {
 							enabled: true,
-							profile: '',
+							profile: profileName,
 							profiles: {
 								[profileName]: {
 									url: profile.url,

--- a/web/frontend/src/routes/settings/stores/proxy-store.svelte.ts
+++ b/web/frontend/src/routes/settings/stores/proxy-store.svelte.ts
@@ -66,7 +66,11 @@ export function createProxyStore(deps: ProxyStoreDeps): ProxyStore {
 	function canSaveProfile(profileName: string): boolean {
 		const result = profileTestResults[profileName];
 		const currentProfile = deps.getConfig()?.scrapers?.proxy?.profiles?.[profileName];
-		return isTestValid(result, currentProfile, TEST_VALIDITY_MS);
+		return (
+			isTestValid(result, currentProfile, TEST_VALIDITY_MS) &&
+			canSaveGlobalProxy() &&
+			!!verificationTokens['global']
+		);
 	}
 
 	function canSaveGlobalProxy(): boolean {
@@ -260,7 +264,7 @@ export function createProxyStore(deps: ProxyStoreDeps): ProxyStore {
 	async function saveProxyProfile(profileName: string): Promise<void> {
 		const config = deps.getConfig();
 		if (!config?.scrapers?.proxy?.profiles?.[profileName]) return;
-		if (savingProfile[profileName]) return;
+		if (savingProfile[profileName] || !canSaveProfile(profileName)) return;
 
 		savingProfile[profileName] = true;
 		deps.setError(null);
@@ -269,7 +273,7 @@ export function createProxyStore(deps: ProxyStoreDeps): ProxyStore {
 		try {
 			await apiClient.request('/api/v1/config', {
 				method: 'PUT',
-				body: JSON.stringify(config),
+				body: JSON.stringify({ ...config, proxy_verification_tokens: verificationTokens }),
 			});
 			toastStore.success(m.settings_proxy_profile_saved({ name: profileName }), 4000);
 		} catch (e) {
@@ -301,23 +305,12 @@ export function createProxyStore(deps: ProxyStoreDeps): ProxyStore {
 
 			const result = await apiClient.testProxy({
 				mode: 'direct',
-				proxy: shouldAlsoValidateGlobalProxy
-					? {
-							enabled: true,
-							profile: defaultProfileName,
-							profiles: config?.scrapers?.proxy?.profiles ?? {},
-						}
-					: {
-							enabled: true,
-							profile: profileName,
-							profiles: {
-								[profileName]: {
-									url: profile.url,
-									username: profile.username ?? '',
-									password: profile.password ?? '',
-								},
-							},
-						},
+				proxy: {
+					enabled: true,
+					default_profile: defaultProfileName,
+					profile: profileName,
+					profiles: config?.scrapers?.proxy?.profiles ?? {},
+				},
 			});
 
 			profileTestResults[profileName] = {

--- a/web/frontend/src/routes/settings/stores/proxy-store.test.ts
+++ b/web/frontend/src/routes/settings/stores/proxy-store.test.ts
@@ -3,11 +3,12 @@ import { createProxyStore } from './proxy-store.svelte';
 import { apiClient } from '$lib/api/client';
 import type { Config } from '$lib/api/types';
 
-vi.mock('$lib/api/client', () => ({ apiClient: { testProxy: vi.fn() } }));
+vi.mock('$lib/api/client', () => ({ apiClient: { testProxy: vi.fn(), request: vi.fn() } }));
 vi.mock('$lib/stores/toast', () => ({ toastStore: { success: vi.fn(), error: vi.fn() } }));
 
 describe('unsaved proxy profile tests', () => {
 	it.each(['main', 'backup'])('tests the selected %s profile and enables saving', async (name) => {
+		vi.mocked(apiClient.request).mockClear();
 		const profiles = {
 			main: { url: 'http://127.0.0.1:7890', username: '', password: '' },
 			backup: { url: 'http://127.0.0.1:7891', username: '', password: '' },
@@ -40,10 +41,20 @@ describe('unsaved proxy profile tests', () => {
 			proxy: {
 				enabled: true,
 				profile: name,
-				profiles: name === 'main' ? profiles : { backup: profiles.backup },
+				default_profile: 'main',
+				profiles,
 			},
 		});
-		expect(store.canSaveProfile(name)).toBe(true);
+		expect(store.canSaveProfile(name)).toBe(name === 'main');
+		await store.saveProxyProfile(name);
+		if (name === 'main') {
+			expect(apiClient.request).toHaveBeenLastCalledWith('/api/v1/config', {
+				method: 'PUT',
+				body: JSON.stringify({ ...config, proxy_verification_tokens: { global: 'verified' } }),
+			});
+		} else {
+			expect(apiClient.request).not.toHaveBeenCalled();
+		}
 		expect(store.verificationTokens['global']).toBe(name === 'main' ? 'verified' : undefined);
 		if (name === 'main') {
 			const globalResult = store.globalProxyTestResult;
@@ -60,6 +71,13 @@ describe('unsaved proxy profile tests', () => {
 			expect(store.canSaveProfile('backup')).toBe(true);
 			expect(store.verificationTokens['global']).toBe('verified');
 			expect(store.globalProxyTestResult).toEqual(globalResult);
+			await store.saveProxyProfile('backup');
+			expect(apiClient.request).toHaveBeenLastCalledWith('/api/v1/config', {
+				method: 'PUT',
+				body: JSON.stringify({ ...config, proxy_verification_tokens: { global: 'verified' } }),
+			});
+			store.setProxyProfileField('main', 'password', 'changed');
+			expect(store.canSaveProfile('backup')).toBe(false);
 		}
 	});
 });

--- a/web/frontend/src/routes/settings/stores/proxy-store.test.ts
+++ b/web/frontend/src/routes/settings/stores/proxy-store.test.ts
@@ -44,5 +44,22 @@ describe('unsaved proxy profile tests', () => {
 			},
 		});
 		expect(store.canSaveProfile(name)).toBe(true);
+		expect(store.verificationTokens['global']).toBe(name === 'main' ? 'verified' : undefined);
+		if (name === 'main') {
+			const globalResult = store.globalProxyTestResult;
+			vi.mocked(apiClient.testProxy).mockResolvedValueOnce({
+				success: true,
+				mode: 'direct',
+				target_url: 'http://example.com',
+				status_code: 200,
+				duration_ms: 1,
+				message: 'ok',
+				verification_token: 'partial-profile-token',
+			});
+			await store.runNamedProxyProfileTest('backup');
+			expect(store.canSaveProfile('backup')).toBe(true);
+			expect(store.verificationTokens['global']).toBe('verified');
+			expect(store.globalProxyTestResult).toEqual(globalResult);
+		}
 	});
 });

--- a/web/frontend/src/routes/settings/stores/proxy-store.test.ts
+++ b/web/frontend/src/routes/settings/stores/proxy-store.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createProxyStore } from './proxy-store.svelte';
+import { apiClient } from '$lib/api/client';
+import type { Config } from '$lib/api/types';
+
+vi.mock('$lib/api/client', () => ({ apiClient: { testProxy: vi.fn() } }));
+vi.mock('$lib/stores/toast', () => ({ toastStore: { success: vi.fn(), error: vi.fn() } }));
+
+describe('unsaved proxy profile tests', () => {
+	it.each(['main', 'backup'])('tests the selected %s profile and enables saving', async (name) => {
+		const profiles = {
+			main: { url: 'http://127.0.0.1:7890', username: '', password: '' },
+			backup: { url: 'http://127.0.0.1:7891', username: '', password: '' },
+		};
+		const config = {
+			scrapers: { proxy: { enabled: true, default_profile: 'main', profiles } },
+		} as Config;
+		vi.mocked(apiClient.testProxy).mockResolvedValue({
+			success: true,
+			mode: 'direct',
+			target_url: 'http://example.com',
+			status_code: 200,
+			duration_ms: 1,
+			message: 'ok',
+			verification_token: 'verified',
+		});
+		const store = createProxyStore({
+			getConfig: () => config,
+			setConfig: vi.fn(),
+			getError: () => null,
+			setError: vi.fn(),
+			getScrapers: () => [],
+			setScrapers: vi.fn(),
+			getScraperConfigNames: () => [],
+			ensureProxyProfilesInitialized: vi.fn(),
+		});
+		await store.runNamedProxyProfileTest(name);
+		expect(apiClient.testProxy).toHaveBeenLastCalledWith({
+			mode: 'direct',
+			proxy: {
+				enabled: true,
+				profile: name,
+				profiles: name === 'main' ? profiles : { backup: profiles.backup },
+			},
+		});
+		expect(store.canSaveProfile(name)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- Resolve proxy connectivity tests from request-supplied profiles rather than persisted settings, allowing first-time setup and testing edits before saving.
- Retain saved-profile fallback when profiles are omitted, without changing normal scraper resolution or mutating persisted configuration.
- Send the selected name when testing a non-default profile.
- Add backend and frontend regressions for bootstrap, edited/disabled settings, profile selection, credentials, and save-token compatibility.

Closes #258

## Validation
- `go test -short ./...`
- Race tests for worker, TUI, websocket, and all API packages
- `go vet ./...`
- `GOTOOLCHAIN=go1.26.6 make lint` (0 issues)
- `go build ./...`
- Targeted frontend tests: 21 passed
- `npm run check`: 0 errors, 0 warnings
- All pre-commit hooks passed
